### PR TITLE
Turns on python-experimental CI tests, original

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,8 +113,8 @@ commands: # a reusable command with parameters
       # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       # This is based on your 1.0 configuration file or project settings
-      - run:
-          command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
+#      - run:
+#          command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
 #      - run:
 #          command: 'docker info >/dev/null 2>&1 || service docker start; '
 #      - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ jobs:
       DOCKER_GENERATOR_IMAGE_NAME: openapitools/openapi-generator
       DOCKER_CODEGEN_CLI_IMAGE_NAME: openapitools/openapi-generator-cli
     steps:
+      - checkout
       - command_build_and_test:
           nodeNo: "3"
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
     steps:
       - command_build_and_test:
           nodeNo: "1"
-jobs:
+workflows:
   version: 2
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,13 +168,6 @@ jobs:
   node3:
     docker:
       - image: fkrull/multi-python
-      - image: swaggerapi/petstore
-        # runs and exposes the swagger server
-        # - run: docker pull swaggerapi/petstore
-        # - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
-        environment:
-          SWAGGER_HOST: http://petstore.swagger.io
-          SWAGGER_BASE_PATH: /v2
     working_directory: ~/OpenAPITools/openapi-generator
     shell: /bin/bash --login
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,13 @@ jobs:
   node3:
     docker:
       - image: fkrull/multi-python
+      - image: swaggerapi/petstore
+        # runs and exposes the swagger server
+        # - run: docker pull swaggerapi/petstore
+        # - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+        environment:
+          SWAGGER_HOST: http://petstore.swagger.io
+          SWAGGER_BASE_PATH: /v2
     working_directory: ~/OpenAPITools/openapi-generator
     shell: /bin/bash --login
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,6 @@ commands: # a reusable command with parameters
       - run: cat /etc/hosts
       # Test
 #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-      - run: sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
       - run: ./CI/circle_parallel.sh
       # Teardown
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,4 +118,9 @@ jobs:
     steps:
       - command_build_and_test:
           nodeNo: "1"
-
+jobs:
+  version: 2
+  build:
+    jobs:
+      - node0
+      - node1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ commands: # a reusable command with parameters
       - run:
           name: "Setup custom environment variables"
           command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV
+      - run: iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
       - run: ./CI/circle_parallel.sh
       # Save dependency cache
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,18 +109,6 @@ commands: # a reusable command with parameters
 #      - run:
 #          command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
 #      - run:
-#          command: 'docker info >/dev/null 2>&1 || service docker start; '
-#      - run:
-#          command: |-
-#            printf '127.0.0.1       petstore.swagger.io
-#            ' | tee -a /etc/hosts
-#      #    - run: docker pull openapitools/openapi-petstore
-#      #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
-#      - run: docker pull swaggerapi/petstore
-#      - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
-#      - run: docker ps -a
-#      - run: sleep 30
-      - run: cat /etc/hosts
       # Test
 #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 commands: # a reusable command with parameters
   command_build_and_test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,97 @@ commands: # a reusable command with parameters
           path: /tmp/circleci-artifacts
       - store_artifacts:
           path: /tmp/circleci-test-results
+  command_docker_build_and_test:
+    parameters:
+      nodeNo:
+        default: "0"
+        type: string
+    steps:
+      # Restore the dependency cache
+      - restore_cache:
+          keys:
+            # Default branch if not
+            - source-v2-{{ .Branch }}-{{ .Revision }}
+            - source-v2-{{ .Branch }}-
+            - source-v2-
+      # Machine Setup
+      #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+      # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+      - checkout
+      # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+      # In many cases you can simplify this from what is generated here.
+      # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      # This is based on your 1.0 configuration file or project settings
+      - run:
+          command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
+      - run:
+          command: 'docker info >/dev/null 2>&1 || service docker start; '
+      - run:
+          command: |-
+            printf '127.0.0.1       petstore.swagger.io
+            ' | tee -a /etc/hosts
+      #    - run: docker pull openapitools/openapi-petstore
+      #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
+      - run: docker pull swaggerapi/petstore
+      - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+      - run: docker ps -a
+      - run: sleep 30
+      - run: cat /etc/hosts
+      # Test
+      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+      - run:
+          name: "Setup custom environment variables"
+          command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV
+      - run: ./CI/circle_parallel.sh
+      # Save dependency cache
+      - save_cache:
+          key: source-v2-{{ .Branch }}-{{ .Revision }}
+          paths:
+            # This is a broad list of cache paths to include many possible development environments
+            # You can probably delete some of these entries
+            - vendor/bundle
+            - ~/virtualenvs
+            - ~/.m2
+            - ~/.ivy2
+            - ~/.sbt
+            - ~/.bundle
+            - ~/.go_workspace
+            - ~/.gradle
+            - ~/.cache/bower
+            - ".git"
+            - ~/.stack
+            - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
+            - ~/R
+      # save "default" cache using the key "source-v2-"
+      - save_cache:
+          key: source-v2-
+          paths:
+            # This is a broad list of cache paths to include many possible development environments
+            # You can probably delete some of these entries
+            - vendor/bundle
+            - ~/virtualenvs
+            - ~/.m2
+            - ~/.ivy2
+            - ~/.sbt
+            - ~/.bundle
+            - ~/.go_workspace
+            - ~/.gradle
+            - ~/.cache/bower
+            - ".git"
+            - ~/.stack
+            - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
+            - ~/R
+      # Teardown
+      #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+      # Save test results
+      - store_test_results:
+          path: /tmp/circleci-test-results
+      # Save artifacts
+      - store_artifacts:
+          path: /tmp/circleci-artifacts
+      - store_artifacts:
+          path: /tmp/circleci-test-results
 jobs:
   node0:
     machine:
