### PR TITLE
[typescript-angular] Support blob response types

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -349,12 +349,12 @@ export class {{classname}} {
 
 {{/hasFormParams}}
     {{^isResponseFile}}
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -353,7 +353,7 @@ export class {{classname}} {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -349,12 +349,14 @@ export class {{classname}} {
 
 {{/hasFormParams}}
     {{^isResponseFile}}
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -349,9 +349,13 @@ export class {{classname}} {
 
 {{/hasFormParams}}
     {{^isResponseFile}}
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
     {{/isResponseFile}}

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
@@ -112,12 +112,12 @@ export class DefaultService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -166,12 +166,12 @@ export class DefaultService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
@@ -116,7 +116,7 @@ export class DefaultService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -170,7 +170,7 @@ export class DefaultService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
@@ -112,9 +112,13 @@ export class DefaultService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Fruit>(`${this.configuration.basePath}/`,
@@ -162,9 +166,13 @@ export class DefaultService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/`,

--- a/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-oneOf/builds/default/api/default.service.ts
@@ -112,12 +112,14 @@ export class DefaultService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -166,12 +168,14 @@ export class DefaultService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
@@ -152,12 +152,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -218,12 +220,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -288,12 +292,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -360,12 +366,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -425,12 +433,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -496,12 +506,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -582,12 +594,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -672,12 +686,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
@@ -152,12 +152,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -218,12 +218,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -288,12 +288,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -360,12 +360,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -425,12 +425,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -496,12 +496,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -582,12 +582,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -672,12 +672,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
@@ -152,9 +152,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -214,9 +218,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -280,9 +288,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -348,9 +360,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -409,9 +425,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -476,9 +496,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -558,9 +582,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -644,9 +672,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
@@ -156,7 +156,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -222,7 +222,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -292,7 +292,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -364,7 +364,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -429,7 +429,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -500,7 +500,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -586,7 +586,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -676,7 +676,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
@@ -121,9 +121,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -176,9 +180,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -229,9 +237,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -289,9 +301,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
@@ -125,7 +125,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -184,7 +184,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -241,7 +241,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -305,7 +305,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
@@ -121,12 +121,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -180,12 +180,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -237,12 +237,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -301,12 +301,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
@@ -121,12 +121,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -180,12 +182,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -237,12 +241,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -301,12 +307,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
@@ -129,12 +129,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -192,12 +192,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -255,12 +255,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -311,12 +311,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -367,12 +367,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -437,12 +437,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -488,12 +488,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -555,12 +555,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
@@ -129,9 +129,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -188,9 +192,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -247,9 +255,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -299,9 +311,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -351,9 +367,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -417,9 +437,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -464,9 +488,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -527,9 +555,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
@@ -133,7 +133,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -196,7 +196,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -259,7 +259,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -315,7 +315,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -371,7 +371,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -441,7 +441,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -492,7 +492,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -559,7 +559,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
@@ -129,12 +129,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -192,12 +194,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -255,12 +259,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -311,12 +317,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -367,12 +375,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -437,12 +447,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -488,12 +500,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -555,12 +569,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,12 +152,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -218,12 +220,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -288,12 +292,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -360,12 +366,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -425,12 +433,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -496,12 +506,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -582,12 +594,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -672,12 +686,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,12 +152,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -218,12 +218,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -288,12 +288,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -360,12 +360,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -425,12 +425,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -496,12 +496,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -582,12 +582,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -672,12 +672,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,9 +152,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -214,9 +218,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -280,9 +288,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -348,9 +360,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -409,9 +425,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -476,9 +496,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -558,9 +582,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -644,9 +672,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -156,7 +156,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -222,7 +222,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -292,7 +292,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -364,7 +364,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -429,7 +429,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -500,7 +500,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -586,7 +586,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -676,7 +676,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,9 +121,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -176,9 +180,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -229,9 +237,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -289,9 +301,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
@@ -125,7 +125,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -184,7 +184,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -241,7 +241,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -305,7 +305,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,12 +121,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -180,12 +180,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -237,12 +237,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -301,12 +301,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,12 +121,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -180,12 +182,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -237,12 +241,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -301,12 +307,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,12 +129,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -192,12 +192,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -255,12 +255,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -311,12 +311,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -367,12 +367,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -437,12 +437,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -488,12 +488,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -555,12 +555,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,9 +129,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -188,9 +192,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -247,9 +255,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -299,9 +311,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -351,9 +367,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -417,9 +437,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -464,9 +488,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -527,9 +555,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
@@ -133,7 +133,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -196,7 +196,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -259,7 +259,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -315,7 +315,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -371,7 +371,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -441,7 +441,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -492,7 +492,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -559,7 +559,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,12 +129,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -192,12 +194,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -255,12 +259,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -311,12 +317,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -367,12 +375,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -437,12 +447,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -488,12 +500,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -555,12 +569,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
@@ -152,12 +152,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -218,12 +218,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -289,12 +289,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -361,12 +361,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -426,12 +426,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -497,12 +497,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -583,12 +583,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -673,12 +673,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
@@ -152,12 +152,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -218,12 +220,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -289,12 +293,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -361,12 +367,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -426,12 +434,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -497,12 +507,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -583,12 +595,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -673,12 +687,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
@@ -152,9 +152,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -214,9 +218,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -281,9 +289,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -349,9 +361,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -410,9 +426,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -477,9 +497,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -559,9 +583,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -645,9 +673,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
@@ -156,7 +156,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -222,7 +222,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -293,7 +293,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -365,7 +365,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -430,7 +430,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -501,7 +501,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -587,7 +587,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -677,7 +677,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
@@ -121,12 +121,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -181,12 +181,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -238,12 +238,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -302,12 +302,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
@@ -125,7 +125,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -185,7 +185,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -242,7 +242,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -306,7 +306,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
@@ -121,9 +121,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -177,9 +181,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -230,9 +238,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -290,9 +302,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
@@ -121,12 +121,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -181,12 +183,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -238,12 +242,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -302,12 +308,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
@@ -129,9 +129,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -188,9 +192,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -247,9 +255,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -299,9 +311,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -352,9 +368,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -418,9 +438,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -465,9 +489,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -528,9 +556,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
@@ -129,12 +129,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -192,12 +194,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -255,12 +259,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -311,12 +317,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -368,12 +376,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -438,12 +448,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -489,12 +501,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -556,12 +570,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
@@ -129,12 +129,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -192,12 +192,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -255,12 +255,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -311,12 +311,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -368,12 +368,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -438,12 +438,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -489,12 +489,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -556,12 +556,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
@@ -133,7 +133,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -196,7 +196,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -259,7 +259,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -315,7 +315,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -372,7 +372,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -442,7 +442,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -493,7 +493,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -560,7 +560,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,12 +152,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -218,12 +218,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -289,12 +289,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -361,12 +361,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -426,12 +426,12 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -497,12 +497,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -583,12 +583,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -673,12 +673,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,12 +152,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -218,12 +220,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -289,12 +293,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -361,12 +367,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -426,12 +434,14 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -497,12 +507,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -583,12 +595,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -673,12 +687,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,9 +152,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -214,9 +218,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -281,9 +289,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -349,9 +361,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -410,9 +426,13 @@ export class PetService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -477,9 +497,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -559,9 +583,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -645,9 +673,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -156,7 +156,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -222,7 +222,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -293,7 +293,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -365,7 +365,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -430,7 +430,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -501,7 +501,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -587,7 +587,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -677,7 +677,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,12 +121,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -181,12 +181,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -238,12 +238,12 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -302,12 +302,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
@@ -125,7 +125,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -185,7 +185,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -242,7 +242,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -306,7 +306,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,9 +121,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -177,9 +181,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -230,9 +238,13 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -290,9 +302,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,12 +121,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -181,12 +183,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -238,12 +242,14 @@ export class StoreService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -302,12 +308,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,9 +129,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -188,9 +192,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -247,9 +255,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -299,9 +311,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -352,9 +368,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -418,9 +438,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -465,9 +489,13 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -528,9 +556,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,12 +129,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -192,12 +194,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -255,12 +259,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -311,12 +317,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -368,12 +376,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -438,12 +448,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -489,12 +501,14 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -556,12 +570,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,12 +129,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -192,12 +192,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -255,12 +255,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -311,12 +311,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -368,12 +368,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -438,12 +438,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -489,12 +489,12 @@ export class UserService {
         }
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -556,12 +556,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
@@ -133,7 +133,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -196,7 +196,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -259,7 +259,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -315,7 +315,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -372,7 +372,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -442,7 +442,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -493,7 +493,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -560,7 +560,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,9 +146,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -203,9 +207,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -264,9 +272,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -327,9 +339,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -383,9 +399,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -445,9 +465,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -522,9 +546,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -603,9 +631,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,12 +146,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -207,12 +207,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -272,12 +272,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -339,12 +339,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -399,12 +399,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -465,12 +465,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -546,12 +546,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -631,12 +631,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -150,7 +150,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -211,7 +211,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -276,7 +276,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -343,7 +343,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -403,7 +403,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -469,7 +469,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -550,7 +550,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -635,7 +635,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,12 +146,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -207,12 +209,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -272,12 +276,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -339,12 +345,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -399,12 +407,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -465,12 +475,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -546,12 +558,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -631,12 +645,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -119,7 +119,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -173,7 +173,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -225,7 +225,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -284,7 +284,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -115,12 +115,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -169,12 +171,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -221,12 +225,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -280,12 +286,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -115,9 +115,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -165,9 +169,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -213,9 +221,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -268,9 +280,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -115,12 +115,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -169,12 +169,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -221,12 +221,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -280,12 +280,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -123,9 +123,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -177,9 +181,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -231,9 +239,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -278,9 +290,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -325,9 +341,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -386,9 +406,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -428,9 +452,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -486,9 +514,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -123,12 +123,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -181,12 +183,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -239,12 +243,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -290,12 +296,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +349,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -406,12 +416,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -452,12 +464,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -514,12 +528,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -127,7 +127,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -185,7 +185,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -243,7 +243,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -294,7 +294,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -410,7 +410,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -456,7 +456,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -518,7 +518,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -123,12 +123,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -181,12 +181,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -239,12 +239,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -290,12 +290,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -406,12 +406,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -452,12 +452,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -514,12 +514,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,9 +146,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -203,9 +207,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -264,9 +272,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -327,9 +339,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -383,9 +399,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -445,9 +465,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -522,9 +546,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -603,9 +631,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,12 +146,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -207,12 +207,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -272,12 +272,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -339,12 +339,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -399,12 +399,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -465,12 +465,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -546,12 +546,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -631,12 +631,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -150,7 +150,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -211,7 +211,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -276,7 +276,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -343,7 +343,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -403,7 +403,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -469,7 +469,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -550,7 +550,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -635,7 +635,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,12 +146,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -207,12 +209,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -272,12 +276,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -339,12 +345,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -399,12 +407,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -465,12 +475,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -546,12 +558,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -631,12 +645,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -119,7 +119,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -173,7 +173,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -225,7 +225,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -284,7 +284,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -115,12 +115,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -169,12 +171,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -221,12 +225,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -280,12 +286,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -115,9 +115,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -165,9 +169,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -213,9 +221,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -268,9 +280,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -115,12 +115,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -169,12 +169,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -221,12 +221,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -280,12 +280,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -123,9 +123,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -177,9 +181,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -231,9 +239,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -278,9 +290,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -325,9 +341,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -386,9 +406,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -428,9 +452,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -486,9 +514,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -123,12 +123,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -181,12 +183,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -239,12 +243,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -290,12 +296,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +349,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -406,12 +416,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -452,12 +464,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -514,12 +528,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -127,7 +127,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -185,7 +185,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -243,7 +243,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -294,7 +294,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -410,7 +410,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -456,7 +456,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -518,7 +518,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -123,12 +123,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -181,12 +181,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -239,12 +239,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -290,12 +290,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -406,12 +406,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -452,12 +452,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -514,12 +514,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,9 +146,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -203,9 +207,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -264,9 +272,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -327,9 +339,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -383,9 +399,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -445,9 +465,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -522,9 +546,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -603,9 +631,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,12 +146,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -207,12 +207,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -272,12 +272,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -339,12 +339,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -399,12 +399,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -465,12 +465,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -546,12 +546,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -631,12 +631,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -150,7 +150,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -211,7 +211,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -276,7 +276,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -343,7 +343,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -403,7 +403,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -469,7 +469,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -550,7 +550,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -635,7 +635,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -146,12 +146,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -207,12 +209,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -272,12 +276,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -339,12 +345,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -399,12 +407,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -465,12 +475,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -546,12 +558,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -631,12 +645,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -119,7 +119,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -173,7 +173,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -225,7 +225,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -284,7 +284,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -115,12 +115,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -169,12 +171,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -221,12 +225,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -280,12 +286,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -115,9 +115,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -165,9 +169,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -213,9 +221,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -268,9 +280,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -115,12 +115,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -169,12 +169,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -221,12 +221,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -280,12 +280,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -123,9 +123,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -177,9 +181,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -231,9 +239,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -278,9 +290,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -325,9 +341,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -386,9 +406,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -428,9 +452,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -486,9 +514,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -123,12 +123,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -181,12 +183,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -239,12 +243,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -290,12 +296,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +349,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -406,12 +416,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -452,12 +464,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -514,12 +528,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -127,7 +127,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -185,7 +185,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -243,7 +243,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -294,7 +294,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -410,7 +410,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -456,7 +456,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -518,7 +518,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -123,12 +123,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -181,12 +181,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -239,12 +239,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -290,12 +290,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -406,12 +406,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -452,12 +452,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -514,12 +514,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,9 +146,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -203,9 +207,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -264,9 +272,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -327,9 +339,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -383,9 +399,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -445,9 +465,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -522,9 +546,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -603,9 +631,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,12 +146,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -207,12 +207,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -272,12 +272,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -339,12 +339,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -399,12 +399,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -465,12 +465,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -546,12 +546,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -631,12 +631,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -150,7 +150,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -211,7 +211,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -276,7 +276,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -343,7 +343,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -403,7 +403,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -469,7 +469,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -550,7 +550,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -635,7 +635,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -146,12 +146,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -207,12 +209,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -272,12 +276,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -339,12 +345,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -399,12 +407,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -465,12 +475,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -546,12 +558,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -631,12 +645,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -119,7 +119,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -173,7 +173,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -225,7 +225,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -284,7 +284,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -115,12 +115,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -169,12 +171,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -221,12 +225,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -280,12 +286,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -115,9 +115,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -165,9 +169,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -213,9 +221,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -268,9 +280,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -115,12 +115,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -169,12 +169,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -221,12 +221,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -280,12 +280,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -123,9 +123,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -177,9 +181,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -231,9 +239,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -278,9 +290,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -325,9 +341,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -386,9 +406,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -428,9 +452,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -486,9 +514,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -123,12 +123,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -181,12 +183,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -239,12 +243,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -290,12 +296,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +349,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -406,12 +416,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -452,12 +464,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -514,12 +528,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -127,7 +127,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -185,7 +185,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -243,7 +243,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -294,7 +294,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -410,7 +410,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -456,7 +456,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -518,7 +518,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -123,12 +123,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -181,12 +181,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -239,12 +239,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -290,12 +290,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -406,12 +406,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -452,12 +452,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -514,12 +514,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -198,12 +198,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -260,12 +262,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -326,12 +330,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -394,12 +400,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -455,12 +463,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -522,12 +532,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -604,12 +616,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -690,12 +704,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -198,12 +198,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -260,12 +260,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -326,12 +326,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -394,12 +394,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -455,12 +455,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -522,12 +522,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -604,12 +604,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -690,12 +690,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -198,9 +198,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -256,9 +260,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -318,9 +326,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -382,9 +394,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -439,9 +455,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -502,9 +522,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -580,9 +604,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -662,9 +690,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/pet.service.ts
@@ -202,7 +202,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -264,7 +264,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -330,7 +330,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -398,7 +398,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -459,7 +459,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -526,7 +526,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -608,7 +608,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -694,7 +694,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -133,9 +133,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -183,9 +187,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -232,9 +240,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -288,9 +300,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -191,7 +191,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -244,7 +244,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -304,7 +304,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -133,12 +133,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -187,12 +189,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -240,12 +244,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -300,12 +306,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/store.service.ts
@@ -133,12 +133,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -187,12 +187,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -240,12 +240,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -300,12 +300,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -169,7 +169,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -228,7 +228,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -287,7 +287,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -339,7 +339,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -391,7 +391,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -457,7 +457,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -503,7 +503,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -566,7 +566,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -165,9 +165,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -220,9 +224,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -275,9 +283,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -323,9 +335,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -371,9 +387,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -433,9 +453,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -475,9 +499,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -534,9 +562,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -165,12 +165,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -224,12 +224,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -283,12 +283,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -335,12 +335,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -387,12 +387,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -453,12 +453,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -499,12 +499,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -562,12 +562,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api/user.service.ts
@@ -165,12 +165,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -224,12 +226,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -283,12 +287,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -335,12 +341,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -387,12 +395,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -453,12 +463,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -499,12 +511,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -562,12 +576,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -209,12 +211,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -274,12 +278,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -341,12 +347,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -401,12 +409,14 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -467,12 +477,14 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -548,12 +560,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -633,12 +647,14 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,9 +148,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
@@ -205,9 +209,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -266,9 +274,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
@@ -329,9 +341,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
@@ -385,9 +401,13 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -447,9 +467,13 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
@@ -524,9 +548,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -605,9 +633,13 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -152,7 +152,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -213,7 +213,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -278,7 +278,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -345,7 +345,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -405,7 +405,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -471,7 +471,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -552,7 +552,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -637,7 +637,7 @@ export class PetService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -148,12 +148,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -209,12 +209,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -274,12 +274,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -341,12 +341,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -401,12 +401,12 @@ export class PetService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -467,12 +467,12 @@ export class PetService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -548,12 +548,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('status', <any>status) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -633,12 +633,12 @@ export class PetService {
             localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -171,12 +173,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -223,12 +227,14 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -282,12 +288,14 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,9 +117,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -167,9 +171,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
@@ -215,9 +223,13 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
@@ -270,9 +282,13 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
@@ -117,12 +117,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -171,12 +171,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -223,12 +223,12 @@ export class StoreService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -282,12 +282,12 @@ export class StoreService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/store.service.ts
@@ -121,7 +121,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -175,7 +175,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -227,7 +227,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -286,7 +286,7 @@ export class StoreService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
@@ -129,7 +129,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -187,7 +187,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -245,7 +245,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -296,7 +296,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -347,7 +347,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -412,7 +412,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -458,7 +458,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }
@@ -520,7 +520,7 @@ export class UserService {
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
             }
         }

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -183,12 +185,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -241,12 +245,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -292,12 +298,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -343,12 +351,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -408,12 +418,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -454,12 +466,14 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 
@@ -516,12 +530,14 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'blob';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
             } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
                 responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,12 +125,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -183,12 +183,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -241,12 +241,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -292,12 +292,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -343,12 +343,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -408,12 +408,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -454,12 +454,12 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 
@@ -516,12 +516,12 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        let responseType_: 'text' | 'json' | 'blob' = 'blob';
         if (localVarHttpHeaderAcceptSelected) {
             if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
                 responseType_ = 'text';
-            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
-                responseType_ = 'blob';
+            } else if (isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
             }
         }
 

--- a/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm/api/user.service.ts
@@ -125,9 +125,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
@@ -179,9 +183,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
@@ -233,9 +241,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
@@ -280,9 +292,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -327,9 +343,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
@@ -388,9 +408,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
@@ -430,9 +454,13 @@ export class UserService {
 
 
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
@@ -488,9 +516,13 @@ export class UserService {
             localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
         }
 
-        let responseType_: 'text' | 'json' = 'json';
-        if(localVarHttpHeaderAcceptSelected && localVarHttpHeaderAcceptSelected.startsWith('text')) {
-            responseType_ = 'text';
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (!localVarHttpHeaderAcceptSelected.includes('json')) {
+                responseType_ = 'blob';
+            }
         }
 
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,


### PR DESCRIPTION
Fixes [#11021](https://github.com/OpenAPITools/openapi-generator/issues/11021)

Generated service methods will try to decide its response type by pattern matching the accept header for text, then json, otherwise defaults to a blob.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ```
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Technical Committee:
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
