### PR TITLE
[Python] Add missing Mock library for Python 2.7.

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-legacy/test-requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/test-requirements.mustache
@@ -10,3 +10,8 @@ pytest~=4.6.7 # needed for python 2.7+3.4
 pytest-cov>=2.8.1
 pytest-randomly==1.2.3 # needed for python 2.7+3.4
 {{/useNose}}
+{{^asyncio}}
+{{^tornado}}
+mock; python_version<'3.0'
+{{/tornado}}
+{{/asyncio}}

--- a/samples/client/petstore/python-legacy/test-requirements.txt
+++ b/samples/client/petstore/python-legacy/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest~=4.6.7 # needed for python 2.7+3.4
 pytest-cov>=2.8.1
 pytest-randomly==1.2.3 # needed for python 2.7+3.4
+mock; python_version<'3.0'

--- a/samples/client/petstore/python-legacy/tests/test_pet_api.py
+++ b/samples/client/petstore/python-legacy/tests/test_pet_api.py
@@ -13,7 +13,12 @@ $ nosetests -v
 
 import os
 import unittest
-from unittest.mock import patch
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    # Python 2.7
+    from mock import patch
 
 import petstore_api
 from petstore_api import Configuration

--- a/samples/openapi3/client/petstore/python-legacy/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-legacy/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest~=4.6.7 # needed for python 2.7+3.4
 pytest-cov>=2.8.1
 pytest-randomly==1.2.3 # needed for python 2.7+3.4
+mock; python_version<'3.0'


### PR DESCRIPTION
It fixes build problems introduced in this PR https://github.com/OpenAPITools/openapi-generator/pull/10686

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @wing328 @spacether 