### PR TITLE
Add isSkipOperationExample check before generating op.requestBodyExamples

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4074,7 +4074,7 @@ public class DefaultCodegen implements CodegenConfig {
                 }
 
                 // add example
-                if (schemas != null) {
+                if (schemas != null && !isSkipOperationExample()) {
                     op.requestBodyExamples = new ExampleGenerator(schemas, this.openAPI).generate(null, new ArrayList<>(getConsumesInfo(this.openAPI, operation)), bodyParam.baseType);
                 }
             }


### PR DESCRIPTION
Add isSkipOperationExample check before generating op.requestBodyExamples in the DefaultCodeGe. This avoids the running out of heap space error you can get when generating a large spec file, even with the skipOperationExample flag is set to true under additional properties. 

Example command:

java -jar ./openapi-generator-cli.jar generate -i http://localhost:5000/swagger/v1/swagger.json --additional-properties=skipOperationExample=true -g dart -o ../server-api -c ./openapi-gen-config.yaml

Now skips example code generation in the body as well when the flag is set to true. Before this would only skip op.examples but generate would still run for op.requestBodyExamples which would blow up the heap stack with no way to disable it. 

