### PR TITLE
[java][okhttp-gson-nextgen] Better null handling in oneOf, anyOf model

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/anyof_model.mustache
@@ -50,6 +50,11 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             return (TypeAdapter<T>) new TypeAdapter<{{classname}}>() {
                 @Override
                 public void write(JsonWriter out, {{classname}} value) throws IOException {
+                    if (value == null || value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     {{#anyOf}}
                     // check if the actual instance is of the type `{{.}}`
                     if (value.getActualInstance() instanceof {{.}}) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/oneof_model.mustache
@@ -50,7 +50,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             return (TypeAdapter<T>) new TypeAdapter<{{classname}}>() {
                 @Override
                 public void write(JsonWriter out, {{classname}} value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/oneof_model.mustache
@@ -50,6 +50,11 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             return (TypeAdapter<T>) new TypeAdapter<{{classname}}>() {
                 @Override
                 public void write(JsonWriter out, {{classname}} value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     {{#oneOf}}
                     // check if the actual instance is of the type `{{.}}`
                     if (value.getActualInstance() instanceof {{.}}) {

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Fruit.java
@@ -78,7 +78,7 @@ public class Fruit extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Fruit>() {
                 @Override
                 public void write(JsonWriter out, Fruit value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Fruit.java
@@ -78,6 +78,11 @@ public class Fruit extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Fruit>() {
                 @Override
                 public void write(JsonWriter out, Fruit value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `Apple`
                     if (value.getActualInstance() instanceof Apple) {
                         JsonObject obj = adapterApple.toJsonTree((Apple)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -78,6 +78,11 @@ public class FruitReq extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<FruitReq>() {
                 @Override
                 public void write(JsonWriter out, FruitReq value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `AppleReq`
                     if (value.getActualInstance() instanceof AppleReq) {
                         JsonObject obj = adapterAppleReq.toJsonTree((AppleReq)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -78,7 +78,7 @@ public class FruitReq extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<FruitReq>() {
                 @Override
                 public void write(JsonWriter out, FruitReq value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -78,6 +78,11 @@ public class GmFruit extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<GmFruit>() {
                 @Override
                 public void write(JsonWriter out, GmFruit value) throws IOException {
+                    if (value == null || value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `Apple`
                     if (value.getActualInstance() instanceof Apple) {
                         JsonObject obj = adapterApple.toJsonTree((Apple)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Mammal.java
@@ -79,6 +79,11 @@ public class Mammal extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Mammal>() {
                 @Override
                 public void write(JsonWriter out, Mammal value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `Pig`
                     if (value.getActualInstance() instanceof Pig) {
                         JsonObject obj = adapterPig.toJsonTree((Pig)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Mammal.java
@@ -79,7 +79,7 @@ public class Mammal extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Mammal>() {
                 @Override
                 public void write(JsonWriter out, Mammal value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -77,7 +77,7 @@ public class NullableShape extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<NullableShape>() {
                 @Override
                 public void write(JsonWriter out, NullableShape value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -77,6 +77,11 @@ public class NullableShape extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<NullableShape>() {
                 @Override
                 public void write(JsonWriter out, NullableShape value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `Quadrilateral`
                     if (value.getActualInstance() instanceof Quadrilateral) {
                         JsonObject obj = adapterQuadrilateral.toJsonTree((Quadrilateral)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Pig.java
@@ -77,7 +77,7 @@ public class Pig extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Pig>() {
                 @Override
                 public void write(JsonWriter out, Pig value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Pig.java
@@ -77,6 +77,11 @@ public class Pig extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Pig>() {
                 @Override
                 public void write(JsonWriter out, Pig value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `BasquePig`
                     if (value.getActualInstance() instanceof BasquePig) {
                         JsonObject obj = adapterBasquePig.toJsonTree((BasquePig)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -77,6 +77,11 @@ public class Quadrilateral extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Quadrilateral>() {
                 @Override
                 public void write(JsonWriter out, Quadrilateral value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `ComplexQuadrilateral`
                     if (value.getActualInstance() instanceof ComplexQuadrilateral) {
                         JsonObject obj = adapterComplexQuadrilateral.toJsonTree((ComplexQuadrilateral)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -77,7 +77,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Quadrilateral>() {
                 @Override
                 public void write(JsonWriter out, Quadrilateral value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Shape.java
@@ -77,6 +77,11 @@ public class Shape extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Shape>() {
                 @Override
                 public void write(JsonWriter out, Shape value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `Quadrilateral`
                     if (value.getActualInstance() instanceof Quadrilateral) {
                         JsonObject obj = adapterQuadrilateral.toJsonTree((Quadrilateral)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Shape.java
@@ -77,7 +77,7 @@ public class Shape extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Shape>() {
                 @Override
                 public void write(JsonWriter out, Shape value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -77,7 +77,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<ShapeOrNull>() {
                 @Override
                 public void write(JsonWriter out, ShapeOrNull value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -77,6 +77,11 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<ShapeOrNull>() {
                 @Override
                 public void write(JsonWriter out, ShapeOrNull value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `Quadrilateral`
                     if (value.getActualInstance() instanceof Quadrilateral) {
                         JsonObject obj = adapterQuadrilateral.toJsonTree((Quadrilateral)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Triangle.java
@@ -79,6 +79,11 @@ public class Triangle extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Triangle>() {
                 @Override
                 public void write(JsonWriter out, Triangle value) throws IOException {
+                    if (value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
                     // check if the actual instance is of the type `EquilateralTriangle`
                     if (value.getActualInstance() instanceof EquilateralTriangle) {
                         JsonObject obj = adapterEquilateralTriangle.toJsonTree((EquilateralTriangle)value.getActualInstance()).getAsJsonObject();

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/main/java/org/openapitools/client/model/Triangle.java
@@ -79,7 +79,7 @@ public class Triangle extends AbstractOpenApiSchema {
             return (TypeAdapter<T>) new TypeAdapter<Triangle>() {
                 @Override
                 public void write(JsonWriter out, Triangle value) throws IOException {
-                    if (value.getActualInstance() == null) {
+                    if (value == null || value.getActualInstance() == null) {
                         elementAdapter.write(out, null);
                         return;
                     }

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/test/java/org/openapitools/client/JSONTest.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/test/java/org/openapitools/client/JSONTest.java
@@ -319,6 +319,7 @@ public class JSONTest {
             FruitReq o = new FruitReq();
             assertEquals(o.getActualInstance(), null);
             assertEquals(json.getGson().toJson(o), "null");
+            assertEquals(json.getGson().toJson(null), "null");
         }
         {
             // Same test, but this time with additional (undeclared) properties.

--- a/samples/client/petstore/java/okhttp-gson-nextgen/src/test/java/org/openapitools/client/JSONTest.java
+++ b/samples/client/petstore/java/okhttp-gson-nextgen/src/test/java/org/openapitools/client/JSONTest.java
@@ -315,6 +315,12 @@ public class JSONTest {
             assertEquals(json.getGson().toJson(inst2), "{\"cultivar\":\"golden delicious\",\"mealy\":false}");
         }
         {
+            // test to ensure the oneOf object can be serialized to "null" correctly
+            FruitReq o = new FruitReq();
+            assertEquals(o.getActualInstance(), null);
+            assertEquals(json.getGson().toJson(o), "null");
+        }
+        {
             // Same test, but this time with additional (undeclared) properties.
             // Since FruitReq has additionalProperties: false, deserialization should fail.
             String str = "{ \"cultivar\": \"golden delicious\", \"mealy\": false, \"garbage_prop\": \"abc\" }";


### PR DESCRIPTION
- better null handling in oneOf, anyOf model
- add more tests


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

