### PR TITLE
[typescript-angular] taggedUnions=true: Support recursive schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -570,19 +570,29 @@ public class DefaultCodegen implements CodegenConfig {
             List<Map<String, Object>> models = (List<Map<String, Object>>) inner.get("models");
             for (Map<String, Object> mo : models) {
                 CodegenModel cm = (CodegenModel) mo.get("model");
-                for (CodegenProperty cp : cm.allVars) {
-                    // detect self import
-                    if (cp.dataType.equalsIgnoreCase(cm.classname) ||
-                            (cp.isContainer && cp.items != null && cp.items.dataType.equalsIgnoreCase(cm.classname))) {
-                        cm.imports.remove(cm.classname); // remove self import
-                        cp.isSelfReference = true;
-                    }
-                }
+                removeSelfReferenceImports(cm);
             }
         }
         setCircularReferences(allModels);
 
         return objs;
+    }
+
+    /**
+     * Removes imports from the model that points to itself
+     * Marks a self referencing property, if detected
+     *
+     * @param model
+     */
+    protected void removeSelfReferenceImports(CodegenModel model) {
+        for (CodegenProperty cp : model.allVars) {
+            // detect self import
+            if (cp.dataType.equalsIgnoreCase(model.classname) ||
+                    (cp.isContainer && cp.items != null && cp.items.dataType.equalsIgnoreCase(model.classname))) {
+                model.imports.remove(model.classname); // remove self import
+                cp.isSelfReference = true;
+            }
+        }
     }
 
     public void setCircularReferences(Map<String, CodegenModel> models) {
@@ -5168,17 +5178,7 @@ public class DefaultCodegen implements CodegenConfig {
                     cm.hasOnlyReadOnly = false;
                 }
 
-                // TODO revise the logic to include map
-                if (cp.isContainer) {
-                    addImport(cm, typeMapping.get("array"));
-                }
-
-                addImport(cm, cp.baseType);
-                CodegenProperty innerCp = cp;
-                while (innerCp != null) {
-                    addImport(cm, innerCp.complexType);
-                    innerCp = innerCp.items;
-                }
+                addImportsForPropertyType(cm, cp);
 
                 // if required, add to the list "requiredVars"
                 if (Boolean.TRUE.equals(cp.required)) {
@@ -5197,6 +5197,27 @@ public class DefaultCodegen implements CodegenConfig {
             }
         }
         return;
+    }
+
+    /**
+     * For a given property, adds all needed imports to the model
+     * This includes a flat property type (e.g. property type: ReferencedModel)
+     * as well as container type (property type: array of ReferencedModel's)
+     * @param model
+     * @param property
+     */
+    protected void addImportsForPropertyType(CodegenModel model, CodegenProperty property) {
+        // TODO revise the logic to include map
+        if (property.isContainer) {
+            addImport(model, typeMapping.get("array"));
+        }
+
+        addImport(model, property.baseType);
+        CodegenProperty innerCp = property;
+        while (innerCp != null) {
+            addImport(model, innerCp.complexType);
+            innerCp = innerCp.items;
+        }
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -582,7 +582,7 @@ public class DefaultCodegen implements CodegenConfig {
      * Removes imports from the model that points to itself
      * Marks a self referencing property, if detected
      *
-     * @param model
+     * @param model Self imports will be removed from this model.imports collection
      */
     protected void removeSelfReferenceImports(CodegenModel model) {
         for (CodegenProperty cp : model.allVars) {
@@ -5203,8 +5203,9 @@ public class DefaultCodegen implements CodegenConfig {
      * For a given property, adds all needed imports to the model
      * This includes a flat property type (e.g. property type: ReferencedModel)
      * as well as container type (property type: array of ReferencedModel's)
-     * @param model
-     * @param property
+     *
+     * @param model The codegen representation of the OAS schema.
+     * @param property The codegen representation of the OAS schema's property.
      */
     protected void addImportsForPropertyType(CodegenModel model, CodegenProperty property) {
         // TODO revise the logic to include map

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -542,8 +542,19 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
                             setChildDiscriminatorValue(cm, child);
                         }
                     }
+
+                    // with tagged union, a child model doesn't extend the parent (all properties are just copied over)
+                    // it means we don't need to import that parent any more
                     if (cm.parent != null) {
                         cm.imports.remove(cm.parent);
+
+                        // however, it's possible that the child model contains a recursive reference to the parent
+                        // in order to support this case, we update the list of imports from properties once again
+                        for (CodegenProperty cp: cm.allVars) {
+                            addImportsForPropertyType(cm, cp);
+                        }
+                        removeSelfReferenceImports(cm);
+
                     }
                 }
                 // Add additional filename information for imports

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -8,13 +8,17 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.*;
+import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.TypeScriptAngularClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class TypeScriptAngularClientCodegenTest {
@@ -266,5 +270,45 @@ public class TypeScriptAngularClientCodegenTest {
         final String importName = "@lib/custom/model";
         codegen.importMapping().put(importedModel, importName);
         Assert.assertEquals(codegen.toModelImport(importedModel), importName);
+    }
+
+    @Test
+    public void testTaggedUnionImports() throws Exception {
+        final String specPath = "src/test/resources/3_0/allOf_composition_discriminator_recursive.yaml";
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(TypeScriptAngularClientCodegen.TAGGED_UNIONS, "true");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-angular")
+                .setInputSpec(specPath)
+                .setAdditionalProperties(properties)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+
+        Generator generator = new DefaultGenerator();
+        generator.opts(clientOptInput).generate();
+
+        TestUtils.assertFileContains(
+                Paths.get(output + "/model/expressionToken.ts"),
+                "import { Token } from './token'", // imports the parent schema
+                "import { TokenMetadata } from './tokenMetadata'", // imports a schema referenced in an inherited property
+                "export interface ExpressionToken {" // no inheritance
+        );
+
+        TestUtils.assertFileNotContains(
+                Paths.get(output + "/model/stringToken.ts"),
+                "import { Token } from './token'"
+        );
+
+        TestUtils.assertFileContains(
+                Paths.get(output + "/model/token.ts"),
+                "import { ExpressionToken } from './expressionToken'",
+                "export type Token = ExpressionToken | StringToken"
+        );
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/allOf_composition_discriminator_recursive.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf_composition_discriminator_recursive.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.2
+info:
+  title: OAI Specification example for Polymorphism
+  version: 1.0.0
+paths:
+  /status:
+    get:
+      responses:
+        '201':
+          description: desc
+
+components:
+  schemas:
+    TokenMetadata:
+      type: object
+      properties:
+        tag1:
+          type: string
+
+    Token:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/TokenMetadata'
+      discriminator:
+        propertyName: type
+        mapping:
+          string: '#/components/schemas/StringToken'
+          expression: '#/components/schemas/ExpressionToken'
+
+    StringToken:
+      allOf:
+        - $ref: '#/components/schemas/Token'
+        - type: object
+          properties:
+            value:
+              type: string
+
+    ExpressionToken:
+      allOf:
+        - $ref: '#/components/schemas/Token'
+        - type: object
+          properties:
+            tokens:
+              type: array
+              items:
+                $ref: '#/components/schemas/Token'


### PR DESCRIPTION
This boils down to preserving the import from the child to the parent schema if the parent is directly referenced in the child.

I added a test with an example yaml spec that features such recursively defined schemas. Basically,
```
Token: ExpressionToken | StringToken

ExpressionToken:
  tokens: Array<Token>
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