@@ -143,7 +234,7 @@ jobs:
       DOCKER_CODEGEN_CLI_IMAGE_NAME: openapitools/openapi-generator-cli
     steps:
       - checkout
-      - command_build_and_test:
+      - command_docker_build_and_test:
           nodeNo: "3"
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,13 +97,6 @@ commands: # a reusable command with parameters
         default: "0"
         type: string
     steps:
-      # Restore the dependency cache
-      - restore_cache:
-          keys:
-            # Default branch if not
-            - source-v2-{{ .Branch }}-{{ .Revision }}
-            - source-v2-{{ .Branch }}-
-            - source-v2-
       # Machine Setup
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
       # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
@@ -132,44 +125,6 @@ commands: # a reusable command with parameters
 #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run: sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
       - run: ./CI/circle_parallel.sh
-      # Save dependency cache
-      - save_cache:
-          key: source-v2-{{ .Branch }}-{{ .Revision }}
-          paths:
-            # This is a broad list of cache paths to include many possible development environments
-            # You can probably delete some of these entries
-            - vendor/bundle
-            - ~/virtualenvs
-            - ~/.m2
-            - ~/.ivy2
-            - ~/.sbt
-            - ~/.bundle
-            - ~/.go_workspace
-            - ~/.gradle
-            - ~/.cache/bower
-            - ".git"
-            - ~/.stack
-            - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
-            - ~/R
-      # save "default" cache using the key "source-v2-"
-      - save_cache:
-          key: source-v2-
-          paths:
-            # This is a broad list of cache paths to include many possible development environments
-            # You can probably delete some of these entries
-            - vendor/bundle
-            - ~/virtualenvs
-            - ~/.m2
-            - ~/.ivy2
-            - ~/.sbt
-            - ~/.bundle
-            - ~/.go_workspace
-            - ~/.gradle
-            - ~/.cache/bower
-            - ".git"
-            - ~/.stack
-            - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
-            - ~/R
       # Teardown
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
       # Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,18 +115,18 @@ commands: # a reusable command with parameters
       # This is based on your 1.0 configuration file or project settings
       - run:
           command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
-      - run:
-          command: 'docker info >/dev/null 2>&1 || service docker start; '
-      - run:
-          command: |-
-            printf '127.0.0.1       petstore.swagger.io
-            ' | tee -a /etc/hosts
-      #    - run: docker pull openapitools/openapi-petstore
-      #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
-      - run: docker pull swaggerapi/petstore
-      - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
-      - run: docker ps -a
-      - run: sleep 30
+#      - run:
+#          command: 'docker info >/dev/null 2>&1 || service docker start; '
+#      - run:
+#          command: |-
+#            printf '127.0.0.1       petstore.swagger.io
+#            ' | tee -a /etc/hosts
+#      #    - run: docker pull openapitools/openapi-petstore
+#      #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
+#      - run: docker pull swaggerapi/petstore
+#      - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+#      - run: docker ps -a
+#      - run: sleep 30
       - run: cat /etc/hosts
       # Test
       - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ commands: # a reusable command with parameters
       - run: cat /etc/hosts
       # Test
       - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+      - run:
