### PR TITLE
Add vscode openapi workspace configuration

### DIFF
--- a/openapi-generator.code-workspace
+++ b/openapi-generator.code-workspace
@@ -68,7 +68,6 @@
 		"recommendations": [
 			"vscjava.vscode-java-pack",
 			"attilabuti.mustache-syntax-vscode",
-			"EditorConfig.EditorConfig",
 			"formulahendry.code-runner",
 			"visualstudioexptteam.vscodeintellicode",
 			"42crunch.vscode-openapi",

--- a/openapi-generator.code-workspace
+++ b/openapi-generator.code-workspace
@@ -26,17 +26,15 @@
 		},
 	],
 	"settings": {
-		"telemetry.telemetryLevel": "off",
-
 		"editor.formatOnType": true,
 		"editor.linkedEditing": true,
 		"editor.tabCompletion": "on",
 		"editor.tabSize": 4,
-		"editor.renderWhitespace": "none",
+		"editor.renderWhitespace": "boundary",
 		"editor.suggest.shareSuggestSelections": true,
 		"editor.suggestSelection": "first",
-		"explorer.confirmDelete": true,
 		"editor.semanticHighlighting.enabled": true,
+		"explorer.confirmDelete": true,
 
 		"files.autoSave": "onFocusChange",
 		"files.exclude": {
@@ -50,11 +48,11 @@
 
 		"task.saveBeforeRun": "always",
 
-		"java.autobuild.enabled": true,
-		"java.format.onType.enabled": true,
+		"java.autobuild.enabled": false,
 		"java.completion.enabled": true,
 		"java.completion.guessMethodArguments": true,
 		"java.completion.maxResults": 5,
+		"java.format.onType.enabled": true,
 
 		"java.referencesCodeLens.enabled": true,
 		"java.saveActions.organizeImports": true,

--- a/openapi-generator.code-workspace
+++ b/openapi-generator.code-workspace
@@ -1,0 +1,81 @@
+{
+	"folders": [
+		{
+			"name": "openapi-generator",
+			"path": "."
+		},
+		{
+			"name": "openapi-generator-cli",
+			"path": "modules/openapi-generator-cli"
+		},
+		{
+			"name": "openapi-generator-core",
+			"path": "modules/openapi-generator-core"
+		},
+		{
+			"name": "openapi-generator-gradle-plugin",
+			"path": "modules/openapi-generator-gradle-plugin"
+		},
+		{
+			"name": "openapi-generator-maven-plugin",
+			"path": "modules/openapi-generator-maven-plugin"
+		},
+		{
+			"name": "openapi-generator-online",
+			"path": "modules/openapi-generator-online"
+		},
+	],
+	"settings": {
+		"telemetry.telemetryLevel": "off",
+
+		"editor.formatOnType": true,
+		"editor.linkedEditing": true,
+		"editor.tabCompletion": "on",
+		"editor.tabSize": 4,
+		"editor.renderWhitespace": "none",
+		"editor.suggest.shareSuggestSelections": true,
+		"editor.suggestSelection": "first",
+		"explorer.confirmDelete": true,
+		"editor.semanticHighlighting.enabled": true,
+
+		"files.autoSave": "onFocusChange",
+		"files.exclude": {
+			"**/.classpath": true,
+			"**/.factorypath": true,
+			"**/.project": true,
+			"**/.settings": true
+		},
+		"files.trimFinalNewlines": false,
+		"files.trimTrailingWhitespace": true,
+
+		"task.saveBeforeRun": "always",
+
+		"java.autobuild.enabled": true,
+		"java.format.onType.enabled": true,
+		"java.completion.enabled": true,
+		"java.completion.guessMethodArguments": true,
+		"java.completion.maxResults": 5,
+
+		"java.referencesCodeLens.enabled": true,
+		"java.saveActions.organizeImports": true,
+		"java.showBuildStatusOnStart.enabled": true,
+
+		"java.dependency.autoRefresh": true,
+		"java.dependency.refreshDelay": 3000,
+		"java.format.enabled": true,
+
+		"maven.pomfile.autoUpdateEffectivePOM": true,
+	},
+	"extensions": {
+		"recommendations": [
+			"vscjava.vscode-java-pack",
+			"attilabuti.mustache-syntax-vscode",
+			"EditorConfig.EditorConfig",
+			"formulahendry.code-runner",
+			"visualstudioexptteam.vscodeintellicode",
+			"42crunch.vscode-openapi",
+			"mermade.openapi-lint"
+
+		]
+	}
+}


### PR DESCRIPTION
Adds visual studio code structured configuration with modules separated for easier navigation:

![image](https://user-images.githubusercontent.com/2544251/144036446-759d4ea1-b2a7-471f-aa3a-0aa4eaa5e6da.png)


Config contains IntelliJ-like configuration for VSC with features like autosave, autorefresh dependencies.

A few plugins are recommended for use like mustache highlighter, java for vcs, and openapi spec linter.