### PR TITLE
Add useTags config option support for java client code generation

### DIFF
--- a/docs/generators/csharp-nancyfx-deprecated.md
+++ b/docs/generators/csharp-nancyfx-deprecated.md
@@ -1,0 +1,209 @@
+---
+title: Documentation for the csharp-nancyfx-deprecated Generator
+---
+
+## METADATA
+
+| Property | Value | Notes |
+| -------- | ----- | ----- |
+| generator name | csharp-nancyfx-deprecated | pass this to the generate command after -g |
+| generator stability | DEPRECATED | |
+| generator type | SERVER | |
+| generator language | C# | |
+| generator default templating engine | mustache | |
+| helpTxt | Generates a C# NancyFX Web API server (deprecated). | |
+
+## CONFIG OPTIONS
+These options may be applied as additional-properties (cli) or configOptions (plugins). Refer to [configuration docs](https://openapi-generator.tech/docs/configuration) for more details.
+
+| Option | Description | Values | Default |
+| ------ | ----------- | ------ | ------- |
+|asyncServer|Set to true to enable the generation of async routes/endpoints.| |false|
+|immutable|Enabled by default. If disabled generates model classes with setters| |true|
+|interfacePrefix|Prefix interfaces with a community standard or widely accepted prefix.| ||
+|optionalProjectFile|Generate {PackageName}.csproj.| |true|
+|packageContext|Optionally overrides the PackageContext which determines the namespace (namespace=packageName.packageContext). If not set, packageContext will default to basePath.| |null|
+|packageGuid|The GUID that will be associated with the C# project| |null|
+|packageName|C# package name (convention: Title.Case).| |Org.OpenAPITools|
+|packageVersion|C# package version.| |1.0.0|
+|returnICollection|Return ICollection&lt;T&gt; instead of the concrete type.| |false|
+|sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|sourceFolder|source folder for generated code| |src|
+|useCollection|Deserialize array types to Collection&lt;T&gt; instead of List&lt;T&gt;.| |false|
+|useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
+|writeModulePath|Enabled by default. If disabled, module paths will not mirror api base path| |true|
+
+## IMPORT MAPPING
+
+| Type/Alias | Imports |
+| ---------- | ------- |
+
+
+## INSTANTIATION TYPES
+
+| Type/Alias | Instantiated By |
+| ---------- | --------------- |
+|array|List|
+|list|List|
+|map|Dictionary|
+
+
+## LANGUAGE PRIMITIVES
+
+<ul class="column-ul">
+<li>Boolean</li>
+<li>Collection</li>
+<li>DateTime</li>
+<li>DateTime?</li>
+<li>DateTimeOffset</li>
+<li>DateTimeOffset?</li>
+<li>Decimal</li>
+<li>Dictionary</li>
+<li>Double</li>
+<li>Float</li>
+<li>Guid</li>
+<li>Guid?</li>
+<li>ICollection</li>
+<li>Int32</li>
+<li>Int64</li>
+<li>List</li>
+<li>LocalDate?</li>
+<li>LocalTime?</li>
+<li>Object</li>
+<li>String</li>
+<li>System.IO.Stream</li>
+<li>ZonedDateTime?</li>
+<li>bool</li>
+<li>bool?</li>
+<li>byte[]</li>
+<li>decimal</li>
+<li>decimal?</li>
+<li>double</li>
+<li>double?</li>
+<li>float</li>
+<li>float?</li>
+<li>int</li>
+<li>int?</li>
+<li>long</li>
+<li>long?</li>
+<li>string</li>
+</ul>
+
+## RESERVED WORDS
+
+<ul class="column-ul">
+<li>async</li>
+<li>await</li>
+<li>dynamic</li>
+<li>var</li>
+<li>yield</li>
+</ul>
+
+## FEATURE SET
+
+
+### Client Modification Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|BasePath|✗|ToolingExtension
+|Authorizations|✗|ToolingExtension
+|UserAgent|✗|ToolingExtension
+|MockServer|✗|ToolingExtension
+
+### Data Type Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|Custom|✗|OAS2,OAS3
+|Int32|✓|OAS2,OAS3
+|Int64|✓|OAS2,OAS3
+|Float|✓|OAS2,OAS3
+|Double|✓|OAS2,OAS3
+|Decimal|✓|ToolingExtension
+|String|✓|OAS2,OAS3
+|Byte|✓|OAS2,OAS3
+|Binary|✓|OAS2,OAS3
+|Boolean|✓|OAS2,OAS3
+|Date|✓|OAS2,OAS3
+|DateTime|✓|OAS2,OAS3
+|Password|✓|OAS2,OAS3
+|File|✓|OAS2
+|Array|✓|OAS2,OAS3
+|Maps|✓|ToolingExtension
+|CollectionFormat|✓|OAS2
+|CollectionFormatMulti|✓|OAS2
+|Enum|✓|OAS2,OAS3
+|ArrayOfEnum|✓|ToolingExtension
+|ArrayOfModel|✓|ToolingExtension
+|ArrayOfCollectionOfPrimitives|✓|ToolingExtension
+|ArrayOfCollectionOfModel|✓|ToolingExtension
+|ArrayOfCollectionOfEnum|✓|ToolingExtension
+|MapOfEnum|✓|ToolingExtension
+|MapOfModel|✓|ToolingExtension
+|MapOfCollectionOfPrimitives|✓|ToolingExtension
+|MapOfCollectionOfModel|✓|ToolingExtension
+|MapOfCollectionOfEnum|✓|ToolingExtension
+
+### Documentation Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|Readme|✗|ToolingExtension
+|Model|✓|ToolingExtension
+|Api|✓|ToolingExtension
+
+### Global Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|Host|✓|OAS2,OAS3
+|BasePath|✓|OAS2,OAS3
+|Info|✓|OAS2,OAS3
+|Schemes|✗|OAS2,OAS3
+|PartialSchemes|✓|OAS2,OAS3
+|Consumes|✓|OAS2
+|Produces|✓|OAS2
+|ExternalDocumentation|✓|OAS2,OAS3
+|Examples|✓|OAS2,OAS3
+|XMLStructureDefinitions|✗|OAS2,OAS3
+|MultiServer|✗|OAS3
+|ParameterizedServer|✗|OAS3
+|ParameterStyling|✗|OAS3
+|Callbacks|✗|OAS3
+|LinkObjects|✗|OAS3
+
+### Parameter Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|Path|✓|OAS2,OAS3
+|Query|✓|OAS2,OAS3
+|Header|✓|OAS2,OAS3
+|Body|✓|OAS2
+|FormUnencoded|✓|OAS2
+|FormMultipart|✓|OAS2
+|Cookie|✗|OAS3
+
+### Schema Support Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|Simple|✓|OAS2,OAS3
+|Composite|✓|OAS2,OAS3
+|Polymorphism|✓|OAS2,OAS3
+|Union|✗|OAS3
+
+### Security Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|BasicAuth|✗|OAS2,OAS3
+|ApiKey|✗|OAS2,OAS3
+|OpenIDConnect|✗|OAS3
+|BearerToken|✗|OAS3
+|OAuth2_Implicit|✗|OAS2,OAS3
+|OAuth2_Password|✗|OAS2,OAS3
+|OAuth2_ClientCredentials|✗|OAS2,OAS3
+|OAuth2_AuthorizationCode|✗|OAS2,OAS3
+
+### Wire Format Feature
+| Name | Supported | Defined By |
+| ---- | --------- | ---------- |
+|JSON|✓|OAS2,OAS3
+|XML|✓|OAS2,OAS3
+|PROTOBUF|✗|ToolingExtension
+|Custom|✗|OAS2,OAS3

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -81,6 +81,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useRuntimeException|Use RuntimeException instead of Exception| |false|
 |useRxJava2|Whether to use the RxJava2 adapter with the retrofit2 library. IMPORTANT: This option has been deprecated.| |false|
 |useRxJava3|Whether to use the RxJava3 adapter with the retrofit2 library. IMPORTANT: This option has been deprecated.| |false|
+|useTags|Use tags for creating interface and controller classnames| |true|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/samples/client/others/java/okhttp-gson-streaming/api/openapi.yaml
+++ b/samples/client/others/java/okhttp-gson-streaming/api/openapi.yaml
@@ -25,6 +25,8 @@ paths:
       x-streaming: true
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: ping
 components:
   schemas:
     SomeObj:

--- a/samples/client/petstore/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/petstore/java/apache-httpclient/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/feign-no-nullable/api/openapi.yaml
+++ b/samples/client/petstore/java/feign-no-nullable/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/feign/api/openapi.yaml
+++ b/samples/client/petstore/java/feign/api/openapi.yaml
@@ -70,6 +70,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -92,6 +94,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     servers:
     - url: http://petstore.swagger.io/v2
     - url: http://path-server-test.petstore.local/v2
@@ -140,6 +144,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -184,6 +190,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -217,6 +225,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -250,6 +260,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -289,6 +301,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -332,6 +346,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -352,6 +368,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -379,6 +397,8 @@ paths:
       - store
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -402,6 +422,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -436,6 +458,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -455,6 +479,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -468,6 +494,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -481,6 +509,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -532,6 +562,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -542,6 +574,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -564,6 +598,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -593,6 +629,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -622,6 +660,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       - fake_classname_tags 123#$%^
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -707,6 +749,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -823,6 +867,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -840,6 +886,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |
         Fake endpoint for testing various parameters
@@ -939,6 +987,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -960,6 +1010,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/property/enum-int:
     post:
       description: Test serialization of enum (int) properties with examples
@@ -982,6 +1034,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -1003,6 +1057,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -1024,6 +1080,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1045,6 +1103,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1072,6 +1132,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1092,6 +1154,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1116,6 +1180,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1134,6 +1200,8 @@ paths:
       - $another-fake?
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request must reference a schema\
@@ -1152,6 +1220,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-binary:
     put:
       description: "For this test, the body has to be a binary file."
@@ -1172,6 +1242,8 @@ paths:
       - fake
       x-contentType: image/png
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1246,6 +1318,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1291,6 +1365,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /fake/health:
     get:
       responses:
@@ -1304,6 +1380,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/http-signature-test:
     get:
       operationId: fake-http-signature-test
@@ -1336,6 +1414,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
 components:
   requestBodies:
     UserArray:

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/google-api-client/api/openapi.yaml
+++ b/samples/client/petstore/java/google-api-client/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/jersey1/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey1/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/native-async/api/openapi.yaml
+++ b/samples/client/petstore/java/native-async/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/native/api/openapi.yaml
+++ b/samples/client/petstore/java/native/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/resources/openapi/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/resources/openapi/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
@@ -69,6 +69,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -90,6 +92,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     servers:
     - url: http://petstore.swagger.io/v2
     - url: http://path-server-test.petstore.local/v2
@@ -139,6 +143,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -181,6 +187,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -212,6 +220,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -245,6 +255,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -282,6 +294,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -325,6 +339,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -345,6 +361,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -372,6 +390,8 @@ paths:
       - store
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -395,6 +415,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -429,6 +451,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -448,6 +472,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -461,6 +487,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -474,6 +502,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -525,6 +555,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -615,6 +653,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -635,6 +675,8 @@ paths:
       - fake_classname_tags 123#$%^
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -700,6 +742,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -816,6 +860,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -833,6 +879,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |
         Fake endpoint for testing various parameters
@@ -934,6 +982,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -955,6 +1005,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -976,6 +1028,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -997,6 +1051,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1018,6 +1074,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1045,6 +1103,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1065,6 +1125,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1089,6 +1151,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1107,6 +1171,8 @@ paths:
       - $another-fake?
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1125,6 +1191,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1181,6 +1249,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1226,6 +1296,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /fake/health:
     get:
       responses:
@@ -1239,6 +1311,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/array-of-enums:
     get:
       operationId: getArrayOfEnums
@@ -1253,6 +1327,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
 components:
   requestBodies:
     UserArray:

--- a/samples/client/petstore/java/rest-assured-jackson/api/openapi.yaml
+++ b/samples/client/petstore/java/rest-assured-jackson/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/rest-assured/api/openapi.yaml
+++ b/samples/client/petstore/java/rest-assured/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/resteasy/api/openapi.yaml
+++ b/samples/client/petstore/java/resteasy/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/resttemplate/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/retrofit2-play26/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2-play26/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/retrofit2/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/retrofit2rx2/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2rx2/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/retrofit2rx3/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2rx3/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/vertx-no-nullable/api/openapi.yaml
+++ b/samples/client/petstore/java/vertx-no-nullable/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/client/petstore/java/vertx/api/openapi.yaml
+++ b/samples/client/petstore/java/vertx/api/openapi.yaml
@@ -48,6 +48,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -83,6 +85,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -128,6 +132,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -173,6 +179,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -203,6 +211,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -236,6 +246,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -270,6 +282,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -309,6 +323,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -329,6 +345,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -358,6 +376,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -381,6 +401,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -415,6 +437,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -436,6 +460,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -458,6 +484,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -480,6 +508,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -524,6 +554,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -616,6 +654,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -691,6 +733,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -793,6 +837,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -816,6 +862,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |-
         Fake endpoint for testing various parameters
@@ -917,6 +965,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -940,6 +990,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -963,6 +1015,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -986,6 +1040,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1009,6 +1065,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: '*/*'
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1036,6 +1094,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1058,6 +1118,8 @@ paths:
       x-codegen-request-body-name: param
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1082,6 +1144,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/create_xml_item:
     post:
       description: this route creates an XmlItem
@@ -1118,6 +1182,8 @@ paths:
       x-codegen-request-body-name: XmlItem
       x-contentType: application/xml
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1142,6 +1208,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1162,6 +1230,8 @@ paths:
       x-codegen-request-body-name: body
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1216,6 +1286,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1258,6 +1330,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
 components:
   schemas:
     Order:

--- a/samples/client/petstore/java/webclient/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient/api/openapi.yaml
@@ -70,6 +70,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -92,6 +94,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     servers:
     - url: http://petstore.swagger.io/v2
     - url: http://path-server-test.petstore.local/v2
@@ -140,6 +144,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -184,6 +190,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -217,6 +225,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -250,6 +260,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -289,6 +301,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -332,6 +346,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -352,6 +368,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -379,6 +397,8 @@ paths:
       - store
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -402,6 +422,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -436,6 +458,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -455,6 +479,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -468,6 +494,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -481,6 +509,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -532,6 +562,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -542,6 +574,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -564,6 +598,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -593,6 +629,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -622,6 +660,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -642,6 +682,8 @@ paths:
       - fake_classname_tags 123#$%^
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -707,6 +749,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -823,6 +867,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -840,6 +886,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |
         Fake endpoint for testing various parameters
@@ -939,6 +987,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -960,6 +1010,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/property/enum-int:
     post:
       description: Test serialization of enum (int) properties with examples
@@ -982,6 +1034,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -1003,6 +1057,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -1024,6 +1080,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1045,6 +1103,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1072,6 +1132,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1092,6 +1154,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1116,6 +1180,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1134,6 +1200,8 @@ paths:
       - $another-fake?
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request must reference a schema\
@@ -1152,6 +1220,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-binary:
     put:
       description: "For this test, the body has to be a binary file."
@@ -1172,6 +1242,8 @@ paths:
       - fake
       x-contentType: image/png
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1246,6 +1318,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1291,6 +1365,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /fake/health:
     get:
       responses:
@@ -1304,6 +1380,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/http-signature-test:
     get:
       operationId: fake-http-signature-test
@@ -1336,6 +1414,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
 components:
   requestBodies:
     UserArray:

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/api/openapi.yaml
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/api/openapi.yaml
@@ -52,6 +52,8 @@ paths:
       tags:
       - usage
       x-accepts: application/json
+      x-tags:
+      - tag: usage
   /any:
     get:
       description: Use any API key
@@ -70,6 +72,8 @@ paths:
       tags:
       - usage
       x-accepts: application/json
+      x-tags:
+      - tag: usage
   /query:
     get:
       description: Use API key in query
@@ -87,6 +91,8 @@ paths:
       tags:
       - usage
       x-accepts: application/json
+      x-tags:
+      - tag: usage
   /header:
     get:
       description: Use API key in header
@@ -104,6 +110,8 @@ paths:
       tags:
       - usage
       x-accepts: application/json
+      x-tags:
+      - tag: usage
 components:
   schemas: {}
   securitySchemes:

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -69,6 +69,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     put:
       operationId: updatePet
       requestBody:
@@ -90,6 +92,8 @@ paths:
       - pet
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     servers:
     - url: http://petstore.swagger.io/v2
     - url: http://path-server-test.petstore.local/v2
@@ -139,6 +143,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/findByTags:
     get:
       deprecated: true
@@ -181,6 +187,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -212,6 +220,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     get:
       description: Returns a single pet
       operationId: getPetById
@@ -245,6 +255,8 @@ paths:
       tags:
       - pet
       x-accepts: application/json
+      x-tags:
+      - tag: pet
     post:
       operationId: updatePetWithForm
       parameters:
@@ -282,6 +294,8 @@ paths:
       - pet
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
@@ -325,6 +339,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /store/inventory:
     get:
       description: Returns a map of status codes to quantities
@@ -345,6 +361,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order:
     post:
       operationId: placeOrder
@@ -372,6 +390,8 @@ paths:
       - store
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -395,6 +415,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
     get:
       description: For valid response try integer IDs with value <= 5 or > 10. Other
         values will generated exceptions
@@ -429,6 +451,8 @@ paths:
       tags:
       - store
       x-accepts: application/json
+      x-tags:
+      - tag: store
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -448,6 +472,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithArray:
     post:
       operationId: createUsersWithArrayInput
@@ -461,6 +487,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/createWithList:
     post:
       operationId: createUsersWithListInput
@@ -474,6 +502,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/login:
     get:
       operationId: loginUser
@@ -525,6 +555,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/logout:
     get:
       operationId: logoutUser
@@ -535,6 +567,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /user/{username}:
     delete:
       description: This can only be done by the logged in user.
@@ -557,6 +591,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     get:
       operationId: getUserByName
       parameters:
@@ -586,6 +622,8 @@ paths:
       tags:
       - user
       x-accepts: application/json
+      x-tags:
+      - tag: user
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -615,6 +653,8 @@ paths:
       - user
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: user
   /fake_classname_test:
     patch:
       description: To test class name in snake case
@@ -635,6 +675,8 @@ paths:
       - fake_classname_tags 123#$%^
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake_classname_tags 123#$%^
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)
@@ -700,6 +742,8 @@ paths:
       - fake
       x-group-parameters: true
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     get:
       description: To test enum parameters
       operationId: testEnumParameters
