### PR TITLE
[NodeJS/Javascript	] Opeanpi examples support + better JSDOC

### DIFF
--- a/modules/openapi-generator/src/main/resources/nodejs-express-server/service.mustache
+++ b/modules/openapi-generator/src/main/resources/nodejs-express-server/service.mustache
@@ -12,23 +12,40 @@ const Service = require('./Service');
 {{/notes}}
 *
 {{#allParams}}
-* {{paramName}} {{{dataType}}} {{{description}}}{{^required}} (optional){{/required}}
+* @param {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} { {{{dataType}}} } {{{description}}}
 {{/allParams}}
 {{^returnType}}
 * no response value expected for this operation
 {{/returnType}}
 {{#returnType}}
-* returns {{{.}}}
+* @returns { {{{.}}} }
 {{/returnType}}
 * */
 const {{{operationId}}} = ({{#allParams}}{{#-first}}{ {{/-first}}{{paramName}}{{^-last}}, {{/-last}}{{#-last}} }{{/-last}}{{/allParams}}) => new Promise(
-  async (resolve, reject) => {
+  (resolve, reject) => {
     try {
+      {{#returnType}}
+      var examples = {};
+      {{#examples}}
+      examples['{{contentType}}'] = {{{example}}};
+      {{/examples}}
+      if (Object.keys(examples).length > 0) {
+        resolve(Service.successResponse(examples[Object.keys(examples)[0]]));
+      } else {
+        resolve(Service.successResponse({
+        {{#allParams}}
+          {{paramName}},
+        {{/allParams}}
+        }));
+      }
+      {{/returnType}}
+      {{^returnType}}
       resolve(Service.successResponse({
-    {{#allParams}}
+      {{#allParams}}
         {{paramName}},
-    {{/allParams}}
+      {{/allParams}}
       }));
+      {{/returnType}}
     } catch (e) {
       reject(Service.rejectResponse(
         e.message || 'Invalid input',


### PR DESCRIPTION
When using the too create nodejs-express-server code, the openapi examples weren't supported.
This meant that it was impossible to have mocks on the automatically generated server.
Added examples support here, implementation copied from mustache in swagger-codegen-cli repo.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
