### PR TITLE
[php] Only use values up to the second accuracy for PHP datetime values

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -318,7 +318,7 @@ class ObjectSerializer
                     // for the problem.
                     // Note that strtotime only handles precision up to a second,
                     // so trimming does not result in data loss.
-                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {
                 return null;

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -315,9 +315,8 @@ class ObjectSerializer
                     // Some API's return a date-time with too high nanosecond
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem.
-                    // Note that strtotime only handles precision up to a second,
-                    // so trimming does not result in data loss.
+                    // for the problem. Note that strtotime only handles precision
+                    // up to a second, so trimming does not result in data loss.
                     return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -316,7 +316,9 @@ class ObjectSerializer
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
                     // for the problem.
-                    return (new \DateTime())->setTimestamp(strtotime($data));
+                    // Note that strtotime only handles precision up to a second,
+                    // so trimming does not result in data loss.
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
                 }
             } else {
                 return null;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -324,9 +324,8 @@ class ObjectSerializer
                     // Some API's return a date-time with too high nanosecond
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem.
-                    // Note that strtotime only handles precision up to a second,
-                    // so trimming does not result in data loss.
+                    // for the problem. Note that strtotime only handles precision
+                    // up to a second, so trimming does not result in data loss.
                     return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -325,7 +325,9 @@ class ObjectSerializer
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
                     // for the problem.
-                    return (new \DateTime())->setTimestamp(strtotime($data));
+                    // Note that strtotime only handles precision up to a second, 
+                    // so trimming does not result in data loss.
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
                 }
             } else {
                 return null;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -325,7 +325,7 @@ class ObjectSerializer
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
                     // for the problem.
-                    // Note that strtotime only handles precision up to a second, 
+                    // Note that strtotime only handles precision up to a second,
                     // so trimming does not result in data loss.
                     return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -327,7 +327,7 @@ class ObjectSerializer
                     // for the problem.
                     // Note that strtotime only handles precision up to a second, 
                     // so trimming does not result in data loss.
-                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {
                 return null;


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/issues/10548

Description
PHP is unable to handle highly precise DateTime Values. While this issue covered most cases, we have a few instances of DateTime which are not handled. (i.e. "2021-10-06T20:17:16.076372256Z")

Example:

```
print_r(strtotime("2021-10-06T20:17:16.076372256Z")); // => ""
print_r(strtotime("2021-10-06T20:17:16.07637225Z")); // =>  "1633551436"
```

To fix this we only use up to the second accuracy by trimming the date string. `strtotime` is only accurate up to number of seconds so this does not result in data loss.
https://www.php.net/manual/en/function.strtotime.php

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [x]  File the PR against the correct branch: master (5.3.0), 6.0.x
- [x]  If your PR is targeting a particular programming language, @mention the technical committee members, so they are more likely to review the pull request.