### PR TITLE
Making PyPi markdown friendly requires additional property

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-legacy/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/setup.mustache
@@ -36,7 +36,8 @@ setup(
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     {{#licenseInfo}}license="{{.}}",
-    {{/licenseInfo}}long_description="""\
+    {{/licenseInfo}}long_description_content_type='text/markdown',
+    long_description="""\
     {{appDescription}}  # noqa: E501
     """
 )

--- a/samples/client/petstore/python-asyncio/setup.py
+++ b/samples/client/petstore/python-asyncio/setup.py
@@ -36,6 +36,7 @@ setup(
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     license="Apache-2.0",
+    long_description_content_type='text/markdown',
     long_description="""\
     This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\  # noqa: E501
     """

--- a/samples/client/petstore/python-legacy/setup.py
+++ b/samples/client/petstore/python-legacy/setup.py
@@ -35,6 +35,7 @@ setup(
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     license="Apache-2.0",
+    long_description_content_type='text/markdown',
     long_description="""\
     This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\  # noqa: E501
     """

--- a/samples/client/petstore/python-tornado/setup.py
+++ b/samples/client/petstore/python-tornado/setup.py
@@ -36,6 +36,7 @@ setup(
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     license="Apache-2.0",
+    long_description_content_type='text/markdown',
     long_description="""\
     This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\  # noqa: E501
     """

--- a/samples/openapi3/client/petstore/python-legacy/setup.py
+++ b/samples/openapi3/client/petstore/python-legacy/setup.py
@@ -35,6 +35,7 @@ setup(
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
     license="Apache-2.0",
+    long_description_content_type='text/markdown',
     long_description="""\
     This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\  # noqa: E501
     """


### PR DESCRIPTION
https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/

Since our `long_description` includes markdown, we now need to explicitly declare the content type by setting `long_description_content_type='text/markdown'`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