+          name: "Setup custom environment variables"
+          command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV
       - run: ./CI/circle_parallel.sh
       # Save dependency cache
       - save_cache:
@@ -89,17 +92,10 @@ commands: # a reusable command with parameters
       - store_artifacts:
           path: /tmp/circleci-test-results
 jobs:
-  build:
-    #    docker:
-    #      #- image: openapitools/openapi-generator
-    #      - image: swaggerapi/petstore
-    #        environment:
-    #          SWAGGER_HOST=http://petstore.swagger.io
-    #          SWAGGER_BASE_PATH=/v2
+  node0:
     machine:
       image: circleci/classic:latest
     working_directory: ~/OpenAPITools/openapi-generator
-    parallelism: 4
     shell: /bin/bash --login
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
@@ -109,3 +105,17 @@ jobs:
     steps:
       - command_build_and_test:
           nodeNo: "0"
+  node1:
+    machine:
+      image: circleci/classic:latest
+    working_directory: ~/OpenAPITools/openapi-generator
+    shell: /bin/bash --login
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      DOCKER_GENERATOR_IMAGE_NAME: openapitools/openapi-generator
+      DOCKER_CODEGEN_CLI_IMAGE_NAME: openapitools/openapi-generator-cli
+    steps:
+      - command_build_and_test:
+          nodeNo: "1"
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,10 +130,7 @@ commands: # a reusable command with parameters
       - run: cat /etc/hosts
       # Test
 #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-      - run:
-          name: "Setup custom environment variables"
-          command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV
-      - run: iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
+      - run: sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
       - run: ./CI/circle_parallel.sh
       # Save dependency cache
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,93 @@
 version: 2
+commands: # a reusable command with parameters
+  command-build-and-test:
+    parameters:
+      nodeNo:
+        default: "0"
+        type: string
+    steps:
+      # Restore the dependency cache
+      - restore_cache:
+          keys:
+            # Default branch if not
+            - source-v2-{{ .Branch }}-{{ .Revision }}
+            - source-v2-{{ .Branch }}-
+            - source-v2-
+      # Machine Setup
+      #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+      # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+      - checkout
+      # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+      # In many cases you can simplify this from what is generated here.
+      # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      # This is based on your 1.0 configuration file or project settings
+      - run:
+          command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
+      - run:
+          command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
+      - run:
+          command: |-
+            printf '127.0.0.1       petstore.swagger.io
+            ' | sudo tee -a /etc/hosts
+      #    - run: docker pull openapitools/openapi-petstore
+      #    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
+      - run: docker pull swaggerapi/petstore
+      - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+      - run: docker ps -a
+      - run: sleep 30
+      - run: cat /etc/hosts
+      # Test
+      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+      - run: ./CI/circle_parallel.sh
+      # Save dependency cache
+      - save_cache:
+          key: source-v2-{{ .Branch }}-{{ .Revision }}
+          paths:
+            # This is a broad list of cache paths to include many possible development environments
+            # You can probably delete some of these entries
+            - vendor/bundle
+            - ~/virtualenvs
+            - ~/.m2
+            - ~/.ivy2
+            - ~/.sbt
+            - ~/.bundle
+            - ~/.go_workspace
+            - ~/.gradle
+            - ~/.cache/bower
+            - ".git"
+            - ~/.stack
+            - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
+            - ~/R
+      # save "default" cache using the key "source-v2-"
+      - save_cache:
+          key: source-v2-
+          paths:
+            # This is a broad list of cache paths to include many possible development environments
+            # You can probably delete some of these entries
+            - vendor/bundle
+            - ~/virtualenvs
+            - ~/.m2
+            - ~/.ivy2
+            - ~/.sbt
+            - ~/.bundle
+            - ~/.go_workspace
+            - ~/.gradle
+            - ~/.cache/bower
+            - ".git"
+            - ~/.stack
+            - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
+            - ~/R
+      # Teardown
+      #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+      # Save test results
+      - store_test_results:
+          path: /tmp/circleci-test-results
+      # Save artifacts
+      - store_artifacts:
+          path: /tmp/circleci-artifacts
+      - store_artifacts:
+          path: /tmp/circleci-test-results
 jobs:
   build:
     #    docker:
@@ -18,85 +107,5 @@ jobs:
       DOCKER_GENERATOR_IMAGE_NAME: openapitools/openapi-generator
       DOCKER_CODEGEN_CLI_IMAGE_NAME: openapitools/openapi-generator-cli
     steps:
