### PR TITLE
[QT][C++]fixed integration test for Oauth

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/CMakeLists.txt.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/CMakeLists.txt.mustache
@@ -12,7 +12,8 @@ else ()
 endif ()
 
 find_package(Qt5Core REQUIRED)
-find_package(Qt5Network REQUIRED){{#contentCompression}}
+find_package(Qt5Network REQUIRED){{#authMethods}}{{#isOAuth}}
+find_package(Qt5Gui REQUIRED){{/isOAuth}}{{/authMethods}}{{#contentCompression}}
 find_package(ZLIB REQUIRED){{/contentCompression}}
 
 add_library(${PROJECT_NAME}
@@ -31,9 +32,9 @@ add_library(${PROJECT_NAME}
     {{prefix}}Helpers.cpp
     {{prefix}}HttpRequest.cpp
     {{prefix}}HttpFileElement.cpp
+    {{prefix}}Oauth.cpp
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network {{#contentCompression}} ${ZLIB_LIBRARIES}{{/contentCompression}})
-
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network{{#authMethods}}{{#isOAuth}} Qt5::Gui{{/isOAuth}}{{/authMethods}}{{#contentCompression}} ${ZLIB_LIBRARIES}{{/contentCompression}})
 if(NOT APPLE)
   target_link_libraries(${PROJECT_NAME} PRIVATE ssl crypto)
 endif()

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.cpp.mustache
@@ -1,6 +1,8 @@
 #include "{{prefix}}Oauth.h"
 
-namespace OpenAPI {
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
 
 /*
  * Base class to perform oauth2 flows
@@ -343,5 +345,6 @@ void ReplyServer::read()
     emit dataReceived(queryParams);
 }
 
-
-}
+{{#cppNamespaceDeclarations}}
+} // namespace {{this}}
+{{/cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.h.mustache
@@ -32,10 +32,10 @@ class oauthToken
 {
 public:
     oauthToken(QString token, int expiresIn, QString scope, QString tokenType) : m_token(token), m_scope(scope), m_type(tokenType){
-        m_validUntil = QDateTime::fromSecsSinceEpoch(QDateTime::currentSecsSinceEpoch() + expiresIn);
+        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() + expiresIn) * 1000);
     }
     oauthToken(){
-        m_validUntil = QDateTime::fromSecsSinceEpoch(QDateTime::currentSecsSinceEpoch() -1);
+        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() -1 )*1000);
     }
     QString getToken(){return m_token;};
     QString getScope(){return m_scope;};

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.h.mustache
@@ -21,8 +21,7 @@
 #include <QUrl>
 #include <QUrlQuery>
 #include <QDateTime>
-
-
+#include <time.h>
 
 {{#cppNamespaceDeclarations}}
 namespace {{this}} {
@@ -32,19 +31,19 @@ class oauthToken
 {
 public:
     oauthToken(QString token, int expiresIn, QString scope, QString tokenType) : m_token(token), m_scope(scope), m_type(tokenType){
-        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() + expiresIn) * 1000);
+        m_validUntil = time(0) + expiresIn;
     }
     oauthToken(){
-        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() -1 )*1000);
+        m_validUntil = time(0) - 1;
     }
     QString getToken(){return m_token;};
     QString getScope(){return m_scope;};
     QString getType(){return m_type;};
-    bool isValid(){return QDateTime::currentDateTime() < m_validUntil;};
+    bool isValid(){return time(0) < m_validUntil;};
 
 private:
     QString m_token;
-    QDateTime m_validUntil;
+    time_t m_validUntil;
     QString m_scope;
     QString m_type;
 };

--- a/samples/client/petstore/cpp-qt/CMakeLists.txt
+++ b/samples/client/petstore/cpp-qt/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wno-unused-variable")
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED)
 find_package(Qt5Test REQUIRED)
+find_package(Qt5Gui REQUIRED)
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/client
@@ -23,7 +24,7 @@ add_executable(${PROJECT_NAME}
     PetStore/UserApiTests.cpp
     )
 target_link_libraries(${PROJECT_NAME} PRIVATE client)
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network Qt5::Test)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network Qt5::Test Qt5::Gui)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_EXTENSIONS OFF)

--- a/samples/client/petstore/cpp-qt/client/CMakeLists.txt
+++ b/samples/client/petstore/cpp-qt/client/CMakeLists.txt
@@ -13,6 +13,7 @@ endif ()
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Network REQUIRED)
+find_package(Qt5Gui REQUIRED)
 
 add_library(${PROJECT_NAME}
     PFXApiResponse.cpp
@@ -27,9 +28,9 @@ add_library(${PROJECT_NAME}
     PFXHelpers.cpp
     PFXHttpRequest.cpp
     PFXHttpFileElement.cpp
+    PFXOauth.cpp
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network )
-
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network Qt5::Gui)
 if(NOT APPLE)
   target_link_libraries(${PROJECT_NAME} PRIVATE ssl crypto)
 endif()

--- a/samples/client/petstore/cpp-qt/client/PFXOauth.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXOauth.cpp
@@ -1,6 +1,6 @@
 #include "PFXOauth.h"
 
-namespace OpenAPI {
+namespace test_namespace {
 
 /*
  * Base class to perform oauth2 flows
@@ -343,5 +343,4 @@ void ReplyServer::read()
     emit dataReceived(queryParams);
 }
 
-
-}
+} // namespace test_namespace

--- a/samples/client/petstore/cpp-qt/client/PFXOauth.h
+++ b/samples/client/petstore/cpp-qt/client/PFXOauth.h
@@ -31,8 +31,7 @@
 #include <QUrl>
 #include <QUrlQuery>
 #include <QDateTime>
-
-
+#include <time.h>
 
 namespace test_namespace {
 
@@ -40,19 +39,19 @@ class oauthToken
 {
 public:
     oauthToken(QString token, int expiresIn, QString scope, QString tokenType) : m_token(token), m_scope(scope), m_type(tokenType){
-        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() + expiresIn) * 1000);
+        m_validUntil = time(0) + expiresIn;
     }
     oauthToken(){
-        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() -1 )*1000);
+        m_validUntil = time(0) - 1;
     }
     QString getToken(){return m_token;};
     QString getScope(){return m_scope;};
     QString getType(){return m_type;};
-    bool isValid(){return QDateTime::currentDateTime() < m_validUntil;};
+    bool isValid(){return time(0) < m_validUntil;};
 
 private:
     QString m_token;
-    QDateTime m_validUntil;
+    time_t m_validUntil;
     QString m_scope;
     QString m_type;
 };

--- a/samples/client/petstore/cpp-qt/client/PFXOauth.h
+++ b/samples/client/petstore/cpp-qt/client/PFXOauth.h
@@ -40,10 +40,10 @@ class oauthToken
 {
 public:
     oauthToken(QString token, int expiresIn, QString scope, QString tokenType) : m_token(token), m_scope(scope), m_type(tokenType){
-        m_validUntil = QDateTime::fromSecsSinceEpoch(QDateTime::currentSecsSinceEpoch() + expiresIn);
+        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() + expiresIn) * 1000);
     }
     oauthToken(){
-        m_validUntil = QDateTime::fromSecsSinceEpoch(QDateTime::currentSecsSinceEpoch() -1);
+        m_validUntil = QDateTime::fromMSecsSinceEpoch((QDateTime::currentSecsSinceEpoch() -1 )*1000);
     }
     QString getToken(){return m_token;};
     QString getScope(){return m_scope;};


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fix for the PR that broke the integration test. #10183

I had to modify the CMakeLists.txt in the Petstore example project and add Qt5::Gui package. 

@wing328 

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
