### PR TITLE
Bugfix of #11176 and related #10706 CPP-QT-QHTTPENGINE Server 

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
@@ -36,7 +36,7 @@ protected:
         if (socket->bytesAvailable() >= socket->contentLength()) {
             emit requestReceived(socket);
         } else {
-            connect(socket, &Socket::readChannelFinished, [this, socket]() {
+            connect(socket, &QHttpEngine::Socket::readChannelFinished, [this, socket]() {
                 emit requestReceived(socket);
             });
         }

--- a/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
@@ -91,7 +91,7 @@ private :
     }
 
     inline QRegularExpressionMatch getRequestMatch(QString serverTemplatePath, QString requestPath){
-        QRegularExpression parExpr( R"(\{([^\/\\s]+)\})" );
+        QRegularExpression parExpr( R"(\{([^\/\s]+)\})" );
         serverTemplatePath.replace( parExpr, R"((?<\1>[^\/\s]+))" );
         serverTemplatePath.append("[\\/]?$");
         QRegularExpression pathExpr( serverTemplatePath );

--- a/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
@@ -36,7 +36,7 @@ protected:
         if (socket->bytesAvailable() >= socket->contentLength()) {
             emit requestReceived(socket);
         } else {
-            connect(socket, &Socket::readChannelFinished, [this, socket, m]() {
+            connect(socket, &Socket::readChannelFinished, [this, socket]() {
                 emit requestReceived(socket);
             });
         }


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

QT Server was not building and not working because of three issues, fixed in this three commits.

@muttleyxd