@@ -816,6 +860,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     patch:
       description: To test "client" model
       operationId: testClientModel
@@ -833,6 +879,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
     post:
       description: |
         Fake endpoint for testing various parameters
@@ -934,6 +982,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/outer/number:
     post:
       description: Test serialization of outer number types
@@ -955,6 +1005,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/string:
     post:
       description: Test serialization of outer string types
@@ -976,6 +1028,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/boolean:
     post:
       description: Test serialization of outer boolean types
@@ -997,6 +1051,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/outer/composite:
     post:
       description: Test serialization of object with outer number type
@@ -1018,6 +1074,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: '*/*'
+      x-tags:
+      - tag: fake
   /fake/jsonFormData:
     get:
       operationId: testJsonFormData
@@ -1045,6 +1103,8 @@ paths:
       - fake
       x-contentType: application/x-www-form-urlencoded
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/inline-additionalProperties:
     post:
       operationId: testInlineAdditionalProperties
@@ -1065,6 +1125,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/body-with-query-params:
     put:
       operationId: testBodyWithQueryParams
@@ -1089,6 +1151,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /another-fake/dummy:
     patch:
       description: To test special tags and operation ID starting with number
@@ -1107,6 +1171,8 @@ paths:
       - $another-fake?
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: $another-fake?
   /fake/body-with-file-schema:
     put:
       description: "For this test, the body for this request much reference a schema\
@@ -1125,6 +1191,8 @@ paths:
       - fake
       x-contentType: application/json
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/test-query-parameters:
     put:
       description: To test the collection format in query parameters
