### PR TITLE
Feat adds content and header properties to CodegenResponse

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -88,6 +88,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
     private boolean hasDiscriminatorWithNonEmptyMapping;
     private CodegenComposedSchemas composedSchemas;
     private boolean hasMultipleTypes = false;
+    private LinkedHashMap<String, CodegenMediaType> content;
 
     @Override
     public int hashCode() {
@@ -99,7 +100,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 getMaxProperties(), getMinProperties(), uniqueItems, getMaxItems(), getMinItems(), getMaxLength(),
                 getMinLength(), exclusiveMinimum, exclusiveMaximum, getMinimum(), getMaximum(), getPattern(),
                 is1xx, is2xx, is3xx, is4xx, is5xx, additionalPropertiesIsAnyType, hasVars, hasRequired,
-                hasDiscriminatorWithNonEmptyMapping, composedSchemas, hasMultipleTypes, responseHeaders);
+                hasDiscriminatorWithNonEmptyMapping, composedSchemas, hasMultipleTypes, responseHeaders, content);
     }
 
     @Override
@@ -148,6 +149,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 getAdditionalPropertiesIsAnyType() == that.getAdditionalPropertiesIsAnyType() &&
                 getHasVars() == that.getHasVars() &&
                 getHasRequired() == that.getHasRequired() &&
+                Objects.equals(content, that.getContent()) &&
                 Objects.equals(responseHeaders, that.getResponseHeaders()) &&
                 Objects.equals(composedSchemas, that.getComposedSchemas()) &&
                 Objects.equals(vars, that.vars) &&
@@ -176,6 +178,14 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 Objects.equals(getPattern(), that.getPattern()) &&
                 Objects.equals(getMultipleOf(), that.getMultipleOf());
 
+    }
+
+    public LinkedHashMap<String, CodegenMediaType> getContent() {
+        return content;
+    }
+
+    public void setContent(LinkedHashMap<String, CodegenMediaType> content) {
+        this.content = content;
     }
 
     public List<CodegenParameter> getResponseHeaders() {
@@ -499,6 +509,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
         sb.append(", composedSchemas=").append(composedSchemas);
         sb.append(", hasMultipleTypes=").append(hasMultipleTypes);
         sb.append(", responseHeaders=").append(responseHeaders);
+        sb.append(", content=").append(content);
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -21,6 +21,7 @@ import java.util.*;
 
 public class CodegenResponse implements IJsonSchemaValidationProperties {
     public final List<CodegenProperty> headers = new ArrayList<CodegenProperty>();
+    private List<CodegenParameter> responseHeaders = new ArrayList<CodegenParameter>();
     public String code;
     public boolean is1xx;
     public boolean is2xx;
@@ -98,7 +99,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 getMaxProperties(), getMinProperties(), uniqueItems, getMaxItems(), getMinItems(), getMaxLength(),
                 getMinLength(), exclusiveMinimum, exclusiveMaximum, getMinimum(), getMaximum(), getPattern(),
                 is1xx, is2xx, is3xx, is4xx, is5xx, additionalPropertiesIsAnyType, hasVars, hasRequired,
-                hasDiscriminatorWithNonEmptyMapping, composedSchemas, hasMultipleTypes);
+                hasDiscriminatorWithNonEmptyMapping, composedSchemas, hasMultipleTypes, responseHeaders);
     }
 
     @Override
@@ -147,6 +148,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 getAdditionalPropertiesIsAnyType() == that.getAdditionalPropertiesIsAnyType() &&
                 getHasVars() == that.getHasVars() &&
                 getHasRequired() == that.getHasRequired() &&
+                Objects.equals(responseHeaders, that.getResponseHeaders()) &&
                 Objects.equals(composedSchemas, that.getComposedSchemas()) &&
                 Objects.equals(vars, that.vars) &&
                 Objects.equals(requiredVars, that.requiredVars) &&
@@ -174,6 +176,14 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 Objects.equals(getPattern(), that.getPattern()) &&
                 Objects.equals(getMultipleOf(), that.getMultipleOf());
 
+    }
+
+    public List<CodegenParameter> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    public void setResponseHeaders(List<CodegenParameter> responseHeaders) {
+        this.responseHeaders = responseHeaders;
     }
 
     @Override
@@ -488,6 +498,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
         sb.append(", getHasDiscriminatorWithNonEmptyMapping=").append(hasDiscriminatorWithNonEmptyMapping);
         sb.append(", composedSchemas=").append(composedSchemas);
         sb.append(", hasMultipleTypes=").append(hasMultipleTypes);
+        sb.append(", responseHeaders=").append(responseHeaders);
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3970,7 +3970,8 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                     r.setResponseHeaders(responseHeaders);
                 }