-    # Restore the dependency cache
-    - restore_cache:
-        keys:
-        # Default branch if not
-        - source-v2-{{ .Branch }}-{{ .Revision }}
-        - source-v2-{{ .Branch }}-
-        - source-v2-
-    # Machine Setup
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
-    - checkout
-    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
-    # In many cases you can simplify this from what is generated here.
-    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    # This is based on your 1.0 configuration file or project settings
-    - run:
-        command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $BASH_ENV
-    - run:
-        command: 'sudo docker info >/dev/null 2>&1 || sudo service docker start; '
-    - run:
-       command: |-
-         printf '127.0.0.1       petstore.swagger.io
-         ' | sudo tee -a /etc/hosts
-#    - run: docker pull openapitools/openapi-petstore
-#    - run: docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
-    - run: docker pull swaggerapi/petstore
-    - run: docker run --name petstore.swagger -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
-    - run: docker ps -a
-    - run: sleep 30
-    - run: cat /etc/hosts
-    # Test
-    - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-    - run: ./CI/circle_parallel.sh 
-    # Save dependency cache
-    - save_cache:
-        key: source-v2-{{ .Branch }}-{{ .Revision }}
-        paths:
-        # This is a broad list of cache paths to include many possible development environments
-        # You can probably delete some of these entries
-        - vendor/bundle
-        - ~/virtualenvs
-        - ~/.m2
-        - ~/.ivy2
-        - ~/.sbt
-        - ~/.bundle
-        - ~/.go_workspace
-        - ~/.gradle
-        - ~/.cache/bower
-        - ".git"
-        - ~/.stack
-        - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
-        - ~/R
-    # save "default" cache using the key "source-v2-"
-    - save_cache:
-        key: source-v2-
-        paths:
-        # This is a broad list of cache paths to include many possible development environments
-        # You can probably delete some of these entries
-        - vendor/bundle
-        - ~/virtualenvs
-        - ~/.m2
-        - ~/.ivy2
-        - ~/.sbt
-        - ~/.bundle
-        - ~/.go_workspace
-        - ~/.gradle
-        - ~/.cache/bower
-        - ".git"
-        - ~/.stack
-        - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
-        - ~/R
-    # Teardown
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # Save test results
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    # Save artifacts
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+      - command-build-and-test:
+          nodeNo: "0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ commands: # a reusable command with parameters
 #      - run: sleep 30
       - run: cat /etc/hosts
       # Test
-      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+#      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
       - run:
           name: "Setup custom environment variables"
           command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,9 +118,37 @@ jobs:
     steps:
       - command_build_and_test:
           nodeNo: "1"
+  node2:
+    machine:
+      image: circleci/classic:latest
+    working_directory: ~/OpenAPITools/openapi-generator
+    shell: /bin/bash --login
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      DOCKER_GENERATOR_IMAGE_NAME: openapitools/openapi-generator
+      DOCKER_CODEGEN_CLI_IMAGE_NAME: openapitools/openapi-generator-cli
+    steps:
+      - command_build_and_test:
+          nodeNo: "2"
+  node3:
+    docker:
+      - image: fkrull/multi-python
+    working_directory: ~/OpenAPITools/openapi-generator
+    shell: /bin/bash --login
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      DOCKER_GENERATOR_IMAGE_NAME: openapitools/openapi-generator
+      DOCKER_CODEGEN_CLI_IMAGE_NAME: openapitools/openapi-generator-cli
+    steps:
+      - command_build_and_test:
+          nodeNo: "3"
 workflows:
   version: 2
   build:
     jobs:
       - node0
       - node1
+      - node2
+      - node3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,9 @@ commands: # a reusable command with parameters
       - run: cat /etc/hosts
       # Test
 #      - run: mvn --no-snapshot-updates --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+      - run:
+          name: "Setup custom environment variables"
+          command: echo 'export CIRCLE_NODE_INDEX="<<parameters.nodeNo>>"' >> $BASH_ENV
       - run: ./CI/circle_parallel.sh
       # Teardown
       #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 commands: # a reusable command with parameters
-  command-build-and-test:
+  command_build_and_test:
     parameters:
       nodeNo:
         default: "0"
@@ -107,5 +107,5 @@ jobs:
       DOCKER_GENERATOR_IMAGE_NAME: openapitools/openapi-generator
       DOCKER_CODEGEN_CLI_IMAGE_NAME: openapitools/openapi-generator-cli
     steps:
