### PR TITLE
[php] use http_build_query for deepObject support

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -148,22 +148,74 @@ class ObjectSerializer
     }
 
     /**
-     * Take value and turn it into a string suitable for inclusion in
-     * the query, by imploding comma-separated if it's an object.
-     * If it's a string, pass through unchanged. It will be url-encoded
-     * later.
+     * Take query parameter properties and turn it into an array suitable for
+     * native http_build_query or GuzzleHttp\Psr7\Query::build.
      *
-     * @param string[]|string|\DateTime $object an object to be serialized to a string
+     * @param mixed  $value       Parameter value
+     * @param string $paramName   Parameter name
+     * @param string $openApiType OpenAPIType eg. array or object
+     * @param string $style       Parameter serialization style
+     * @param bool   $explode     Parameter explode option
      *
-     * @return string the serialized object
+     * @return array
      */
-    public static function toQueryValue($object)
-    {
-        if (is_array($object)) {
-            return implode(',', $object);
-        } else {
-            return self::toString($object);
+    public static function toQueryValue(
+        $value,
+        string $paramName,
+        string $openApiType = 'string',
+        string $style = 'form',
+        bool $explode = true
+    ): array {
+        // return empty string
+        if (empty($value)) return ["$paramName" => ''];
+
+        $query = [];
+        $value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
+
+        if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
+            // recursive function
+            // nested arrays doesn't work, but it might help in future
+            $toDeepObject = function ($val, $styleVal, $name) use (&$toDeepObject) {
+                $result = [];
+                foreach ($val as $key => $value) {
+                    $prop = ($styleVal === 'deepObject') ? "${name}[${key}]" : $key;
+                    $result[$prop] = (is_array($value)) ? $toDeepObject($value, $styleVal, $name) : $value;
+                }
+                return $result;
+            };
+
+            return $toDeepObject($value, $style, $paramName);
         }
+
+        if ($openApiType === 'object' && is_array($value)) {
+            // need recursive function again
+            // nested array might not work however
+            $flattenArray = function ($arr) use (&$flattenArray) {
+                $result = [];
+                foreach (array_keys($arr) as $key) {
+                    $val = $arr[$key];
+                    $result[] = $key;
+                    if (is_array($val)) {
+                        $result = array_merge($result, $flattenArray($val));
+                    } else {
+                        $result[] = $val;
+                    }
+                }
+                return $result;
+            };
+
+            $value = $flattenArray($value);
+        }
+
+        if (in_array($style, ['spaceDelimited', 'pipeDelimited'], true) && $openApiType === 'array') {
+            $query[$paramName] = ($explode) ? $value : self::serializeCollection($value, $style);
+            return $query;
+        }
+
+        // consider style is form
+        $query[$paramName] = ($explode) ? $value : self::serializeCollection((array)$value, $style);
+
+        return $query;
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -167,52 +167,39 @@ class ObjectSerializer
         bool $explode = true
     ): array {
         // return empty string
-        if (empty($value)) return ["$paramName" => ''];
+        if (empty($value)) return ["{$paramName}" => ''];
 
         $query = [];
         $value = (in_array($openApiType, ['object', 'array'], true)) ? (array)$value : $value;
 
-        if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
-            // recursive function
-            // nested arrays doesn't work, but it might help in future
-            $toDeepObject = function ($val, $styleVal, $name) use (&$toDeepObject) {
-                $result = [];
-                foreach ($val as $key => $value) {
-                    $prop = ($styleVal === 'deepObject') ? "${name}[${key}]" : $key;
-                    $result[$prop] = (is_array($value)) ? $toDeepObject($value, $styleVal, $name) : $value;
-                }
-                return $result;
-            };
+        // since \GuzzleHttp\Psr7\Query::build fails with nested arrays
+        // need to flatten array first
+        $flattenArray = function ($arr, $name, &$result = []) use (&$flattenArray, $style, $explode) {
+            if (!is_array($arr)) return $arr;
 
-            return $toDeepObject($value, $style, $paramName);
-        }
+            foreach ($arr as $k => $v) {
+                $prop = ($style === 'deepObject') ? $prop = "{$name}[{$k}]" : $k;
 
-        if ($openApiType === 'object' && is_array($value)) {
-            // need recursive function again
-            // nested array might not work however
-            $flattenArray = function ($arr) use (&$flattenArray) {
-                $result = [];
-                foreach (array_keys($arr) as $key) {
-                    $val = $arr[$key];
-                    $result[] = $key;
-                    if (is_array($val)) {
-                        $result = array_merge($result, $flattenArray($val));
-                    } else {
-                        $result[] = $val;
+                if (is_array($v)) {
+                    $flattenArray($v, $prop, $result);
+                } else {
+                    if ($style !== 'deepObject' && !$explode) {
+                        // push key itself
+                        $result[] = $prop;
                     }
+                    $result[$prop] = $v;
                 }
-                return $result;
-            };
+            }
+            return $result;
+        };
 
-            $value = $flattenArray($value);
+        $value = $flattenArray($value, $paramName);
+
+        if ($openApiType === 'object' && ($style === 'deepObject' || $explode)) {
+            return $value;
         }
 
-        if (in_array($style, ['spaceDelimited', 'pipeDelimited'], true) && $openApiType === 'array') {
-            $query[$paramName] = ($explode) ? $value : self::serializeCollection($value, $style);
-            return $query;
-        }
-
-        // consider style is form
+        // handle style in serializeCollection
         $query[$paramName] = ($explode) ? $value : self::serializeCollection((array)$value, $style);
 
         return $query;

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -439,4 +439,24 @@ class ObjectSerializer
             return $instance;
         }
     }
+
+    /**
+     * Native `http_build_query` wrapper.
+     * @see https://www.php.net/manual/en/function.http-build-query
+     *
+     * @param array|object $data           May be an array or object containing properties.
+     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
+     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
+     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
+     *
+     * @return string
+     */
+    public static function buildQuery(
+        $data,
+        string $numeric_prefix = '',
+        ?string $arg_separator = null,
+        int $encoding_type = \PHP_QUERY_RFC3986
+    ): string {
+        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    }
 }

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -668,7 +668,7 @@ use {{invokerPackage}}\ObjectSerializer;
         $operationHost = $operationHosts[$this->hostIndex];
 
         {{/servers.0}}
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, "", null, PHP_QUERY_RFC3986);
         return new Request(
             '{{httpMethod}}',
             {{^servers.0}}$this->config->getHost(){{/servers.0}}{{#servers.0}}$operationHost{{/servers.0}} . $resourcePath . ($query ? "?{$query}" : ''),

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -668,7 +668,7 @@ use {{invokerPackage}}\ObjectSerializer;
         $operationHost = $operationHosts[$this->hostIndex];
 
         {{/servers.0}}
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             '{{httpMethod}}',
             {{^servers.0}}$this->config->getHost(){{/servers.0}}{{#servers.0}}$operationHost{{/servers.0}} . $resourcePath . ($query ? "?{$query}" : ''),

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -668,7 +668,7 @@ use {{invokerPackage}}\ObjectSerializer;
         $operationHost = $operationHosts[$this->hostIndex];
 
         {{/servers.0}}
-        $query = http_build_query($queryParams, "", null, PHP_QUERY_RFC3986);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             '{{httpMethod}}',
             {{^servers.0}}$this->config->getHost(){{/servers.0}}{{#servers.0}}$operationHost{{/servers.0}} . $resourcePath . ($query ? "?{$query}" : ''),

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -497,31 +497,13 @@ use {{invokerPackage}}\ObjectSerializer;
 
         {{#queryParams}}
         // query params
-        {{#isExplode}}
-        if (${{paramName}} !== null) {
-        {{#style}}
-            if('form' === '{{style}}' && is_array(${{paramName}})) {
-                foreach(${{paramName}} as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['{{baseName}}'] = ${{paramName}};
-            }
-        {{/style}}
-        {{^style}}
-            $queryParams['{{baseName}}'] = ${{paramName}};
-        {{/style}}
-        }
-        {{/isExplode}}
-        {{^isExplode}}
-        if (is_array(${{paramName}})) {
-            ${{paramName}} = ObjectSerializer::serializeCollection(${{paramName}}, '{{style}}{{^style}}{{collectionFormat}}{{/style}}', true);
-        }
-        if (${{paramName}} !== null) {
-            $queryParams['{{baseName}}'] = ${{paramName}};
-        }
-        {{/isExplode}}
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            ${{paramName}},
+            '{{baseName}}', // param base name
+            '{{#schema}}{{openApiType}}{{/schema}}', // openApiType
+            '{{style}}', // style
+            {{#isExplode}}true{{/isExplode}}{{^isExplode}}false{{/isExplode}} // explode
+        ) ?? []);
         {{/queryParams}}
 
         {{#headerParams}}

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -597,7 +597,7 @@ use {{invokerPackage}}\ObjectSerializer;
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -650,7 +650,7 @@ use {{invokerPackage}}\ObjectSerializer;
         $operationHost = $operationHosts[$this->hostIndex];
 
         {{/servers.0}}
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             '{{httpMethod}}',
             {{^servers.0}}$this->config->getHost(){{/servers.0}}{{#servers.0}}$operationHost{{/servers.0}} . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -375,7 +375,7 @@ class AnotherFakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -375,7 +375,7 @@ class AnotherFakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -359,7 +359,7 @@ class AnotherFakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -375,7 +375,7 @@ class AnotherFakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -350,7 +350,7 @@ class DefaultApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -350,7 +350,7 @@ class DefaultApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -334,7 +334,7 @@ class DefaultApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -350,7 +350,7 @@ class DefaultApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -358,7 +358,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -607,7 +607,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -862,7 +862,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1117,7 +1117,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1372,7 +1372,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1627,7 +1627,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1888,7 +1888,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2104,7 +2104,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2320,7 +2320,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2558,7 +2558,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2827,7 +2827,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3243,7 +3243,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3553,7 +3553,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3882,7 +3882,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4106,7 +4106,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4343,7 +4343,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4674,7 +4674,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -2463,6 +2463,7 @@ class FakeApi
      */
     public function testDeepObjectQueryParams($filter)
     {
+        $queryParams = [];
         // query params filter
         if ($filter !== null) {
             if('form' === 'deepObject' && is_array($filter)) {
@@ -2476,6 +2477,26 @@ class FakeApi
         }
 
         $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+
+        return $query;
+    }
+
+    public function testDeepObjectQueryParamsOldBehavior($filter)
+    {
+        $queryParams = [];
+        // query params filter
+        if ($filter !== null) {
+            if('form' === 'deepObject' && is_array($filter)) {
+                foreach($filter as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['filter'] = $filter;
+            }
+        }
+
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
 
         return $query;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -358,7 +358,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -607,7 +607,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -862,7 +862,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1117,7 +1117,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1372,7 +1372,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1627,7 +1627,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1888,7 +1888,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2104,7 +2104,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2320,7 +2320,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2459,49 +2459,6 @@ class FakeApi
     }
 
     /**
-     * @see https://github.com/OpenAPITools/openapi-generator/pull/11225
-     */
-    public function testDeepObjectQueryParams($filter)
-    {
-        $queryParams = [];
-        // query params filter
-        if ($filter !== null) {
-            if('form' === 'deepObject' && is_array($filter)) {
-                foreach($filter as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['filter'] = $filter;
-            }
-        }
-
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
-
-        return $query;
-    }
-
-    public function testDeepObjectQueryParamsOldBehavior($filter)
-    {
-        $queryParams = [];
-        // query params filter
-        if ($filter !== null) {
-            if('form' === 'deepObject' && is_array($filter)) {
-                foreach($filter as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['filter'] = $filter;
-            }
-        }
-
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
-
-        return $query;
-    }
-
-    /**
      * Create request for operation 'testBodyWithQueryParams'
      *
      * @param  string $query (required)
@@ -2601,7 +2558,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2870,7 +2827,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3286,7 +3243,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3596,7 +3553,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3925,7 +3882,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4149,7 +4106,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4386,7 +4343,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4717,7 +4674,7 @@ class FakeApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -535,16 +535,13 @@ class FakeApi
         $multipart = false;
 
         // query params
-        if ($query_1 !== null) {
-            if('form' === 'form' && is_array($query_1)) {
-                foreach($query_1 as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['query_1'] = $query_1;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $query_1,
+            'query_1', // param base name
+            'string', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
 
         // header params
         if ($header_1 !== null) {
@@ -2490,16 +2487,13 @@ class FakeApi
         $multipart = false;
 
         // query params
-        if ($query !== null) {
-            if('form' === 'form' && is_array($query)) {
-                foreach($query as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['query'] = $query;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $query,
+            'query', // param base name
+            'string', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
 
 
 
@@ -3439,49 +3433,37 @@ class FakeApi
         $multipart = false;
 
         // query params
-        if ($enum_query_string_array !== null) {
-            if('form' === 'form' && is_array($enum_query_string_array)) {
-                foreach($enum_query_string_array as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['enum_query_string_array'] = $enum_query_string_array;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_query_string_array,
+            'enum_query_string_array', // param base name
+            'array', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($enum_query_string !== null) {
-            if('form' === 'form' && is_array($enum_query_string)) {
-                foreach($enum_query_string as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['enum_query_string'] = $enum_query_string;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_query_string,
+            'enum_query_string', // param base name
+            'string', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($enum_query_integer !== null) {
-            if('form' === 'form' && is_array($enum_query_integer)) {
-                foreach($enum_query_integer as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['enum_query_integer'] = $enum_query_integer;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_query_integer,
+            'enum_query_integer', // param base name
+            'integer', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($enum_query_double !== null) {
-            if('form' === 'form' && is_array($enum_query_double)) {
-                foreach($enum_query_double as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['enum_query_double'] = $enum_query_double;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_query_double,
+            'enum_query_double', // param base name
+            'number', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
 
         // header params
         if (is_array($enum_header_string_array)) {
@@ -3775,49 +3757,37 @@ class FakeApi
         $multipart = false;
 
         // query params
-        if ($required_string_group !== null) {
-            if('form' === 'form' && is_array($required_string_group)) {
-                foreach($required_string_group as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['required_string_group'] = $required_string_group;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $required_string_group,
+            'required_string_group', // param base name
+            'integer', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($required_int64_group !== null) {
-            if('form' === 'form' && is_array($required_int64_group)) {
-                foreach($required_int64_group as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['required_int64_group'] = $required_int64_group;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $required_int64_group,
+            'required_int64_group', // param base name
+            'integer', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($string_group !== null) {
-            if('form' === 'form' && is_array($string_group)) {
-                foreach($string_group as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['string_group'] = $string_group;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $string_group,
+            'string_group', // param base name
+            'integer', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($int64_group !== null) {
-            if('form' === 'form' && is_array($int64_group)) {
-                foreach($int64_group as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['int64_group'] = $int64_group;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $int64_group,
+            'int64_group', // param base name
+            'integer', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
 
         // header params
         if ($required_boolean_group !== null) {
@@ -4562,66 +4532,61 @@ class FakeApi
         $multipart = false;
 
         // query params
-        if (is_array($pipe)) {
-            $pipe = ObjectSerializer::serializeCollection($pipe, 'pipeDelimited', true);
-        }
-        if ($pipe !== null) {
-            $queryParams['pipe'] = $pipe;
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $pipe,
+            'pipe', // param base name
+            'array', // openApiType
+            'pipeDelimited', // style
+            false // explode
+        ) ?? []);
         // query params
-        if (is_array($ioutil)) {
-            $ioutil = ObjectSerializer::serializeCollection($ioutil, 'form', true);
-        }
-        if ($ioutil !== null) {
-            $queryParams['ioutil'] = $ioutil;
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $ioutil,
+            'ioutil', // param base name
+            'array', // openApiType
+            'form', // style
+            false // explode
+        ) ?? []);
         // query params
-        if (is_array($http)) {
-            $http = ObjectSerializer::serializeCollection($http, 'spaceDelimited', true);
-        }
-        if ($http !== null) {
-            $queryParams['http'] = $http;
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $http,
+            'http', // param base name
+            'array', // openApiType
+            'spaceDelimited', // style
+            false // explode
+        ) ?? []);
         // query params
-        if (is_array($url)) {
-            $url = ObjectSerializer::serializeCollection($url, 'form', true);
-        }
-        if ($url !== null) {
-            $queryParams['url'] = $url;
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $url,
+            'url', // param base name
+            'array', // openApiType
+            'form', // style
+            false // explode
+        ) ?? []);
         // query params
-        if ($context !== null) {
-            if('form' === 'form' && is_array($context)) {
-                foreach($context as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['context'] = $context;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $context,
+            'context', // param base name
+            'array', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($language !== null) {
-            if('form' === 'form' && is_array($language)) {
-                foreach($language as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['language'] = $language;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $language,
+            'language', // param base name
+            'object', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($allow_empty !== null) {
-            if('form' === 'form' && is_array($allow_empty)) {
-                foreach($allow_empty as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['allowEmpty'] = $allow_empty;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $allow_empty,
+            'allowEmpty', // param base name
+            'string', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
 
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -2459,6 +2459,28 @@ class FakeApi
     }
 
     /**
+     * @see https://github.com/OpenAPITools/openapi-generator/pull/11225
+     */
+    public function testDeepObjectQueryParams($filter)
+    {
+        // query params filter
+        if ($filter !== null) {
+            if('form' === 'deepObject' && is_array($filter)) {
+                foreach($filter as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['filter'] = $filter;
+            }
+        }
+
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+
+        return $query;
+    }
+
+    /**
      * Create request for operation 'testBodyWithQueryParams'
      *
      * @param  string $query (required)

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -342,7 +342,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -358,7 +358,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -588,7 +588,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -604,7 +604,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -843,7 +843,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -859,7 +859,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1098,7 +1098,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1114,7 +1114,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1353,7 +1353,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1369,7 +1369,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1608,7 +1608,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1624,7 +1624,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1869,7 +1869,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1885,7 +1885,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2085,7 +2085,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -2101,7 +2101,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2301,7 +2301,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -2317,7 +2317,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2536,7 +2536,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -2552,7 +2552,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2805,7 +2805,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -2821,7 +2821,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3217,7 +3217,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -3237,7 +3237,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3519,7 +3519,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -3535,7 +3535,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -3832,7 +3832,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -3852,7 +3852,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4060,7 +4060,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -4076,7 +4076,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4297,7 +4297,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -4313,7 +4313,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -4623,7 +4623,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -4639,7 +4639,7 @@ class FakeApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -380,7 +380,7 @@ class FakeClassnameTags123Api
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -380,7 +380,7 @@ class FakeClassnameTags123Api
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -359,7 +359,7 @@ class FakeClassnameTags123Api
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -380,7 +380,7 @@ class FakeClassnameTags123Api
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PATCH',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -360,7 +360,7 @@ class PetApi
         }
         $operationHost = $operationHosts[$this->hostIndex];
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
@@ -599,7 +599,7 @@ class PetApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -873,7 +873,7 @@ class PetApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1153,7 +1153,7 @@ class PetApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1429,7 +1429,7 @@ class PetApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1683,7 +1683,7 @@ class PetApi
         }
         $operationHost = $operationHosts[$this->hostIndex];
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PUT',
             $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1931,7 +1931,7 @@ class PetApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2232,7 +2232,7 @@ class PetApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2539,7 +2539,7 @@ class PetApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -811,12 +811,13 @@ class PetApi
         $multipart = false;
 
         // query params
-        if (is_array($status)) {
-            $status = ObjectSerializer::serializeCollection($status, 'form', true);
-        }
-        if ($status !== null) {
-            $queryParams['status'] = $status;
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $status,
+            'status', // param base name
+            'array', // openApiType
+            'form', // style
+            false // explode
+        ) ?? []);
 
 
 
@@ -1091,12 +1092,13 @@ class PetApi
         $multipart = false;
 
         // query params
-        if (is_array($tags)) {
-            $tags = ObjectSerializer::serializeCollection($tags, 'form', true);
-        }
-        if ($tags !== null) {
-            $queryParams['tags'] = $tags;
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $tags,
+            'tags', // param base name
+            'array', // openApiType
+            'form', // style
+            false // explode
+        ) ?? []);
 
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -360,7 +360,7 @@ class PetApi
         }
         $operationHost = $operationHosts[$this->hostIndex];
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
@@ -599,7 +599,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -873,7 +873,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1153,7 +1153,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1429,7 +1429,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1683,7 +1683,7 @@ class PetApi
         }
         $operationHost = $operationHosts[$this->hostIndex];
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PUT',
             $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1931,7 +1931,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2232,7 +2232,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2539,7 +2539,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -334,7 +334,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -360,7 +360,7 @@ class PetApi
         }
         $operationHost = $operationHosts[$this->hostIndex];
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
@@ -579,7 +579,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -599,7 +599,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -854,7 +854,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -874,7 +874,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1135,7 +1135,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1155,7 +1155,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1410,7 +1410,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1431,7 +1431,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1659,7 +1659,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1685,7 +1685,7 @@ class PetApi
         }
         $operationHost = $operationHosts[$this->hostIndex];
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PUT',
             $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1913,7 +1913,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1933,7 +1933,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2214,7 +2214,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -2234,7 +2234,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2521,7 +2521,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -2541,7 +2541,7 @@ class PetApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -332,7 +332,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -589,7 +589,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -867,7 +867,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1136,7 +1136,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -332,7 +332,7 @@ class StoreApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -589,7 +589,7 @@ class StoreApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -867,7 +867,7 @@ class StoreApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1136,7 +1136,7 @@ class StoreApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -316,7 +316,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -332,7 +332,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -568,7 +568,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -589,7 +589,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -851,7 +851,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -867,7 +867,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1120,7 +1120,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1136,7 +1136,7 @@ class StoreApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -1498,27 +1498,21 @@ class UserApi
         $multipart = false;
 
         // query params
-        if ($username !== null) {
-            if('form' === 'form' && is_array($username)) {
-                foreach($username as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['username'] = $username;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $username,
+            'username', // param base name
+            'string', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
         // query params
-        if ($password !== null) {
-            if('form' === 'form' && is_array($password)) {
-                foreach($password as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            }
-            else {
-                $queryParams['password'] = $password;
-            }
-        }
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $password,
+            'password', // param base name
+            'string', // openApiType
+            'form', // style
+            true // explode
+        ) ?? []);
 
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -330,7 +330,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -554,7 +554,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -778,7 +778,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1004,7 +1004,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1275,7 +1275,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1571,7 +1571,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1778,7 +1778,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2021,7 +2021,7 @@ class UserApi
             $headers
         );
 
-        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -330,7 +330,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -554,7 +554,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -778,7 +778,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1004,7 +1004,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1275,7 +1275,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1571,7 +1571,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1778,7 +1778,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -2021,7 +2021,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -314,7 +314,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -330,7 +330,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -538,7 +538,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -554,7 +554,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -762,7 +762,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -778,7 +778,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'POST',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -988,7 +988,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1004,7 +1004,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'DELETE',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1259,7 +1259,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1275,7 +1275,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1549,7 +1549,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1565,7 +1565,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1756,7 +1756,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -1772,7 +1772,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1999,7 +1999,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($queryParams);
             }
         }
 
@@ -2015,7 +2015,7 @@ class UserApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = ObjectSerializer::buildQuery($queryParams);
         return new Request(
             'PUT',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenAPI\Client;
 
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
@@ -123,6 +124,187 @@ class ObjectSerializerTest extends TestCase
             'With numeric short timezone' => [
                 '2021-10-06T20:17:16.076372256+03',
                 '2021-10-06T20:17:16.076372+03',
+            ],
+        ];
+    }
+
+    /**
+     * @covers ObjectSerializer::toQueryValue
+     * @dataProvider provideQueryParams
+     */
+    public function testToQueryValue(
+        $data,
+        string $paramName,
+        string $openApiType,
+        string $style,
+        bool $explode,
+        $expected
+    ): void {
+        $value = ObjectSerializer::toQueryValue($data, $paramName, $openApiType, $style, $explode);
+        $query = Query::build($value);
+        $this->assertEquals($expected, $query);
+    }
+
+    public function provideQueryParams(): array
+    {
+        $array = ['blue', 'black', 'brown'];
+        $object = ['R' => 100, 'G' => 200, 'B' => 150];
+
+        return [
+            // style form
+            // color=
+            'form empty, explode on' => [
+                '', 'color', 'string', 'form', true, 'color=',
+            ],
+            // color=
+            'form empty, explode off' => [
+                '', 'color', 'string', 'form', false, 'color=',
+            ],
+            // color=blue
+            'form string, explode on' => [
+                'blue', 'color', 'string', 'form', true, 'color=blue',
+            ],
+            // color=blue
+            'form string, explode off' => [
+                'blue', 'color', 'string', 'form', false, 'color=blue',
+            ],
+            // color=blue&color=black&color=brown
+            'form array, explode on' => [
+                $array, 'color', 'array', 'form', true, 'color=blue&color=black&color=brown',
+            ],
+            // color=blue,black,brown
+            'form array, explode off' => [
+                $array, 'color', 'array', 'form', false, 'color=blue%2Cblack%2Cbrown',
+            ],
+            // R=100&G=200&B=150
+            'form object, explode on' => [
+                $object, 'color', 'object', 'form', true, 'R=100&G=200&B=150',
+            ],
+            // color=R,100,G,200,B,150
+            'form object, explode off' => [
+                $object, 'color', 'object', 'form', false, 'color=R%2C100%2CG%2C200%2CB%2C150',
+            ],
+
+            // SPACE DELIMITED
+            // color=blue
+            'spaceDelimited primitive, explode off' => [
+                'blue', 'color', 'string', 'spaceDelimited', false, 'color=blue',
+            ],
+            // color=blue
+            'spaceDelimited primitive, explode on' => [
+                'blue', 'color', 'string', 'spaceDelimited', true, 'color=blue',
+            ],
+            // color=blue%20black%20brown
+            'spaceDelimited array, explode off' => [
+                $array, 'color', 'array', 'spaceDelimited', false, 'color=blue%20black%20brown',
+            ],
+            // color=blue&color=black&color=brown
+            'spaceDelimited array, explode on' => [
+                $array, 'color', 'array', 'spaceDelimited', true, 'color=blue&color=black&color=brown',
+            ],
+            // color=R%20100%20G%20200%20B%20150
+            // swagger editor gives color=R,100,G,200,B,150
+            'spaceDelimited object, explode off' => [
+                $object, 'color', 'object', 'spaceDelimited', false, 'color=R%20100%20G%20200%20B%20150',
+            ],
+            // R=100&G=200&B=150
+            'spaceDelimited object, explode on' => [
+                $object, 'color', 'object', 'spaceDelimited', true, 'R=100&G=200&B=150',
+            ],
+
+            // PIPE DELIMITED
+            // color=blue
+            'pipeDelimited primitive, explode off' => [
+                'blue', 'color', 'string', 'pipeDelimited', false, 'color=blue',
+            ],
+            // color=blue
+            'pipeDelimited primitive, explode on' => [
+                'blue', 'color', 'string', 'pipeDelimited', true, 'color=blue',
+            ],
+            // color=blue|black|brown
+            'pipeDelimited array, explode off' => [
+                $array, 'color', 'array', 'pipeDelimited', false, 'color=blue%7Cblack%7Cbrown',
+            ],
+            // color=blue&color=black&color=brown
+            'pipeDelimited array, explode on' => [
+                $array, 'color', 'array', 'pipeDelimited', true, 'color=blue&color=black&color=brown',
+            ],
+            // color=R|100|G|200|B|150
+            // swagger editor gives color=R,100,G,200,B,150
+            'pipeDelimited object, explode off' => [
+                $object, 'color', 'object', 'pipeDelimited', false, 'color=R%7C100%7CG%7C200%7CB%7C150',
+            ],
+            // R=100&G=200&B=150
+            'pipeDelimited object, explode on' => [
+                $object, 'color', 'object', 'pipeDelimited', true, 'R=100&G=200&B=150',
+            ],
+
+            // DEEP OBJECT
+            // color=blue
+            'deepObject primitive, explode off' => [
+                'blue', 'color', 'string', 'deepObject', false, 'color=blue',
+            ],
+            'deepObject primitive, explode on' => [
+                'blue', 'color', 'string', 'deepObject', true, 'color=blue',
+            ],
+            // color=blue,black,brown
+            'deepObject array, explode off' => [
+                $array, 'color', 'array', 'deepObject', false, 'color=blue%2Cblack%2Cbrown',
+            ],
+            // color=blue&color=black&color=brown
+            'deepObject array, explode on' => [
+                $array, 'color', 'array', 'deepObject', true, 'color=blue&color=black&color=brown',
+            ],
+            // color[R]=100&color[G]=200&color[B]=150
+            'deepObject object, explode off' => [
+                $object, 'color', 'object', 'deepObject', false, 'color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150',
+            ],
+            // color[R]=100&color[G]=200&color[B]=150
+            'deepObject object, explode on' => [
+                $object, 'color', 'object', 'deepObject', true, 'color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150',
+            ],
+        ];
+    }
+
+    /**
+     * @covers ObjectSerializer::toQueryValue
+     * @dataProvider provideDeepObjects
+     */
+    public function testDeepObjectStyleQueryParam(
+        $data,
+        $paramName,
+        $expected
+    ): void {
+        $value = Query::build(ObjectSerializer::toQueryValue($data, $paramName, 'object', 'deepObject', true));
+        parse_str($value, $result);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function provideDeepObjects(): array
+    {
+        return [
+            /** example @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-examples */
+            'example OpenAPISpec doc' => [
+                ['R' => 100, 'G' => 200, 'B' => 150],
+                'color',
+                [
+                    'color' => [
+                        'R' => 100,
+                        'G' => 200,
+                        'B' => 150,
+                    ],
+                ],
+            ],
+            /** example @see https://swagger.io/docs/specification/serialization/ */
+            'example Swagger doc' => [
+                ['role' => 'admin', 'firstName' => 'Alex'],
+                'id',
+                [
+                    'id' => [
+                        'role' => 'admin',
+                        'firstName' => 'Alex',
+                    ],
+                ],
             ],
         ];
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -263,6 +263,21 @@ class ObjectSerializerTest extends TestCase
             'deepObject object, explode on' => [
                 $object, 'color', 'object', 'deepObject', true, 'color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150',
             ],
+            // filter[or][0][name]=John&filter[or][1][email]=john@doe.com
+            'example from @nadar' => [
+                [
+                    'or' =>
+                    [
+                        ['name' => 'John'],
+                        ['email' => 'john@doe.com'],
+                    ],
+                ],
+                'filter',
+                'object',
+                'deepObject',
+                true,
+                'filter%5Bor%5D%5B0%5D%5Bname%5D=John&filter%5Bor%5D%5B1%5D%5Bemail%5D=john%40doe.com'
+            ],
         ];
     }
 

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -172,9 +172,17 @@ class ObjectSerializerTest extends TestCase
             'form array, explode on' => [
                 $array, 'color', 'array', 'form', true, 'color=blue&color=black&color=brown',
             ],
+            // color=blue&color=black&color=brown
+            'form nested array, explode on' => [
+                ['foobar' => $array], 'color', 'array', 'form', true, 'color=blue&color=black&color=brown',
+            ],
             // color=blue,black,brown
             'form array, explode off' => [
                 $array, 'color', 'array', 'form', false, 'color=blue%2Cblack%2Cbrown',
+            ],
+            // color=blue,black,brown
+            'form nested array, explode off' => [
+                ['foobar' => $array], 'color', 'array', 'form', false, 'color=blue%2Cblack%2Cbrown',
             ],
             // R=100&G=200&B=150
             'form object, explode on' => [

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenAPI\Client;
 
-use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
@@ -141,7 +140,7 @@ class ObjectSerializerTest extends TestCase
         $expected
     ): void {
         $value = ObjectSerializer::toQueryValue($data, $paramName, $openApiType, $style, $explode);
-        $query = Query::build($value);
+        $query = ObjectSerializer::buildQuery($value);
         $this->assertEquals($expected, $query);
     }
 
@@ -298,7 +297,7 @@ class ObjectSerializerTest extends TestCase
         $paramName,
         $expected
     ): void {
-        $value = Query::build(ObjectSerializer::toQueryValue($data, $paramName, 'object', 'deepObject', true));
+        $value = ObjectSerializer::buildQuery(ObjectSerializer::toQueryValue($data, $paramName, 'object', 'deepObject', true));
         parse_str($value, $result);
         $this->assertEquals($expected, $result);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ParametersTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ParametersTest.php
@@ -56,6 +56,27 @@ class ParametersTest extends TestCase
         $this->assertSame('{"foo":"bar"}', $request->getBody()->getContents());
     }
 
+    /**
+     * @see https://github.com/OpenAPITools/openapi-generator/pull/11225
+     * @dataProvider provideQueryParameters
+     */
+    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $expected)
+    {
+        $request = $this->fakeApi->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
+        $this->assertEquals($expected, urldecode($request->getUri()->getQuery()));
+    }
+
+    public function provideQueryParameters()
+    {
+        $array = ['blue', 'black', 'brown'];
+        $object = ['R' => 100, 'G' => 200, 'B' => 150];
+        return [
+            [
+                $array, $array, $array, $array, $array, 'blue', $object, 'pipe=blue|black|brown&ioutil=blue,black,brown&http=blue black brown&url=blue,black,brown&context=blue&context=black&context=brown&R=100&G=200&B=150&allowEmpty=blue',
+            ],
+        ];
+    }
+
 //    missing example for collection path param in config
 //    public function testPathParamCollection()
 //    {

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/RequestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/RequestTest.php
@@ -37,11 +37,25 @@ class RequestTest extends TestCase
 
     public function testDeepObjectParametersInQueryString()
     {
-        $user = new User([]);
-        $queryparam = $this->api->testDeepObjectQueryParams(['search' => ['like' => 'test']], $user);
-
+        $queryparam = $this->api->testDeepObjectQueryParams(['search' => ['like' => 'test']]);
         $this->assertSame('filter%5Bsearch%5D%5Blike%5D=test', $queryparam);
         // for better readability
         $this->assertSame('filter[search][like]=test', urldecode($queryparam));
+
+        // if nothing is provided
+        $this->assertSame('', $this->api->testDeepObjectQueryParams(null));
+
+        // if nothing is provided
+        $this->assertSame('filter=bar', $this->api->testDeepObjectQueryParams('bar'));
+        $this->assertSame('filter=bar', urldecode($this->api->testDeepObjectQueryParams('bar')));
+
+        // do the same tests with the old behavior: testDeepObjectQueryParamsOldBehavior
+
+        // if nothing is provided
+        $this->assertSame('', $this->api->testDeepObjectQueryParamsOldBehavior(null));
+
+        // if nothing is provided
+        $this->assertSame('filter=bar', $this->api->testDeepObjectQueryParamsOldBehavior('bar'));
+        $this->assertSame('filter=bar', urldecode($this->api->testDeepObjectQueryParamsOldBehavior('bar')));
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/RequestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/RequestTest.php
@@ -3,7 +3,6 @@
 namespace OpenAPI\Client;
 
 use OpenAPI\Client\Api\FakeApi;
-use OpenAPI\Client\Model\User;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/FakeHttpClient.php';
@@ -33,29 +32,5 @@ class RequestTest extends TestCase
 
         // JSON serialization of form data is not supported
         $this->assertEquals('param=value&param2=value2', $requestContent);
-    }
-
-    public function testDeepObjectParametersInQueryString()
-    {
-        $queryparam = $this->api->testDeepObjectQueryParams(['search' => ['like' => 'test']]);
-        $this->assertSame('filter%5Bsearch%5D%5Blike%5D=test', $queryparam);
-        // for better readability
-        $this->assertSame('filter[search][like]=test', urldecode($queryparam));
-
-        // if nothing is provided
-        $this->assertSame('', $this->api->testDeepObjectQueryParams(null));
-
-        // if nothing is provided
-        $this->assertSame('filter=bar', $this->api->testDeepObjectQueryParams('bar'));
-        $this->assertSame('filter=bar', urldecode($this->api->testDeepObjectQueryParams('bar')));
-
-        // do the same tests with the old behavior: testDeepObjectQueryParamsOldBehavior
-
-        // if nothing is provided
-        $this->assertSame('', $this->api->testDeepObjectQueryParamsOldBehavior(null));
-
-        // if nothing is provided
-        $this->assertSame('filter=bar', $this->api->testDeepObjectQueryParamsOldBehavior('bar'));
-        $this->assertSame('filter=bar', urldecode($this->api->testDeepObjectQueryParamsOldBehavior('bar')));
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/RequestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/RequestTest.php
@@ -3,6 +3,7 @@
 namespace OpenAPI\Client;
 
 use OpenAPI\Client\Api\FakeApi;
+use OpenAPI\Client\Model\User;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/FakeHttpClient.php';
@@ -32,5 +33,15 @@ class RequestTest extends TestCase
 
         // JSON serialization of form data is not supported
         $this->assertEquals('param=value&param2=value2', $requestContent);
+    }
+
+    public function testDeepObjectParametersInQueryString()
+    {
+        $user = new User([]);
+        $queryparam = $this->api->testDeepObjectQueryParams(['search' => ['like' => 'test']], $user);
+
+        $this->assertSame('filter%5Bsearch%5D%5Blike%5D=test', $queryparam);
+        // for better readability
+        $this->assertSame('filter[search][like]=test', urldecode($queryparam));
     }
 }


### PR DESCRIPTION
This fixes #11222 

The [Query::build()](https://github.com/guzzle/psr7/blob/master/src/Query.php#L71) function does not support deepObjects in query params, but the [OpenAPI defintion](https://swagger.io/docs/specification/serialization/) does. 

> `/users?id[role]=admin&id[firstName]=Alex` an example from the docs.

I have replaced the `Query::build()` function with PHP's internal [http_build_query](https://www.php.net/http_build_query) function. I have adjust PHP default encoding to match the default encoding from `Query::build()` which is `PHP_QUERY_RFC3986`.

This change will only have an effect for the query string of the URL, encoding POST bodys is still done by `Query::build()`.