### PR TITLE
[BUG][csharp-netcore] Fix Multi Files for the same FormField  (#11132)

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -371,12 +371,15 @@ namespace {{packageName}}.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/RequestOptions.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/RequestOptions.mustache
@@ -38,7 +38,7 @@ namespace {{packageName}}.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -59,7 +59,7 @@ namespace {{packageName}}.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -278,10 +278,12 @@ namespace {{packageName}}.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var content = new StreamContent(fileParam.Value.Content);
-                    content.Headers.ContentType = new MediaTypeHeaderValue(fileParam.Value.ContentType);
-                    multipartContent.Add(content, fileParam.Key,
-                        fileParam.Value.Name);
+                    foreach (var file in fileParam.Value)
+                    {
+                        var content = new StreamContent(file.Content);
+                        content.Headers.ContentType = new MediaTypeHeaderValue(file.ContentType);
+                        multipartContent.Add(content, fileParam.Key, file.Name);
+                    }
                 }
             }
             return multipartContent;

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/RequestOptions.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/RequestOptions.mustache
@@ -38,7 +38,7 @@ namespace {{packageName}}.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, FileParameter> FileParameters { get; set; }
+        public Multimap<string, FileParameter> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -59,7 +59,7 @@ namespace {{packageName}}.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, FileParameter>();
+            FileParameters = new Multimap<string, FileParameter>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -370,12 +370,15 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -370,12 +370,15 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -277,10 +277,12 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var content = new StreamContent(fileParam.Value.Content);
-                    content.Headers.ContentType = new MediaTypeHeaderValue(fileParam.Value.ContentType);
-                    multipartContent.Add(content, fileParam.Key,
-                        fileParam.Value.Name);
+                    foreach (var file in fileParam.Value)
+                    {
+                        var content = new StreamContent(file.Content);
+                        content.Headers.ContentType = new MediaTypeHeaderValue(file.ContentType);
+                        multipartContent.Add(content, fileParam.Key, file.Name);
+                    }
                 }
             }
             return multipartContent;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, FileParameter> FileParameters { get; set; }
+        public Multimap<string, FileParameter> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, FileParameter>();
+            FileParameters = new Multimap<string, FileParameter>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -371,12 +371,15 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -371,12 +371,15 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -370,12 +370,15 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -371,12 +371,15 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -370,12 +370,15 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var fileParam in options.FileParameters)
                 {
-                    var bytes = ClientUtils.ReadAsBytes(fileParam.Value);
-                    var fileStream = fileParam.Value as FileStream;
-                    if (fileStream != null)
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
-                    else
-                        request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    foreach (var file in fileParam.Value)
+                    {
+                        var bytes = ClientUtils.ReadAsBytes(file);
+                        var fileStream = file as FileStream;
+                        if (fileStream != null)
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, System.IO.Path.GetFileName(fileStream.Name)));
+                        else
+                            request.Files.Add(FileParameter.Create(fileParam.Key, bytes, "no_file_name_provided"));
+                    }
                 }
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/RequestOptions.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/RequestOptions.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
-        public Dictionary<string, Stream> FileParameters { get; set; }
+        public Multimap<string, Stream> FileParameters { get; set; }
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -67,7 +67,7 @@ namespace Org.OpenAPITools.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
-            FileParameters = new Dictionary<string, Stream>();
+            FileParameters = new Multimap<string, Stream>();
             Cookies = new List<Cookie>();
         }
     }


### PR DESCRIPTION
Fix issue #11132

FileParameters at Request Options is a Dictionary so we weren't able to send more than one file with the same key.
Refactor FileParamerts to Multimap to enable sending more than one file with the same key.

I did the development only for csharp-netcore but it has no impacts and can be made to the others generators.

If you find it useful say it at the review.
@mandrean 
@shibayan 
@Blackclaws 
@lucamazzanti 

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