-      - command-build-and-test:
+      - command_build_and_test:
           nodeNo: "0"

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -1,6 +1,0 @@
-FROM buildpack-deps:bionic
-COPY setup.sh /
-RUN bash setup.sh && rm /setup.sh
-RUN apt-get update && \
-    apt-get install -y python-pip python-setuptools && \
-    rm -rf /var/cache/apt/lists

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -1,0 +1,6 @@
+FROM buildpack-deps:bionic
+COPY setup.sh /
+RUN bash setup.sh && rm /setup.sh
+RUN apt-get update && \
+    apt-get install -y python-pip python-setuptools && \
+    rm -rf /var/cache/apt/lists

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -64,12 +64,6 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #cd Python-3.8.9
   #./configure --enable-optimizations
   #sudo make altinstall
-  pyenv --version
-  pyenv install --list 
-  pyenv install 3.6.3
-  pyenv install 3.9.0
-  pyenv global 3.6.3
-  python3 --version
 
   # Install node@stable (for angular 6)
   set +e

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -68,20 +68,20 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #sudo make altinstall
 
   # Install node@stable (for angular 6)
-#  set +e
-#  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-#  export NVM_DIR="/opt/circleci/.nvm"
-#  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  #  set +e
+  #  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+  #  export NVM_DIR="/opt/circleci/.nvm"
+  #  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
   #nvm install stable
   # install v16 instead of the latest stable version
-#  nvm install 16
-#  nvm alias default 16
-#  node --version
+  #  nvm install 16
+  #  nvm alias default 16
+  #  node --version
 
   # Each step uses the same `$BASH_ENV`, so need to modify it
-#  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-#  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-  apt install maven
+  #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+  #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+  apt-get install -y maven
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -81,6 +81,8 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # Each step uses the same `$BASH_ENV`, so need to modify it
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+  which java
+  java -version
   apt-get update && apt-get install -y maven
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,7 +82,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y maven default-jre
+  apt-get update && apt-get install -y default-jdk maven
   java -version
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -59,6 +59,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #sudo make altinstall
   pyenv install --list 
   pyenv install 3.6.3
+  pyenv install 3.9.0
   pyenv global 3.6.3
   python3 --version
 

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,7 +82,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven docker.io
+  apt-get update && apt-get install -y default-jdk maven docker-ce
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -86,8 +86,8 @@ elif [ "$NODE_INDEX" = "3" ]; then
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
-  echo whoami
-  sudo echo whoami
+  whoami
+  sudo whoami
   sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,7 +82,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven docker.io systemd
+  apt-get update && apt-get install -y default-jdk maven docker.io
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
@@ -92,7 +92,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
 
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image
-  systemctl start docker
+  service docker start
   printf '127.0.0.1       petstore.swagger.io' | tee -a /etc/hosts
   docker pull openapitools/openapi-petstore
   docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -88,8 +88,6 @@ elif [ "$NODE_INDEX" = "3" ]; then
   echo $JAVA_HOME
 
   # show os version
-  lsb_release -a
-  cat /etc/lsb-release
   uname -a
 
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -81,7 +81,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # Each step uses the same `$BASH_ENV`, so need to modify it
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-  apt-get update install -y maven
+  apt-get update && apt-get install -y maven
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -90,7 +90,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image
   docker info >/dev/null 2>&1 || service docker start;
-  |- printf '127.0.0.1       petstore.swagger.io' | tee -a /etc/hosts
+  printf '127.0.0.1       petstore.swagger.io' | tee -a /etc/hosts
   docker pull openapitools/openapi-petstore
   docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore
   docker pull swaggerapi/petstore

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,7 +82,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven docker.io
+  apt-get update && apt-get install -y default-jdk maven docker.io systemd
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -92,7 +92,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
 
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image
-  sudo systemctl start docker
+  systemctl start docker
   printf '127.0.0.1       petstore.swagger.io' | tee -a /etc/hosts
   docker pull openapitools/openapi-petstore
   docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,7 +82,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven
+  apt-get update && apt-get install -y default-jdk maven sudo
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -86,6 +86,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
+  sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,8 +82,8 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
+  apt-get update && apt-get install -y maven default-jre
   java -version
