### PR TITLE
Forbid using standard streams in archunit

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
@@ -430,7 +430,6 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
      * @param serializer
      */
     private void addBuiltValueSerializer(BuiltValueSerializer serializer) {
-        System.out.println("######## Add serializer!");
         additionalProperties.compute("builtValueSerializers", (k, v) -> {
             Set<BuiltValueSerializer> serializers = v == null ? Sets.newHashSet() : ((Set<BuiltValueSerializer>) v);
             serializers.add(serializer);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ArchUnitRulesTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ArchUnitRulesTest.java
@@ -4,6 +4,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.GeneralCodingRules;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -17,6 +18,14 @@ public class ArchUnitRulesTest {
                 .importPackages("org.openapitools.codegen.languages");
 
         ArchUnitRulesTest.LOGGERS_SHOULD_BE_NOT_PUBLIC_NOT_STATIC_AND_FINAL.check(importedClasses);
+    }
+
+    @Test
+    public void classesNotAllowedToUseStandardStreams() {
+        final JavaClasses importedClasses = new ClassFileImporter()
+                .importPackages("org.openapitools.codegen.languages");
+
+        GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS.check(importedClasses);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/archunit_ignore_patterns.txt
+++ b/modules/openapi-generator/src/test/resources/archunit_ignore_patterns.txt
@@ -1,0 +1,2 @@
+# This rule is for ArchUnitRulesTest.classesNotAllowedToUseStandardStreams to ignore method `postProcess()` of CodegenConfig as it contains funding information
+.*\.postProcess\(\).*


### PR DESCRIPTION
new archunit test check for not allowing to use standard streams like System.out and System.err, this PR replaces https://github.com/OpenAPITools/openapi-generator/pull/11128

@wing328 @jimschubert 