### PR TITLE
[Java-OKHTTP-GSON] Do not set content-type if content type is null

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson-nextgen/api.mustache
@@ -173,7 +173,7 @@ public class {{classname}} {
             {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}
         };
         final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
-        if (localVarHeaderParams != null) {
+        if (localVarHeaderParams != null && localVarContentTypes != null) {
             localVarHeaderParams.put("Content-Type", localVarContentType);
         }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -204,7 +204,7 @@ public class {{classname}} {
             {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}
         };
         final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
-        if (localVarHeaderParams != null) {
+        if (localVarHeaderParams != null && localVarContentTypes != null) {
             localVarHeaderParams.put("Content-Type", localVarContentType);
         }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The content type being null leads to an empty content type header. The resteasy server cannot process an empty content type:
```
java.lang.IllegalArgumentException: RESTEASY003340: Failure parsing MediaType string: 
	at org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate.internalParse(MediaTypeHeaderDelegate.java:96) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate.parse(MediaTypeHeaderDelegate.java:69) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate.fromString(MediaTypeHeaderDelegate.java:33) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate.fromString(MediaTypeHeaderDelegate.java:19) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at javax.ws.rs.core.MediaType.valueOf(MediaType.java:172) ~[jakarta.ws.rs-api_2.1.6.jar:2.1.6]
	at org.jboss.resteasy.specimpl.ResteasyHttpHeaders.getMediaType(ResteasyHttpHeaders.java:151) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.specimpl.ResteasyHttpHeaders.testParsing(ResteasyHttpHeaders.java:69) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.plugins.server.servlet.ServletUtil.extractHttpHeaders(ServletUtil.java:83) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:226) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:60) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55) ~[org.jboss.resteasy.core_4.7.1.Final.jar:?]

```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@xhh
