### PR TITLE
[Kotlin][Multiplatform] Build and test Kotlin Multiplatform samples in CI

### DIFF
--- a/.github/workflows/samples-kotlin.yaml
+++ b/.github/workflows/samples-kotlin.yaml
@@ -30,8 +30,7 @@ jobs:
           #- samples/client/petstore/kotlin-json-request-string
           - samples/client/petstore/kotlin-jvm-okhttp4-coroutines
           - samples/client/petstore/kotlin-moshi-codegen
-          # need some special setup
-          #- samples/client/petstore/kotlin-multiplatform
+          - samples/client/petstore/kotlin-multiplatform
           - samples/client/petstore/kotlin-nonpublic
           - samples/client/petstore/kotlin-nullable
           - samples/client/petstore/kotlin-okhttp3

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
@@ -93,4 +93,7 @@ tasks {
             }
         }
     }
+    register("test") {
+        dependsOn("allTests")
+    }
 }

--- a/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
@@ -93,4 +93,7 @@ tasks {
             }
         }
     }
+    register("test") {
+        dependsOn("allTests")
+    }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR adds building and testing the Kotlin Multiplatform samples in the project's CI.

Kotlin technical committee:
@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
