### PR TITLE
[Go] Parse integer array query parameters. Fix typos

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/api.mustache
@@ -22,7 +22,7 @@ type {{classname}}Router interface { {{#operations}}{{#operation}}
 
 // {{classname}}Servicer defines the api actions for the {{classname}} service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type {{classname}}Servicer interface { {{#operations}}{{#operation}}
 	{{#isDeprecated}}

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -46,7 +46,7 @@ func New{{classname}}Controller(s {{classname}}Servicer, opts ...{{classname}}Op
 	return controller
 }
 
-// Routes returns all of the api route for the {{classname}}Controller
+// Routes returns all the api routes for the {{classname}}Controller
 func (c *{{classname}}Controller) Routes() Routes {
 	return Routes{ {{#operations}}{{#operation}}
 		{
@@ -130,10 +130,33 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		return
 	}
 	{{/isBoolean}}
+	{{#isArray}}
+	{{#items.isLong}}
+	{{paramName}}Param, err := parseInt64ArrayParameter(query.Get("{{baseName}}"), ",", {{required}})
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	{{/items.isLong}}
+	{{#items.isInteger}}
+	{{paramName}}Param, err := parseInt32ArrayParameter(query.Get("{{baseName}}"), ",", {{required}})
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	{{/items.isInteger}}
+	{{^items.isLong}}
+	{{^items.isInteger}}
+	{{paramName}}Param := strings.Split(query.Get("{{baseName}}"), ",")
+	{{/items.isInteger}}
+	{{/items.isLong}}
+	{{/isArray}}
 	{{^isLong}}
 	{{^isInteger}}
 	{{^isBoolean}}
-	{{paramName}}Param := {{#isArray}}strings.Split({{/isArray}}query.Get("{{baseName}}"){{#isArray}}, ","){{/isArray}}
+	{{^isArray}}
+	{{paramName}}Param := query.Get("{{baseName}}")
+	{{/isArray}}
 	{{/isBoolean}}
 	{{/isInteger}}
 	{{/isLong}}

--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -32,13 +32,13 @@ func IsZeroValue(val interface{}) bool {
 	return val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface())
 }
 
-// AssertInterfaceRequired recursively checks each struct in a slice against the callback.
+// AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
-// AssertNestedValueRequired checks each struct in the nested slice against the callback.
+// AssertRecurseValueRequired checks each struct in the nested slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
 	switch value.Kind() {

--- a/modules/openapi-generator/src/main/resources/go-server/impl.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/impl.mustache
@@ -1,7 +1,7 @@
 {{>partial_header}}
 package {{packageName}}
 
-//Implementation response defines an error code with the associated body
+// ImplResponse response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	{{#addResponseHeaders}}

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -57,7 +57,7 @@ type UserApiRouter interface {
 
 // PetApiServicer defines the api actions for the PetApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
 	AddPet(context.Context, Pet) (ImplResponse, error)
@@ -74,7 +74,7 @@ type PetApiServicer interface {
 
 // StoreApiServicer defines the api actions for the StoreApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type StoreApiServicer interface { 
 	DeleteOrder(context.Context, string) (ImplResponse, error)
@@ -86,7 +86,7 @@ type StoreApiServicer interface {
 
 // UserApiServicer defines the api actions for the UserApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type UserApiServicer interface { 
 	CreateUser(context.Context, User) (ImplResponse, error)

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -47,7 +47,7 @@ func NewPetApiController(s PetApiServicer, opts ...PetApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the PetApiController
+// Routes returns all the api routes for the PetApiController
 func (c *PetApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -47,7 +47,7 @@ func NewStoreApiController(s StoreApiServicer, opts ...StoreApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the StoreApiController
+// Routes returns all the api routes for the StoreApiController
 func (c *StoreApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -47,7 +47,7 @@ func NewUserApiController(s UserApiServicer, opts ...UserApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the UserApiController
+// Routes returns all the api routes for the UserApiController
 func (c *UserApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-api-server/go/helpers.go
+++ b/samples/server/petstore/go-api-server/go/helpers.go
@@ -36,13 +36,13 @@ func IsZeroValue(val interface{}) bool {
 	return val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface())
 }
 
-// AssertInterfaceRequired recursively checks each struct in a slice against the callback.
+// AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
-// AssertNestedValueRequired checks each struct in the nested slice against the callback.
+// AssertRecurseValueRequired checks each struct in the nested slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
 	switch value.Kind() {

--- a/samples/server/petstore/go-api-server/go/impl.go
+++ b/samples/server/petstore/go-api-server/go/impl.go
@@ -9,7 +9,7 @@
 
 package petstoreserver
 
-//Implementation response defines an error code with the associated body
+// ImplResponse response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	Headers map[string][]string

--- a/samples/server/petstore/go-chi-server/go/api.go
+++ b/samples/server/petstore/go-chi-server/go/api.go
@@ -57,7 +57,7 @@ type UserApiRouter interface {
 
 // PetApiServicer defines the api actions for the PetApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
 	AddPet(context.Context, Pet) (ImplResponse, error)
@@ -74,7 +74,7 @@ type PetApiServicer interface {
 
 // StoreApiServicer defines the api actions for the StoreApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type StoreApiServicer interface { 
 	DeleteOrder(context.Context, string) (ImplResponse, error)
@@ -86,7 +86,7 @@ type StoreApiServicer interface {
 
 // UserApiServicer defines the api actions for the UserApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type UserApiServicer interface { 
 	CreateUser(context.Context, User) (ImplResponse, error)

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -47,7 +47,7 @@ func NewPetApiController(s PetApiServicer, opts ...PetApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the PetApiController
+// Routes returns all the api routes for the PetApiController
 func (c *PetApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-chi-server/go/api_store.go
+++ b/samples/server/petstore/go-chi-server/go/api_store.go
@@ -47,7 +47,7 @@ func NewStoreApiController(s StoreApiServicer, opts ...StoreApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the StoreApiController
+// Routes returns all the api routes for the StoreApiController
 func (c *StoreApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -47,7 +47,7 @@ func NewUserApiController(s UserApiServicer, opts ...UserApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the UserApiController
+// Routes returns all the api routes for the UserApiController
 func (c *UserApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-chi-server/go/helpers.go
+++ b/samples/server/petstore/go-chi-server/go/helpers.go
@@ -36,13 +36,13 @@ func IsZeroValue(val interface{}) bool {
 	return val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface())
 }
 
-// AssertInterfaceRequired recursively checks each struct in a slice against the callback.
+// AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
-// AssertNestedValueRequired checks each struct in the nested slice against the callback.
+// AssertRecurseValueRequired checks each struct in the nested slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
 	switch value.Kind() {

--- a/samples/server/petstore/go-chi-server/go/impl.go
+++ b/samples/server/petstore/go-chi-server/go/impl.go
@@ -9,7 +9,7 @@
 
 package petstoreserver
 
-//Implementation response defines an error code with the associated body
+// ImplResponse response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	Headers map[string][]string

--- a/samples/server/petstore/go-server-required/go/api.go
+++ b/samples/server/petstore/go-server-required/go/api.go
@@ -57,7 +57,7 @@ type UserApiRouter interface {
 
 // PetApiServicer defines the api actions for the PetApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
 	AddPet(context.Context, Pet) (ImplResponse, error)
@@ -74,7 +74,7 @@ type PetApiServicer interface {
 
 // StoreApiServicer defines the api actions for the StoreApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type StoreApiServicer interface { 
 	DeleteOrder(context.Context, string) (ImplResponse, error)
@@ -86,7 +86,7 @@ type StoreApiServicer interface {
 
 // UserApiServicer defines the api actions for the UserApi service
 // This interface intended to stay up to date with the openapi yaml used to generate it,
-// while the service implementation can ignored with the .openapi-generator-ignore file
+// while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type UserApiServicer interface { 
 	CreateUser(context.Context, User) (ImplResponse, error)

--- a/samples/server/petstore/go-server-required/go/api_pet.go
+++ b/samples/server/petstore/go-server-required/go/api_pet.go
@@ -47,7 +47,7 @@ func NewPetApiController(s PetApiServicer, opts ...PetApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the PetApiController
+// Routes returns all the api routes for the PetApiController
 func (c *PetApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-server-required/go/api_store.go
+++ b/samples/server/petstore/go-server-required/go/api_store.go
@@ -47,7 +47,7 @@ func NewStoreApiController(s StoreApiServicer, opts ...StoreApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the StoreApiController
+// Routes returns all the api routes for the StoreApiController
 func (c *StoreApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-server-required/go/api_user.go
+++ b/samples/server/petstore/go-server-required/go/api_user.go
@@ -47,7 +47,7 @@ func NewUserApiController(s UserApiServicer, opts ...UserApiOption) Router {
 	return controller
 }
 
-// Routes returns all of the api route for the UserApiController
+// Routes returns all the api routes for the UserApiController
 func (c *UserApiController) Routes() Routes {
 	return Routes{ 
 		{

--- a/samples/server/petstore/go-server-required/go/helpers.go
+++ b/samples/server/petstore/go-server-required/go/helpers.go
@@ -36,13 +36,13 @@ func IsZeroValue(val interface{}) bool {
 	return val == nil || reflect.DeepEqual(val, reflect.Zero(reflect.TypeOf(val)).Interface())
 }
 
-// AssertInterfaceRequired recursively checks each struct in a slice against the callback.
+// AssertRecurseInterfaceRequired recursively checks each struct in a slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseInterfaceRequired(obj interface{}, callback func(interface{}) error) error {
 	return AssertRecurseValueRequired(reflect.ValueOf(obj), callback)
 }
 
-// AssertNestedValueRequired checks each struct in the nested slice against the callback.
+// AssertRecurseValueRequired checks each struct in the nested slice against the callback.
 // This method traverse nested slices in a preorder fashion.
 func AssertRecurseValueRequired(value reflect.Value, callback func(interface{}) error) error {
 	switch value.Kind() {

--- a/samples/server/petstore/go-server-required/go/impl.go
+++ b/samples/server/petstore/go-server-required/go/impl.go
@@ -9,7 +9,7 @@
 
 package petstoreserver
 
-//Implementation response defines an error code with the associated body
+// ImplResponse response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
 	Headers map[string][]string


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
_*Affects the Go-server only._

## Limited support of integer array parameters in a query
Adds a code generation to parse query parameter fields of `int32 array` and `int64 array` types. Assumes that `style: form` and `explode: false` are used as serialization method.

```yaml
openapi: "3.0.0"
info:
  description: Example API
  version: 1.0.0
  title: "Example API"

servers:
  - url: http://localhost:8080/api/v1
    description: development server

paths:
  /companies:
    get:
      summary: Filter companies by specified criteria
      operationId: find
      parameters:
        - name: ids
          in: query
          example: "500, 501"
          schema:
            type: array
            items:
              type: integer
              format: int64
      tags:
        - Company
      responses:
        200:
          description: Successful operation
```

Before:
```go
parentIDsParam := strings.Split(query.Get("ids"), ",")
```
After:
```go
mtinfoIDsParam, err := parseInt64ArrayParameter(query.Get("ids"), ",", false)
if err != nil {
	c.errorHandler(w, r, &ParsingError{Err: err}, nil)
	return
}
```

## Other
Fixes minor typos in comments.

## Technical committee
@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
