### PR TITLE
[typescript-rxjs]  Add RxJS 7 support

### DIFF
--- a/docs/generators/typescript-rxjs.md
+++ b/docs/generators/typescript-rxjs.md
@@ -32,6 +32,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |nullSafeAdditionalProps|Set to make additional properties types declare that their indexer may return undefined| |false|
 |paramNaming|Naming convention for parameters: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name| |camelCase|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
+|rxjs7|Whether to use RxJS 7 or not.| |false|
 |snapshot|When setting this property to true, the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -33,6 +33,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
     public static final String NPM_REPOSITORY = "npmRepository";
     public static final String WITH_PROGRESS_SUBSCRIBER = "withProgressSubscriber";
+    public static final String RXJS_7 = "rxjs7";
 
     protected String npmRepository = null;
     protected Set<String> reservedParamNames = new HashSet<>();
@@ -44,7 +45,6 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
         outputFolder = "generated-code/typescript-rxjs";
         embeddedTemplateDir = templateDir = "typescript-rxjs";
-
         this.apiPackage = "apis";
         this.apiTemplateFiles.put("apis.mustache", ".ts");
         this.modelPackage = "models";
@@ -56,6 +56,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(WITH_PROGRESS_SUBSCRIBER, "Setting this property to true will generate API controller methods with support for subscribing to request progress.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
+        this.cliOptions.add(new CliOption(RXJS_7, "Whether to use RxJS 7 or not.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
 
         // these are used in the api template for more efficient destructuring
         this.reservedParamNames.add("headers");

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -1,9 +1,17 @@
 // tslint:disable
 {{>licenseInfo}}
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
+{{#rxjs7}}
+import type { AjaxResponse } from 'rxjs/ajax';
+import { BaseAPI{{#hasRequiredParams}}, throwIfNullOrUndefined{{/hasRequiredParams}}{{#hasPathParams}}, encodeURI{{/hasPathParams}}{{#hasListContainers}}, COLLECTION_FORMATS{{/hasListContainers}} } from '../runtime';
+import type { OperationOpts{{#hasHttpHeaders}}, HttpHeaders{{/hasHttpHeaders}}{{#hasQueryParams}}, HttpQuery{{/hasQueryParams}} } from '../runtime';
+{{/rxjs7}}
+{{^rxjs7}}
 import { BaseAPI{{#hasHttpHeaders}}, HttpHeaders{{/hasHttpHeaders}}{{#hasQueryParams}}, HttpQuery{{/hasQueryParams}}{{#hasRequiredParams}}, throwIfNullOrUndefined{{/hasRequiredParams}}{{#hasPathParams}}, encodeURI{{/hasPathParams}}{{#hasListContainers}}, COLLECTION_FORMATS{{/hasListContainers}}, OperationOpts, RawAjaxResponse } from '../runtime';
+{{/rxjs7}}
+
 {{#imports.0}}
-import {
+import type {
     {{#imports}}
     {{className}},
     {{/imports}}
@@ -41,8 +49,14 @@ export class {{classname}} extends BaseAPI {
 {{#withProgressSubscriber}}
     {{nickname}}({{#allParams.0}}{ {{#allParams}}{{paramName}}{{#vendorExtensions.x-param-name-alternative}}: {{vendorExtensions.x-param-name-alternative}}{{/vendorExtensions.x-param-name-alternative}}{{^-last}}, {{/-last}}{{/allParams}} }: {{operationIdCamelCase}}Request, {{/allParams.0}}opts?: Pick<OperationOpts, 'progressSubscriber'>): Observable<{{{returnType}}}{{^returnType}}void{{/returnType}}>
 {{/withProgressSubscriber}}
+{{#rxjs7}}
+    {{nickname}}({{#allParams.0}}{ {{#allParams}}{{paramName}}{{#vendorExtensions.x-param-name-alternative}}: {{vendorExtensions.x-param-name-alternative}}{{/vendorExtensions.x-param-name-alternative}}{{^-last}}, {{/-last}}{{/allParams}} }: {{operationIdCamelCase}}Request, {{/allParams.0}}opts?: OperationOpts): Observable<{{#returnType}}AjaxResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}void | AjaxResponse<void>{{/returnType}}>
+    {{nickname}}({{#allParams.0}}{ {{#allParams}}{{paramName}}{{#vendorExtensions.x-param-name-alternative}}: {{vendorExtensions.x-param-name-alternative}}{{/vendorExtensions.x-param-name-alternative}}{{^-last}}, {{/-last}}{{/allParams}} }: {{operationIdCamelCase}}Request, {{/allParams.0}}opts?: OperationOpts): Observable<{{#returnType}}{{{returnType}}} | AjaxResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}void | AjaxResponse<void>{{/returnType}}> {
+{{/rxjs7}}
+{{^rxjs7}}
     {{nickname}}({{#allParams.0}}{ {{#allParams}}{{paramName}}{{#vendorExtensions.x-param-name-alternative}}: {{vendorExtensions.x-param-name-alternative}}{{/vendorExtensions.x-param-name-alternative}}{{^-last}}, {{/-last}}{{/allParams}} }: {{operationIdCamelCase}}Request, {{/allParams.0}}opts?: OperationOpts): Observable<{{#returnType}}RawAjaxResponse<{{{.}}}>{{/returnType}}{{^returnType}}void | RawAjaxResponse<void>{{/returnType}}>
     {{nickname}}({{#allParams.0}}{ {{#allParams}}{{paramName}}{{#vendorExtensions.x-param-name-alternative}}: {{vendorExtensions.x-param-name-alternative}}{{/vendorExtensions.x-param-name-alternative}}{{^-last}}, {{/-last}}{{/allParams}} }: {{operationIdCamelCase}}Request, {{/allParams.0}}opts?: OperationOpts): Observable<{{#returnType}}{{{returnType}}} | RawAjaxResponse<{{{returnType}}}>{{/returnType}}{{^returnType}}void | RawAjaxResponse<void>{{/returnType}}> {
+{{/rxjs7}}
         {{#hasParams}}
         {{#allParams}}
         {{#required}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelAllOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelAllOf.mustache
@@ -1,5 +1,5 @@
 {{#hasImports}}
-import {
+import type {
     {{#imports}}
     {{{.}}},
     {{/imports}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelGeneric.mustache
@@ -1,5 +1,5 @@
 {{#hasImports}}
-import {
+import type {
     {{#imports}}
     {{{.}}},
     {{/imports}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelOneOf.mustache
@@ -1,5 +1,5 @@
 {{#hasImports}}
-import {
+import type {
     {{#imports}}
     {{{.}}},
     {{/imports}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/package.mustache
@@ -10,10 +10,10 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "rxjs": "^6.3.3"
+    "rxjs": "{{#rxjs7}}^7.2.0{{/rxjs7}}{{^rxjs7}}^6.3.3{{/rxjs7}}"
   },
   "devDependencies": {
-    "typescript": "^3.7"
+    "typescript": "{{#rxjs7}}^4.0{{/rxjs7}}{{^rxjs7}}^3.7{{/rxjs7}}"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
   "publishConfig": {

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/paramNamePartial.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/paramNamePartial.mustache
@@ -1,2 +1,2 @@
-{{! helper to output the alias of a parameter if provided and to not clutter the main template  }}
+{{! helper to output the alias of a parameter if provided and to not clutter the main template }}
 {{#vendorExtensions.x-param-name-alternative}}{{vendorExtensions.x-param-name-alternative}}{{/vendorExtensions.x-param-name-alternative}}{{^vendorExtensions.x-param-name-alternative}}{{paramName}}{{/vendorExtensions.x-param-name-alternative}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -1,7 +1,10 @@
 // tslint:disable
 {{>licenseInfo}}
-import { Observable, of{{#withProgressSubscriber}}, Subscriber{{/withProgressSubscriber}} } from 'rxjs';
-import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
+import { of } from 'rxjs';
+import type { Observable{{#withProgressSubscriber}}, Subscriber{{/withProgressSubscriber}} } from 'rxjs';
+import { ajax } from 'rxjs/ajax';
+import type { {{#rxjs7}}AjaxConfig,{{/rxjs7}} AjaxResponse{{^rxjs7}}, AjaxRequest{{/rxjs7}} } from 'rxjs/ajax';
+
 import { map, concatMap } from 'rxjs/operators';
 import { servers } from './servers';
 
@@ -69,9 +72,9 @@ export class BaseAPI {
         this.withMiddleware(postMiddlewares.map((post) => ({ post })));
 
     protected request<T>(requestOpts: RequestOpts): Observable<T>
-    protected request<T>(requestOpts: RequestOpts, responseOpts?: ResponseOpts): Observable<RawAjaxResponse<T>>
-    protected request<T>(requestOpts: RequestOpts, responseOpts?: ResponseOpts): Observable<T | RawAjaxResponse<T>> {
-        return this.rxjsRequest(this.createRequestArgs(requestOpts)).pipe(
+    protected request<T>(requestOpts: RequestOpts, responseOpts?: ResponseOpts): Observable<{{#rxjs7}}AjaxResponse{{/rxjs7}}{{^rxjs7}}RawAjaxResponse{{/rxjs7}}<T>>
+    protected request<T>(requestOpts: RequestOpts, responseOpts?: ResponseOpts): Observable<T | {{#rxjs7}}AjaxResponse{{/rxjs7}}{{^rxjs7}}RawAjaxResponse{{/rxjs7}}<T>> {
+        return this.rxjsRequest{{#rxjs7}}<T>{{/rxjs7}}(this.createRequestArgs(requestOpts)).pipe(
             map((res) => {
                 const { status, response } = res;
                 if (status >= 200 && status < 300) {
@@ -82,7 +85,7 @@ export class BaseAPI {
         );
     }
 
-    private createRequestArgs = ({ url: baseUrl, query, method, headers, body, responseType{{#withProgressSubscriber}}, progressSubscriber{{/withProgressSubscriber}} }: RequestOpts): RequestArgs => {
+    private createRequestArgs = ({ url: baseUrl, query, method, headers, body, responseType{{#withProgressSubscriber}}, progressSubscriber{{/withProgressSubscriber}} }: RequestOpts): {{#rxjs7}}AjaxConfig{{/rxjs7}}{{^rxjs7}}RequestArgs{{/rxjs7}} => {
         // only add the queryString to the URL if there are query parameters.
         // this is done to avoid urls ending with a '?' character which buggy webservers
         // do not handle correctly sometimes.
@@ -99,15 +102,19 @@ export class BaseAPI {
             {{/withProgressSubscriber}}
         };
     }
-
+    {{#rxjs7}}
+    private rxjsRequest = <T>(params: AjaxConfig): Observable<AjaxResponse<T>> =>
+    {{/rxjs7}}
+    {{^rxjs7}}
     private rxjsRequest = (params: RequestArgs): Observable<AjaxResponse> =>
+    {{/rxjs7}}
         of(params).pipe(
             map((request) => {
                 this.middleware.filter((item) => item.pre).forEach((mw) => (request = mw.pre!(request)));
                 return request;
             }),
             concatMap((args) =>
-                ajax(args).pipe(
+                ajax{{#rxjs7}}<T>{{/rxjs7}}(args).pipe(
                     map((response) => {
                         this.middleware.filter((item) => item.post).forEach((mw) => (response = mw.post!(response)));
                         return response;
@@ -145,13 +152,14 @@ export type HttpHeaders = { [key: string]: string };
 export type HttpQuery = Partial<{ [key: string]: string | number | null | boolean | Array<string | number | null | boolean> }>; // partial is needed for strict mode
 export type HttpBody = Json | FormData;
 
-export interface RequestOpts extends AjaxRequest {
+export interface RequestOpts extends  {{#rxjs7}}AjaxConfig{{/rxjs7}} {{^rxjs7}}AjaxRequest{{/rxjs7}} {
+    // TODO: replace custom 'query' prop with 'queryParams'
     query?: HttpQuery; // additional prop
     // the following props have improved types over AjaxRequest
     method: HttpMethod;
     headers?: HttpHeaders;
     body?: HttpBody;
-    responseType?: 'json' | 'blob' | 'arraybuffer' | 'text';
+    {{^rxjs7}}responseType?: 'json' | 'blob' | 'arraybuffer' | 'text';{{/rxjs7}}
     {{#withProgressSubscriber}}
     progressSubscriber?: Subscriber<ProgressEvent>;
     {{/withProgressSubscriber}}
@@ -167,11 +175,12 @@ export interface OperationOpts {
     {{/withProgressSubscriber}}
     responseOpts?: ResponseOpts;
 }
-
+ {{^rxjs7}}
 // AjaxResponse with typed response
 export interface RawAjaxResponse<T> extends AjaxResponse {
     response: T;
 }
+{{/rxjs7}}
 
 export const encodeURI = (value: any) => encodeURIComponent(`${value}`);
 
@@ -182,17 +191,19 @@ const queryString = (params: HttpQuery): string => Object.entries(params)
     )
     .join('&');
 
+{{^rxjs7}}
 // alias fallback for not being a breaking change
 export const querystring = queryString;
 
 /**
- * @deprecated
- */
+* @deprecated
+*/
 export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
-    if (!params || params[key] == null) {
+    if (!params || params[key] == null) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
 };
+{{/rxjs7}}
 
 export const throwIfNullOrUndefined = (value: any, paramName: string, nickname: string) => {
     if (value == null) {
@@ -200,11 +211,19 @@ export const throwIfNullOrUndefined = (value: any, paramName: string, nickname: 
     }
 };
 
+{{^rxjs7}}
 // alias for easier importing
 export interface RequestArgs extends AjaxRequest {}
 export interface ResponseArgs extends AjaxResponse {}
+{{/rxjs7}}
 
 export interface Middleware {
+{{#rxjs7}}
+    pre?(request: AjaxConfig): AjaxConfig;
+    post?(response: AjaxResponse<any>): AjaxResponse<any>;
+{{/rxjs7}}
+{{^rxjs7}}
     pre?(request: RequestArgs): RequestArgs;
     post?(response: ResponseArgs): ResponseArgs;
+{{/rxjs7}}
 }

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
@@ -17,11 +17,11 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     public getConfiguration(): T {
-        return this.variableConfiguration
+        return this.variableConfiguration;
     }
 
     public getDescription(): string {
-        return this.description
+        return this.description;
     }
 
     /**
@@ -34,7 +34,7 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
             var re = new RegExp("{" + key + "}","g");
             replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
         }
-        return replacedUrl
+        return replacedUrl;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, COLLECTION_FORMATS, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     ApiResponse,
     Pet,
 } from '../models';

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     Order,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     User,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import {
+import type {
     Category,
     Tag,
 } from './';

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -11,8 +11,11 @@
  * Do not edit the class manually.
  */
 
-import { Observable, of } from 'rxjs';
-import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
+import { of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { ajax } from 'rxjs/ajax';
+import type {  AjaxResponse, AjaxRequest } from 'rxjs/ajax';
+
 import { map, concatMap } from 'rxjs/operators';
 import { servers } from './servers';
 
@@ -107,7 +110,6 @@ export class BaseAPI {
             responseType: responseType ?? 'json',
         };
     }
-
     private rxjsRequest = (params: RequestArgs): Observable<AjaxResponse> =>
         of(params).pipe(
             map((request) => {
@@ -153,7 +155,8 @@ export type HttpHeaders = { [key: string]: string };
 export type HttpQuery = Partial<{ [key: string]: string | number | null | boolean | Array<string | number | null | boolean> }>; // partial is needed for strict mode
 export type HttpBody = Json | FormData;
 
-export interface RequestOpts extends AjaxRequest {
+export interface RequestOpts extends   AjaxRequest {
+    // TODO: replace custom 'query' prop with 'queryParams'
     query?: HttpQuery; // additional prop
     // the following props have improved types over AjaxRequest
     method: HttpMethod;
@@ -169,7 +172,6 @@ export interface ResponseOpts {
 export interface OperationOpts {
     responseOpts?: ResponseOpts;
 }
-
 // AjaxResponse with typed response
 export interface RawAjaxResponse<T> extends AjaxResponse {
     response: T;
@@ -188,10 +190,10 @@ const queryString = (params: HttpQuery): string => Object.entries(params)
 export const querystring = queryString;
 
 /**
- * @deprecated
- */
+* @deprecated
+*/
 export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
-    if (!params || params[key] == null) {
+    if (!params || params[key] == null) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
 };

--- a/samples/client/petstore/typescript-rxjs/builds/default/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/servers.ts
@@ -17,11 +17,11 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     public getConfiguration(): T {
-        return this.variableConfiguration
+        return this.variableConfiguration;
     }
 
     public getDescription(): string {
-        return this.description
+        return this.description;
     }
 
     /**
@@ -34,7 +34,7 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
             var re = new RegExp("{" + key + "}","g");
             replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
         }
-        return replacedUrl
+        return replacedUrl;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, COLLECTION_FORMATS, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     ApiResponse,
     Pet,
 } from '../models';

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     Order,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     User,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import {
+import type {
     Category,
     Tag,
 } from './';

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -11,8 +11,11 @@
  * Do not edit the class manually.
  */
 
-import { Observable, of } from 'rxjs';
-import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
+import { of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { ajax } from 'rxjs/ajax';
+import type {  AjaxResponse, AjaxRequest } from 'rxjs/ajax';
+
 import { map, concatMap } from 'rxjs/operators';
 import { servers } from './servers';
 
@@ -107,7 +110,6 @@ export class BaseAPI {
             responseType: responseType ?? 'json',
         };
     }
-
     private rxjsRequest = (params: RequestArgs): Observable<AjaxResponse> =>
         of(params).pipe(
             map((request) => {
@@ -153,7 +155,8 @@ export type HttpHeaders = { [key: string]: string };
 export type HttpQuery = Partial<{ [key: string]: string | number | null | boolean | Array<string | number | null | boolean> }>; // partial is needed for strict mode
 export type HttpBody = Json | FormData;
 
-export interface RequestOpts extends AjaxRequest {
+export interface RequestOpts extends   AjaxRequest {
+    // TODO: replace custom 'query' prop with 'queryParams'
     query?: HttpQuery; // additional prop
     // the following props have improved types over AjaxRequest
     method: HttpMethod;
@@ -169,7 +172,6 @@ export interface ResponseOpts {
 export interface OperationOpts {
     responseOpts?: ResponseOpts;
 }
-
 // AjaxResponse with typed response
 export interface RawAjaxResponse<T> extends AjaxResponse {
     response: T;
@@ -188,10 +190,10 @@ const queryString = (params: HttpQuery): string => Object.entries(params)
 export const querystring = queryString;
 
 /**
- * @deprecated
- */
+* @deprecated
+*/
 export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
-    if (!params || params[key] == null) {
+    if (!params || params[key] == null) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
 };

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/servers.ts
@@ -17,11 +17,11 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     public getConfiguration(): T {
-        return this.variableConfiguration
+        return this.variableConfiguration;
     }
 
     public getDescription(): string {
-        return this.description
+        return this.description;
     }
 
     /**
@@ -34,7 +34,7 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
             var re = new RegExp("{" + key + "}","g");
             replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
         }
-        return replacedUrl
+        return replacedUrl;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, COLLECTION_FORMATS, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     ApiResponse,
     Pet,
 } from '../models';

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     Order,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     User,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import {
+import type {
     Category,
     Tag,
 } from './';

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -11,8 +11,11 @@
  * Do not edit the class manually.
  */
 
-import { Observable, of } from 'rxjs';
-import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
+import { of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { ajax } from 'rxjs/ajax';
+import type {  AjaxResponse, AjaxRequest } from 'rxjs/ajax';
+
 import { map, concatMap } from 'rxjs/operators';
 import { servers } from './servers';
 
@@ -107,7 +110,6 @@ export class BaseAPI {
             responseType: responseType ?? 'json',
         };
     }
-
     private rxjsRequest = (params: RequestArgs): Observable<AjaxResponse> =>
         of(params).pipe(
             map((request) => {
@@ -153,7 +155,8 @@ export type HttpHeaders = { [key: string]: string };
 export type HttpQuery = Partial<{ [key: string]: string | number | null | boolean | Array<string | number | null | boolean> }>; // partial is needed for strict mode
 export type HttpBody = Json | FormData;
 
-export interface RequestOpts extends AjaxRequest {
+export interface RequestOpts extends   AjaxRequest {
+    // TODO: replace custom 'query' prop with 'queryParams'
     query?: HttpQuery; // additional prop
     // the following props have improved types over AjaxRequest
     method: HttpMethod;
@@ -169,7 +172,6 @@ export interface ResponseOpts {
 export interface OperationOpts {
     responseOpts?: ResponseOpts;
 }
-
 // AjaxResponse with typed response
 export interface RawAjaxResponse<T> extends AjaxResponse {
     response: T;
@@ -188,10 +190,10 @@ const queryString = (params: HttpQuery): string => Object.entries(params)
 export const querystring = queryString;
 
 /**
- * @deprecated
- */
+* @deprecated
+*/
 export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
-    if (!params || params[key] == null) {
+    if (!params || params[key] == null) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
 };

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/servers.ts
@@ -17,11 +17,11 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     public getConfiguration(): T {
-        return this.variableConfiguration
+        return this.variableConfiguration;
     }
 
     public getDescription(): string {
-        return this.description
+        return this.description;
     }
 
     /**
@@ -34,7 +34,7 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
             var re = new RegExp("{" + key + "}","g");
             replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
         }
-        return replacedUrl
+        return replacedUrl;
     }
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/PetApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, COLLECTION_FORMATS, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     ApiResponse,
     Pet,
 } from '../models';

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/StoreApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     Order,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/apis/UserApi.ts
@@ -11,9 +11,10 @@
  * Do not edit the class manually.
  */
 
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { BaseAPI, HttpHeaders, HttpQuery, throwIfNullOrUndefined, encodeURI, OperationOpts, RawAjaxResponse } from '../runtime';
-import {
+
+import type {
     User,
 } from '../models';
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import {
+import type {
     Category,
     Tag,
 } from './';

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/runtime.ts
@@ -11,8 +11,11 @@
  * Do not edit the class manually.
  */
 
-import { Observable, of, Subscriber } from 'rxjs';
-import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
+import { of } from 'rxjs';
+import type { Observable, Subscriber } from 'rxjs';
+import { ajax } from 'rxjs/ajax';
+import type {  AjaxResponse, AjaxRequest } from 'rxjs/ajax';
+
 import { map, concatMap } from 'rxjs/operators';
 import { servers } from './servers';
 
@@ -108,7 +111,6 @@ export class BaseAPI {
             progressSubscriber,
         };
     }
-
     private rxjsRequest = (params: RequestArgs): Observable<AjaxResponse> =>
         of(params).pipe(
             map((request) => {
@@ -154,7 +156,8 @@ export type HttpHeaders = { [key: string]: string };
 export type HttpQuery = Partial<{ [key: string]: string | number | null | boolean | Array<string | number | null | boolean> }>; // partial is needed for strict mode
 export type HttpBody = Json | FormData;
 
-export interface RequestOpts extends AjaxRequest {
+export interface RequestOpts extends   AjaxRequest {
+    // TODO: replace custom 'query' prop with 'queryParams'
     query?: HttpQuery; // additional prop
     // the following props have improved types over AjaxRequest
     method: HttpMethod;
@@ -172,7 +175,6 @@ export interface OperationOpts {
     progressSubscriber?: Subscriber<ProgressEvent>;
     responseOpts?: ResponseOpts;
 }
-
 // AjaxResponse with typed response
 export interface RawAjaxResponse<T> extends AjaxResponse {
     response: T;
@@ -191,10 +193,10 @@ const queryString = (params: HttpQuery): string => Object.entries(params)
 export const querystring = queryString;
 
 /**
- * @deprecated
- */
+* @deprecated
+*/
 export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
-    if (!params || params[key] == null) {
+    if (!params || params[key] == null) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
 };

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/servers.ts
@@ -17,11 +17,11 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     public getConfiguration(): T {
-        return this.variableConfiguration
+        return this.variableConfiguration;
     }
 
     public getDescription(): string {
-        return this.description
+        return this.description;
     }
 
     /**
@@ -34,7 +34,7 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
             var re = new RegExp("{" + key + "}","g");
             replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
         }
-        return replacedUrl
+        return replacedUrl;
     }
 }
 


### PR DESCRIPTION
This PR adds support for RxJS 7.
Related PR : https://github.com/OpenAPITools/openapi-generator/pull/9958

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)