### PR TITLE
Revert "Has generators set default template engine (#11245)"

### DIFF
--- a/bin/configs/python-experimental.yaml
+++ b/bin/configs/python-experimental.yaml
@@ -2,6 +2,7 @@ generatorName: python-experimental
 outputDir: samples/openapi3/client/petstore/python-experimental
 inputSpec: modules/openapi-generator/src/test/resources/3_0/python-experimental/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
 templateDir: modules/openapi-generator/src/main/resources/python-experimental
+templatingEngineName: handlebars
 additionalProperties:
   packageName: petstore_api
   recursionLimit: "1234"

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -46,7 +46,7 @@ public class WorkflowSettings {
     public static final boolean DEFAULT_ENABLE_MINIMAL_UPDATE = false;
     public static final boolean DEFAULT_STRICT_SPEC_BEHAVIOR = true;
     public static final boolean DEFAULT_GENERATE_ALIAS_AS_MODEL = false;
-    public static final String DEFAULT_TEMPLATING_ENGINE_NAME = null; // this is set by the generator
+    public static final String DEFAULT_TEMPLATING_ENGINE_NAME = "mustache";
     public static final Map<String, String> DEFAULT_GLOBAL_PROPERTIES = Collections.unmodifiableMap(new HashMap<>());
 
     private String inputSpec;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -305,8 +305,6 @@ public interface CodegenConfig {
 
     Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings);
 
-    public String defaultTemplatingEngine();
-
     public GeneratorLanguage generatorLanguage();
 
     /*

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7358,11 +7358,6 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    public String defaultTemplatingEngine() {
-        return "mustache";
-    }
-
-    @Override
     public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.JAVA; }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -91,18 +91,11 @@ public class CodegenConfigurator {
             WorkflowSettings workflowSettings = settings.getWorkflowSettings();
             List<TemplateDefinition> userDefinedTemplateSettings = settings.getFiles();
 
-            CodegenConfig config = CodegenConfigLoader.forName(generatorSettings.getGeneratorName());
-            String templatingEngineName = workflowSettings.getTemplatingEngineName();
-            if (isEmpty(templatingEngineName)) {
-                // if templatingEngineName is empty check the config for a default
-                templatingEngineName = config.defaultTemplatingEngine();
-            }
-
             // We copy "cached" properties into configurator so it is appropriately configured with all settings in external files.
             // FIXME: target is to eventually move away from CodegenConfigurator properties except gen/workflow settings.
             configurator.generatorName = generatorSettings.getGeneratorName();
             configurator.inputSpec = workflowSettings.getInputSpec();
-            configurator.templatingEngineName = templatingEngineName;
+            configurator.templatingEngineName = workflowSettings.getTemplatingEngineName();
             if (workflowSettings.getGlobalProperties() != null) {
                 configurator.globalProperties.putAll(workflowSettings.getGlobalProperties());
             }
@@ -489,17 +482,15 @@ public class CodegenConfigurator {
         Validate.notEmpty(generatorName, "generator name must be specified");
         Validate.notEmpty(inputSpec, "input spec must be specified");
 
-        GeneratorSettings generatorSettings = generatorSettingsBuilder.build();
-        CodegenConfig config = CodegenConfigLoader.forName(generatorSettings.getGeneratorName());
         if (isEmpty(templatingEngineName)) {
-            // if templatingEngineName is empty check the config for a default
-            String defaultTemplatingEngine = config.defaultTemplatingEngine();
-            workflowSettingsBuilder.withTemplatingEngineName(defaultTemplatingEngine);
+            // Built-in templates are mustache, but allow users to use a simplified handlebars engine for their custom templates.
+            workflowSettingsBuilder.withTemplatingEngineName("mustache");
         } else {
             workflowSettingsBuilder.withTemplatingEngineName(templatingEngineName);
         }
 
         // at this point, all "additionalProperties" are set, and are now immutable per GeneratorSettings instance.
+        GeneratorSettings generatorSettings = generatorSettingsBuilder.build();
         WorkflowSettings workflowSettings = workflowSettingsBuilder.build();
 
         if (workflowSettings.isVerbose()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
@@ -2087,10 +2087,5 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
     }
 
     @Override
-    public String defaultTemplatingEngine() {
-        return "handlebars";
-    }
-
-    @Override
     public String generatorLanguageVersion() { return ">=3.9"; };
 }


### PR DESCRIPTION
This reverts commit dd3bba8c9442f2ee40d6ea8f0872ab0be43714b9.
Because it broke peoples builds per this issue https://github.com/OpenAPITools/openapi-generator/issues/11276

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
