### PR TITLE
Not creating "Accept:null" header for Java-Jersey2 generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1193,9 +1193,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     Invocation.Builder invocationBuilder;
     if (accept != null) {
       invocationBuilder = target.request().accept(accept);
-      } else {
+    } else {
       invocationBuilder = target.request();
-      }
+    }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1190,7 +1190,12 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request().accept(accept);
+    Invocation.Builder invocationBuilder;
+    if (accept != null) {
+      invocationBuilder = target.request().accept(accept);
+      } else {
+      invocationBuilder = target.request();
+      }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -1106,7 +1106,12 @@ public class ApiClient extends JavaTimeFormatter {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request().accept(accept);
+    Invocation.Builder invocationBuilder;
+    if (accept != null) {
+      invocationBuilder = target.request().accept(accept);
+      } else {
+      invocationBuilder = target.request();
+      }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -1109,9 +1109,9 @@ public class ApiClient extends JavaTimeFormatter {
     Invocation.Builder invocationBuilder;
     if (accept != null) {
       invocationBuilder = target.request().accept(accept);
-      } else {
+    } else {
       invocationBuilder = target.request();
-      }
+    }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1106,7 +1106,12 @@ public class ApiClient extends JavaTimeFormatter {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request().accept(accept);
+    Invocation.Builder invocationBuilder;
+    if (accept != null) {
+      invocationBuilder = target.request().accept(accept);
+      } else {
+      invocationBuilder = target.request();
+      }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1109,9 +1109,9 @@ public class ApiClient extends JavaTimeFormatter {
     Invocation.Builder invocationBuilder;
     if (accept != null) {
       invocationBuilder = target.request().accept(accept);
-      } else {
+    } else {
       invocationBuilder = target.request();
-      }
+    }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1036,7 +1036,12 @@ public class ApiClient extends JavaTimeFormatter {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request().accept(accept);
+    Invocation.Builder invocationBuilder;
+    if (accept != null) {
+      invocationBuilder = target.request().accept(accept);
+      } else {
+      invocationBuilder = target.request();
+      }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1039,9 +1039,9 @@ public class ApiClient extends JavaTimeFormatter {
     Invocation.Builder invocationBuilder;
     if (accept != null) {
       invocationBuilder = target.request().accept(accept);
-      } else {
+    } else {
       invocationBuilder = target.request();
-      }
+    }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -984,9 +984,9 @@ public class ApiClient extends JavaTimeFormatter {
     Invocation.Builder invocationBuilder;
     if (accept != null) {
       invocationBuilder = target.request().accept(accept);
-      } else {
+    } else {
       invocationBuilder = target.request();
-      }
+    }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -981,7 +981,12 @@ public class ApiClient extends JavaTimeFormatter {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request().accept(accept);
+    Invocation.Builder invocationBuilder;
+    if (accept != null) {
+      invocationBuilder = target.request().accept(accept);
+      } else {
+      invocationBuilder = target.request();
+      }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1190,7 +1190,12 @@ public class ApiClient extends JavaTimeFormatter {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request().accept(accept);
+    Invocation.Builder invocationBuilder;
+    if (accept != null) {
+      invocationBuilder = target.request().accept(accept);
+      } else {
+      invocationBuilder = target.request();
+      }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1193,9 +1193,9 @@ public class ApiClient extends JavaTimeFormatter {
     Invocation.Builder invocationBuilder;
     if (accept != null) {
       invocationBuilder = target.request().accept(accept);
-      } else {
+    } else {
       invocationBuilder = target.request();
-      }
+    }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
       String value = entry.getValue();


### PR DESCRIPTION
Before the fix, if using Jersey2 as generator and including DELETE operations that don't "accept" any body, the generated code executes HTTP requests with header "Accept:null", which is not a valid header.
After the fix, it will not create "Accept:null" as the header.

This is to fix issue #6882
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
