### PR TITLE
ISSUE-11242: Fix Java native path param encoding

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -76,7 +76,7 @@ public class ApiClient {
    * @return URL-encoded representation of the input string.
    */
   public static String urlEncode(String s) {
-    return URLEncoder.encode(s, UTF_8);
+    return URLEncoder.encode(s, UTF_8).replaceAll("\\+", "%20");
   }
 
   /**

--- a/modules/openapi-generator/src/test/resources/3_0/issue11242.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue11242.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: Issue 11242 - Path Param encoding
+  description: "White space encoding in path parameters"
+  version: "1.0.0"
+servers:
+  - url: localhost:8080
+paths:
+  /api/{someParam}:
+    parameters:
+      - in: path
+        name: someParam
+        schema:
+          type: string
+        required: true
+        description: Some parameter.
+    get:
+      operationId: GetSomeParam
+      summary: View some param
+      responses:
+        '200':
+          description: Some return value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeReturnValue'
+              example:
+                someParam: someValue
+components:
+  schemas:
+    SomeReturnValue:
+      type: object
+      required:
+        - someParam
+      properties:
+        someParam:
+          type: string

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
@@ -81,7 +81,7 @@ public class ApiClient {
    * @return URL-encoded representation of the input string.
    */
   public static String urlEncode(String s) {
-    return URLEncoder.encode(s, UTF_8);
+    return URLEncoder.encode(s, UTF_8).replaceAll("\\+", "%20");
   }
 
   /**

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -81,7 +81,7 @@ public class ApiClient {
    * @return URL-encoded representation of the input string.
    */
   public static String urlEncode(String s) {
-    return URLEncoder.encode(s, UTF_8);
+    return URLEncoder.encode(s, UTF_8).replaceAll("\\+", "%20");
   }
 
   /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #11242 white space encoding in path parameters

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
