### PR TITLE
[Protobuf-Schema] Namespace updates

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -91,7 +91,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         apiTemplateFiles.put("api.mustache", ".proto");
         embeddedTemplateDir = templateDir = "protobuf-schema";
         hideGenerationTimestamp = Boolean.TRUE;
-        modelPackage = "messages";
+        modelPackage = "models";
         apiPackage = "services";
 
         defaultIncludes = new HashSet<>(
@@ -167,11 +167,19 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         apiDocTemplateFiles.clear(); // TODO: add api doc template
         modelDocTemplateFiles.clear(); // TODO: add model doc template
 
-        modelPackage = "models";
-        apiPackage = "services";
-
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
+        }
+        else {
+            additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
+        }
+
+        if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
+            additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
+        }
+
+        if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
+            additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
         }
 
         if (additionalProperties.containsKey(this.NUMBERED_FIELD_NUMBER_LIST)) {

--- a/modules/openapi-generator/src/main/resources/protobuf-schema/api.mustache
+++ b/modules/openapi-generator/src/main/resources/protobuf-schema/api.mustache
@@ -1,7 +1,7 @@
 {{>partial_header}}
 syntax = "proto3";
 
-package {{{packageName}}};
+package {{#lambda.lowercase}}{{{packageName}}}.{{{apiPackage}}}.{{{classname}}};{{/lambda.lowercase}}
 
 import "google/protobuf/empty.proto";
 {{#imports}}

--- a/modules/openapi-generator/src/main/resources/protobuf-schema/model.mustache
+++ b/modules/openapi-generator/src/main/resources/protobuf-schema/model.mustache
@@ -1,7 +1,7 @@
 {{>partial_header}}
 syntax = "proto3";
 
-package {{{packageName}}};
+package {{#lambda.lowercase}}{{{packageName}}};{{/lambda.lowercase}}
 
 {{#imports}}
 {{#import}}

--- a/modules/openapi-generator/src/test/resources/3_0/protobuf-schema/pet.proto
+++ b/modules/openapi-generator/src/test/resources/3_0/protobuf-schema/pet.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 
-package ;
+package openapitools;
 
 import public "models/lizard_all_of.proto";
 import public "models/snake_all_of.proto";

--- a/samples/config/petstore/protobuf-schema/services/pet_service.proto
+++ b/samples/config/petstore/protobuf-schema/services/pet_service.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 
-package petstore;
+package petstore.services.petservice;
 
 import "google/protobuf/empty.proto";
 import public "models/api_response.proto";

--- a/samples/config/petstore/protobuf-schema/services/store_service.proto
+++ b/samples/config/petstore/protobuf-schema/services/store_service.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 
-package petstore;
+package petstore.services.storeservice;
 
 import "google/protobuf/empty.proto";
 import public "models/order.proto";

--- a/samples/config/petstore/protobuf-schema/services/user_service.proto
+++ b/samples/config/petstore/protobuf-schema/services/user_service.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 
-package petstore;
+package petstore.services.userservice;
 
 import "google/protobuf/empty.proto";
 import public "models/user.proto";


### PR DESCRIPTION
resolve #11114 

## Codegen
- fixed default packageName to **openapitools**
- api mustache packageName changed to {**{packageName}}.{{apiPackage}}.{{classname}}**
- package name changed to lowercase following the protobuf convention