@@ -1181,6 +1249,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile
@@ -1226,6 +1296,8 @@ paths:
       - pet
       x-contentType: multipart/form-data
       x-accepts: application/json
+      x-tags:
+      - tag: pet
   /fake/health:
     get:
       responses:
@@ -1239,6 +1311,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/array-of-enums:
     get:
       operationId: getArrayOfEnums
@@ -1253,6 +1327,8 @@ paths:
       tags:
       - fake
       x-accepts: application/json
+      x-tags:
+      - tag: fake
 components:
   requestBodies:
     UserArray:

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,17 @@
+package org.openapitools;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+
+}

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
@@ -1,0 +1,23 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZonedDateTime;
+
+@Configuration
+public class JacksonConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(ThreeTenModule.class)
+  ThreeTenModule threeTenModule() {
+    ThreeTenModule module = new ThreeTenModule();
+    module.addDeserializer(Instant.class, CustomInstantDeserializer.INSTANT);
+    module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
+    module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
+    return module;
+  }
+}

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,64 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenAPI2SpringBoot implements CommandLineRunner {
+
+    @Override
+    public void run(String... arg0) throws Exception {
+        if (arg0.length > 0 && arg0[0].equals("exitcode")) {
+            throw new ExitException();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        new SpringApplication(OpenAPI2SpringBoot.class).run(args);
+    }
+
+    static class ExitException extends RuntimeException implements ExitCodeGenerator {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int getExitCode() {
+            return 10;
+        }
+
+    }
+
+    @Bean
+    public WebMvcConfigurer webConfigurer() {
+        return new WebMvcConfigurerAdapter() {
+            /*@Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("*")
+                        .allowedHeaders("Content-Type");
+            }*/
+
+            @Override
+            public void addResourceHandlers(ResourceHandlerRegistry registry) {
+                registry.addResourceHandler("/swagger-ui/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.14.2/");
+            }
+        };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,17 @@
+package org.openapitools;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+
+}

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
@@ -1,0 +1,23 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZonedDateTime;
+
+@Configuration
+public class JacksonConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(ThreeTenModule.class)
+  ThreeTenModule threeTenModule() {
+    ThreeTenModule module = new ThreeTenModule();
+    module.addDeserializer(Instant.class, CustomInstantDeserializer.INSTANT);
+    module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
+    module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
+    return module;
+  }
+}

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
@@ -1,0 +1,23 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZonedDateTime;
+
+@Configuration
+public class JacksonConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(ThreeTenModule.class)
+  ThreeTenModule threeTenModule() {
+    ThreeTenModule module = new ThreeTenModule();
+    module.addDeserializer(Instant.class, CustomInstantDeserializer.INSTANT);
+    module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
+    module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
+    return module;
+  }
+}

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/CustomInstantDeserializer.java
@@ -1,0 +1,232 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.threetenbp.DecimalUtils;
+import com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase;
+import com.fasterxml.jackson.datatype.threetenbp.function.BiFunction;
+import com.fasterxml.jackson.datatype.threetenbp.function.Function;
+import org.threeten.bp.DateTimeException;
+import org.threeten.bp.DateTimeUtils;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.temporal.Temporal;
+import org.threeten.bp.temporal.TemporalAccessor;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Deserializer for ThreeTen temporal {@link Instant}s, {@link OffsetDateTime}, and {@link ZonedDateTime}s.
+ * Adapted from the jackson threetenbp InstantDeserializer to add support for deserializing rfc822 format.
+ *
+ * @author Nick Williams
+ */
+public class CustomInstantDeserializer<T extends Temporal>
+    extends ThreeTenDateTimeDeserializerBase<T> {
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomInstantDeserializer<Instant> INSTANT = new CustomInstantDeserializer<Instant>(
+      Instant.class, DateTimeFormatter.ISO_INSTANT,
+      new Function<TemporalAccessor, Instant>() {
+        @Override
+        public Instant apply(TemporalAccessor temporalAccessor) {
+          return Instant.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, Instant>() {
+        @Override
+        public Instant apply(FromIntegerArguments a) {
+          return Instant.ofEpochMilli(a.value);
+        }
+      },
+      new Function<FromDecimalArguments, Instant>() {
+        @Override
+        public Instant apply(FromDecimalArguments a) {
+          return Instant.ofEpochSecond(a.integer, a.fraction);
+        }
+      },
+      null
+  );
+
+  public static final CustomInstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new CustomInstantDeserializer<OffsetDateTime>(
+      OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+      new Function<TemporalAccessor, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(TemporalAccessor temporalAccessor) {
+          return OffsetDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromIntegerArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(FromDecimalArguments a) {
+          return OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<OffsetDateTime, ZoneId, OffsetDateTime>() {
+        @Override
+        public OffsetDateTime apply(OffsetDateTime d, ZoneId z) {
+          return d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()));
+        }
+      }
+  );
+
+  public static final CustomInstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new CustomInstantDeserializer<ZonedDateTime>(
+      ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME,
+      new Function<TemporalAccessor, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(TemporalAccessor temporalAccessor) {
+          return ZonedDateTime.from(temporalAccessor);
+        }
+      },
+      new Function<FromIntegerArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromIntegerArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId);
+        }
+      },
+      new Function<FromDecimalArguments, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(FromDecimalArguments a) {
+          return ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId);
+        }
+      },
+      new BiFunction<ZonedDateTime, ZoneId, ZonedDateTime>() {
+        @Override
+        public ZonedDateTime apply(ZonedDateTime zonedDateTime, ZoneId zoneId) {
+          return zonedDateTime.withZoneSameInstant(zoneId);
+        }
+      }
+  );
+
+  protected final Function<FromIntegerArguments, T> fromMilliseconds;
+
+  protected final Function<FromDecimalArguments, T> fromNanoseconds;
+
+  protected final Function<TemporalAccessor, T> parsedToValue;
+
+  protected final BiFunction<T, ZoneId, T> adjust;
+
+  protected CustomInstantDeserializer(Class<T> supportedType,
+                    DateTimeFormatter parser,
+                    Function<TemporalAccessor, T> parsedToValue,
+                    Function<FromIntegerArguments, T> fromMilliseconds,
+                    Function<FromDecimalArguments, T> fromNanoseconds,
+                    BiFunction<T, ZoneId, T> adjust) {
+    super(supportedType, parser);
+    this.parsedToValue = parsedToValue;
+    this.fromMilliseconds = fromMilliseconds;
+    this.fromNanoseconds = fromNanoseconds;
+    this.adjust = adjust == null ? new BiFunction<T, ZoneId, T>() {
+      @Override
+      public T apply(T t, ZoneId zoneId) {
+        return t;
+      }
+    } : adjust;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
+    super((Class<T>) base.handledType(), f);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
+  @Override
+  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+    if (dtf == _formatter) {
+      return this;
+    }
+    return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    //NOTE: Timestamps contain no timezone info, and are always in configured TZ. Only
+    //string values have to be adjusted to the configured TZ.
+    switch (parser.getCurrentTokenId()) {
+      case JsonTokenId.ID_NUMBER_FLOAT: {
+        BigDecimal value = parser.getDecimalValue();
+        long seconds = value.longValue();
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
+        return fromNanoseconds.apply(new FromDecimalArguments(
+            seconds, nanoseconds, getZone(context)));
+      }
+
+      case JsonTokenId.ID_NUMBER_INT: {
+        long timestamp = parser.getLongValue();
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+          return this.fromNanoseconds.apply(new FromDecimalArguments(
+              timestamp, 0, this.getZone(context)
+          ));
+        }
+        return this.fromMilliseconds.apply(new FromIntegerArguments(
+            timestamp, this.getZone(context)
+        ));
+      }
+
+      case JsonTokenId.ID_STRING: {
+        String string = parser.getText().trim();
+        if (string.length() == 0) {
+          return null;
+        }
+        if (string.endsWith("+0000")) {
+          string = string.substring(0, string.length() - 5) + "Z";
+        }
+        T value;
+        try {
+          TemporalAccessor acc = _formatter.parse(string);
+          value = parsedToValue.apply(acc);
+          if (context.isEnabled(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)) {
+            return adjust.apply(value, this.getZone(context));
+          }
+        } catch (DateTimeException e) {
+          throw _peelDTE(e);
+        }
+        return value;
+      }
+    }
+    throw context.mappingException("Expected type float, integer, or string.");
+  }
+
+  private ZoneId getZone(DeserializationContext context) {
+    // Instants are always in UTC, so don't waste compute cycles
+    return (_valueClass == Instant.class) ? null : DateTimeUtils.toZoneId(context.getTimeZone());
+  }
+
+  private static class FromIntegerArguments {
+    public final long value;
+    public final ZoneId zoneId;
+
+    private FromIntegerArguments(long value, ZoneId zoneId) {
+      this.value = value;
+      this.zoneId = zoneId;
+    }
+  }
+
+  private static class FromDecimalArguments {
+    public final long integer;
+    public final int fraction;
+    public final ZoneId zoneId;
+
+    private FromDecimalArguments(long integer, int fraction, ZoneId zoneId) {
+      this.integer = integer;
+      this.fraction = fraction;
+      this.zoneId = zoneId;
+    }
+  }
+}

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/JacksonConfiguration.java
@@ -1,0 +1,23 @@
+package org.openapitools.configuration;
+
+import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.threeten.bp.Instant;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZonedDateTime;
+
+@Configuration
+public class JacksonConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(ThreeTenModule.class)
+  ThreeTenModule threeTenModule() {
+    ThreeTenModule module = new ThreeTenModule();
+    module.addDeserializer(Instant.class, CustomInstantDeserializer.INSTANT);
+    module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
+    module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
+    return module;
+  }
+}

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.virtualan.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,0 +1,23 @@
+package org.openapitools;
+
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.openapitools", "org.openapitools.api" , "org.openapitools.configuration"})
+public class OpenApiGeneratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenApiGeneratorApplication.class, args);
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
+    }
+
+}


### PR DESCRIPTION
Feature request: #10109

This PR adds a new configuration option "useTags" to the Java generator similar to the one that can be found e. g. in the Spring generator. 
The flag defaults to `true` to keep backwards compatibility (despite the default for the other generators is false). 
Setting it the `false` will prevent the generator to create one interface per tag (which might be not desirable). 

There has been a similar PR before, but it has been closed without comment: [10156](https://github.com/OpenAPITools/openapi-generator/pull/10156)

/cc Technical committee members @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
