### PR TITLE
[Kotlin][Multiplatform] Declare API classes and methods as open

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -16,7 +16,7 @@ import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 
 {{#operations}}
-{{#nonPublicApi}}internal {{/nonPublicApi}}class {{classname}}(
+{{#nonPublicApi}}internal {{/nonPublicApi}}open class {{classname}}(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
     httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
@@ -33,7 +33,7 @@ import kotlinx.serialization.encoding.*
     {{#returnType}}
     @Suppress("UNCHECKED_CAST")
     {{/returnType}}
-    suspend fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}): HttpResponse<{{{returnType}}}{{^returnType}}Unit{{/returnType}}> {
+    open suspend fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}): HttpResponse<{{{returnType}}}{{^returnType}}Unit{{/returnType}}> {
 
         val localVariableAuthNames = listOf<String>({{#authMethods}}"{{name}}"{{^-last}}, {{/-last}}{{/authMethods}})
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 
-class PetApi(
+open class PetApi(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
     httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
@@ -47,7 +47,7 @@ class PetApi(
      * @param body Pet object that needs to be added to the store 
      * @return void
      */
-    suspend fun addPet(body: Pet): HttpResponse<Unit> {
+    open suspend fun addPet(body: Pet): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>("petstore_auth")
 
@@ -80,7 +80,7 @@ class PetApi(
      * @param apiKey  (optional)
      * @return void
      */
-    suspend fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?): HttpResponse<Unit> {
+    open suspend fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>("petstore_auth")
 
@@ -114,7 +114,7 @@ class PetApi(
      * @return kotlin.collections.List<Pet>
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>): HttpResponse<kotlin.collections.List<Pet>> {
+    open suspend fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>): HttpResponse<kotlin.collections.List<Pet>> {
 
         val localVariableAuthNames = listOf<String>("petstore_auth")
 
@@ -158,7 +158,7 @@ class PetApi(
      * @return kotlin.collections.List<Pet>
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>): HttpResponse<kotlin.collections.List<Pet>> {
+    open suspend fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>): HttpResponse<kotlin.collections.List<Pet>> {
 
         val localVariableAuthNames = listOf<String>("petstore_auth")
 
@@ -202,7 +202,7 @@ class PetApi(
      * @return Pet
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun getPetById(petId: kotlin.Long): HttpResponse<Pet> {
+    open suspend fun getPetById(petId: kotlin.Long): HttpResponse<Pet> {
 
         val localVariableAuthNames = listOf<String>("api_key")
 
@@ -234,7 +234,7 @@ class PetApi(
      * @param body Pet object that needs to be added to the store 
      * @return void
      */
-    suspend fun updatePet(body: Pet): HttpResponse<Unit> {
+    open suspend fun updatePet(body: Pet): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>("petstore_auth")
 
@@ -268,7 +268,7 @@ class PetApi(
      * @param status Updated status of the pet (optional)
      * @return void
      */
-    suspend fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?): HttpResponse<Unit> {
+    open suspend fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>("petstore_auth")
 
@@ -306,7 +306,7 @@ class PetApi(
      * @return ModelApiResponse
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: io.ktor.client.request.forms.InputProvider?): HttpResponse<ModelApiResponse> {
+    open suspend fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: io.ktor.client.request.forms.InputProvider?): HttpResponse<ModelApiResponse> {
 
         val localVariableAuthNames = listOf<String>("petstore_auth")
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 
-class StoreApi(
+open class StoreApi(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
     httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
@@ -46,7 +46,7 @@ class StoreApi(
      * @param orderId ID of the order that needs to be deleted 
      * @return void
      */
-    suspend fun deleteOrder(orderId: kotlin.String): HttpResponse<Unit> {
+    open suspend fun deleteOrder(orderId: kotlin.String): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -78,7 +78,7 @@ class StoreApi(
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun getInventory(): HttpResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>> {
+    open suspend fun getInventory(): HttpResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>> {
 
         val localVariableAuthNames = listOf<String>("api_key")
 
@@ -121,7 +121,7 @@ class StoreApi(
      * @return Order
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun getOrderById(orderId: kotlin.Long): HttpResponse<Order> {
+    open suspend fun getOrderById(orderId: kotlin.Long): HttpResponse<Order> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -154,7 +154,7 @@ class StoreApi(
      * @return Order
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun placeOrder(body: Order): HttpResponse<Order> {
+    open suspend fun placeOrder(body: Order): HttpResponse<Order> {
 
         val localVariableAuthNames = listOf<String>()
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
 
-class UserApi(
+open class UserApi(
     baseUrl: String = ApiClient.BASE_URL,
     httpClientEngine: HttpClientEngine? = null,
     httpClientConfig: ((HttpClientConfig<*>) -> Unit)? = null,
@@ -46,7 +46,7 @@ class UserApi(
      * @param body Created user object 
      * @return void
      */
-    suspend fun createUser(body: User): HttpResponse<Unit> {
+    open suspend fun createUser(body: User): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -78,7 +78,7 @@ class UserApi(
      * @param body List of user object 
      * @return void
      */
-    suspend fun createUsersWithArrayInput(body: kotlin.collections.List<User>): HttpResponse<Unit> {
+    open suspend fun createUsersWithArrayInput(body: kotlin.collections.List<User>): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -119,7 +119,7 @@ class UserApi(
      * @param body List of user object 
      * @return void
      */
-    suspend fun createUsersWithListInput(body: kotlin.collections.List<User>): HttpResponse<Unit> {
+    open suspend fun createUsersWithListInput(body: kotlin.collections.List<User>): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -160,7 +160,7 @@ class UserApi(
      * @param username The name that needs to be deleted 
      * @return void
      */
-    suspend fun deleteUser(username: kotlin.String): HttpResponse<Unit> {
+    open suspend fun deleteUser(username: kotlin.String): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -193,7 +193,7 @@ class UserApi(
      * @return User
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun getUserByName(username: kotlin.String): HttpResponse<User> {
+    open suspend fun getUserByName(username: kotlin.String): HttpResponse<User> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -227,7 +227,7 @@ class UserApi(
      * @return kotlin.String
      */
     @Suppress("UNCHECKED_CAST")
-    suspend fun loginUser(username: kotlin.String, password: kotlin.String): HttpResponse<kotlin.String> {
+    open suspend fun loginUser(username: kotlin.String, password: kotlin.String): HttpResponse<kotlin.String> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -260,7 +260,7 @@ class UserApi(
      * 
      * @return void
      */
-    suspend fun logoutUser(): HttpResponse<Unit> {
+    open suspend fun logoutUser(): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -293,7 +293,7 @@ class UserApi(
      * @param body Updated user object 
      * @return void
      */
-    suspend fun updateUser(username: kotlin.String, body: User): HttpResponse<Unit> {
+    open suspend fun updateUser(username: kotlin.String, body: User): HttpResponse<Unit> {
 
         val localVariableAuthNames = listOf<String>()
 


### PR DESCRIPTION
This PR changes the Kotlin multiplatform templates so that:
- API classes can be subclassed.
- API methods can be overridden.

The motivation for this change is to make it easier to use API classes in tests. By making the class and methods `open`, it is possible to override the API class behavior and provide stubs.

An example of how this is useful in a test scenario can be seen [here](https://github.com/Airthings/openapi-multiplatform-multi-module/blob/subclass-pet-api/shared/src/commonTest/kotlin/com.airthings.openapi.test/GreeterTest.kt#L38).

```kotlin
private class PetApiStub(private val findPetsByStatusResponse: List<Pet>) : PetApi() {
    override suspend fun findPetsByStatus(status: List<String>): HttpResponse<List<Pet>> =
        HttpResponseStub(responseStub = findPetsByStatusResponse)
}
```

**CCs:**
Kotlin technical committee:
@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
