### PR TITLE
Add support for asynchronous API for JavaJaxRsSpec

### DIFF
--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -57,6 +57,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
+|supportAsync|Wrap responses in CompletionStage type, allowing asynchronous computation (requires JAX-RS 2.1).| |false|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -57,6 +57,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
+|supportAsync|Wrap responses in CompletionStage type, allowing asynchronous computation (requires JAX-RS 2.1).| |false|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -33,7 +33,6 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public static final String USE_SWAGGER_ANNOTATIONS = "useSwaggerAnnotations";
     public static final String OPEN_API_SPEC_FILE_LOCATION = "openApiSpecFileLocation";
     public static final String GENERATE_BUILDERS = "generateBuilders";
-    public static final String SUPPORT_ASYNC = "supportAsync";
 
     public static final String QUARKUS_LIBRARY = "quarkus";
     public static final String THORNTAIL_LIBRARY = "thorntail";
@@ -47,7 +46,6 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     private boolean generateBuilders = false;
     private boolean useSwaggerAnnotations = true;
     private boolean useJackson = false;
-    private boolean supportAsync = false;
     private String openApiSpecFileLocation = "src/main/openapi/openapi.yaml";
 
     public JavaJAXRSSpecServerCodegen() {
@@ -125,7 +123,12 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
             }
         }
         if (additionalProperties.containsKey(SUPPORT_ASYNC)) {
-            this.supportAsync = Boolean.parseBoolean(additionalProperties.get(SUPPORT_ASYNC).toString());
+            supportAsync = Boolean.parseBoolean(additionalProperties.get(SUPPORT_ASYNC).toString());
+            if (!supportAsync) {
+                additionalProperties.remove(SUPPORT_ASYNC);
+            } else {
+                setJava8ModeAndAdditionalProperties(true);
+            }
         }
         if (QUARKUS_LIBRARY.equals(library) || THORNTAIL_LIBRARY.equals(library) || HELIDON_LIBRARY.equals(library) || OPEN_LIBERTY_LIBRARY.equals(library) || KUMULUZEE_LIBRARY.equals(library)) {
             useSwaggerAnnotations = false;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -33,6 +33,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public static final String USE_SWAGGER_ANNOTATIONS = "useSwaggerAnnotations";
     public static final String OPEN_API_SPEC_FILE_LOCATION = "openApiSpecFileLocation";
     public static final String GENERATE_BUILDERS = "generateBuilders";
+    public static final String SUPPORT_ASYNC = "supportAsync";
 
     public static final String QUARKUS_LIBRARY = "quarkus";
     public static final String THORNTAIL_LIBRARY = "thorntail";
@@ -46,6 +47,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     private boolean generateBuilders = false;
     private boolean useSwaggerAnnotations = true;
     private boolean useJackson = false;
+    private boolean supportAsync = false;
     private String openApiSpecFileLocation = "src/main/openapi/openapi.yaml";
 
     public JavaJAXRSSpecServerCodegen() {
@@ -102,6 +104,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         cliOptions.add(CliOption.newBoolean(RETURN_RESPONSE, "Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true.").defaultValue(String.valueOf(returnResponse)));
         cliOptions.add(CliOption.newBoolean(USE_SWAGGER_ANNOTATIONS, "Whether to generate Swagger annotations.", useSwaggerAnnotations));
         cliOptions.add(CliOption.newString(OPEN_API_SPEC_FILE_LOCATION, "Location where the file containing the spec will be generated in the output folder. No file generated when set to null or empty string."));
+        cliOptions.add(CliOption.newBoolean(SUPPORT_ASYNC, "Wrap responses in CompletionStage type, allowing asynchronous computation (requires JAX-RS 2.1).", supportAsync));
     }
 
     @Override
@@ -120,6 +123,9 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
             if (!returnResponse) {
                 additionalProperties.remove(RETURN_RESPONSE);
             }
+        }
+        if (additionalProperties.containsKey(SUPPORT_ASYNC)) {
+            this.supportAsync = Boolean.parseBoolean(additionalProperties.get(SUPPORT_ASYNC).toString());
         }
         if (QUARKUS_LIBRARY.equals(library) || THORNTAIL_LIBRARY.equals(library) || HELIDON_LIBRARY.equals(library) || OPEN_LIBERTY_LIBRARY.equals(library) || KUMULUZEE_LIBRARY.equals(library)) {
             useSwaggerAnnotations = false;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
@@ -9,6 +9,10 @@ import javax.ws.rs.core.Response;
 {{#useSwaggerAnnotations}}
 import io.swagger.annotations.*;
 {{/useSwaggerAnnotations}}
+{{#supportAsync}}
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
+{{/supportAsync}}
 
 import java.io.InputStream;
 import java.util.Map;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/apiInterface.mustache
@@ -10,4 +10,4 @@
         {{/isOAuth}}{{/authMethods}} }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-tags}} })
     @ApiResponses(value = { {{#responses}}
         @ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{baseType}}}.class{{#returnContainer}}, responseContainer = "{{{.}}}"{{/returnContainer}}){{^-last}},{{/-last}}{{/responses}} }){{/useSwaggerAnnotations}}
-    {{#returnResponse}}Response{{/returnResponse}}{{^returnResponse}}{{>returnTypeInterface}}{{/returnResponse}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}},{{/-last}}{{/allParams}});
+    {{#supportAsync}}{{>returnAsyncTypeInterface}}{{/supportAsync}}{{^supportAsync}}{{#returnResponse}}Response{{/returnResponse}}{{^returnResponse}}{{>returnTypeInterface}}{{/returnResponse}}{{/supportAsync}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}},{{/-last}}{{/allParams}});

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/apiMethod.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/apiMethod.mustache
@@ -11,6 +11,6 @@
     @ApiResponses(value = { {{#responses}}
         @ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{baseType}}}.class{{#containerType}}, responseContainer = "{{{.}}}"{{/containerType}}){{^-last}},{{/-last}}{{/responses}}
     }){{/useSwaggerAnnotations}}
-    public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>cookieParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}},{{/-last}}{{/allParams}}) {
-        return Response.ok().entity("magic!").build();
+    public {{#supportAsync}}CompletionStage<{{/supportAsync}}Response{{#supportAsync}}>{{/supportAsync}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>cookieParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}},{{/-last}}{{/allParams}}) {
+        return {{#supportAsync}}CompletableFuture.supplyAsync(() -> {{/supportAsync}}Response.ok().entity("magic!").build(){{#supportAsync}}){{/supportAsync}};
     }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -140,6 +140,11 @@
 {{/useBeanValidation}}
   </dependencies>
   <properties>
+{{#java8}}
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+{{/java8}}
     <jackson-version>2.9.9</jackson-version>
     <junit-version>4.13.1</junit-version>
 {{#useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/returnAsyncTypeInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/returnAsyncTypeInterface.mustache
@@ -1,0 +1,1 @@
+CompletionStage<{{#returnResponse}}Response{{/returnResponse}}{{^returnResponse}}{{#returnContainer}}{{#isMap}}Map<String, {{{returnBaseType}}}>{{/isMap}}{{#isArray}}{{{returnContainer}}}<{{{returnBaseType}}}>{{/isArray}}{{/returnContainer}}{{^returnContainer}}{{{returnBaseType}}}{{/returnContainer}}{{/returnResponse}}>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -28,6 +28,10 @@ import java.util.Map;
 
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 import static org.openapitools.codegen.TestUtils.validateJavaSourceFiles;
+import static org.openapitools.codegen.languages.AbstractJavaJAXRSServerCodegen.USE_TAGS;
+import static org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen.INTERFACE_ONLY;
+import static org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen.SUPPORT_ASYNC;
+import static org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen.RETURN_RESPONSE;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -418,5 +422,171 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         Path path = Paths.get(outputPath + "/src/gen/java/org/openapitools/api/ExamplesApi.java");
 
         assertFileContains(path, "\nimport java.util.Set;\n");
+    }
+
+    @Test
+    public void generateApiWithAsyncSupport() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/ping.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(SUPPORT_ASYNC, true); //Given support async is enabled
+
+        final ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen); //Using JavaJAXRSSpecServerCodegen
+
+        final DefaultGenerator generator = new DefaultGenerator();
+        final List<File> files = generator.opts(input).generate(); //When generating files
+
+        //Then the java files are compilable
+        validateJavaSourceFiles(files);
+
+        //And the generated class contains CompletionStage<Response>
+        TestUtils.ensureContainsFile(files, output, "src/gen/java/org/openapitools/api/PingApi.java");
+        assertFileContains(output.toPath().resolve("src/gen/java/org/openapitools/api/PingApi.java"),
+                "\nimport java.util.concurrent.CompletionStage;\n",
+                "\nimport java.util.concurrent.CompletableFuture;\n",
+                "\npublic CompletionStage<Response> pingGet() {\n",
+                "\nCompletableFuture.supplyAsync(() -> Response.ok().entity(\"magic!\").build())\n"
+                );
+    }
+
+    @Test
+    public void generateApiWithAsyncSupportAndInterfaceOnly() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/ping.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(SUPPORT_ASYNC, true); //Given support async is enabled
+        codegen.additionalProperties().put(INTERFACE_ONLY, true); //And only interfaces are generated
+
+        final ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen); //Using JavaJAXRSSpecServerCodegen
+
+        final DefaultGenerator generator = new DefaultGenerator();
+        final List<File> files = generator.opts(input).generate(); //When generating files
+
+        //Then the java files are compilable
+        validateJavaSourceFiles(files);
+
+        //And the generated interface contains CompletionStage<Void>
+        TestUtils.ensureContainsFile(files, output, "src/gen/java/org/openapitools/api/PingApi.java");
+        assertFileContains(output.toPath().resolve("src/gen/java/org/openapitools/api/PingApi.java"),
+                "\nimport java.util.concurrent.CompletionStage;\n",
+                "\nCompletionStage<Void> pingGet();\n");
+    }
+
+    @Test
+    public void generateApiWithAsyncSupportAndInterfaceOnlyAndResponse() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/ping.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(SUPPORT_ASYNC, true); //Given support async is enabled
+        codegen.additionalProperties().put(INTERFACE_ONLY, true); //And only interfaces are generated
+        codegen.additionalProperties().put(RETURN_RESPONSE, true); //And return type is Response
+
+        final ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen); //Using JavaJAXRSSpecServerCodegen
+
+        final DefaultGenerator generator = new DefaultGenerator();
+        final List<File> files = generator.opts(input).generate(); //When generating files
+
+        //Then the java files are compilable
+        validateJavaSourceFiles(files);
+
+        //And the generated interface contains CompletionStage<Response>
+        TestUtils.ensureContainsFile(files, output, "src/gen/java/org/openapitools/api/PingApi.java");
+        assertFileContains(output.toPath().resolve( "src/gen/java/org/openapitools/api/PingApi.java"),
+                "\nimport java.util.concurrent.CompletionStage;\n",
+                "\nCompletionStage<Response> pingGet();\n");
+    }
+
+
+    @Test
+    public void generatePetstoreAPIWithAsyncSupport() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/petstore.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(SUPPORT_ASYNC, true); //Given support async is enabled
+        codegen.additionalProperties().put(INTERFACE_ONLY, true); //And only interfaces are generated
+
+        final ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen); //using JavaJAXRSSpecServerCodegen
+
+        final DefaultGenerator generator = new DefaultGenerator();
+        final List<File> files = generator.opts(input).generate(); //When generating files
+
+        //Then the java files are compilable
+        validateJavaSourceFiles(files);
+
+        //And the generated interfaces contains CompletionStage
+        TestUtils.ensureContainsFile(files, output, "src/gen/java/org/openapitools/api/PetApi.java");
+        assertFileContains(output.toPath().resolve("src/gen/java/org/openapitools/api/PetApi.java"),
+                "\nimport java.util.concurrent.CompletionStage;\n",
+                "CompletionStage<Void> deletePet", //Support empty response
+                "CompletionStage<List<Pet>> findPetsByStatus", //Support type of arrays response
+                "CompletionStage<Pet> getPetById" //Support single type response
+        );
+
+        TestUtils.ensureContainsFile(files, output, "src/gen/java/org/openapitools/api/StoreApi.java");
+        assertFileContains(output.toPath().resolve("src/gen/java/org/openapitools/api/StoreApi.java"),
+                "\nimport java.util.concurrent.CompletionStage;\n",
+                "CompletionStage<Map<String, Integer>>" //Support map response
+        );
+
+        TestUtils.ensureContainsFile(files, output, "src/gen/java/org/openapitools/api/UserApi.java");
+        assertFileContains(output.toPath().resolve("src/gen/java/org/openapitools/api/UserApi.java"),
+                "\nimport java.util.concurrent.CompletionStage;\n",
+                "CompletionStage<String>" //Support simple types
+        );
+    }
+
+    @Test
+    public void generatePingWithAsyncSupportPrimitiveType() throws Exception {
+        final File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_4832.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(SUPPORT_ASYNC, true); //Given support async is enabled
+        codegen.additionalProperties().put(INTERFACE_ONLY, true); //And only interfaces are generated
+        codegen.additionalProperties().put(USE_TAGS, true); //And use tags to generate everything in PingApi.java
+
+        final ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen); //using JavaJAXRSSpecServerCodegen
+
+        final DefaultGenerator generator = new DefaultGenerator();
+        final List<File> files = generator.opts(input).generate(); //When generating files
+
+        //Then the java files are compilable
+        validateJavaSourceFiles(files);
+
+        //And the generated interfaces contains CompletionStage with proper classes instead of primitive types
+        TestUtils.ensureContainsFile(files, output, "src/gen/java/org/openapitools/api/PingApi.java");
+        TestUtils.assertFileContains(output.toPath().resolve("src/gen/java/org/openapitools/api/PingApi.java"),
+                "CompletionStage<Boolean> pingGetBoolean", //Support primitive types response
+                "CompletionStage<Integer> pingGetInteger" //Support primitive types response
+        );
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 import static org.openapitools.codegen.TestUtils.validateJavaSourceFiles;
+import static org.openapitools.codegen.languages.AbstractJavaCodegen.JAVA8_MODE;
 import static org.openapitools.codegen.languages.AbstractJavaJAXRSServerCodegen.USE_TAGS;
 import static org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen.INTERFACE_ONLY;
 import static org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen.SUPPORT_ASYNC;
@@ -99,6 +100,8 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "xyz.yyyyy.iiii.invoker");
         codegen.additionalProperties().put("serverPort", "8088");
         codegen.additionalProperties().put(JavaJAXRSSpecServerCodegen.OPEN_API_SPEC_FILE_LOCATION, "openapi.yml");
+        codegen.additionalProperties().put(SUPPORT_ASYNC, true);
+        codegen.additionalProperties().put(JAVA8_MODE, false);
         codegen.processOpts();
 
         OpenAPI openAPI = new OpenAPI();
@@ -116,6 +119,8 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaJAXRSServerCodegen.SERVER_PORT), "8088");
         Assert.assertEquals(codegen.getOpenApiSpecFileLocation(), "openapi.yml");
         Assert.assertEquals(codegen.additionalProperties().get(JavaJAXRSSpecServerCodegen.OPEN_API_SPEC_FILE_LOCATION), "openapi.yml");
+        Assert.assertEquals(codegen.additionalProperties().get(SUPPORT_ASYNC), "true");
+        Assert.assertEquals(codegen.additionalProperties().get(JAVA8_MODE), true); //overridden by supportAsync=true
     }
 
     /**

--- a/modules/openapi-generator/src/test/resources/3_0/issue_4832.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_4832.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.1
+info:
+  title: ping that return primitive types
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8082/'
+paths:
+  /pingBoolean:
+    get:
+      operationId: pingGetBoolean
+      tags: [Ping]
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                type: boolean
+  /pingInteger:
+    get:
+      operationId: pingGetInteger
+      tags: [Ping]
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                type: integer
+                format: int32
+


### PR DESCRIPTION
resolves #4832
This PR is an attempt at addressing https://github.com/OpenAPITools/openapi-generator/issues/4832

## Motivation

Since version 2.1, JAX-RS server side component has support for returning a `CompletionStage` to mark the request as eligible for asynchronous processing. The advantage this approach has over the AsyncResponse based API is that it is richer and allows you to create asynchronous pipelines. 

It is also extended by 3rd party libraries such as [Reactor](https://github.com/reactor/reactor-core), [RxJava](https://github.com/ReactiveX/RxJava) or [Mutiny](https://github.com/smallrye/smallrye-mutiny). All of those allow to convert from/to `CompletionStage`, examples:
* Reactor:
```java
CompletionStage<String> single = Mono.just("something").toFuture();
CompletionStage<List<String>> many = Flux.just("something", "somethingelse")
                .collectList()
                .toFuture()
```
* RxJava3
```java
CompletionStage<String> single = Maybe.just("something").toCompletionStage();
CompletionStage<List<String>> many = Flowable.fromArray("something", "somethingelse")
                .toList()
                .toCompletionStage();
```
* Mutiny
```java
CompletionStage<String> single = Uni.createFrom().item("something").subscribeAsCompletionStage();
CompletionStage<List<String> many = Multi.createFrom().items("something", "somethingelse")
                .collect()
                .asList()
                .subscribeAsCompletionStage();
```

## Code changes
This PR adds the option `supportAsync` to the Java JAX-RS spec generator and updates the mustache templates.

When set to true, the generated API interfaces and classes will return `CompletionStage` to support running asynchronous operation in JAX-RS (supported since JAX-RS 2.1). 

This option also enables java8 mode as `CompletionStage` requires a JDK > 1.8

## Tests

Unit Tested for:
* Generation with `interfaceOnly=true` with the `petstore.yaml` file
* Generation with `interfaceOnly=true` for complex types with the `ping.yaml` file
* Generation with `interfaceOnly=true` for primitive types with the `issue_4832.yaml` file
* Generation with `interfaceOnly=true` and `returnResponse=true` with the `ping.yaml` file
* Generation with `interfaceOnly=false` classes with `ping.yaml`

Sample of generated API interfaces (`interfaceOnly=true`):
```java
//PingApi.java w/  returnResponse=true
CompletionStage<Response> pingGet();

// PetApi.java w/ returnResponse=false
CompletionStage<Pet> getPetById(@PathParam("petId") @ApiParam("ID of pet to return") Long petId);
CompletionStage<List<Pet>> findPetsByStatus(@QueryParam("status") @NotNull  @ApiParam("Status values that need to be considered for filter")  List<String> status);

//FakeApi.java
CompletionStage<Boolean> getBool(); //primitive type converted to class

// StoreApi.java
CompletionStage<Map<String, Integer>> getInventory();
CompletionStage<Order> placeOrder(@Valid @NotNull Order order);
CompletionStage<Void> deleteOrder(@PathParam("orderId") @ApiParam("ID of the order that needs to be deleted") String orderId);
```

Sample of generated API class (`interfaceOnly=false`):
```java
public CompletionStage<Response> pingGet() {
    return CompletableFuture.supplyAsync(() -> Response.ok().entity("magic!").build());
}
```
Note that the current implementation from master, always returns `Response`. So no specific types are returned with `supportAsync=true` too: `CompletionStage<Response>`.

Project generated from it was compile successfully after running:
```bash
$ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
-i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
-g jaxrs-spec -p interfaceOnly=true,supportAsync=true -o ~/tmp

$ cd ~/tmp 
$ mvn clean package
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@nmuesch