### PR TITLE
[BUG][kotlin] Make Kotlin client generate comma separated list for array path params

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -217,7 +217,7 @@ import {{packageName}}.infrastructure.toMultiValue
 
         return RequestConfig(
             method = RequestMethod.{{httpMethod}},
-            path = "{{path}}"{{#pathParams}}.replace("{"+"{{baseName}}"+"}", "${{{paramName}}}"){{/pathParams}},
+            path = "{{path}}"{{#pathParams}}.replace("{"+"{{baseName}}"+"}", {{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}"${{{paramName}}}"{{/isContainer}}){{/pathParams}},
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
resolve #7199

The Kotlin client codegen currently cannot handle path params of type array. The code being generated for the path is currently this: `path = "/stuff/{ids}".replace("{"+"ids"+"}", "$ids")`. This works fine, but not if `ids` is a list or an array, since the `toString()` method is used to create the string.

With the current code, if `ids` contains 123 and 456, then `path` would be set to:
* `/stuff/[123,456]` if `collectionType` is list.
* `/stuff/[Ljava.lang.String;@6a98f353` if `collectionType` is array.

In both cases, `/stuff/123,456` is the expected result.

If we change the code from
`path = "/stuff/{ids}".replace("{"+"ids"+"}", "$ids")`
to 
`path = "/stuff/{ids}".replace("{"+"ids"+"}", ids.joinToString(","))`,
we get the expected result.

OpenAPI Spec demonstrating this:
```
openapi: 3.0.0
info:
  version: 1.0.0
  title: Demo
paths:
  '/{ids}':
    get:
      parameters:
        - name: ids
          in: path
          required: true
          schema:
            type: array
            items:
              type: string
          style: simple
      responses:
        200:
          description: Successful operation
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m