### PR TITLE
[typescript-fetch] new middlewares: fail and complete

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -105,11 +105,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -300,7 +300,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -33,13 +33,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -66,27 +72,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -265,6 +299,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -116,11 +116,11 @@ export class BaseAPI {
 
             throw response;
         } catch (err) {
-            let error;
+            let error = err;
 
             for (const middleware of this.middleware) {
                 if (middleware.fail) {
-                    error = (await middleware.fail(responseContext, err)) || err;
+                    error = (await middleware.fail(responseContext, error)) || error;
                 }
             }
 
@@ -311,7 +311,7 @@ export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
     fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
-    complete?(context: RequestContext): void;
+    complete?(context: RequestContext): Promise<void>;
 }
 
 export interface ApiResponse<T> {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -44,13 +44,19 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
+    withFailMiddleware<T extends BaseAPI>(this: T, ...failMiddlewares: Array<Middleware['fail']>) {
+        const middlewares = failMiddlewares.map((fail) => ({ fail }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
+    withCompleteMiddleware<T extends BaseAPI>(this: T, ...completeMiddlewares: Array<Middleware['complete']>) {
+        const middlewares = completeMiddlewares.map((complete) => ({ complete }));
+        return this.withMiddleware<T>(...middlewares);
+    }
+
     protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
         const { url, init } = this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response.status >= 200 && response.status < 300) {
-            return response;
-        }
-        throw response;
+        return this.fetchApi(url, init);
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -77,27 +83,55 @@ export class BaseAPI {
     }
 
     private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
+        let fetchParams = {url, init};
+        const requestContext = {
+            fetch: this.fetchApi,
+            ...fetchParams,
+        };
+
         for (const middleware of this.middleware) {
             if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
+                fetchParams = (await middleware.pre(requestContext)) || fetchParams;
             }
         }
-        let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
+
+        try {
+            let response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+            const responseContext = {
+                fetch: this.fetchApi,
+                url: fetchParams.url,
+                init: fetchParams.init,
+                response: response.clone(),
+            };
+
+            for (const middleware of this.middleware) {
+                if (middleware.post) {
+                    response = (await middleware.post(responseContext)) || response;
+                }
+            }
+
+            if (response.status >= 200 && response.status < 300) {
+                return response;
+            }
+
+            throw response;
+        } catch (err) {
+            let error;
+
+            for (const middleware of this.middleware) {
+                if (middleware.fail) {
+                    error = (await middleware.fail(responseContext, err)) || err;
+                }
+            }
+
+            throw error;
+        } finally {
+            for (const middleware of this.middleware) {
+                if (middleware.complete) {
+                    middleware.complete(requestContext);
+                }
             }
         }
-        return response;
     }
 
     /**
@@ -276,6 +310,8 @@ export interface ResponseContext {
 export interface Middleware {
     pre?(context: RequestContext): Promise<FetchParams | void>;
     post?(context: ResponseContext): Promise<Response | void>;
+    fail?(context: RequestContext, err: unknown): Promise<unknown | void>;
+    complete?(context: RequestContext): void;
 }
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
This PR introduce two new middlewares: `fail` and `complete`.

Why we need these two new middlewares?

Because the old `post` middleware can be only executed when the request is successful. it will not be executed when something going wrong during the whole request process.

Therefore, I add these two middlewares in `try/catch` block to approach this.

By the way, the old `pre` and `post` middlewares will ***not be effected***, they should act like before. So this PR has no breaking changes.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
