### PR TITLE
Fix date issue for Safari

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -561,7 +561,7 @@ class ApiClient {
     */{{/emitJSDoc}}
     static parseDate(str) {
         if (isNaN(str)) {
-            return new Date(str.replace(/(\d)(T)(\d)/i, '$1 $3'));
+            return new Date(str.replace(/ /g,"T"));
         }
         return new Date(+str);
     }

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -559,6 +559,11 @@ class ApiClient {
     * @param {String} str The date value as a string.
     * @returns {Date} The parsed date object.
     */{{/emitJSDoc}}
+
+    {{#emitJSDoc}}/**
+    * If the date string contains a space between date and time
+    * replace it with a 'T' separator 
+    */{{/emitJSDoc}}
     static parseDate(str) {
         if (isNaN(str)) {
             return new Date(str.replace(/ /g,"T"));

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -563,6 +563,7 @@ class ApiClient {
     {{#emitJSDoc}}/**
     * If the date string contains a space between date and time
     * replace it with a 'T' separator 
+    * fix_issue 9523 
     */{{/emitJSDoc}}
     static parseDate(str) {
         if (isNaN(str)) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Invalid values in date strings not recognized as simplified ISO format as defined by ECMA-262 may or may not result in NaN, depending on the browser and values provided.

Example:
new Date('2015-11-25 03:14:15');
will be treated as a local date of 25 November, 2015 in Firefox 30 and an invalid date in Safari 7.

As mentioned in the bug, a date string like '2021-03-14 03:14:15' is not valid according to the spec and especially fails in Safari. In the above date string there is a missing date-time separator 'T' and also the current code removes any 'T' and replaces with a space. This causes the code to break in Safari.

Fix:
If there is a missing space, it will be replaced by 'T'

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
