### PR TITLE
[Kotlin] Add escaping of $ to baseName for Kotlin generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3392,7 +3392,7 @@ public class DefaultCodegen implements CodegenConfig {
         ModelUtils.syncValidationProperties(p, property);
 
         property.name = toVarName(name);
-        property.baseName = name;
+        property.baseName = escapeUnsafeCharacters(name);
         if (p.getType() == null) {
             property.openApiType = getSchemaType(p);
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -279,7 +279,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     @Override
     public String escapeUnsafeCharacters(String input) {
-        return input.replace("*/", "*_/").replace("/*", "/_*");
+        return input.replace("*/", "*_/").replace("/*", "/_*").replace("$", "\\$");
     }
 
     public CodegenConstants.ENUM_PROPERTY_NAMING_TYPE getEnumPropertyNaming() {

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
@@ -1,4 +1,4 @@
 {{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
     @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swaggerAnnotations}}{{#deprecated}}
     @Deprecated(message = ""){{/deprecated}}
-    @field:JsonProperty("{{{baseName}}}"){{#isInherited}} override{{/isInherited}} {{>modelMutable}} {{{name}}}: {{#isEnum}}{{#isArray}}{{baseType}}<{{/isArray}}{{classname}}.{{nameInCamelCase}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}
+    @get:JsonProperty("{{{baseName}}}"){{#isInherited}} override{{/isInherited}} {{>modelMutable}} {{{name}}}: {{#isEnum}}{{#isArray}}{{baseType}}<{{/isArray}}{{classname}}.{{nameInCamelCase}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -77,6 +77,12 @@ public class AbstractKotlinCodegenTest {
         assertEquals(codegen.toEnumValue("data", "Something"), "\"data\"");
     }
 
+    @Test
+    public void escapeUnsafeCharacters() {
+        assertEquals(codegen.escapeUnsafeCharacters("foo*/bar"), "foo*_/bar");
+        assertEquals(codegen.escapeUnsafeCharacters("$schema"), "\\$schema");
+    }
+
     private static class P_AbstractKotlinCodegen extends AbstractKotlinCodegen {
         @Override
         public CodegenType getTag() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -45,6 +45,7 @@ public class KotlinClientCodegenModelTest {
                 .addProperties("id", new IntegerSchema().format("int64"))
                 .addProperties("name", new StringSchema())
                 .addProperties("createdAt", new DateTimeSchema())
+                .addProperties("$schema", new StringSchema())
                 .addRequiredItem("id")
                 .addRequiredItem("name");
     }
@@ -75,7 +76,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 3);
+        Assert.assertEquals(cm.vars.size(), 4);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -105,6 +106,16 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseType, "java.time.OffsetDateTime");
         Assert.assertFalse(property3.required);
         Assert.assertFalse(property3.isContainer);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "\\$schema");
+        Assert.assertEquals(property4.dataType, "kotlin.String");
+        Assert.assertEquals(property4.name, "dollarSchema");
+        Assert.assertEquals(property4.defaultValue, null);
+        Assert.assertEquals(property4.baseType, "kotlin.String");
+        Assert.assertFalse(property4.required);
+        Assert.assertTrue(property4.isPrimitiveType);
+        Assert.assertFalse(property4.isContainer);
     }
 
     @Test(description = "convert a simple model: threetenbp")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -360,4 +360,24 @@ public class KotlinSpringServerCodegenTest {
                 "@org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME)"
         );
     }
+
+    @Test(description = "test $ in property name")
+    public void dollarTest() throws Exception {
+        String baseModelPackage = "zz";
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile(); //may be move to /build
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_10350.yaml");
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, baseModelPackage + ".yyyy.model.xxxx");
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(input).generate();
+        File resultSourcePath = new File(output, "src/main/kotlin");
+        File outputModel = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        FileUtils.copyDirectory(new File(resultSourcePath, baseModelPackage), new File(outputModel, baseModelPackage));
+        //no exception
+        ClassLoader cl = KotlinTestUtils.buildModule(Collections.singletonList(outputModel.getAbsolutePath()), Thread.currentThread().getContextClassLoader());
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_10350.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_10350.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Issue 10350
+  version: 0.0.1
+paths:
+  /test:
+    get:
+      operationId: demo
+      parameters:
+        - $ref: '#/components/parameters/expand'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/test'
+components:
+  schemas:
+    test:
+      type: object
+      properties:
+        title:
+          type: string
+        $test:
+          type: string
+  parameters:
+    expand:
+      in: query
+      name: $expand
+      schema:
+        type: string

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -137,7 +137,7 @@ interface UserApi {
             value = ["/user/login"],
             produces = ["application/xml", "application/json"]
     )
-    fun loginUser(@NotNull @Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$") @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: kotlin.String
+    fun loginUser(@NotNull @Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+\$") @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: kotlin.String
 ,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: kotlin.String
 ): ResponseEntity<kotlin.String> {
         return getDelegate().loginUser(username, password);

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
@@ -20,10 +20,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Category(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
-    @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+\$")
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("name") val name: kotlin.String? = null
+    @get:JsonProperty("name") val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -21,13 +21,13 @@ import io.swagger.annotations.ApiModelProperty
 data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("code") val code: kotlin.Int? = null,
+    @get:JsonProperty("code") val code: kotlin.Int? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("type") val type: kotlin.String? = null,
+    @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("message") val message: kotlin.String? = null
+    @get:JsonProperty("message") val message: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
@@ -25,22 +25,22 @@ import io.swagger.annotations.ApiModelProperty
 data class Order(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("petId") val petId: kotlin.Long? = null,
+    @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("quantity") val quantity: kotlin.Int? = null,
+    @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
+    @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
     @ApiModelProperty(example = "null", value = "Order Status")
-    @field:JsonProperty("status") val status: Order.Status? = null,
+    @get:JsonProperty("status") val status: Order.Status? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("complete") val complete: kotlin.Boolean? = false
+    @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
 ) {
 
     /**

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,19 +33,19 @@ data class Pet(
     @field:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("category") val category: Category? = null,
+    @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
+    @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
     @ApiModelProperty(example = "null", value = "pet status in the store")
     @Deprecated(message = "")
-    @field:JsonProperty("status") val status: Pet.Status? = null
+    @get:JsonProperty("status") val status: Pet.Status? = null
 ) {
 
     /**

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -20,10 +20,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("name") val name: kotlin.String? = null
+    @get:JsonProperty("name") val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
@@ -26,28 +26,28 @@ import io.swagger.annotations.ApiModelProperty
 data class User(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("username") val username: kotlin.String? = null,
+    @get:JsonProperty("username") val username: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("firstName") val firstName: kotlin.String? = null,
+    @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("lastName") val lastName: kotlin.String? = null,
+    @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("email") val email: kotlin.String? = null,
+    @get:JsonProperty("email") val email: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("password") val password: kotlin.String? = null,
+    @get:JsonProperty("password") val password: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("phone") val phone: kotlin.String? = null,
+    @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "User Status")
-    @field:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
+    @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
@@ -20,10 +20,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Category(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("name") val name: kotlin.String? = null
+    @get:JsonProperty("name") val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -21,13 +21,13 @@ import io.swagger.annotations.ApiModelProperty
 data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("code") val code: kotlin.Int? = null,
+    @get:JsonProperty("code") val code: kotlin.Int? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("type") val type: kotlin.String? = null,
+    @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("message") val message: kotlin.String? = null
+    @get:JsonProperty("message") val message: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
@@ -25,22 +25,22 @@ import io.swagger.annotations.ApiModelProperty
 data class Order(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("petId") val petId: kotlin.Long? = null,
+    @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("quantity") val quantity: kotlin.Int? = null,
+    @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
+    @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
     @ApiModelProperty(example = "null", value = "Order Status")
-    @field:JsonProperty("status") val status: Order.Status? = null,
+    @get:JsonProperty("status") val status: Order.Status? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("complete") val complete: kotlin.Boolean? = false
+    @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
 ) {
 
     /**

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,18 +33,18 @@ data class Pet(
     @field:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("category") val category: Category? = null,
+    @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
+    @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
     @ApiModelProperty(example = "null", value = "pet status in the store")
-    @field:JsonProperty("status") val status: Pet.Status? = null
+    @get:JsonProperty("status") val status: Pet.Status? = null
 ) {
 
     /**

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -20,10 +20,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("name") val name: kotlin.String? = null
+    @get:JsonProperty("name") val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
@@ -26,28 +26,28 @@ import io.swagger.annotations.ApiModelProperty
 data class User(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("username") val username: kotlin.String? = null,
+    @get:JsonProperty("username") val username: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("firstName") val firstName: kotlin.String? = null,
+    @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("lastName") val lastName: kotlin.String? = null,
+    @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("email") val email: kotlin.String? = null,
+    @get:JsonProperty("email") val email: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("password") val password: kotlin.String? = null,
+    @get:JsonProperty("password") val password: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("phone") val phone: kotlin.String? = null,
+    @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "User Status")
-    @field:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
+    @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
@@ -20,10 +20,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Category(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("name") val name: kotlin.String? = null
+    @get:JsonProperty("name") val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -21,13 +21,13 @@ import io.swagger.annotations.ApiModelProperty
 data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("code") val code: kotlin.Int? = null,
+    @get:JsonProperty("code") val code: kotlin.Int? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("type") val type: kotlin.String? = null,
+    @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("message") val message: kotlin.String? = null
+    @get:JsonProperty("message") val message: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
@@ -25,22 +25,22 @@ import io.swagger.annotations.ApiModelProperty
 data class Order(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("petId") val petId: kotlin.Long? = null,
+    @get:JsonProperty("petId") val petId: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("quantity") val quantity: kotlin.Int? = null,
+    @get:JsonProperty("quantity") val quantity: kotlin.Int? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
+    @get:JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
 
     @ApiModelProperty(example = "null", value = "Order Status")
-    @field:JsonProperty("status") val status: Order.Status? = null,
+    @get:JsonProperty("status") val status: Order.Status? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("complete") val complete: kotlin.Boolean? = false
+    @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
 ) {
 
     /**

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -33,18 +33,18 @@ data class Pet(
     @field:JsonProperty("photoUrls", required = true) val photoUrls: kotlin.collections.List<kotlin.String>,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @field:Valid
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("category") val category: Category? = null,
+    @get:JsonProperty("category") val category: Category? = null,
 
     @field:Valid
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
+    @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
     @ApiModelProperty(example = "null", value = "pet status in the store")
-    @field:JsonProperty("status") val status: Pet.Status? = null
+    @get:JsonProperty("status") val status: Pet.Status? = null
 ) {
 
     /**

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -20,10 +20,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("name") val name: kotlin.String? = null
+    @get:JsonProperty("name") val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
@@ -26,28 +26,28 @@ import io.swagger.annotations.ApiModelProperty
 data class User(
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("id") val id: kotlin.Long? = null,
+    @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("username") val username: kotlin.String? = null,
+    @get:JsonProperty("username") val username: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("firstName") val firstName: kotlin.String? = null,
+    @get:JsonProperty("firstName") val firstName: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("lastName") val lastName: kotlin.String? = null,
+    @get:JsonProperty("lastName") val lastName: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("email") val email: kotlin.String? = null,
+    @get:JsonProperty("email") val email: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("password") val password: kotlin.String? = null,
+    @get:JsonProperty("password") val password: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "")
-    @field:JsonProperty("phone") val phone: kotlin.String? = null,
+    @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @ApiModelProperty(example = "null", value = "User Status")
-    @field:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
+    @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
 ) {
 
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
closes #10350

This eliminates compilation errors caused by generated annotations with a `$`, which are interpreted by the Kotlin compiler as String Templates.

Testing this was tricky because a Kotlin file with the `@field` Jackson annotation inexplicably compiles using the Kotlin Classloader used in KotlinSpringServerCodegenTest (even though the generated code doesn't compile in any Kotlin compiler I am aware of). The only way I could find to generate a _failing_ test was to change `@field` to `@get`. I only did this in dataClassOptVar.mustache but this change does have a ripple effect in the generated Petstore samples. It may be prudent to revert the change to the mustache once you confirm what is happening.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m