### PR TITLE
[Kotlin] Fully qualified "Any" for enums in encode and decode function

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -67,12 +67,12 @@ import kotlinx.serialization.*
         /**
          * Converts the provided [data] to a [String] on success, null otherwise.
          */
-        fun encode(data: Any?): kotlin.String? = if (data is {{classname}}) "$data" else null
+        fun encode(data: kotlin.Any?): kotlin.String? = if (data is {{classname}}) "$data" else null
 
         /**
          * Returns a valid [{{classname}}] for [data], null otherwise.
          */
-        fun decode(data: Any?): {{classname}}? = data?.let {
+        fun decode(data: kotlin.Any?): {{classname}}? = data?.let {
           val normalizedData = "$it".lowercase()
           values().firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
@@ -50,12 +50,12 @@ enum class PetEnum(val value: kotlin.String) {
         /**
          * Converts the provided [data] to a [String] on success, null otherwise.
          */
-        fun encode(data: Any?): kotlin.String? = if (data is PetEnum) "$data" else null
+        fun encode(data: kotlin.Any?): kotlin.String? = if (data is PetEnum) "$data" else null
 
         /**
          * Returns a valid [PetEnum] for [data], null otherwise.
          */
-        fun decode(data: Any?): PetEnum? = data?.let {
+        fun decode(data: kotlin.Any?): PetEnum? = data?.let {
           val normalizedData = "$it".lowercase()
           values().firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()


### PR DESCRIPTION
For the case, an enum value is named Any, the parameter in encode and decode should be fully qualified.
I have not created an issue, because these change is not worth the time.

@jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
