### PR TITLE
[KOTLIN] add `modelMutable` additional properties parser

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -416,6 +416,10 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             LOGGER.info("NOTE: To enable file post-processing, 'enablePostProcessFile' must be set to `true` (--enable-post-process-file for CLI).");
         }
 
+        if (additionalProperties.containsKey(MODEL_MUTABLE)) {
+            additionalProperties.put(MODEL_MUTABLE, Boolean.parseBoolean(additionalProperties.get(MODEL_MUTABLE).toString()));
+        }
+
         if (additionalProperties.containsKey(CodegenConstants.ENUM_PROPERTY_NAMING)) {
             setEnumPropertyNaming((String) additionalProperties.get(CodegenConstants.ENUM_PROPERTY_NAMING));
         }

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Category.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Category.kt
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Category (
-    var id: kotlin.Long? = null,
-    var name: kotlin.String? = null
+    val id: kotlin.Long? = null,
+    val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/ModelApiResponse.kt
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ModelApiResponse (
-    var code: kotlin.Int? = null,
-    var type: kotlin.String? = null,
-    var message: kotlin.String? = null
+    val code: kotlin.Int? = null,
+    val type: kotlin.String? = null,
+    val message: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Order.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Order.kt
@@ -28,13 +28,13 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Order (
-    var id: kotlin.Long? = null,
-    var petId: kotlin.Long? = null,
-    var quantity: kotlin.Int? = null,
-    var shipDate: java.time.OffsetDateTime? = null,
+    val id: kotlin.Long? = null,
+    val petId: kotlin.Long? = null,
+    val quantity: kotlin.Int? = null,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
-    var status: Order.Status? = null,
-    var complete: kotlin.Boolean? = false
+    val status: Order.Status? = null,
+    val complete: kotlin.Boolean? = false
 ) {
 
     /**

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Pet.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Pet.kt
@@ -30,13 +30,13 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Pet (
-    @SerializedName("name") private var _name: kotlin.String?,
-    @SerializedName("photoUrls") private var _photoUrls: kotlin.Array<kotlin.String>?,
-    var id: kotlin.Long? = null,
-    var category: Category? = null,
-    var tags: kotlin.Array<Tag>? = null,
+    @SerializedName("name") private val _name: kotlin.String?,
+    @SerializedName("photoUrls") private val _photoUrls: kotlin.Array<kotlin.String>?,
+    val id: kotlin.Long? = null,
+    val category: Category? = null,
+    val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
-    var status: Pet.Status? = null
+    val status: Pet.Status? = null
 ) {
 
     /**
@@ -53,9 +53,9 @@ data class Pet (
     
     }
 
-        var name get() = _name ?: throw IllegalArgumentException("name is required")
-                    set(value){ _name = value }
-        var photoUrls get() = _photoUrls ?: throw IllegalArgumentException("photoUrls is required")
-                    set(value){ _photoUrls = value }
+        val name get() = _name ?: throw IllegalArgumentException("name is required")
+                    
+        val photoUrls get() = _photoUrls ?: throw IllegalArgumentException("photoUrls is required")
+                    
 }
 

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Tag.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/Tag.kt
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Tag (
-    var id: kotlin.Long? = null,
-    var name: kotlin.String? = null
+    val id: kotlin.Long? = null,
+    val name: kotlin.String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/User.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/model/User.kt
@@ -30,15 +30,15 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class User (
-    var id: kotlin.Long? = null,
-    var username: kotlin.String? = null,
-    var firstName: kotlin.String? = null,
-    var lastName: kotlin.String? = null,
-    var email: kotlin.String? = null,
-    var password: kotlin.String? = null,
-    var phone: kotlin.String? = null,
+    val id: kotlin.Long? = null,
+    val username: kotlin.String? = null,
+    val firstName: kotlin.String? = null,
+    val lastName: kotlin.String? = null,
+    val email: kotlin.String? = null,
+    val password: kotlin.String? = null,
+    val phone: kotlin.String? = null,
     /* User Status */
-    var userStatus: kotlin.Int? = null
+    val userStatus: kotlin.Int? = null
 ) {
 
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Bugfix for #9175

### Cause
It occurred because there is no `modelMutable` boolean parser. So the value will be treated as a string instead of a boolean.

cc @jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
