### PR TITLE
[Kotlin][Multiplatform] Fix and improve HTTP client configuration

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
@@ -34,15 +34,20 @@ import {{packageName}}.auth.*
         KotlinxSerializer(json).ignoreOutgoingContent()
     }
 
-    private val defaultHttpClientConfig: (HttpClientConfig<*>) -> Unit by lazy {
-        val jsonConfig: JsonFeature.Config.() -> Unit = { this.serializer = this@ApiClient.serializer }
-        { it.install(JsonFeature, jsonConfig) }
+    private val clientConfig: (HttpClientConfig<*>) -> Unit by lazy {
+        {
+            // Hold a reference to the serializer to avoid freezing the entire ApiClient instance
+            // when the JsonFeature is configured.
+            val serializerReference = serializer
+            it.install(JsonFeature) { serializer = serializerReference }
+            httpClientConfig?.invoke(it)
+        }
     }
 
     private val client: HttpClient by lazy {
-        val clientConfig: (HttpClientConfig<*>) -> Unit = httpClientConfig ?: defaultHttpClientConfig
         httpClientEngine?.let { HttpClient(it, clientConfig) } ?: HttpClient(clientConfig)
     }
+
     {{#hasAuthMethods}}
     private val authentications: kotlin.collections.Map<String, Authentication> by lazy {
         mapOf({{#authMethods}}{{#isBasic}}{{#isBasicBasic}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### PR Description

This PR updates the Kotlin Multiplatform library templates with the following:

- Fix an object freezing related issue that occurs on iOS when configuring the HTTP client. In the current version of the template, the entire `ApiClient` instance is captured when configuring the HTTP client. This does not work on iOS and throws an exception. The fix is implemented by capturing only the `serializer` instance.

- Always use the HTTP client config that is defined in the API client class and extend it with the optional constructor provided configuration. Without this change, the client of the generated `ApiClient` class must also configure JSON serialization in order for the generated code to work. 

### Example usage
These changes were tested and validated in a demo project:
https://github.com/Airthings/openapi-multiplatform-multi-module/tree/serializer-config-in-generated-code

### CCs
Kotlin technical committee: @jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
