### PR TITLE
python-experimental, redundant docstrings removed

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_composed_or_anytype.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_composed_or_anytype.handlebars
@@ -32,25 +32,6 @@ class {{#if this.classname}}{{classname}}{{else}}{{#if nameInSnakeCase}}{{name}}
 
     {{{unescapedDescription}}}
 {{/if}}
-
-    Attributes:
-{{#each vars}}
-    {{baseName}} ({{#if isArray}}tuple,{{/if}}{{#if isBoolean}}bool,{{/if}}{{#if isDate}}date,{{/if}}{{#if isDateTime}}datetime,{{/if}}{{#if isMap}}dict,{{/if}}{{#if isFloat}}float,{{/if}}{{#if isNumber}}float,{{/if}}{{#if isUnboundedInteger}}int,{{/if}}{{#if isShort}}int,{{/if}}{{#if isLong}}int,{{/if}}{{#if isString}}str,{{/if}}{{#if isByteArray}}str,{{/if}}{{#if isNull}} none_type,{{/if}}): {{#if description}}{{description}}{{/if}}
-{{/each}}
-{{#if hasValidation}}
-    _validations (dict): the validations which apply to the current Schema
-        The value is a dict that stores validations for max_length, min_length, max_items,
-        min_items, exclusive_maximum, inclusive_maximum, exclusive_minimum,
-        inclusive_minimum, and regex.
-{{/if}}
-{{#with additionalProperties}}
-    _additional_properties (Schema): the definition used for additional properties
-        that are not defined in _properties
-{{/with}}
-{{#if getHasDiscriminatorWithNonEmptyMapping}}
-    _discriminator(cls) -> dict: the key is the required discriminator propertyName
-        the value is a dict mapping from a string name to the corresponding Schema class
-{{/if}}
     """
 {{/if}}
 {{#or isMap isAnyType}}

--- a/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_dict.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_dict.handlebars
@@ -15,25 +15,6 @@ class {{#if this.classname}}{{classname}}{{else}}{{#if nameInSnakeCase}}{{name}}
 
     {{{unescapedDescription}}}
 {{/if}}
-
-    Attributes:
-{{#each vars}}
-    {{baseName}} ({{#if isArray}}tuple,{{/if}}{{#if isBoolean}}bool,{{/if}}{{#if isDate}}date,{{/if}}{{#if isDateTime}}datetime,{{/if}}{{#if isMap}}dict,{{/if}}{{#if isFloat}}float,{{/if}}{{#if isDouble}}float,{{/if}}{{#if isNumber}}int, float,{{/if}}{{#if isUnboundedInteger}}int,{{/if}}{{#if isShort}}int,{{/if}}{{#if isLong}}int,{{/if}}{{#if isString}}str,{{/if}}{{#if isByteArray}}str,{{/if}}{{#if isNull}} none_type,{{/if}}): {{#if description}}{{description}}{{/if}}
-{{/each}}
-{{#if hasValidation}}
-    _validations (dict): the validations which apply to the current Schema
-        The value is a dict that stores validations for max_length, min_length, max_items,
-        min_items, exclusive_maximum, inclusive_maximum, exclusive_minimum,
-        inclusive_minimum, and regex.
-{{/if}}
-{{#with additionalProperties}}
-    _additional_properties (Schema): the definition used for additional properties
-        that are not defined in _properties
-{{/with}}
-{{#if getHasDiscriminatorWithNonEmptyMapping}}
-    _discriminator(cls) -> dict: the key is the required discriminator propertyName
-        the value is a dict mapping from a string name to the corresponding Schema class
-{{/if}}
     """
 {{/if}}
 {{> model_templates/dict_partial }}

--- a/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_list.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_list.handlebars
@@ -15,15 +15,6 @@ class {{#if this.classname}}{{classname}}{{else}}{{#if nameInSnakeCase}}{{name}}
 
     {{{unescapedDescription}}}
 {{/if}}
-
-    Attributes:
-    _items (Schema): the schema definition of the array items
-{{#if hasValidation}}
-    _validations (dict): the validations which apply to the current Schema
-         The value is a dict that stores validations for max_length, min_length, max_items,
-         min_items, exclusive_maximum, inclusive_maximum, exclusive_minimum,
-         inclusive_minimum, and regex.
-{{/if}}
     """
 {{/if}}
 {{#with items}}

--- a/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_simple.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/model_templates/schema_simple.handlebars
@@ -18,14 +18,6 @@ class {{#if this.classname}}{{classname}}{{else}}{{#if nameInSnakeCase}}{{name}}
 
     {{{unescapedDescription}}}
 {{/if}}
-
-    Attributes:
-{{#if hasValidation}}
-    _validations (dict): the validations which apply to the current Schema
-         The value is a dict that stores validations for max_length, min_length, max_items,
-         min_items, exclusive_maximum, inclusive_maximum, exclusive_minimum,
-         inclusive_minimum, and regex.
-{{/if}}
     """
 {{/if}}
 {{#if isEnum}}


### PR DESCRIPTION
Removes docstrings from models because type hints already includes this info

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
