### PR TITLE
[php][bug] Fix DateTime microseconds bug in ObjectSerializer

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -318,7 +318,7 @@ class ObjectSerializer
                     // for the problem.
                     // Note that strtotime only handles precision up to a second,
                     // so trimming does not result in data loss.
-                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {
                 return null;

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -121,6 +121,20 @@ class ObjectSerializer
     }
 
     /**
+     * Shorter timestamp microseconds to 6 digits length.
+     *
+     * @param string $timestamp Original timestamp
+     *
+     * @return string the shorten timestamp
+     */
+    public static function sanitizeTimestamp($timestamp)
+    {
+        if (!is_string($timestamp)) return $timestamp;
+
+        return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
+    }
+
+    /**
      * Take value and turn it into a string suitable for inclusion in
      * the path, by url-encoding.
      *
@@ -313,11 +327,9 @@ class ObjectSerializer
                     return new \DateTime($data);
                 } catch (\Exception $exception) {
                     // Some API's return a date-time with too high nanosecond
-                    // precision for php's DateTime to handle. This conversion
-                    // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem. Note that strtotime only handles precision
-                    // up to a second, so trimming does not result in data loss.
-                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
+                    // precision for php's DateTime to handle.
+                    // With provided regexp 6 digits of microseconds saved
+                    return new \DateTime(self::sanitizeTimestamp($data));
                 }
             } else {
                 return null;

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -315,9 +315,8 @@ class ObjectSerializer
                     // Some API's return a date-time with too high nanosecond
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem.
-                    // Note that strtotime only handles precision up to a second,
-                    // so trimming does not result in data loss.
+                    // for the problem. Note that strtotime only handles precision
+                    // up to a second, so trimming does not result in data loss.
                     return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -316,7 +316,9 @@ class ObjectSerializer
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
                     // for the problem.
-                    return (new \DateTime())->setTimestamp(strtotime($data));
+                    // Note that strtotime only handles precision up to a second,
+                    // so trimming does not result in data loss.
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
                 }
             } else {
                 return null;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -324,9 +324,8 @@ class ObjectSerializer
                     // Some API's return a date-time with too high nanosecond
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem.
-                    // Note that strtotime only handles precision up to a second,
-                    // so trimming does not result in data loss.
+                    // for the problem. Note that strtotime only handles precision
+                    // up to a second, so trimming does not result in data loss.
                     return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -325,7 +325,9 @@ class ObjectSerializer
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
                     // for the problem.
-                    return (new \DateTime())->setTimestamp(strtotime($data));
+                    // Note that strtotime only handles precision up to a second, 
+                    // so trimming does not result in data loss.
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
                 }
             } else {
                 return null;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -130,6 +130,20 @@ class ObjectSerializer
     }
 
     /**
+     * Shorter timestamp microseconds to 6 digits length.
+     *
+     * @param string $timestamp Original timestamp
+     *
+     * @return string the shorten timestamp
+     */
+    public static function sanitizeTimestamp($timestamp)
+    {
+        if (!is_string($timestamp)) return $timestamp;
+
+        return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
+    }
+
+    /**
      * Take value and turn it into a string suitable for inclusion in
      * the path, by url-encoding.
      *
@@ -322,11 +336,9 @@ class ObjectSerializer
                     return new \DateTime($data);
                 } catch (\Exception $exception) {
                     // Some API's return a date-time with too high nanosecond
-                    // precision for php's DateTime to handle. This conversion
-                    // (string -> unix timestamp -> DateTime) is a workaround
-                    // for the problem. Note that strtotime only handles precision
-                    // up to a second, so trimming does not result in data loss.
-                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
+                    // precision for php's DateTime to handle.
+                    // With provided regexp 6 digits of microseconds saved
+                    return new \DateTime(self::sanitizeTimestamp($data));
                 }
             } else {
                 return null;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -325,7 +325,7 @@ class ObjectSerializer
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
                     // for the problem.
-                    // Note that strtotime only handles precision up to a second, 
+                    // Note that strtotime only handles precision up to a second,
                     // so trimming does not result in data loss.
                     return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -327,7 +327,7 @@ class ObjectSerializer
                     // for the problem.
                     // Note that strtotime only handles precision up to a second, 
                     // so trimming does not result in data loss.
-                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.')))));
+                    return (new \DateTime())->setTimestamp(strtotime(substr($data, 0, strpos($data, '.'))));
                 }
             } else {
                 return null;

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -64,4 +64,66 @@ class ObjectSerializerTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @covers ObjectSerializer::sanitizeTimestamp
+     * @dataProvider provideTimestamps
+     */
+    public function testSanitizeTimestamp(string $timestamp, string $expected): void
+    {
+        $this->assertEquals($expected, ObjectSerializer::sanitizeTimestamp($timestamp));
+    }
+
+    /**
+     * Test datetime deserialization.
+     *
+     * @covers ObjectSerializer::deserialize
+     * @dataProvider provideTimestamps
+     *
+     * @see https://github.com/OpenAPITools/openapi-generator/issues/7942
+     * @see https://github.com/OpenAPITools/openapi-generator/issues/10548
+     */
+    public function testDateTimeParseSecondAccuracy(string $timestamp, string $expected): void
+    {
+        $dateTime = ObjectSerializer::deserialize($timestamp, '\DateTime');
+        $this->assertEquals(new \DateTime($expected), $dateTime);
+    }
+
+    public function provideTimestamps(): array
+    {
+        return [
+            'String from #7942' => [
+                '2020-11-11T15:17:58.868722633Z',
+                '2020-11-11T15:17:58.868722Z',
+            ],
+            'String from #10548' => [
+                '2021-10-06T20:17:16.076372256Z',
+                '2021-10-06T20:17:16.076372Z',
+            ],
+            'Without timezone' => [
+                '2021-10-06T20:17:16.076372256',
+                '2021-10-06T20:17:16.076372',
+            ],
+            'Without microseconds' => [
+                '2021-10-06T20:17:16',
+                '2021-10-06T20:17:16',
+            ],
+            'Without microseconds with timezone' => [
+                '2021-10-06T20:17:16Z',
+                '2021-10-06T20:17:16Z',
+            ],
+            'With numeric timezone' => [
+                '2021-10-06T20:17:16.076372256+03:00',
+                '2021-10-06T20:17:16.076372+03:00',
+            ],
+            'With numeric timezone without delimiter' => [
+                '2021-10-06T20:17:16.076372256+0300',
+                '2021-10-06T20:17:16.076372+0300',
+            ],
+            'With numeric short timezone' => [
+                '2021-10-06T20:17:16.076372256+03',
+                '2021-10-06T20:17:16.076372+03',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
That's enhanced version of #11003 PR(thanks to original author @carmenquan). Please, let me know if my fix solves your problem.

Closes #10548


```console
vendor/bin/phpunit tests/ObjectSerializerTest.php
Xdebug requires Zend Engine API version 320160303.
The Zend Engine API version 320190902 which is installed, is newer.
Contact Derick Rethans at http://xdebug.org/docs/faq#api for a later version of Xdebug.

PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

...................                                               19 / 19 (100%)

Time: 00:00.009, Memory: 6.00 MB

OK (19 tests, 29 assertions)
```

cc @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09), @renepardon (2018/12), @carmenquan
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
