### PR TITLE
Handling golang client generation for oneOf with no discriminator and useOneOfDiscriminatorLookup is true

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
@@ -48,8 +48,38 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	}
 
 	{{/mappedModels}}
-	{{/discriminator}}
 	return nil
+	{{/discriminator}}
+	{{^discriminator}}
+        match := 0
+        {{#oneOf}}
+        // try to unmarshal data into {{{.}}}
+        err = json.Unmarshal(data, &dst.{{{.}}})
+        if err == nil {
+                json{{{.}}}, _ := json.Marshal(dst.{{{.}}})
+                if string(json{{{.}}}) == "{}" { // empty struct
+                        dst.{{{.}}} = nil
+                } else {
+                        match++
+                }
+        } else {
+                dst.{{{.}}} = nil
+        }
+
+        {{/oneOf}}
+        if match > 1 { // more than 1 match
+                // reset to nil
+                {{#oneOf}}
+                dst.{{{.}}} = nil
+                {{/oneOf}}
+
+                return fmt.Errorf("Data matches more than one schema in oneOf({{classname}})")
+        } else if match == 1 {
+                return nil // exactly one match
+        } else { // no match
+                return fmt.Errorf("Data failed to match schemas in oneOf({{classname}})")
+        }
+	{{/discriminator}}
 	{{/useOneOfDiscriminatorLookup}}
 	{{^useOneOfDiscriminatorLookup}}
 	match := 0


### PR DESCRIPTION
Trying to address issue  https://github.com/OpenAPITools/openapi-generator/issues/7961 

The idea of the fix is we use the same code of useOneOfDiscriminatorLookup(false) of the condition useOneOfDiscriminatorLookup(true) and  discriminator is not defined.

Validation:
1. Have oneOf without discriminator in the openapi spec
2. Use `useOneOfDiscriminatorLookup: true` to generate golang client
3. Generated code can be compiled and the code will unmarshal each struct

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ph4r5h4d
