### PR TITLE
[Kotlin][Multiplatform] Upgrade Kotlin to version 1.6.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
@@ -1,17 +1,17 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    kotlin("multiplatform"){{^omitGradlePluginVersions}} version "1.5.31" // kotlin_version{{/omitGradlePluginVersions}}
-    kotlin("plugin.serialization"){{^omitGradlePluginVersions}} version "1.5.31" // kotlin_version{{/omitGradlePluginVersions}}
+    kotlin("multiplatform"){{^omitGradlePluginVersions}} version "1.6.0" // kotlin_version{{/omitGradlePluginVersions}}
+    kotlin("plugin.serialization"){{^omitGradlePluginVersions}} version "1.6.0" // kotlin_version{{/omitGradlePluginVersions}}
 }
 
 group = "{{groupId}}"
 version = "{{artifactVersion}}"
 
-val kotlin_version = "1.5.31"
+val kotlin_version = "1.6.0"
 val coroutines_version = "1.5.2"
 val serialization_version = "1.3.0"
-val ktor_version = "1.6.3"
+val ktor_version = "1.6.4"
 
 repositories {
     mavenCentral()

--- a/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
@@ -1,17 +1,17 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    kotlin("multiplatform") version "1.5.31" // kotlin_version
-    kotlin("plugin.serialization") version "1.5.31" // kotlin_version
+    kotlin("multiplatform") version "1.6.0" // kotlin_version
+    kotlin("plugin.serialization") version "1.6.0" // kotlin_version
 }
 
 group = "org.openapitools"
 version = "1.0.0"
 
-val kotlin_version = "1.5.31"
+val kotlin_version = "1.6.0"
 val coroutines_version = "1.5.2"
 val serialization_version = "1.3.0"
-val ktor_version = "1.6.3"
+val ktor_version = "1.6.4"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### PR Description

- The PR upgrades the Kotlin version used by the Kotlin Multiplatform template to version 1.6.0.
- Ktor is upgraded to version 1.6.4, the [the recommended version to use](https://kotlinlang.org/docs/releases.html#release-details) with Kotlin 1.6.0. 

Upgrading to 1.6.0 was [deliberately avoided](https://github.com/OpenAPITools/openapi-generator/pull/10900#discussion_r753263348) in #10900 because Jetpack Compose was not compatible with Kotlin 1.6.0. This issue is now resolved because Jetpack Compose can be used with Kotlin 1.6.0 when using [Compose compiler version 1.1.0-beta04](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.1.0-beta04).  

This change was validated in KMM demo project that uses this branch to generate the petstore sample code and Jetpack Compose: https://github.com/Airthings/openapi-multiplatform-multi-module/commit/050f0862b6575ea34deb4e3ca2c4321527a587b2 

#### CCs
Kotlin technical committee:
@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