-                r.setContent(getContent(response.getContent(), imports));
+                String mediaTypeSchemaSuffix = String.format("For%sResponseBody", r.code);
+                r.setContent(getContent(response.getContent(), imports, mediaTypeSchemaSuffix));
 
                 if (r.baseType != null &&
                         !defaultIncludes.contains(r.baseType) &&
@@ -4515,7 +4516,7 @@ public class DefaultCodegen implements CodegenConfig {
             codegenParameter.isDeprecated = parameter.getDeprecated();
         }
         codegenParameter.jsonSchema = Json.pretty(parameter);
-        codegenParameter.setContent(getContent(parameter.getContent(), imports));
+        codegenParameter.setContent(getContent(parameter.getContent(), imports, "ForParameter"));
 
         if (GlobalSettings.getProperty("debugParser") != null) {
             LOGGER.info("working on Parameter {}", parameter.getName());
@@ -6599,8 +6600,8 @@ public class DefaultCodegen implements CodegenConfig {
         codegenParameter.pattern = toRegularExpression(schema.getPattern());
     }
 
-    protected String toMediaTypeSchemaName(String contentType) {
-        return toModelName(contentType + "Schema");
+    protected String toMediaTypeSchemaName(String contentType, String mediaTypeSchemaSuffix) {
+        return toModelName("Schema" +  contentType + mediaTypeSchemaSuffix);
     }
 
     private CodegenParameter heeaderToCodegenParameter(Header header, String headerName, Set<String> imports) {
@@ -6627,7 +6628,7 @@ public class DefaultCodegen implements CodegenConfig {
         return param;
     }
 
-    protected LinkedHashMap<String, CodegenMediaType> getContent(Content content, Set<String> imports) {
+    protected LinkedHashMap<String, CodegenMediaType> getContent(Content content, Set<String> imports, String mediaTypeSchemaSuffix) {
         if (content == null) {
             return null;
         }
@@ -6662,7 +6663,7 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             }
             String contentType = contentEntry.getKey();
-            CodegenProperty schemaProp = fromProperty(toMediaTypeSchemaName(contentType), mt.getSchema());
+            CodegenProperty schemaProp = fromProperty(toMediaTypeSchemaName(contentType, mediaTypeSchemaSuffix), mt.getSchema());
             CodegenMediaType codegenMt = new CodegenMediaType(schemaProp, ceMap);
             cmtContent.put(contentType, codegenMt);
         }
@@ -6690,7 +6691,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (schema == null) {
             throw new RuntimeException("Request body cannot be null. Possible cause: missing schema in body parameter (OAS v2): " + body);
         }
-        codegenParameter.setContent(getContent(body.getContent(), imports));
+        codegenParameter.setContent(getContent(body.getContent(), imports, "ForRequestBody"));
 
         if (StringUtils.isNotBlank(schema.get$ref())) {
             name = ModelUtils.getSimpleRef(schema.get$ref());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3965,7 +3965,7 @@ public class DefaultCodegen implements CodegenConfig {
                     for (Entry<String, Header> entry: headers.entrySet()) {
                         String headerName = entry.getKey();
                         Header header = entry.getValue();
-                        CodegenParameter responseHeader = heeaderToCodegenParameter(header, headerName, imports);
+                        CodegenParameter responseHeader = heeaderToCodegenParameter(header, headerName, imports, String.format("%sResponseParameter", r.code));
                         responseHeaders.add(responseHeader);
                     }
                     r.setResponseHeaders(responseHeaders);
@@ -4079,6 +4079,7 @@ public class DefaultCodegen implements CodegenConfig {
                 param = ModelUtils.getReferencedParameter(this.openAPI, param);
 
                 CodegenParameter p = fromParameter(param, imports);
+                p.setContent(getContent(param.getContent(), imports, "RequestParameter" + toModelName(param.getName())));
 
                 // ensure unique params
                 if (ensureUniqueParams) {
@@ -4516,7 +4517,6 @@ public class DefaultCodegen implements CodegenConfig {
             codegenParameter.isDeprecated = parameter.getDeprecated();
         }
         codegenParameter.jsonSchema = Json.pretty(parameter);
-        codegenParameter.setContent(getContent(parameter.getContent(), imports, "Parameter"));
 
         if (GlobalSettings.getProperty("debugParser") != null) {
             LOGGER.info("working on Parameter {}", parameter.getName());
@@ -6604,7 +6604,7 @@ public class DefaultCodegen implements CodegenConfig {
         return "SchemaFor" + mediaTypeSchemaSuffix +  toModelName(contentType);
     }
 
-    private CodegenParameter heeaderToCodegenParameter(Header header, String headerName, Set<String> imports) {
+    private CodegenParameter heeaderToCodegenParameter(Header header, String headerName, Set<String> imports, String mediaTypeSchemaSuffix) {
         if (header == null) {
             return null;
         }
@@ -6625,6 +6625,7 @@ public class DefaultCodegen implements CodegenConfig {
         headerParam.setContent(header.getContent());
         headerParam.setExtensions(header.getExtensions());
         CodegenParameter param = fromParameter(headerParam, imports);
+        param.setContent(getContent(headerParam.getContent(), imports, mediaTypeSchemaSuffix));
         return param;
     }
 
@@ -6647,7 +6648,7 @@ public class DefaultCodegen implements CodegenConfig {
                         for (Entry<String, Header> headerEntry: encHeaders.entrySet()) {
                             String headerName = headerEntry.getKey();
                             Header header = ModelUtils.getReferencedHeader(this.openAPI, headerEntry.getValue());
-                            CodegenParameter param = heeaderToCodegenParameter(header, headerName, imports);
+                            CodegenParameter param = heeaderToCodegenParameter(header, headerName, imports, mediaTypeSchemaSuffix);
                             headers.add(param);
                         }
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6612,7 +6612,10 @@ public class DefaultCodegen implements CodegenConfig {
         headerParam.setDescription(header.getDescription());
         headerParam.setRequired(header.getRequired());
         headerParam.setDeprecated(header.getDeprecated());
-        headerParam.setStyle(Parameter.StyleEnum.valueOf(header.getStyle().name()));
+        Header.StyleEnum style = header.getStyle();
+        if (style != null) {
+            headerParam.setStyle(Parameter.StyleEnum.valueOf(style.name()));
+        }
         headerParam.setExplode(header.getExplode());
         headerParam.setSchema(header.getSchema());
         headerParam.setExamples(header.getExamples());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3965,12 +3965,12 @@ public class DefaultCodegen implements CodegenConfig {
                     for (Entry<String, Header> entry: headers.entrySet()) {
                         String headerName = entry.getKey();
                         Header header = entry.getValue();
-                        CodegenParameter responseHeader = heeaderToCodegenParameter(header, headerName, imports, String.format("%sResponseParameter", r.code));
+                        CodegenParameter responseHeader = heeaderToCodegenParameter(header, headerName, imports, String.format(Locale.ROOT, "%sResponseParameter", r.code));
                         responseHeaders.add(responseHeader);
                     }
                     r.setResponseHeaders(responseHeaders);
                 }
-                String mediaTypeSchemaSuffix = String.format("%sResponseBody", r.code);
+                String mediaTypeSchemaSuffix = String.format(Locale.ROOT, "%sResponseBody", r.code);
                 r.setContent(getContent(response.getContent(), imports, mediaTypeSchemaSuffix));
 
                 if (r.baseType != null &&

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3970,6 +3970,7 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                     r.setResponseHeaders(responseHeaders);
                 }
+                r.setContent(getContent(response.getContent(), imports));
 
                 if (r.baseType != null &&
                         !defaultIncludes.contains(r.baseType) &&

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3959,6 +3959,18 @@ public class DefaultCodegen implements CodegenConfig {
                 ApiResponse response = operationGetResponsesEntry.getValue();
                 addProducesInfo(response, op);
                 CodegenResponse r = fromResponse(key, response);
+                Map<String, Header> headers = response.getHeaders();
+                if (headers != null) {
+                    List<CodegenParameter> responseHeaders = new ArrayList<>();
+                    for (Entry<String, Header> entry: headers.entrySet()) {
+                        String headerName = entry.getKey();
+                        Header header = entry.getValue();
+                        CodegenParameter responseHeader = heeaderToCodegenParameter(header, headerName, imports);
+                        responseHeaders.add(responseHeader);
+                    }
+                    r.setResponseHeaders(responseHeaders);
+                }
+
                 if (r.baseType != null &&
                         !defaultIncludes.contains(r.baseType) &&
                         !languageSpecificPrimitives.contains(r.baseType)) {
@@ -6590,6 +6602,27 @@ public class DefaultCodegen implements CodegenConfig {
         return toModelName(contentType + "Schema");
     }
 
+    private CodegenParameter heeaderToCodegenParameter(Header header, String headerName, Set<String> imports) {
+        if (header == null) {
+            return null;
+        }
+        Parameter headerParam = new Parameter();
+        headerParam.setName(headerName);
+        headerParam.setIn("header");
+        headerParam.setDescription(header.getDescription());
+        headerParam.setRequired(header.getRequired());
+        headerParam.setDeprecated(header.getDeprecated());
+        headerParam.setStyle(Parameter.StyleEnum.valueOf(header.getStyle().name()));
+        headerParam.setExplode(header.getExplode());
+        headerParam.setSchema(header.getSchema());
+        headerParam.setExamples(header.getExamples());
+        headerParam.setExample(header.getExample());
+        headerParam.setContent(header.getContent());
+        headerParam.setExtensions(header.getExtensions());
+        CodegenParameter param = fromParameter(headerParam, imports);
+        return param;
+    }
+
     protected LinkedHashMap<String, CodegenMediaType> getContent(Content content, Set<String> imports) {
         if (content == null) {
             return null;
@@ -6609,20 +6642,7 @@ public class DefaultCodegen implements CodegenConfig {
                         for (Entry<String, Header> headerEntry: encHeaders.entrySet()) {
                             String headerName = headerEntry.getKey();
                             Header header = ModelUtils.getReferencedHeader(this.openAPI, headerEntry.getValue());
-                            Parameter headerParam = new Parameter();
-                            headerParam.setName(headerName);
-                            headerParam.setIn("header");
-                            headerParam.setDescription(header.getDescription());
-                            headerParam.setRequired(header.getRequired());
-                            headerParam.setDeprecated(header.getDeprecated());
-                            headerParam.setStyle(Parameter.StyleEnum.valueOf(header.getStyle().name()));
-                            headerParam.setExplode(header.getExplode());
-                            headerParam.setSchema(header.getSchema());
-                            headerParam.setExamples(header.getExamples());
-                            headerParam.setExample(header.getExample());
-                            headerParam.setContent(header.getContent());
-                            headerParam.setExtensions(header.getExtensions());
-                            CodegenParameter param = fromParameter(headerParam, imports);
+                            CodegenParameter param = heeaderToCodegenParameter(header, headerName, imports);
                             headers.add(param);
                         }
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3970,7 +3970,7 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                     r.setResponseHeaders(responseHeaders);
                 }
-                String mediaTypeSchemaSuffix = String.format("For%sResponseBody", r.code);
+                String mediaTypeSchemaSuffix = String.format("%sResponseBody", r.code);
                 r.setContent(getContent(response.getContent(), imports, mediaTypeSchemaSuffix));
 
                 if (r.baseType != null &&
@@ -4516,7 +4516,7 @@ public class DefaultCodegen implements CodegenConfig {
             codegenParameter.isDeprecated = parameter.getDeprecated();
         }
         codegenParameter.jsonSchema = Json.pretty(parameter);
-        codegenParameter.setContent(getContent(parameter.getContent(), imports, "ForParameter"));
+        codegenParameter.setContent(getContent(parameter.getContent(), imports, "Parameter"));
 
         if (GlobalSettings.getProperty("debugParser") != null) {
             LOGGER.info("working on Parameter {}", parameter.getName());
@@ -6601,7 +6601,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     protected String toMediaTypeSchemaName(String contentType, String mediaTypeSchemaSuffix) {
-        return toModelName("Schema" +  contentType + mediaTypeSchemaSuffix);
+        return "SchemaFor" + mediaTypeSchemaSuffix +  toModelName(contentType);
     }
 
     private CodegenParameter heeaderToCodegenParameter(Header header, String headerName, Set<String> imports) {
@@ -6691,7 +6691,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (schema == null) {
             throw new RuntimeException("Request body cannot be null. Possible cause: missing schema in body parameter (OAS v2): " + body);
         }
-        codegenParameter.setContent(getContent(body.getContent(), imports, "ForRequestBody"));
+        codegenParameter.setContent(getContent(body.getContent(), imports, "RequestBody"));
 
         if (StringUtils.isNotBlank(schema.get$ref())) {
             name = ModelUtils.getSimpleRef(schema.get$ref());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1673,12 +1673,12 @@ public class DefaultCodegenTest {
     public void testDefaultResponseShouldBeLast() {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         Operation myOperation = new Operation().operationId("myOperation").responses(
-            new ApiResponses()
-            .addApiResponse(
-                "default", new ApiResponse().description("Default"))
-            .addApiResponse(
-                "422", new ApiResponse().description("Error"))
-            );
+                new ApiResponses()
+                        .addApiResponse(
+                                "default", new ApiResponse().description("Default"))
+                        .addApiResponse(
+                                "422", new ApiResponse().description("Error"))
+        );
         openAPI.path("/here", new PathItem().get(myOperation));
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
@@ -2353,49 +2353,49 @@ public class DefaultCodegenTest {
     @Test
     public void testFormComposedSchema() {
         OpenAPI openAPI = TestUtils.parseContent("openapi: 3.0.1\n" +
-            "info:\n" +
-            "  version: '1.0.0'\n" +
-            "  title: the title\n" +
-            "\n" +
-            "paths:\n" +
-            "  '/users/me':\n" +
-            "    post:\n" +
-            "      description: Change user password.\n" +
-            "      operationId: changeCurrentUserPassword\n" +
-            "      requestBody:\n" +
-            "        required: true\n" +
-            "        content:\n" +
-            "          multipart/form-data:\n" +
-            "            schema:\n" +
-            "              $ref: '#/components/schemas/ChangePasswordRequest'\n" +
-            "      responses:\n" +
-            "        '200':\n" +
-            "          description: Successful operation\n" +
-            "          content: {}\n" +
-            "\n" +
-            "components:\n" +
-            "  schemas:\n" +
-            "    CommonPasswordRequest:\n" +
-            "      type: object\n" +
-            "      required: [ password, passwordConfirmation ]\n" +
-            "      properties:\n" +
-            "        password:\n" +
-            "          type: string\n" +
-            "          format: password\n" +
-            "        passwordConfirmation:\n" +
-            "          type: string\n" +
-            "          format: password\n" +
-            "\n" +
-            "    ChangePasswordRequest:\n" +
-            "      type: object\n" +
-            "      allOf:\n" +
-            "        - $ref: '#/components/schemas/CommonPasswordRequest'\n" +
-            "        - type: object\n" +
-            "          required: [ oldPassword ]\n" +
-            "          properties:\n" +
-            "            oldPassword:\n" +
-            "              type: string\n" +
-            "              format: password\n");
+                "info:\n" +
+                "  version: '1.0.0'\n" +
+                "  title: the title\n" +
+                "\n" +
+                "paths:\n" +
+                "  '/users/me':\n" +
+                "    post:\n" +
+                "      description: Change user password.\n" +
+                "      operationId: changeCurrentUserPassword\n" +
+                "      requestBody:\n" +
+                "        required: true\n" +
+                "        content:\n" +
+                "          multipart/form-data:\n" +
+                "            schema:\n" +
+                "              $ref: '#/components/schemas/ChangePasswordRequest'\n" +
+                "      responses:\n" +
+                "        '200':\n" +
+                "          description: Successful operation\n" +
+                "          content: {}\n" +
+                "\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    CommonPasswordRequest:\n" +
+                "      type: object\n" +
+                "      required: [ password, passwordConfirmation ]\n" +
+                "      properties:\n" +
+                "        password:\n" +
+                "          type: string\n" +
+                "          format: password\n" +
+                "        passwordConfirmation:\n" +
+                "          type: string\n" +
+                "          format: password\n" +
+                "\n" +
+                "    ChangePasswordRequest:\n" +
+                "      type: object\n" +
+                "      allOf:\n" +
+                "        - $ref: '#/components/schemas/CommonPasswordRequest'\n" +
+                "        - type: object\n" +
+                "          required: [ oldPassword ]\n" +
+                "          properties:\n" +
+                "            oldPassword:\n" +
+                "              type: string\n" +
+                "              format: password\n");
 
         final DefaultCodegen cg = new DefaultCodegen();
         cg.setOpenAPI(openAPI);
@@ -2404,16 +2404,16 @@ public class DefaultCodegenTest {
 
         final PathItem path = openAPI.getPaths().get("/users/me");
         final CodegenOperation operation = cg.fromOperation(
-            "/users/me",
-            "post",
-            path.getPost(),
-            path.getServers());
+                "/users/me",
+                "post",
+                path.getPost(),
+                path.getServers());
         assertEquals(operation.formParams.size(), 3,
-            "The list of parameters should include inherited type");
+                "The list of parameters should include inherited type");
 
         final List<String> names = operation.formParams.stream()
-            .map(param -> param.paramName)
-            .collect(Collectors.toList());
+                .map(param -> param.paramName)
+                .collect(Collectors.toList());
         assertTrue(names.contains("password"));
         assertTrue(names.contains("passwordConfirmation"));
         assertTrue(names.contains("oldPassword"));
@@ -3347,7 +3347,7 @@ public class DefaultCodegenTest {
                 assertTrue(hasRequired);
             } else {
                 // All variables must be in the above sets
-                 fail();
+                fail();
             }
         }
     }
@@ -3930,7 +3930,8 @@ public class DefaultCodegenTest {
         assertFalse(cr.primitiveType);
     }
 
-    public void testParameterContent() {
+    @Test
+    public void testRequestParameterContent() {
         DefaultCodegen codegen = new DefaultCodegen();
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/content-data.yaml");
         codegen.setOpenAPI(openAPI);
@@ -3948,6 +3949,7 @@ public class DefaultCodegenTest {
         CodegenProperty cp = mt.getSchema();
         assertTrue(cp.isMap);
         assertEquals(cp.complexType, "object");
+        assertEquals(cp.baseName, "ApplicationJsonSchema");
 
         CodegenParameter coordinatesReferencedSchema = co.queryParams.get(1);
         content = coordinatesReferencedSchema.getContent();
@@ -3956,13 +3958,7 @@ public class DefaultCodegenTest {
         cp = mt.getSchema();
         assertFalse(cp.isMap); // because it is a referenced schema
         assertEquals(cp.complexType, "coordinates");
-
-        CodegenResponse cr = co.responses.get(0);
-        List<CodegenParameter> responseHeaders = cr.getResponseHeaders();
-        assertEquals(1, responseHeaders.size());
-        CodegenParameter header = responseHeaders.get(0);
-        assertEquals("X-Rate-Limit-Limit", header.baseName);
-        assertTrue(header.isUnboundedInteger);
+        assertEquals(cp.baseName, "ApplicationJsonSchema");
     }
 
     @Test
@@ -4004,6 +4000,65 @@ public class DefaultCodegenTest {
         cp = mt.getSchema();
         assertEquals(cp.baseName, "ApplicationJsonSchema");
         assertEquals(cp.complexType, "coordinates");
+
+        mt = content.get("text/plain");
+        assertNull(mt.getEncoding());
+        cp = mt.getSchema();
+        assertEquals(cp.baseName, "TextPlainSchema");
+        assertTrue(cp.isString);
+    }
+
+    @Test
+    public void testResponseContentAndHeader() {
+        DefaultCodegen codegen = new DefaultCodegen();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/content-data.yaml");
+        codegen.setOpenAPI(openAPI);
+        String path;
+        CodegenOperation co;
+
+        path = "/jsonQueryParams";
+        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        CodegenParameter coordinatesInlineSchema = co.queryParams.get(0);
+        LinkedHashMap<String, CodegenMediaType> content = coordinatesInlineSchema.getContent();
+        assertNotNull(content);
+        assertEquals(content.keySet(), new HashSet<>(Arrays.asList("application/json")));
+
+        CodegenParameter schemaParam = co.queryParams.get(2);
+        assertEquals(schemaParam.getSchema().baseName, "stringWithMinLength");
+
+
+        CodegenResponse cr = co.responses.get(0);
+        List<CodegenParameter> responseHeaders = cr.getResponseHeaders();
+        assertEquals(1, responseHeaders.size());
+        CodegenParameter header = responseHeaders.get(0);
+        assertEquals("X-Rate-Limit", header.baseName);
+        assertTrue(header.isUnboundedInteger);
+        assertEquals(header.getSchema().baseName, "X-Rate-Limit");
+
+        content = cr.getContent();
+        assertEquals(content.keySet(), new HashSet<>(Arrays.asList("application/json", "text/plain")));
+        CodegenMediaType mt = content.get("application/json");
+        assertNull(mt.getEncoding());
+        CodegenProperty cp = mt.getSchema();
+        assertFalse(cp.isMap); // because it is a referenced schema
+        assertEquals(cp.complexType, "coordinates");
+        assertEquals(cp.baseName, "ApplicationJsonSchema");
+
+        mt = content.get("text/plain");
+        assertNull(mt.getEncoding());
+        cp = mt.getSchema();
+        assertEquals(cp.baseName, "TextPlainSchema");
+        assertTrue(cp.isString);
+
+        cr = co.responses.get(1);
+        content = cr.getContent();
+        assertEquals(content.keySet(), new HashSet<>(Arrays.asList("application/json", "text/plain")));
+        mt = content.get("application/json");
+        assertNull(mt.getEncoding());
+        cp = mt.getSchema();
+        assertFalse(cp.isMap); // because it is a referenced schema
+        assertEquals(cp.complexType, "coordinates");
+        assertEquals(cp.baseName, "ApplicationJsonSchema");
 
         mt = content.get("text/plain");
         assertNull(mt.getEncoding());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -3949,7 +3949,7 @@ public class DefaultCodegenTest {
         CodegenProperty cp = mt.getSchema();
         assertTrue(cp.isMap);
         assertEquals(cp.complexType, "object");
-        assertEquals(cp.baseName, "SchemaForParameterApplicationJson");
+        assertEquals(cp.baseName, "SchemaForRequestParameterCoordinatesInlineSchemaApplicationJson");
 
         CodegenParameter coordinatesReferencedSchema = co.queryParams.get(1);
         content = coordinatesReferencedSchema.getContent();
@@ -3958,7 +3958,7 @@ public class DefaultCodegenTest {
         cp = mt.getSchema();
         assertFalse(cp.isMap); // because it is a referenced schema
         assertEquals(cp.complexType, "coordinates");
-        assertEquals(cp.baseName, "SchemaForParameterApplicationJson");
+        assertEquals(cp.baseName, "SchemaForRequestParameterCoordinatesReferencedSchemaApplicationJson");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -3956,6 +3956,13 @@ public class DefaultCodegenTest {
         cp = mt.getSchema();
         assertFalse(cp.isMap); // because it is a referenced schema
         assertEquals(cp.complexType, "coordinates");
+
+        CodegenResponse cr = co.responses.get(0);
+        List<CodegenParameter> responseHeaders = cr.getResponseHeaders();
+        assertEquals(1, responseHeaders.size());
+        CodegenParameter header = responseHeaders.get(0);
+        assertEquals("X-Rate-Limit-Limit", header.baseName);
+        assertTrue(header.isUnboundedInteger);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -3949,7 +3949,7 @@ public class DefaultCodegenTest {
         CodegenProperty cp = mt.getSchema();
         assertTrue(cp.isMap);
         assertEquals(cp.complexType, "object");
-        assertEquals(cp.baseName, "ApplicationJsonSchema");
+        assertEquals(cp.baseName, "SchemaForParameterApplicationJson");
 
         CodegenParameter coordinatesReferencedSchema = co.queryParams.get(1);
         content = coordinatesReferencedSchema.getContent();
@@ -3958,7 +3958,7 @@ public class DefaultCodegenTest {
         cp = mt.getSchema();
         assertFalse(cp.isMap); // because it is a referenced schema
         assertEquals(cp.complexType, "coordinates");
-        assertEquals(cp.baseName, "ApplicationJsonSchema");
+        assertEquals(cp.baseName, "SchemaForParameterApplicationJson");
     }
 
     @Test
@@ -3978,13 +3978,13 @@ public class DefaultCodegenTest {
         CodegenMediaType mt = content.get("application/json");
         assertNull(mt.getEncoding());
         CodegenProperty cp = mt.getSchema();
-        assertEquals(cp.baseName, "ApplicationJsonSchema");
+        assertEquals(cp.baseName, "SchemaForRequestBodyApplicationJson");
         assertNotNull(cp);
 
         mt = content.get("text/plain");
         assertNull(mt.getEncoding());
         cp = mt.getSchema();
-        assertEquals(cp.baseName, "TextPlainSchema");
+        assertEquals(cp.baseName, "SchemaForRequestBodyTextPlain");
         assertNotNull(cp);
         // Note: the inline model resolver has a bug for this use case; it extracts an inline request body into a component
         // but the schema it references is not string type
@@ -3998,13 +3998,13 @@ public class DefaultCodegenTest {
         mt = content.get("application/json");
         assertNull(mt.getEncoding());
         cp = mt.getSchema();
-        assertEquals(cp.baseName, "ApplicationJsonSchema");
+        assertEquals(cp.baseName, "SchemaForRequestBodyApplicationJson");
         assertEquals(cp.complexType, "coordinates");
 
         mt = content.get("text/plain");
         assertNull(mt.getEncoding());
         cp = mt.getSchema();
-        assertEquals(cp.baseName, "TextPlainSchema");
+        assertEquals(cp.baseName, "SchemaForRequestBodyTextPlain");
         assertTrue(cp.isString);
     }
 
@@ -4042,12 +4042,12 @@ public class DefaultCodegenTest {
         CodegenProperty cp = mt.getSchema();
         assertFalse(cp.isMap); // because it is a referenced schema
         assertEquals(cp.complexType, "coordinates");
-        assertEquals(cp.baseName, "ApplicationJsonSchema");
+        assertEquals(cp.baseName, "SchemaFor200ResponseBodyApplicationJson");
 
         mt = content.get("text/plain");
         assertNull(mt.getEncoding());
         cp = mt.getSchema();
-        assertEquals(cp.baseName, "TextPlainSchema");
+        assertEquals(cp.baseName, "SchemaFor200ResponseBodyTextPlain");
         assertTrue(cp.isString);
 
         cr = co.responses.get(1);
@@ -4058,12 +4058,12 @@ public class DefaultCodegenTest {
         cp = mt.getSchema();
         assertFalse(cp.isMap); // because it is a referenced schema
         assertEquals(cp.complexType, "coordinates");
-        assertEquals(cp.baseName, "ApplicationJsonSchema");
+        assertEquals(cp.baseName, "SchemaFor201ResponseBodyApplicationJson");
 
         mt = content.get("text/plain");
         assertNull(mt.getEncoding());
         cp = mt.getSchema();
-        assertEquals(cp.baseName, "TextPlainSchema");
+        assertEquals(cp.baseName, "SchemaFor201ResponseBodyTextPlain");
         assertTrue(cp.isString);
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/content-data.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/content-data.yaml
@@ -26,14 +26,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/coordinates'
+        - name: stringWithMinLength
+          in: query
+          schema:
+            $ref: '#/components/schemas/stringWithMinLength'
       responses:
-        '201':
+        '200':
           description: 'OK'
+          headers:
+            X-Rate-Limit:
+              description: "The number of allowed requests in the current period"
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/coordinates'
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/stringWithMinLength'
+        '201':
+          description: 'Created OK'
           headers:
             X-Rate-Limit-Limit:
               description: "The number of allowed requests in the current period"
               schema:
                 type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/coordinates'
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/stringWithMinLength'
   /inlineRequestBodySchemasDifferingByContentType:
     post:
       requestBody:

--- a/modules/openapi-generator/src/test/resources/3_0/content-data.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/content-data.yaml
@@ -29,6 +29,11 @@ paths:
       responses:
         '201':
           description: 'OK'
+          headers:
+            X-Rate-Limit-Limit:
+              description: "The number of allowed requests in the current period"
+              schema:
+                type: integer
   /inlineRequestBodySchemasDifferingByContentType:
     post:
       requestBody:

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.micronaut.http.client.annotation.Client;
 import org.openapitools.query.QueryParam;
 import io.micronaut.core.convert.format.Format;
 import reactor.core.publisher.Mono;
+import java.time.LocalDateTime;
 import org.openapitools.model.User;
 import javax.annotation.Generated;
 import java.util.ArrayList;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -20,6 +20,7 @@ import org.openapitools.client.Configuration;
 import org.openapitools.client.model.*;
 import org.openapitools.client.Pair;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
@@ -4,6 +4,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.EncodingUtils;
 import org.openapitools.client.model.ApiResponse;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/UserApi.java
@@ -4,6 +4,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.EncodingUtils;
 import org.openapitools.client.model.ApiResponse;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/UserApi.java
@@ -2,6 +2,7 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.ApiClient;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/api/UserApi.java
@@ -20,6 +20,7 @@ import org.openapitools.client.Configuration;
 import org.openapitools.client.model.*;
 import org.openapitools.client.Pair;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
@@ -8,6 +8,7 @@ import org.openapitools.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import java.time.LocalDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -8,6 +8,7 @@ import org.openapitools.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/UserApi.java
@@ -12,6 +12,7 @@
 
 package org.openapitools.client.api;
 
+import java.util.Date;
 import org.openapitools.client.model.User;
 
 import java.io.InputStream;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
@@ -17,6 +17,7 @@ import org.openapitools.client.ApiException;
 import org.openapitools.client.ApiResponse;
 import org.openapitools.client.Pair;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -17,6 +17,7 @@ import org.openapitools.client.ApiException;
 import org.openapitools.client.ApiResponse;
 import org.openapitools.client.Pair;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import java.io.IOException;
 
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.lang.reflect.Type;

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/api/UserApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.lang.reflect.Type;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.lang.reflect.Type;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.lang.reflect.Type;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client.api;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.api;
 
 import com.google.gson.reflect.TypeToken;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/api/UserApi.java
@@ -7,6 +7,7 @@ import org.openapitools.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
@@ -2,6 +2,7 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.ApiClient;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.Collections;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
@@ -2,6 +2,7 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.ApiClient;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.Collections;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/UserApi.java
@@ -11,6 +11,7 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okhttp3.MultipartBody;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -9,6 +9,7 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okhttp3.MultipartBody;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -10,6 +10,7 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okhttp3.MultipartBody;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/api/UserApi.java
@@ -10,6 +10,7 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import okhttp3.MultipartBody;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
@@ -1,6 +1,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiClient;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/api/UserApiImpl.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/api/UserApiImpl.java
@@ -1,5 +1,6 @@
 package org.openapitools.client.api;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import io.vertx.core.AsyncResult;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/api/rxjava/UserApi.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/api/rxjava/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.client.api.rxjava;
 
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.User;
 import org.openapitools.client.ApiClient;
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/UserApi.java
@@ -1,6 +1,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiClient;
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/UserApiImpl.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/UserApiImpl.java
@@ -1,5 +1,6 @@
 package org.openapitools.client.api;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import io.vertx.core.AsyncResult;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/rxjava/UserApi.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/rxjava/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.client.api.rxjava;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 import org.openapitools.client.ApiClient;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -2,6 +2,7 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.ApiClient;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.HashMap;

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -11,6 +11,7 @@
  */
 package org.openapitools.client.api
 
+import java.time.OffsetDateTime
 import org.openapitools.client.model.User
 import org.openapitools.client.core._
 import org.openapitools.client.core.CollectionFormats._

--- a/samples/client/petstore/scala-httpclient-deprecated/src/main/scala/org/openapitools/example/api/UserApi.scala
+++ b/samples/client/petstore/scala-httpclient-deprecated/src/main/scala/org/openapitools/example/api/UserApi.scala
@@ -14,6 +14,7 @@ package org.openapitools.example.api
 
 import java.text.SimpleDateFormat
 
+import java.util.Date
 import org.openapitools.client.model.User
 import org.openapitools.example.invoker.{ApiInvoker, ApiException}
 

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -11,6 +11,7 @@
  */
 package org.openapitools.client.api
 
+import java.time.OffsetDateTime
 import org.openapitools.client.model.User
 import org.openapitools.client.core.JsonSupport._
 import sttp.client._

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -8,6 +8,7 @@ import org.openapitools.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import java.time.OffsetDateTime;
 import org.openapitools.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/UserApi.java
@@ -7,6 +7,7 @@ import org.openapitools.api.factories.UserApiServiceFactory;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/UserApiService.java
@@ -6,6 +6,7 @@ import org.openapitools.model.*;
 import org.wso2.msf4j.formparam.FormDataParam;
 import org.wso2.msf4j.formparam.FileInfo;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -3,6 +3,7 @@ package org.openapitools.api.impl;
 import org.openapitools.api.*;
 import org.openapitools.model.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/UserApiController.java
@@ -1,6 +1,7 @@
 package com.puppies.store.apis;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package com.puppies.store.apis;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package com.puppies.store.apis;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework-async/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-async/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-async/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-async/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-async/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-async/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework-controller-only/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-controller-only/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework-no-interface/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-no-interface/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-no-nullable/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-nullable/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-no-nullable/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-no-nullable/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-no-nullable/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-no-nullable/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-play-framework/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/UserApiController.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.typesafe.config.Config;

--- a/samples/server/petstore/java-play-framework/app/controllers/UserApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/UserApiControllerImp.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import play.mvc.Http;

--- a/samples/server/petstore/java-play-framework/app/controllers/UserApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/UserApiControllerImpInterface.java
@@ -1,6 +1,7 @@
 package controllers;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import apimodels.User;
 
 import com.google.inject.Inject;

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApi.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.vertxweb.server.api;
 
+import java.time.OffsetDateTime;
 import org.openapitools.vertxweb.server.model.User;
 
 import org.openapitools.vertxweb.server.ApiResponse;

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
@@ -1,5 +1,6 @@
 package org.openapitools.vertxweb.server.api;
 
+import java.time.OffsetDateTime;
 import org.openapitools.vertxweb.server.model.User;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiImpl.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiImpl.java
@@ -1,5 +1,6 @@
 package org.openapitools.vertxweb.server.api;
 
+import java.time.OffsetDateTime;
 import org.openapitools.vertxweb.server.model.User;
 
 import org.openapitools.vertxweb.server.ApiResponse;

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/api/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.api;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/api/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.api;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.api;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.Map;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApiService.java
@@ -6,6 +6,7 @@ import org.openapitools.model.*;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.List;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -4,6 +4,7 @@ import org.openapitools.api.*;
 import org.openapitools.model.*;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.List;

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
@@ -7,6 +7,7 @@ import org.openapitools.api.factories.UserApiServiceFactory;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApiService.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -3,6 +3,7 @@ package org.openapitools.api.impl;
 import org.openapitools.api.*;
 import org.openapitools.model.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@ import org.openapitools.api.UserApiService;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/UserApiService.java
@@ -4,6 +4,7 @@ import org.openapitools.api.*;
 import org.openapitools.model.*;
 
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/default/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -4,6 +4,7 @@ import org.openapitools.api.*;
 import org.openapitools.model.*;
 
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/src/gen/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.List;

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.List;

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/org/openapitools/api/UserApi.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import org.joda.time.DateTime;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -4,6 +4,7 @@ import org.openapitools.api.*;
 import org.openapitools.model.*;
 
 
+import org.joda.time.DateTime;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/org/openapitools/api/UserApi.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -4,6 +4,7 @@ import org.openapitools.api.*;
 import org.openapitools.model.*;
 
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/api/UserApi.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.Map;

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/api/UserApiService.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.List;

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 
 import java.util.List;

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@ import org.openapitools.api.UserApiService;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import org.joda.time.DateTime;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/UserApiService.java
@@ -4,6 +4,7 @@ import org.openapitools.api.*;
 import org.openapitools.model.*;
 
 
+import org.joda.time.DateTime;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -4,6 +4,7 @@ import org.openapitools.api.*;
 import org.openapitools.model.*;
 
 
+import org.joda.time.DateTime;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.api;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
@@ -1,5 +1,6 @@
 package org.openapitools.api;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/UserApi.java
@@ -7,6 +7,7 @@ import org.openapitools.api.factories.UserApiServiceFactory;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/UserApiService.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 import com.sun.jersey.multipart.FormDataParam;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 import com.sun.jersey.multipart.FormDataParam;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/UserApi.java
@@ -7,6 +7,7 @@ import org.openapitools.api.factories.UserApiServiceFactory;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/UserApiService.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 import com.sun.jersey.multipart.FormDataParam;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 import com.sun.jersey.multipart.FormDataParam;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
@@ -7,6 +7,7 @@ import org.openapitools.api.factories.UserApiServiceFactory;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApiService.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -3,6 +3,7 @@ package org.openapitools.api.impl;
 import org.openapitools.api.*;
 import org.openapitools.model.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
@@ -7,6 +7,7 @@ import org.openapitools.api.factories.UserApiServiceFactory;
 import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApiService.java
@@ -5,6 +5,7 @@ import org.openapitools.model.*;
 
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/impl/UserApiServiceImpl.java
@@ -3,6 +3,7 @@ package org.openapitools.api.impl;
 import org.openapitools.api.*;
 import org.openapitools.model.*;
 
+import java.util.Date;
 import java.util.List;
 import org.openapitools.model.User;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.LocalDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/spring-mvc-no-nullable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-no-nullable/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/spring-mvc-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import org.threeten.bp.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.virtualan.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.virtualan.model.User;
 import io.swagger.annotations.*;
 import io.virtualan.annotation.ApiVirtual;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
@@ -6,6 +6,7 @@
 package org.openapitools.api;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
Feat adds content and header properties to CodegenResponse
These are needed
- to allow responses to work for different response bodies dependent upon content type
- to allow generated code to surface response header information and send correct accept headers to the server

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
