### PR TITLE
[powershell] better null comparison

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
@@ -144,7 +144,7 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
 
     {{/hasHttpSignatureMethods}}
     if ($SkipCertificateCheck -eq $true) {
-        if ($Configuration["Proxy"] -eq $null) {
+        if ($null -eq $Configuration["Proxy"]) {
             # skip certification check, no proxy
             $Response = Invoke-WebRequest -Uri $UriBuilder.Uri `
                                       -Method $Method `
@@ -166,7 +166,7 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
                                       -ProxyUseDefaultCredentials
         }
     } else {
-        if ($Configuration["Proxy"] -eq $null) {
+        if ($null -eq $Configuration["Proxy"]) {
             # perform certification check, no proxy
             $Response = Invoke-WebRequest -Uri $UriBuilder.Uri `
                                       -Method $Method `
@@ -241,7 +241,7 @@ function DeserializeResponse {
         [string[]]$ContentTypes
     )
 
-    If ($ContentTypes -eq $null) {
+    If ($null -eq $ContentTypes) {
         $ContentTypes = [string[]]@()
     }
 

--- a/modules/openapi-generator/src/main/resources/powershell/appveyor.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/appveyor.mustache
@@ -20,7 +20,7 @@ test_script:
       }
 deploy_script:
   - pwsh: |
-      if ($env:APPVEYOR_REPO_TAG -eq $true -and $env:NuGetApiKey -ne $null) {
+      if ($env:APPVEYOR_REPO_TAG -eq $true -and $null -ne $env:NuGetApiKey) {
           .\Build.ps1
           try {
               Publish-Module -NuGetApiKey $env:NuGetApiKey -Path .\src\{{{packageName}}}\ -Confirm:$False -Verbose

--- a/modules/openapi-generator/src/main/resources/powershell/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/configuration.mustache
@@ -172,7 +172,7 @@ function Set-{{{apiNamePrefix}}}Configuration {
             $Script:Configuration['DefaultHeaders'] = $DefaultHeaders
         }
 
-        If ($Proxy -ne $null) {
+        If ($null -ne $Proxy) {
             If ($Proxy.GetType().FullName -ne "System.Net.SystemWebProxy" -and $Proxy.GetType().FullName -ne "System.Net.WebRequest+WebProxyWrapperOpaque") {
                 throw "Incorrect Proxy type '$($Proxy.GetType().FullName)'. Must be System.Net.SystemWebProxy or System.Net.WebRequest+WebProxyWrapperOpaque."
             }

--- a/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
@@ -73,7 +73,7 @@ function Initialize-{{{apiNamePrefix}}}{{{classname}}} {
         {{#vars}}
         {{^isNullable}}
         {{#required}}
-        if (${{{name}}} -eq $null) {
+        if ($null -eq ${{{name}}}) {
             throw "invalid value for '{{{name}}}', '{{{name}}}' cannot be null."
         }
 

--- a/samples/client/petstore/powershell/appveyor.yml
+++ b/samples/client/petstore/powershell/appveyor.yml
@@ -26,7 +26,7 @@ test_script:
       }
 deploy_script:
   - pwsh: |
-      if ($env:APPVEYOR_REPO_TAG -eq $true -and $env:NuGetApiKey -ne $null) {
+      if ($env:APPVEYOR_REPO_TAG -eq $true -and $null -ne $env:NuGetApiKey) {
           .\Build.ps1
           try {
               Publish-Module -NuGetApiKey $env:NuGetApiKey -Path .\src\PSPetstore\ -Confirm:$False -Verbose

--- a/samples/client/petstore/powershell/src/PSPetstore/Client/PSConfiguration.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Client/PSConfiguration.ps1
@@ -178,7 +178,7 @@ function Set-PSConfiguration {
             $Script:Configuration['DefaultHeaders'] = $DefaultHeaders
         }
 
-        If ($Proxy -ne $null) {
+        If ($null -ne $Proxy) {
             If ($Proxy.GetType().FullName -ne "System.Net.SystemWebProxy" -and $Proxy.GetType().FullName -ne "System.Net.WebRequest+WebProxyWrapperOpaque") {
                 throw "Incorrect Proxy type '$($Proxy.GetType().FullName)'. Must be System.Net.SystemWebProxy or System.Net.WebRequest+WebProxyWrapperOpaque."
             }

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
@@ -59,11 +59,11 @@ function Initialize-PSPet {
         'Creating PSCustomObject: PSPetstore => PSPet' | Write-Debug
         $PSBoundParameters | Out-DebugParameter | Write-Debug
 
-        if ($Name -eq $null) {
+        if ($null -eq $Name) {
             throw "invalid value for 'Name', 'Name' cannot be null."
         }
 
-        if ($PhotoUrls -eq $null) {
+        if ($null -eq $PhotoUrls) {
             throw "invalid value for 'PhotoUrls', 'PhotoUrls' cannot be null."
         }
 

--- a/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
@@ -131,7 +131,7 @@ function Invoke-PSApiClient {
     }
 
     if ($SkipCertificateCheck -eq $true) {
-        if ($Configuration["Proxy"] -eq $null) {
+        if ($null -eq $Configuration["Proxy"]) {
             # skip certification check, no proxy
             $Response = Invoke-WebRequest -Uri $UriBuilder.Uri `
                                       -Method $Method `
@@ -153,7 +153,7 @@ function Invoke-PSApiClient {
                                       -ProxyUseDefaultCredentials
         }
     } else {
-        if ($Configuration["Proxy"] -eq $null) {
+        if ($null -eq $Configuration["Proxy"]) {
             # perform certification check, no proxy
             $Response = Invoke-WebRequest -Uri $UriBuilder.Uri `
                                       -Method $Method `
@@ -228,7 +228,7 @@ function DeserializeResponse {
         [string[]]$ContentTypes
     )
 
-    If ($ContentTypes -eq $null) {
+    If ($null -eq $ContentTypes) {
         $ContentTypes = [string[]]@()
     }
 


### PR DESCRIPTION
better `$null` comparison by putting $null on the LHS


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
