### PR TITLE
[Kotlin][Multiplatform] Support custom Ktor HTTP client configuration

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -5,6 +5,7 @@ package {{apiPackage}}
 {{/imports}}
 
 import {{packageName}}.infrastructure.*
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
@@ -18,8 +19,9 @@ import kotlinx.serialization.encoding.*
 {{#nonPublicApi}}internal {{/nonPublicApi}}class {{classname}}(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
+    httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
     jsonSerializer: Json = ApiClient.JSON_DEFAULT
-) : ApiClient(baseUrl, httpClientEngine, jsonSerializer) {
+) : ApiClient(baseUrl, httpClientEngine, httpClientConfig, jsonSerializer) {
 
     {{#operation}}
     /**

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
@@ -16,6 +16,7 @@ import io.ktor.client.utils.EmptyContent
 import io.ktor.http.*
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.content.PartData
+import kotlin.Unit
 import kotlinx.serialization.json.Json
 
 import {{apiPackage}}.*
@@ -25,16 +26,32 @@ import {{packageName}}.auth.*
 {{#nonPublicApi}}internal {{/nonPublicApi}}open class ApiClient(
         private val baseUrl: String,
         httpClientEngine: HttpClientEngine?,
+        httpClientConfig: ((HttpClientConfig<*>) -> Unit)?,
         private val json: Json
 ) {
+
+    constructor(
+        baseUrl: String,
+        httpClientEngine: HttpClientEngine?,
+        json: Json
+    ): this(
+        baseUrl = baseUrl,
+        httpClientEngine = httpClientEngine,
+        httpClientConfig = null,
+        json = json
+    )
 
     private val serializer: JsonSerializer by lazy {
         KotlinxSerializer(json).ignoreOutgoingContent()
     }
 
-    private val client: HttpClient by lazy {
+    private val defaultHttpClientConfig: (HttpClientConfig<*>) -> Unit by lazy {
         val jsonConfig: JsonFeature.Config.() -> Unit = { this.serializer = this@ApiClient.serializer }
-        val clientConfig: (HttpClientConfig<*>) -> Unit = { it.install(JsonFeature, jsonConfig) }
+        { it.install(JsonFeature, jsonConfig) }
+    }
+
+    private val client: HttpClient by lazy {
+        val clientConfig: (HttpClientConfig<*>) -> Unit = httpClientConfig ?: defaultHttpClientConfig
         httpClientEngine?.let { HttpClient(it, clientConfig) } ?: HttpClient(clientConfig)
     }
     {{#hasAuthMethods}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
@@ -26,20 +26,9 @@ import {{packageName}}.auth.*
 {{#nonPublicApi}}internal {{/nonPublicApi}}open class ApiClient(
         private val baseUrl: String,
         httpClientEngine: HttpClientEngine?,
-        httpClientConfig: ((HttpClientConfig<*>) -> Unit)?,
+        httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
         private val json: Json
 ) {
-
-    constructor(
-        baseUrl: String,
-        httpClientEngine: HttpClientEngine?,
-        json: Json
-    ): this(
-        baseUrl = baseUrl,
-        httpClientEngine = httpClientEngine,
-        httpClientConfig = null,
-        json = json
-    )
 
     private val serializer: JsonSerializer by lazy {
         KotlinxSerializer(json).ignoreOutgoingContent()

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -24,6 +24,7 @@ import org.openapitools.client.models.ApiResponse
 import org.openapitools.client.models.Pet
 
 import org.openapitools.client.infrastructure.*
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
@@ -36,8 +37,9 @@ import kotlinx.serialization.encoding.*
 class PetApi(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
+    httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
     jsonSerializer: Json = ApiClient.JSON_DEFAULT
-) : ApiClient(baseUrl, httpClientEngine, jsonSerializer) {
+) : ApiClient(baseUrl, httpClientEngine, httpClientConfig, jsonSerializer) {
 
     /**
      * Add a new pet to the store

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -23,6 +23,7 @@ package org.openapitools.client.apis
 import org.openapitools.client.models.Order
 
 import org.openapitools.client.infrastructure.*
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
@@ -35,8 +36,9 @@ import kotlinx.serialization.encoding.*
 class StoreApi(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
+    httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
     jsonSerializer: Json = ApiClient.JSON_DEFAULT
-) : ApiClient(baseUrl, httpClientEngine, jsonSerializer) {
+) : ApiClient(baseUrl, httpClientEngine, httpClientConfig, jsonSerializer) {
 
     /**
      * Delete purchase order by ID

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -23,6 +23,7 @@ package org.openapitools.client.apis
 import org.openapitools.client.models.User
 
 import org.openapitools.client.infrastructure.*
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
@@ -35,8 +36,9 @@ import kotlinx.serialization.encoding.*
 class UserApi(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
+    httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
     jsonSerializer: Json = ApiClient.JSON_DEFAULT
-) : ApiClient(baseUrl, httpClientEngine, jsonSerializer) {
+) : ApiClient(baseUrl, httpClientEngine, httpClientConfig, jsonSerializer) {
 
     /**
      * Create user

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -26,20 +26,9 @@ import org.openapitools.client.auth.*
 open class ApiClient(
         private val baseUrl: String,
         httpClientEngine: HttpClientEngine?,
-        httpClientConfig: ((HttpClientConfig<*>) -> Unit)?,
+        httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
         private val json: Json
 ) {
-
-    constructor(
-        baseUrl: String,
-        httpClientEngine: HttpClientEngine?,
-        json: Json
-    ): this(
-        baseUrl = baseUrl,
-        httpClientEngine = httpClientEngine,
-        httpClientConfig = null,
-        json = json
-    )
 
     private val serializer: JsonSerializer by lazy {
         KotlinxSerializer(json).ignoreOutgoingContent()

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -16,6 +16,7 @@ import io.ktor.client.utils.EmptyContent
 import io.ktor.http.*
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.content.PartData
+import kotlin.Unit
 import kotlinx.serialization.json.Json
 
 import org.openapitools.client.apis.*
@@ -25,16 +26,32 @@ import org.openapitools.client.auth.*
 open class ApiClient(
         private val baseUrl: String,
         httpClientEngine: HttpClientEngine?,
+        httpClientConfig: ((HttpClientConfig<*>) -> Unit)?,
         private val json: Json
 ) {
+
+    constructor(
+        baseUrl: String,
+        httpClientEngine: HttpClientEngine?,
+        json: Json
+    ): this(
+        baseUrl = baseUrl,
+        httpClientEngine = httpClientEngine,
+        httpClientConfig = null,
+        json = json
+    )
 
     private val serializer: JsonSerializer by lazy {
         KotlinxSerializer(json).ignoreOutgoingContent()
     }
 
-    private val client: HttpClient by lazy {
+    private val defaultHttpClientConfig: (HttpClientConfig<*>) -> Unit by lazy {
         val jsonConfig: JsonFeature.Config.() -> Unit = { this.serializer = this@ApiClient.serializer }
-        val clientConfig: (HttpClientConfig<*>) -> Unit = { it.install(JsonFeature, jsonConfig) }
+        { it.install(JsonFeature, jsonConfig) }
+    }
+
+    private val client: HttpClient by lazy {
+        val clientConfig: (HttpClientConfig<*>) -> Unit = httpClientConfig ?: defaultHttpClientConfig
         httpClientEngine?.let { HttpClient(it, clientConfig) } ?: HttpClient(clientConfig)
     }
     private val authentications: kotlin.collections.Map<String, Authentication> by lazy {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### PR Description

#### The Problem
It is currently not possible to configure the Ktor HTTP client when using generated Kotlin Multiplatform code.
Configuring the HTTP client can be useful for logging or customising request headers, to name a few use cases.

This issue has been raised in #10130 .

#### The Solution

This PR makes it possible to configure the Ktor HTTP client by allowing to pass an optional `httpClientConfig` parameter to the generated API classes.

An example of how the new `httpClientConfig` parameter can be used can be seen [here](https://github.com/Airthings/openapi-multiplatform-multi-module/compare/configurable-http-client#diff-04d693ee26583a89dce08ae4bcb2f5120653955239bf92713a883afe481742c5R12):

```kotlin
private val petApi = PetApi(httpClientConfig = createHttpClientConfig())

private fun createHttpClientConfig(): ((HttpClientConfig<*>) -> Unit) =
        { clientConfig ->
            clientConfig.install(UserAgent) {
                agent = "my-pet-store-app/${Platform().platform}"
            }
            clientConfig.install(Logging) {
                logger = object : Logger {
                    override fun log(message: String) {
                        println("HttpClient: $message")
                    }
                }
                level = LogLevel.ALL
            }
        }
```

Fixes #10130 

### CCs
Kotlin technical committee: @jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

Reporter of #10130 : @krzema12

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
