### PR TITLE
Address #11248 (usePromise property of typescript-inversify templates)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-inversify/HttpClient.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/HttpClient.mustache
@@ -1,38 +1,40 @@
 import IHttpClient from './IHttpClient';
 
+{{^usePromise}}
 {{^useRxJS6}}
 import { Observable } from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
 import { Observable, from } from 'rxjs';
 {{/useRxJS6}}
+{{/usePromise}}
 
+import {injectable} from 'inversify';
 import 'whatwg-fetch';
 import HttpResponse from './HttpResponse';
-import {injectable} from 'inversify';
 import { Headers } from './Headers';
 
 @injectable()
 class HttpClient implements IHttpClient {
 
-    get(url:string, headers?: Headers):Observable<HttpResponse> {
+    get(url:string, headers?: Headers): {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse> {
         return this.performNetworkCall(url, 'GET', undefined, headers);
     }
 
-    post(url: string, body?: {}|FormData, headers?: Headers): Observable<HttpResponse> {
+    post(url: string, body?: {}|FormData, headers?: Headers): {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse> {
         return this.performNetworkCall(url, 'POST', this.getJsonBody(body), this.addJsonHeaders(headers));
     }
 
-    put(url: string, body?: {}, headers?: Headers): Observable<HttpResponse> {
+    put(url: string, body?: {}, headers?: Headers): {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse> {
         return this.performNetworkCall(url, 'PUT', this.getJsonBody(body), this.addJsonHeaders(headers));
     }
 
-    patch(url: string, body?: {}, headers?: Headers): Observable<HttpResponse> {
+    patch(url: string, body?: {}, headers?: Headers): {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse> {
         return this.performNetworkCall(url, 'PATCH', this.getJsonBody(body), this.addJsonHeaders(headers));
     }
 
 
-    delete(url: string, headers?: Headers): Observable<HttpResponse> {
+    delete(url: string, headers?: Headers): {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse> {
         return this.performNetworkCall(url, 'DELETE', undefined, headers);
     }
 
@@ -50,7 +52,7 @@ class HttpClient implements IHttpClient {
         }, headers);
     };
 
-    private performNetworkCall(url: string, method: string, body?: any, headers?: Headers): Observable<HttpResponse> {
+    private performNetworkCall(url: string, method: string, body?: any, headers?: Headers): {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse> {
 
         // when using fetch & a multipart upload, the requests content-type is handled by the browser, so should be left unset otherwise the multipart boundary is not added
         if(headers && headers['Content-Type'] === 'multipart/form-data') {
@@ -77,12 +79,17 @@ class HttpClient implements IHttpClient {
             });
         });
 
+{{#usePromise}}
+        return promise;
+{{/usePromise}}
+{{^usePromise}}
         {{^useRxJS6}}
             return Observable.fromPromise(promise);
         {{/useRxJS6}}
         {{#useRxJS6}}
             return from(promise);
         {{/useRxJS6}}
+{{/usePromise}}
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/IHttpClient.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/IHttpClient.mustache
@@ -1,18 +1,20 @@
+{{^usePromise}}
 {{^useRxJS6}}
 import { Observable } from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
 import { Observable, from } from 'rxjs';
 {{/useRxJS6}}
+{{/usePromise}}
 import HttpResponse from './HttpResponse';
 import { Headers } from './Headers';
 
 interface IHttpClient {
-    get(url:string, headers?: Headers):Observable<HttpResponse>
-    post(url:string, body?:{}|FormData, headers?: Headers):Observable<HttpResponse>
-    put(url:string, body?:{}, headers?: Headers):Observable<HttpResponse>
-    patch(url:string, body?:{}, headers?: Headers):Observable<HttpResponse>
-    delete(url:string, headers?: Headers):Observable<HttpResponse>
+    get(url:string, headers?: Headers):{{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse>
+    post(url:string, body?:{}|FormData, headers?: Headers):{{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse>
+    put(url:string, body?:{}, headers?: Headers):{{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse>
+    patch(url:string, body?:{}, headers?: Headers):{{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse>
+    delete(url:string, headers?: Headers):{{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse>
 }
 
 export default IHttpClient

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
@@ -1,16 +1,18 @@
 {{>licenseInfo}}
 /* tslint:disable:no-unused-variable member-ordering */
 
+{{^usePromise}}
 {{^useRxJS6}}
 import { Observable } from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
 import { Observable } from 'rxjs';
 {{/useRxJS6}}
-
 import { map } from 'rxjs/operators';
-import IHttpClient from '../IHttpClient';
+{{/usePromise}}
+
 import { inject, injectable } from 'inversify';
+import IHttpClient from '../IHttpClient';
 import { IAPIConfiguration } from '../IAPIConfiguration';
 import { Headers } from '../Headers';
 import HttpResponse from '../HttpResponse';
@@ -52,7 +54,7 @@ export class {{classname}} {
      * {{summary}}
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
-     {{/allParams}}{{#useHttpClient}}* @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     {{/allParams}}* {{#useHttpClient}}@param observe set whether or not to return the data as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.{{/useHttpClient}}
      */
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe?: 'body', headers?: Headers): {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>;
@@ -179,13 +181,13 @@ export class {{classname}} {
 {{/formParams}}
 
 {{/hasFormParams}}
-        const response: Observable<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>> = this.httpClient.{{httpMethod}}(`${this.basePath}{{{path}}}{{#hasQueryParams}}?${queryParameters.join('&')}{{/hasQueryParams}}`{{#bodyParam}}, {{paramName}} {{/bodyParam}}{{#hasFormParams}}, formData{{/hasFormParams}}, headers);
+        const response: {{#usePromise}}Promise{{/usePromise}}{{^usePromise}}Observable{{/usePromise}}<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>> = this.httpClient.{{httpMethod}}(`${this.basePath}{{{path}}}{{#hasQueryParams}}?${queryParameters.join('&')}{{/hasQueryParams}}`{{#bodyParam}}, {{paramName}} {{/bodyParam}}{{#hasFormParams}}, formData{{/hasFormParams}}, headers);
         if (observe === 'body') {
-               return response.pipe(
-                   map((httpResponse: HttpResponse) => <{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>(httpResponse.response))
-               ){{#usePromise}}.toPromise(){{/usePromise}};
+               return response.{{#usePromise}}then{{/usePromise}}{{^usePromise}}pipe{{/usePromise}}(
+                   {{^usePromise}}map({{/usePromise}}(httpResponse: HttpResponse) => <{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>(httpResponse.response){{^usePromise}}){{/usePromise}}
+               ){{^usePromise}}.toPromise(){{/usePromise}};
         }
-        return response{{#usePromise}}.toPromise(){{/usePromise}};
+        return response{{^usePromise}}.toPromise(){{/usePromise}};
     }
 
 {{/operation}}}

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
@@ -185,9 +185,9 @@ export class {{classname}} {
         if (observe === 'body') {
                return response.{{#usePromise}}then{{/usePromise}}{{^usePromise}}pipe{{/usePromise}}(
                    {{^usePromise}}map({{/usePromise}}(httpResponse: HttpResponse) => <{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>(httpResponse.response){{^usePromise}}){{/usePromise}}
-               ){{^usePromise}}.toPromise(){{/usePromise}};
+               );
         }
-        return response{{^usePromise}}.toPromise(){{/usePromise}};
+        return response;
     }
 
 {{/operation}}}

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/apiInterface.mustache
@@ -1,11 +1,13 @@
 {{>licenseInfo}}
 import { Headers } from '../Headers';
+{{^usePromise}}
 {{^useRxJS6}}
 import { Observable } from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
 import { Observable } from 'rxjs';
 {{/useRxJS6}}
+{{/usePromise}}
 {{#imports}}
 import { {{classname}} } from '../{{filename}}';
 {{/imports}}

--- a/samples/client/petstore/typescript-inversify/HttpClient.ts
+++ b/samples/client/petstore/typescript-inversify/HttpClient.ts
@@ -2,15 +2,15 @@ import IHttpClient from './IHttpClient';
 
 import { Observable } from 'rxjs/Observable';
 
+import {injectable} from 'inversify';
 import 'whatwg-fetch';
 import HttpResponse from './HttpResponse';
-import {injectable} from 'inversify';
 import { Headers } from './Headers';
 
 @injectable()
 class HttpClient implements IHttpClient {
 
-    get(url:string, headers?: Headers):Observable<HttpResponse> {
+    get(url:string, headers?: Headers): Observable<HttpResponse> {
         return this.performNetworkCall(url, 'GET', undefined, headers);
     }
 

--- a/samples/client/petstore/typescript-inversify/api/pet.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/pet.service.ts
@@ -12,10 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Observable } from 'rxjs/Observable';
-
 import { map } from 'rxjs/operators';
-import IHttpClient from '../IHttpClient';
+
 import { inject, injectable } from 'inversify';
+import IHttpClient from '../IHttpClient';
 import { IAPIConfiguration } from '../IAPIConfiguration';
 import { Headers } from '../Headers';
 import HttpResponse from '../HttpResponse';
@@ -41,7 +41,7 @@ export class PetService {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
-     
+     * 
      */
     public addPet(body: Pet, observe?: 'body', headers?: Headers): Observable<any>;
     public addPet(body: Pet, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -64,9 +64,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -75,7 +75,7 @@ export class PetService {
      * 
      * @param petId Pet id to delete
      * @param apiKey 
-     
+     * 
      */
     public deletePet(petId: number, apiKey?: string, observe?: 'body', headers?: Headers): Observable<any>;
     public deletePet(petId: number, apiKey?: string, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -101,9 +101,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -111,7 +111,7 @@ export class PetService {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
-     
+     * 
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, observe?: 'body', headers?: Headers): Observable<Array<Pet>>;
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, observe?: 'response', headers?: Headers): Observable<HttpResponse<Array<Pet>>>;
@@ -138,9 +138,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Array<Pet>>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -148,7 +148,7 @@ export class PetService {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
-     
+     * 
      */
     public findPetsByTags(tags: Array<string>, observe?: 'body', headers?: Headers): Observable<Array<Pet>>;
     public findPetsByTags(tags: Array<string>, observe?: 'response', headers?: Headers): Observable<HttpResponse<Array<Pet>>>;
@@ -175,9 +175,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Array<Pet>>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -185,7 +185,7 @@ export class PetService {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
-     
+     * 
      */
     public getPetById(petId: number, observe?: 'body', headers?: Headers): Observable<Pet>;
     public getPetById(petId: number, observe?: 'response', headers?: Headers): Observable<HttpResponse<Pet>>;
@@ -204,9 +204,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Pet>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -214,7 +214,7 @@ export class PetService {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
-     
+     * 
      */
     public updatePet(body: Pet, observe?: 'body', headers?: Headers): Observable<any>;
     public updatePet(body: Pet, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -237,9 +237,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -249,7 +249,7 @@ export class PetService {
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
-     
+     * 
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'body', headers?: Headers): Observable<any>;
     public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -280,9 +280,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -292,7 +292,7 @@ export class PetService {
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
-     
+     * 
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'body', headers?: Headers): Observable<ApiResponse>;
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'response', headers?: Headers): Observable<HttpResponse<ApiResponse>>;
@@ -323,9 +323,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <ApiResponse>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 }

--- a/samples/client/petstore/typescript-inversify/api/pet.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/pet.service.ts
@@ -64,9 +64,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -101,9 +101,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -138,9 +138,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Array<Pet>>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -175,9 +175,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Array<Pet>>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -204,9 +204,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Pet>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -237,9 +237,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -280,9 +280,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -323,9 +323,9 @@ export class PetService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <ApiResponse>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 }

--- a/samples/client/petstore/typescript-inversify/api/store.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/store.service.ts
@@ -55,9 +55,9 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -79,9 +79,9 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <{ [key: string]: number; }>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -104,9 +104,9 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Order>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -130,9 +130,9 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Order>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 }

--- a/samples/client/petstore/typescript-inversify/api/store.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/store.service.ts
@@ -12,10 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Observable } from 'rxjs/Observable';
-
 import { map } from 'rxjs/operators';
-import IHttpClient from '../IHttpClient';
+
 import { inject, injectable } from 'inversify';
+import IHttpClient from '../IHttpClient';
 import { IAPIConfiguration } from '../IAPIConfiguration';
 import { Headers } from '../Headers';
 import HttpResponse from '../HttpResponse';
@@ -40,7 +40,7 @@ export class StoreService {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
-     
+     * 
      */
     public deleteOrder(orderId: string, observe?: 'body', headers?: Headers): Observable<any>;
     public deleteOrder(orderId: string, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -55,16 +55,16 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
-     
+     * 
      */
     public getInventory(observe?: 'body', headers?: Headers): Observable<{ [key: string]: number; }>;
     public getInventory(observe?: 'response', headers?: Headers): Observable<HttpResponse<{ [key: string]: number; }>>;
@@ -79,9 +79,9 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <{ [key: string]: number; }>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -89,7 +89,7 @@ export class StoreService {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
-     
+     * 
      */
     public getOrderById(orderId: number, observe?: 'body', headers?: Headers): Observable<Order>;
     public getOrderById(orderId: number, observe?: 'response', headers?: Headers): Observable<HttpResponse<Order>>;
@@ -104,9 +104,9 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Order>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -114,7 +114,7 @@ export class StoreService {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
-     
+     * 
      */
     public placeOrder(body: Order, observe?: 'body', headers?: Headers): Observable<Order>;
     public placeOrder(body: Order, observe?: 'response', headers?: Headers): Observable<HttpResponse<Order>>;
@@ -130,9 +130,9 @@ export class StoreService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <Order>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 }

--- a/samples/client/petstore/typescript-inversify/api/user.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/user.service.ts
@@ -56,9 +56,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -82,9 +82,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -108,9 +108,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -133,9 +133,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -158,9 +158,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <User>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -196,9 +196,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <string>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -216,9 +216,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 
@@ -247,9 +247,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               ).toPromise();
+               );
         }
-        return response.toPromise();
+        return response;
     }
 
 }

--- a/samples/client/petstore/typescript-inversify/api/user.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/user.service.ts
@@ -12,10 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Observable } from 'rxjs/Observable';
-
 import { map } from 'rxjs/operators';
-import IHttpClient from '../IHttpClient';
+
 import { inject, injectable } from 'inversify';
+import IHttpClient from '../IHttpClient';
 import { IAPIConfiguration } from '../IAPIConfiguration';
 import { Headers } from '../Headers';
 import HttpResponse from '../HttpResponse';
@@ -40,7 +40,7 @@ export class UserService {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
-     
+     * 
      */
     public createUser(body: User, observe?: 'body', headers?: Headers): Observable<any>;
     public createUser(body: User, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -56,9 +56,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -66,7 +66,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
-     
+     * 
      */
     public createUsersWithArrayInput(body: Array<User>, observe?: 'body', headers?: Headers): Observable<any>;
     public createUsersWithArrayInput(body: Array<User>, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -82,9 +82,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -92,7 +92,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
-     
+     * 
      */
     public createUsersWithListInput(body: Array<User>, observe?: 'body', headers?: Headers): Observable<any>;
     public createUsersWithListInput(body: Array<User>, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -108,9 +108,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -118,7 +118,7 @@ export class UserService {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
-     
+     * 
      */
     public deleteUser(username: string, observe?: 'body', headers?: Headers): Observable<any>;
     public deleteUser(username: string, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -133,9 +133,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -143,7 +143,7 @@ export class UserService {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
-     
+     * 
      */
     public getUserByName(username: string, observe?: 'body', headers?: Headers): Observable<User>;
     public getUserByName(username: string, observe?: 'response', headers?: Headers): Observable<HttpResponse<User>>;
@@ -158,9 +158,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <User>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -169,7 +169,7 @@ export class UserService {
      * 
      * @param username The user name for login
      * @param password The password for login in clear text
-     
+     * 
      */
     public loginUser(username: string, password: string, observe?: 'body', headers?: Headers): Observable<string>;
     public loginUser(username: string, password: string, observe?: 'response', headers?: Headers): Observable<HttpResponse<string>>;
@@ -196,16 +196,16 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <string>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
     /**
      * Logs out current logged in user session
      * 
-     
+     * 
      */
     public logoutUser(observe?: 'body', headers?: Headers): Observable<any>;
     public logoutUser(observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -216,9 +216,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 
@@ -227,7 +227,7 @@ export class UserService {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
      * @param body Updated user object
-     
+     * 
      */
     public updateUser(username: string, body: User, observe?: 'body', headers?: Headers): Observable<any>;
     public updateUser(username: string, body: User, observe?: 'response', headers?: Headers): Observable<HttpResponse<any>>;
@@ -247,9 +247,9 @@ export class UserService {
         if (observe === 'body') {
                return response.pipe(
                    map((httpResponse: HttpResponse) => <any>(httpResponse.response))
-               );
+               ).toPromise();
         }
-        return response;
+        return response.toPromise();
     }
 
 }


### PR DESCRIPTION
Fixes #11248 Inconsistent application of usePromise property in typescript-inversify templates

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu  @taxpon  @sebastianhaas  @kenisteward  @Vrolijkx  @macjohnny  @topce  @akehir  @petejohansonxo  @amakhrov 