### PR TITLE
[PHP] Allow guzzlehttp/psr7 ^1.7 or ^2.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/composer.mustache
@@ -29,7 +29,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^7.3",
-        "guzzlehttp/psr7": "^2.0"
+        "guzzlehttp/psr7": "^1.7 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",

--- a/samples/client/petstore/php/OpenAPIClient-php/composer.json
+++ b/samples/client/petstore/php/OpenAPIClient-php/composer.json
@@ -23,7 +23,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^7.3",
-        "guzzlehttp/psr7": "^2.0"
+        "guzzlehttp/psr7": "^1.7 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix [#11152](https://github.com/OpenAPITools/openapi-generator/issues/11152)

Allows the use of guzzlehttp/psr7 in versions 1.8.x and v2.0.x

This ensures that the created package can be used in combination with libraries that still require 1.x of guzzlehttp/psr7 and as all the necessary functions of 2.x already exists in 1.8.x, it requires only a composer.json change.

Furthermore, it is also what is required by guzzlehttp itself in 7.3.0 or higher itself: https://github.com/guzzle/guzzle/blob/7.3.0/composer.json

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @ybelenko, @renepardon