### PR TITLE
Has generators set default template engine

### DIFF
--- a/bin/configs/python-experimental.yaml
+++ b/bin/configs/python-experimental.yaml
@@ -2,7 +2,6 @@ generatorName: python-experimental
 outputDir: samples/openapi3/client/petstore/python-experimental
 inputSpec: modules/openapi-generator/src/test/resources/3_0/python-experimental/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
 templateDir: modules/openapi-generator/src/main/resources/python-experimental
-templatingEngineName: handlebars
 additionalProperties:
   packageName: petstore_api
   recursionLimit: "1234"

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -46,7 +46,7 @@ public class WorkflowSettings {
     public static final boolean DEFAULT_ENABLE_MINIMAL_UPDATE = false;
     public static final boolean DEFAULT_STRICT_SPEC_BEHAVIOR = true;
     public static final boolean DEFAULT_GENERATE_ALIAS_AS_MODEL = false;
-    public static final String DEFAULT_TEMPLATING_ENGINE_NAME = "mustache";
+    public static final String DEFAULT_TEMPLATING_ENGINE_NAME = null; // this is set by the generator
     public static final Map<String, String> DEFAULT_GLOBAL_PROPERTIES = Collections.unmodifiableMap(new HashMap<>());
 
     private String inputSpec;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -304,4 +304,6 @@ public interface CodegenConfig {
     void setRemoveEnumValuePrefix(boolean removeEnumValuePrefix);
 
     Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings);
+
+    public String defaultTemplatingEngine();
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7356,4 +7356,9 @@ public class DefaultCodegen implements CodegenConfig {
         }
         return xOf;
     }
+
+    @Override
+    public String defaultTemplatingEngine() {
+        return "mustache";
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -482,15 +482,17 @@ public class CodegenConfigurator {
         Validate.notEmpty(generatorName, "generator name must be specified");
         Validate.notEmpty(inputSpec, "input spec must be specified");
 
+        GeneratorSettings generatorSettings = generatorSettingsBuilder.build();
+        CodegenConfig config = CodegenConfigLoader.forName(generatorSettings.getGeneratorName());
         if (isEmpty(templatingEngineName)) {
-            // Built-in templates are mustache, but allow users to use a simplified handlebars engine for their custom templates.
-            workflowSettingsBuilder.withTemplatingEngineName("mustache");
+            // if templatingEngineName is empty check the config for a default
+            String defaultTemplatingEngine = config.defaultTemplatingEngine();
+            workflowSettingsBuilder.withTemplatingEngineName(defaultTemplatingEngine);
         } else {
             workflowSettingsBuilder.withTemplatingEngineName(templatingEngineName);
         }
 
         // at this point, all "additionalProperties" are set, and are now immutable per GeneratorSettings instance.
-        GeneratorSettings generatorSettings = generatorSettingsBuilder.build();
         WorkflowSettings workflowSettings = workflowSettingsBuilder.build();
 
         if (workflowSettings.isVerbose()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -91,11 +91,18 @@ public class CodegenConfigurator {
             WorkflowSettings workflowSettings = settings.getWorkflowSettings();
             List<TemplateDefinition> userDefinedTemplateSettings = settings.getFiles();
 
+            CodegenConfig config = CodegenConfigLoader.forName(generatorSettings.getGeneratorName());
+            String templatingEngineName = workflowSettings.getTemplatingEngineName();
+            if (isEmpty(templatingEngineName)) {
+                // if templatingEngineName is empty check the config for a default
+                templatingEngineName = config.defaultTemplatingEngine();
+            }
+
             // We copy "cached" properties into configurator so it is appropriately configured with all settings in external files.
             // FIXME: target is to eventually move away from CodegenConfigurator properties except gen/workflow settings.
             configurator.generatorName = generatorSettings.getGeneratorName();
             configurator.inputSpec = workflowSettings.getInputSpec();
-            configurator.templatingEngineName = workflowSettings.getTemplatingEngineName();
+            configurator.templatingEngineName = templatingEngineName;
             if (workflowSettings.getGlobalProperties() != null) {
                 configurator.globalProperties.putAll(workflowSettings.getGlobalProperties());
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
@@ -2075,4 +2075,9 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
         }
         return co;
     }
+
+    @Override
+    public String defaultTemplatingEngine() {
+        return "handlebars";
+    }
 }

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+5.4.0-SNAPSHOT

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.4.0-SNAPSHOT
+unset


### PR DESCRIPTION
Allows generators to set defaultTemplateEngine
python-experimental needs to use handlebars as its default template engine
If we don't allow this then when devs use generator that need to use handlebars by default the devs must always pass in the -e or templatingEngineName yaml input; even though all the template files are handlebars files for python-experimental.

For context the python-experimental generator only works with handlebars templates.
That template engine allows any depth of indented partials and python-experimental uses it to render inline schemas.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Can I get a review core team?
@wing328 (2015/07) ❤️
@jimschubert (2016/05) ❤️
@cbornet (2016/05)
@ackintosh (2018/02) ❤️
@jmini (2018/04) ❤️
@etherealjoy (2019/06)
@spacether (2020/05) ❤️
cc @OpenAPITools/generator-core-team