### PR TITLE
[php-slim4] Bump required PHP version to 7.4

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
@@ -19,7 +19,7 @@ This server has been generated with [Laminas (Zend) PSR-7 implementation](https:
 ## Requirements
 
 * Web server with URL rewriting
-* PHP 7.3 or newer
+* PHP 7.4 or newer
 
 This package contains `.htaccess` for Apache configuration.
 If you use another server(Nginx, HHVM, IIS, lighttpd) check out [Web Servers](https://www.slimframework.com/docs/v3/start/web-servers.html) doc.

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "slim/slim": "^4.5.0",
     "dyorg/slim-token-authentication": "dev-slim4",
     "ybelenko/openapi-data-mocker": "^1.0",

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/licenseInfo.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/licenseInfo.mustache
@@ -2,7 +2,7 @@
  {{#appName}}
  * {{{.}}}
  {{/appName}}
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package {{invokerPackage}}
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/README.md
+++ b/samples/server/petstore/php-slim4/README.md
@@ -8,7 +8,7 @@ This server has been generated with [Slim PSR-7](https://github.com/slimphp/Slim
 ## Requirements
 
 * Web server with URL rewriting
-* PHP 7.3 or newer
+* PHP 7.4 or newer
 
 This package contains `.htaccess` for Apache configuration.
 If you use another server(Nginx, HHVM, IIS, lighttpd) check out [Web Servers](https://www.slimframework.com/docs/v3/start/web-servers.html) doc.

--- a/samples/server/petstore/php-slim4/composer.json
+++ b/samples/server/petstore/php-slim4/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "slim/slim": "^4.5.0",
     "dyorg/slim-token-authentication": "dev-slim4",
     "ybelenko/openapi-data-mocker": "^1.0",

--- a/samples/server/petstore/php-slim4/config/dev/example.inc.php
+++ b/samples/server/petstore/php-slim4/config/dev/example.inc.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/config/prod/example.inc.php
+++ b/samples/server/petstore/php-slim4/config/prod/example.inc.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractStoreApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractStoreApi.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractUserApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractUserApi.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
+++ b/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/BaseModel.php
+++ b/samples/server/petstore/php-slim4/lib/BaseModel.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Middleware/JsonBodyParserMiddleware.php
+++ b/samples/server/petstore/php-slim4/lib/Middleware/JsonBodyParserMiddleware.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Model/ApiResponse.php
+++ b/samples/server/petstore/php-slim4/lib/Model/ApiResponse.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Model/Category.php
+++ b/samples/server/petstore/php-slim4/lib/Model/Category.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Model/Order.php
+++ b/samples/server/petstore/php-slim4/lib/Model/Order.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Model/Pet.php
+++ b/samples/server/petstore/php-slim4/lib/Model/Pet.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Model/Tag.php
+++ b/samples/server/petstore/php-slim4/lib/Model/Tag.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/Model/User.php
+++ b/samples/server/petstore/php-slim4/lib/Model/User.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim4/lib/SlimRouter.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/public/index.php
+++ b/samples/server/petstore/php-slim4/public/index.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team

--- a/samples/server/petstore/php-slim4/tests/BaseModelTest.php
+++ b/samples/server/petstore/php-slim4/tests/BaseModelTest.php
@@ -2,7 +2,7 @@
 
 /**
  * OpenAPI Petstore
- * PHP version 7.3
+ * PHP version 7.4
  *
  * @package OpenAPIServer
  * @author  OpenAPI Generator team


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Related #11038
Since latest Slim(4.9.0) requires PHP ^7.3, then I don't see any reason to test updated samples. Everything should work.

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @renepardon

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
