### PR TITLE
Only use values up to the second accuracy for PHP datetime values

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -315,8 +315,9 @@ class ObjectSerializer
                     // Some API's return a date-time with too high nanosecond
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem.
-                    return (new \DateTime())->setTimestamp(strtotime($data));
+                    // for the problem. Note that strtotime only handles precision
+                    // up to a second, so trimming does not result in data loss.
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {
                 return null;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -324,8 +324,9 @@ class ObjectSerializer
                     // Some API's return a date-time with too high nanosecond
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem.
-                    return (new \DateTime())->setTimestamp(strtotime($data));
+                    // for the problem. Note that strtotime only handles precision
+                    // up to a second, so trimming does not result in data loss.
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {
                 return null;


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/issues/10548

PHP is unable to handle highly precise DateTime Values. While this issue covered most cases, we have a few instances of DateTime which are not handled. (i.e. "2021-10-06T20:17:16.076372256Z")

Example:

print_r(strtotime("2021-10-06T20:17:16.076372256Z")); // => ""
print_r(strtotime("2021-10-06T20:17:16.07637225Z")); // =>  "1633551436"
To fix this we only use up to the second accuracy by trimming the date string. strtotime is only accurate up to number of seconds so this does not result in data loss.
https://www.php.net/manual/en/function.strtotime.php