-  apt-get update && apt-get install -y maven
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -17,20 +17,20 @@ function cleanup {
 trap cleanup EXIT
 
 if [ "$NODE_INDEX" = "0" ]; then
-  echo "Running node $NODE_INDEX to test 'samples.circleci.node0' defined in pom.xml ..."
+  echo "Running node $NODE_INDEX to test 'samples.circleci.node$NODE_INDEX' defined in pom.xml ..."
   #sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
   java -version
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node0 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   mvn --no-snapshot-updates --quiet javadoc:javadoc -Psamples.circleci.node1 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 elif [ "$NODE_INDEX" = "1" ]; then
-  echo "Running node $NODE_INDEX to test 'samples.circleci' defined in pom.xml ..."
+  echo "Running node $NODE_INDEX to test 'samples.circleci.node$NODE_INDEX' defined in pom.xml ..."
   java -version
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node1 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
 elif [ "$NODE_INDEX" = "2" ]; then
-  echo "Running node $NODE_INDEX to test haskell"
+  echo "Running node $NODE_INDEX to test 'samples.circleci.node$NODE_INDEX' defined in pom.xml ..."
   # install haskell
   #curl -sSLk https://get.haskellstack.org/ | sh
   #stack upgrade
@@ -58,7 +58,7 @@ elif [ "$NODE_INDEX" = "2" ]; then
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node2 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 elif [ "$NODE_INDEX" = "3" ]; then
 
-  echo "Running node $NODE_INDEX to test 'samples.circleci.node3' defined in pom.xml ..."
+  echo "Running node $NODE_INDEX to test 'samples.circleci.node$NODE_INDEX' defined in pom.xml ..."
   #wget https://www.python.org/ftp/python/3.8.9/Python-3.8.9.tgz
   #tar -xf Python-3.8.9.tgz
   #cd Python-3.8.9

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -91,7 +91,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
 
   # docker installation
   sudo apt-get update
-  sudo apt-get install \
+  sudo apt-get install -y \
     ca-certificates \
     curl \
     gnupg \

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -86,6 +86,8 @@ elif [ "$NODE_INDEX" = "3" ]; then
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
+  echo whoami
+  sudo echo whoami
   sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -86,12 +86,20 @@ elif [ "$NODE_INDEX" = "3" ]; then
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
-  # docker installation
-  sudo apt-get update
-  sudo apt-get install docker-ce docker-ce-cli containerd.io
-
   # show os version
   uname -a
+
+  # docker installation
+  sudo apt-get update
+  sudo apt-get install \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+  echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -89,7 +89,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
 
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image
-  docker info >/dev/null 2>&1 || service docker start;
+  service docker start;
   printf '127.0.0.1       petstore.swagger.io' | tee -a /etc/hosts
   docker pull openapitools/openapi-petstore
   docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,7 +82,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven docker-ce
+  apt-get update && apt-get install -y default-jdk maven docker.io
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
@@ -92,7 +92,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
 
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image
-  service docker start;
+  sudo systemctl start docker
   printf '127.0.0.1       petstore.swagger.io' | tee -a /etc/hosts
   docker pull openapitools/openapi-petstore
   docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -86,8 +86,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
-  whoami
-  sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
+  sudo iptables -A PREROUTING -t nat -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -81,7 +81,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # Each step uses the same `$BASH_ENV`, so need to modify it
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-  apt-get install -y maven
+  apt-get update install -y maven
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -57,6 +57,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #cd Python-3.8.9
   #./configure --enable-optimizations
   #sudo make altinstall
+  pyenv --version
   pyenv install --list 
   pyenv install 3.6.3
   pyenv install 3.9.0

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -11,7 +11,9 @@ export NODE_ENV=test
 
 function cleanup {
   # Show logs of 'petstore.swagger' container to troubleshoot Unit Test failures, if any.
-  docker logs petstore.swagger # container name specified in circle.yml
+  if [ "$NODE_INDEX" != "3" ]; then
+    docker logs petstore.swagger # container name specified in circle.yml
+  fi
 }
 
 trap cleanup EXIT

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -87,6 +87,11 @@ elif [ "$NODE_INDEX" = "3" ]; then
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
 
+  # show os version
+  lsb_release -a
+  cat /etc/lsb-release
+  uname -a
+
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image
   service docker start;

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,7 +82,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven docker.io
+  apt-get update && apt-get install -y default-jdk maven docker.io sudo
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
@@ -92,7 +92,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
 
   # Note: it may be possible to run openapitools/openapi-petstore as a second docker image
   # I wasn't abe to get it working so run the server in the image
-  service docker start
+  sudo service docker start
   printf '127.0.0.1       petstore.swagger.io' | tee -a /etc/hosts
   docker pull openapitools/openapi-petstore
   docker run -d -e OPENAPI_BASE_PATH=/v3 -e DISABLE_API_KEY=1 -e DISABLE_OAUTH=1 -p 80:8080 openapitools/openapi-petstore

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -81,7 +81,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # Each step uses the same `$BASH_ENV`, so need to modify it
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-  which java
+  # echo which java
   java -version
   apt-get update && apt-get install -y maven
 

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -66,19 +66,20 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #sudo make altinstall
 
   # Install node@stable (for angular 6)
-  set +e
-  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-  export NVM_DIR="/opt/circleci/.nvm"
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+#  set +e
+#  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+#  export NVM_DIR="/opt/circleci/.nvm"
+#  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
   #nvm install stable
   # install v16 instead of the latest stable version
-  nvm install 16
-  nvm alias default 16
-  node --version
+#  nvm install 16
+#  nvm alias default 16
+#  node --version
 
   # Each step uses the same `$BASH_ENV`, so need to modify it
-  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+#  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+#  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+apt install maven
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,12 +82,11 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven sudo
+  apt-get update && apt-get install -y default-jdk maven sudo iptables
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
   whoami
-  sudo whoami
   sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -16,11 +16,18 @@ function cleanup {
 
 trap cleanup EXIT
 
-if [ "$NODE_INDEX" = "1" ]; then
+if [ "$NODE_INDEX" = "0" ]; then
+  echo "Running node $NODE_INDEX to test 'samples.circleci.node0' defined in pom.xml ..."
+  #sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
+  java -version
+
+  mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node0 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  mvn --no-snapshot-updates --quiet javadoc:javadoc -Psamples.circleci.node1 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+elif [ "$NODE_INDEX" = "1" ]; then
   echo "Running node $NODE_INDEX to test 'samples.circleci' defined in pom.xml ..."
   java -version
 
-  mvn --no-snapshot-updates --quiet verify -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node1 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
 elif [ "$NODE_INDEX" = "2" ]; then
   echo "Running node $NODE_INDEX to test haskell"
@@ -48,7 +55,7 @@ elif [ "$NODE_INDEX" = "2" ]; then
   go version
 
   # run integration tests
-  mvn --no-snapshot-updates --quiet verify -Psamples.misc -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node2 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 elif [ "$NODE_INDEX" = "3" ]; then
 
   echo "Running node $NODE_INDEX to test 'samples.circleci.node3' defined in pom.xml ..."
@@ -80,14 +87,6 @@ elif [ "$NODE_INDEX" = "3" ]; then
   echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-
-else
-  echo "Running node $NODE_INDEX to test 'samples.circleci.others' defined in pom.xml ..."
-  #sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
-  java -version
-
-  mvn --no-snapshot-updates --quiet verify -Psamples.circleci.others -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  mvn --no-snapshot-updates --quiet javadoc:javadoc -Psamples.circleci -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi
 
 

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -82,10 +82,13 @@ elif [ "$NODE_INDEX" = "3" ]; then
   #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
   #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
   # echo which java
-  apt-get update && apt-get install -y default-jdk maven docker.io sudo
+  apt-get update && apt-get install -y default-jdk maven sudo
   java -version
   export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
   echo $JAVA_HOME
+  # docker installation
+  sudo apt-get update
+  sudo apt-get install docker-ce docker-ce-cli containerd.io
 
   # show os version
   uname -a

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -84,6 +84,8 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # echo which java
   apt-get update && apt-get install -y default-jdk maven
   java -version
+  export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
+  echo $JAVA_HOME
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -79,7 +79,7 @@ elif [ "$NODE_INDEX" = "3" ]; then
   # Each step uses the same `$BASH_ENV`, so need to modify it
 #  echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
 #  echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-apt install maven
+  apt install maven
 
   mvn --no-snapshot-updates --quiet verify -Psamples.circleci.node3 -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 fi

--- a/modules/openapi-generator/src/main/resources/python-experimental/tox.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/tox.handlebars
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py39
 
 [testenv]
 deps=-r{toxinidir}/requirements.txt

--- a/pom.xml
+++ b/pom.xml
@@ -1282,6 +1282,7 @@
                 <module>samples/client/petstore/python</module>
                 <module>samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent</module>
                 <module>samples/openapi3/client/petstore/python</module>
+                <module>samples/openapi3/client/petstore/python-experimental</module>
                 <!-- TODO comment out below when the test for typescript-nestjs is ready
                 <module>samples/client/petstore/typescript-nestjs-v6-provided-in-root</module>-->
                 <!-- comment out due to error `npm run build`

--- a/pom.xml
+++ b/pom.xml
@@ -1279,8 +1279,8 @@
             </activation>
             <modules>
                 <!-- clients -->
-                <module>samples/client/petstore/python</module>
-                <module>samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent</module>
+<!--                <module>samples/client/petstore/python</module>-->
+<!--                <module>samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent</module>-->
                 <module>samples/openapi3/client/petstore/python</module>
                 <module>samples/openapi3/client/petstore/python-experimental</module>
                 <!-- TODO comment out below when the test for typescript-nestjs is ready

--- a/pom.xml
+++ b/pom.xml
@@ -1164,11 +1164,11 @@
         </profile>
         <!-- test with JDK8 in CircleCI -->
         <profile>
-            <id>samples.circleci</id>
+            <id>samples.circleci.node1</id>
             <activation>
                 <property>
                     <name>env</name>
-                    <value>samples.circleci</value>
+                    <value>samples.circleci.node1</value>
                 </property>
             </activation>
             <modules>
@@ -1312,13 +1312,13 @@
                 <module>samples/client/petstore/javascript-promise-es6</module>
             </modules>
         </profile>
-        <!-- other tests in CircleCI -->
+        <!-- node0 tests in CircleCI -->
         <profile>
-            <id>samples.circleci.others</id>
+            <id>samples.circleci.node0</id>
             <activation>
                 <property>
                     <name>env</name>
-                    <value>samples.circleci.others</value>
+                    <value>samples.circleci.node0</value>
                 </property>
             </activation>
             <modules>
@@ -1408,11 +1408,11 @@
         </profile>
         <!-- test with Haskell -->
         <profile>
-            <id>samples.misc</id>
+            <id>samples.circleci.node2</id>
             <activation>
                 <property>
                     <name>env</name>
-                    <value>samples.misc</value>
+                    <value>samples.circleci.node2</value>
                 </property>
             </activation>
             <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1279,7 +1279,7 @@
             </activation>
             <modules>
                 <!-- clients -->
-<!--                <module>samples/client/petstore/python</module>-->
+                <module>samples/client/petstore/python</module>
 <!--                <module>samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent</module>-->
                 <module>samples/openapi3/client/petstore/python</module>
                 <module>samples/openapi3/client/petstore/python-experimental</module>

--- a/samples/openapi3/client/petstore/python-experimental/pom.xml
+++ b/samples/openapi3/client/petstore/python-experimental/pom.xml
@@ -1,0 +1,46 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.openapitools</groupId>
+    <artifactId>PythonExperimentalOAS3PetstoreTests</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Python Experimental OpenAPI3 Petstore Client</name>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>make</executable>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/openapi3/client/petstore/python-experimental/tox.ini
+++ b/samples/openapi3/client/petstore/python-experimental/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py39
 
 [testenv]
 deps=-r{toxinidir}/requirements.txt


### PR DESCRIPTION
Turns on python-experimental CI tests

- pom.xml samples updated to indicate which node number corresponds to which set of samples
- circleci config file adjusted to allow a single node to use a different executor like docker for example

Reasons that I made these changes:
- the pyenv on the current machine is out of date and does not allow installation of new python versions >= 3.7
- to do that one would need build pyenv from scratch
- our current solution feels brittle and is not meeting the specific needs of the languages in a node. Everything is piled into one place
- How about we use docker images instead, built only for what we need? This PR demonstrates that by breaking out circleci node3 into a docker image with additional installations into it.

I have found a docker image which contains all python versions and will allow us to test python 2.7 all the way up to 3.9 which python-experimental needs. We will need to install the below into it:
- [DONE] maven
- [DONE] java jdk
- docker (to run the server)
- typescript/node for the other node3 tests

How about I make a dockerhub account for openapi generator which holds this new image?
If we need to switch to other CI sites in the future, using this image should be easier than installing all needed software onto one machine like we currently do.
Does this sound like a good plan to you?
What email account can I use to make the dockerhub acccount for openapi generator (I don't want it to be my personal one)?

## Help!
- I am having trouble installing docker in this `Linux b2caa1cb8dfd 5.11.0-1022-aws #23~20.04.1-Ubuntu SMP Mon Nov 15 14:03:19 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux` image

TODO:
- install docker in the running image
- run the server in the background of it
- turn the python-legacy samples tests back on
- install whatever typescript/node/angular and javascript need to run

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
