### PR TITLE
[Scala-Akka-Http] Fix deprecated `ActorMaterializer` since akka-http 2.6

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
@@ -11,7 +11,7 @@ import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.{ ByteString, Timeout }
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
@@ -81,7 +81,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
 
   protected val settings: ApiSettings = ApiSettings(system)
 
-  private implicit val materializer: ActorMaterializer = ActorMaterializer()
+  private implicit val materializer: Materializer = Materializer(system)
   private implicit val serialization: Serialization = jackson.Serialization
 
 

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiInvoker.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiInvoker.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.{ ByteString, Timeout }
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
@@ -91,7 +91,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
 
   protected val settings: ApiSettings = ApiSettings(system)
 
-  private implicit val materializer: ActorMaterializer = ActorMaterializer()
+  private implicit val materializer: Materializer = Materializer(system)
   private implicit val serialization: Serialization = jackson.Serialization
 
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes a deprecation issue in the Akka HTTP client generator for Scala. The `ActorMaterializer` type and constructor have been deprecated since Akka HTTP 2.6.0 and are throwing a warning.

```
ApiInvoker.scala:94:58
[E]      method apply in object ActorMaterializer is deprecated (since 2.6.0): Use the system wide materializer with stream attributes or configuration settings to change defaults
[E]      L94:   private implicit val materializer: ActorMaterializer = ActorMaterializer()
ApiInvoker.scala:94:38
[E]      class ActorMaterializer in package stream is deprecated (since 2.6.0): The Materializer now has all methods the ActorMaterializer used to have
[E]      L94:   private implicit val materializer: ActorMaterializer = ActorMaterializer()
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


cc @clasnake @jimschubert @shijinkui @ramzimaalej @chameleon82 @Bouillie