### PR TITLE
[DefaultCodegen] Update 'addConsumesInfo' that mediaType supports '/*' and '*/*'

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5968,7 +5968,11 @@ public class DefaultCodegen implements CodegenConfig {
                 // skip as it implies `consumes` in OAS2 is not defined
                 continue;
             } else {
-                mediaType.put("mediaType", escapeText(escapeQuotationMark(key)));
+                String[] keySplitBySlash = key.split("/");
+                for (int i=0; i < keySplitBySlash.length; i++) {
+                    keySplitBySlash[i] = escapeText(escapeQuotationMark(keySplitBySlash[i]));
+                }
+                mediaType.put("mediaType", String.join("/", keySplitBySlash));
             }
             mediaTypeList.add(mediaType);
         }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
#10598 
When users assign the media type with star (e.g. image/\*, application/\*, or \*/\*) in the OpenAPI request body, the current version will encode the '/\*' and '\*/' to '/\_\*' and '\*\_/' since some languages (e.g. Java, Typescript) view them as multi-line comments. However, it is not a concern in the media type case. 

For example Typescript in the current version,
```
// to determine the Content-Type header
const consumes: string[] = [
    'image/_*'
];
```
Expected output
```
// to determine the Content-Type header
const consumes: string[] = [
    'image/*'
];
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
