### PR TITLE
Adds generator default template engine

### DIFF
--- a/bin/configs/python-experimental-nogeneratorName.yaml
+++ b/bin/configs/python-experimental-nogeneratorName.yaml
@@ -1,6 +1,0 @@
-outputDir: samples/openapi3/client/petstore/python-experimental
-inputSpec: modules/openapi-generator/src/test/resources/3_0/python-experimental/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
-templateDir: modules/openapi-generator/src/main/resources/python-experimental
-additionalProperties:
-  packageName: petstore_api
-  recursionLimit: "1234"

--- a/bin/configs/python-experimental-nogeneratorName.yaml
+++ b/bin/configs/python-experimental-nogeneratorName.yaml
@@ -1,0 +1,6 @@
+outputDir: samples/openapi3/client/petstore/python-experimental
+inputSpec: modules/openapi-generator/src/test/resources/3_0/python-experimental/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+templateDir: modules/openapi-generator/src/main/resources/python-experimental
+additionalProperties:
+  packageName: petstore_api
+  recursionLimit: "1234"

--- a/bin/configs/python-experimental.yaml
+++ b/bin/configs/python-experimental.yaml
@@ -2,7 +2,6 @@ generatorName: python-experimental
 outputDir: samples/openapi3/client/petstore/python-experimental
 inputSpec: modules/openapi-generator/src/test/resources/3_0/python-experimental/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
 templateDir: modules/openapi-generator/src/main/resources/python-experimental
-templatingEngineName: handlebars
 additionalProperties:
   packageName: petstore_api
   recursionLimit: "1234"

--- a/bin/configs/python-flask-nogeneratorName.yaml
+++ b/bin/configs/python-flask-nogeneratorName.yaml
@@ -1,0 +1,3 @@
+outputDir: samples/server/petstore/python-flask
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/python-flask

--- a/bin/configs/python-flask-nogeneratorName.yaml
+++ b/bin/configs/python-flask-nogeneratorName.yaml
@@ -1,3 +1,0 @@
-outputDir: samples/server/petstore/python-flask
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
-templateDir: modules/openapi-generator/src/main/resources/python-flask

--- a/docs/generators/ada-server.md
+++ b/docs/generators/ada-server.md
@@ -10,6 +10,7 @@ title: Documentation for the ada-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Ada | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Ada server implementation (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/ada.md
+++ b/docs/generators/ada.md
@@ -10,6 +10,7 @@ title: Documentation for the ada Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Ada | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Ada client implementation (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/android.md
+++ b/docs/generators/android.md
@@ -10,6 +10,7 @@ title: Documentation for the android Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Android client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/apache2.md
+++ b/docs/generators/apache2.md
@@ -10,6 +10,7 @@ title: Documentation for the apache2 Generator
 | generator stability | STABLE | |
 | generator type | CONFIG | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Apache2 Config file with the permissions | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/apex.md
+++ b/docs/generators/apex.md
@@ -10,6 +10,7 @@ title: Documentation for the apex Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Apex | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Apex API client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/asciidoc.md
+++ b/docs/generators/asciidoc.md
@@ -10,6 +10,7 @@ title: Documentation for the asciidoc Generator
 | generator stability | STABLE | |
 | generator type | DOCUMENTATION | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates asciidoc markup based documentation. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -10,6 +10,7 @@ title: Documentation for the aspnetcore Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | C# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an ASP.NET Core Web API server. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/avro-schema.md
+++ b/docs/generators/avro-schema.md
@@ -10,6 +10,7 @@ title: Documentation for the avro-schema Generator
 | generator stability | BETA | |
 | generator type | SCHEMA | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Avro model (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/bash.md
+++ b/docs/generators/bash.md
@@ -10,6 +10,7 @@ title: Documentation for the bash Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Bash | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Bash client script based on cURL. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/c.md
+++ b/docs/generators/c.md
@@ -10,6 +10,7 @@ title: Documentation for the c Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | C | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C (libcurl) client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/clojure.md
+++ b/docs/generators/clojure.md
@@ -10,6 +10,7 @@ title: Documentation for the clojure Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Clojure | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Clojure client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-pistache-server.md
+++ b/docs/generators/cpp-pistache-server.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-pistache-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C++ API server (based on Pistache) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-qt-client.md
+++ b/docs/generators/cpp-qt-client.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-qt-client Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Qt C++ client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-qt-qhttpengine-server.md
+++ b/docs/generators/cpp-qt-qhttpengine-server.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-qt-qhttpengine-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Qt C++ Server using the QHTTPEngine HTTP Library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-restbed-server.md
+++ b/docs/generators/cpp-restbed-server.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-restbed-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C++ API Server with Restbed (https://github.com/Corvusoft/restbed). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-restsdk.md
+++ b/docs/generators/cpp-restsdk.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-restsdk Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C++ API client with C++ REST SDK (https://github.com/Microsoft/cpprestsdk). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-tiny.md
+++ b/docs/generators/cpp-tiny.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-tiny Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C++ Arduino REST API client. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-tizen.md
+++ b/docs/generators/cpp-tizen.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-tizen Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Samsung Tizen C++ client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cpp-ue4.md
+++ b/docs/generators/cpp-ue4.md
@@ -10,6 +10,7 @@ title: Documentation for the cpp-ue4 Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | C++ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Unreal Engine 4 C++ Module (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/crystal.md
+++ b/docs/generators/crystal.md
@@ -10,6 +10,7 @@ title: Documentation for the crystal Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | Crystal | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Crystal client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/csharp-dotnet2.md
+++ b/docs/generators/csharp-dotnet2.md
@@ -10,6 +10,7 @@ title: Documentation for the csharp-dotnet2 Generator
 | generator stability | DEPRECATED | |
 | generator type | CLIENT | |
 | generator language | C# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C# .Net 2.0 client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/csharp-nancyfx.md
+++ b/docs/generators/csharp-nancyfx.md
@@ -10,6 +10,7 @@ title: Documentation for the csharp-nancyfx Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | C# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C# NancyFX Web API server. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/csharp-netcore-functions.md
+++ b/docs/generators/csharp-netcore-functions.md
@@ -10,6 +10,7 @@ title: Documentation for the csharp-netcore-functions Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | C# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a csharp server. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/csharp-netcore.md
+++ b/docs/generators/csharp-netcore.md
@@ -10,6 +10,7 @@ title: Documentation for the csharp-netcore Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | C# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a C# client library (.NET Standard, .NET Core). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/csharp.md
+++ b/docs/generators/csharp.md
@@ -10,6 +10,7 @@ title: Documentation for the csharp Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | C# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a CSharp client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/cwiki.md
+++ b/docs/generators/cwiki.md
@@ -9,6 +9,7 @@ title: Documentation for the cwiki Generator
 | generator name | cwiki | pass this to the generate command after -g |
 | generator stability | STABLE | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates confluence wiki markup. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/dart-dio-next.md
+++ b/docs/generators/dart-dio-next.md
@@ -10,6 +10,7 @@ title: Documentation for the dart-dio-next Generator
 | generator stability | EXPERIMENTAL | |
 | generator type | CLIENT | |
 | generator language | Dart | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Dart Dio client library with null-safety. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/dart-dio.md
+++ b/docs/generators/dart-dio.md
@@ -10,6 +10,7 @@ title: Documentation for the dart-dio Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Dart | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Dart Dio client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/dart-jaguar.md
+++ b/docs/generators/dart-jaguar.md
@@ -10,6 +10,7 @@ title: Documentation for the dart-jaguar Generator
 | generator stability | DEPRECATED | |
 | generator type | CLIENT | |
 | generator language | Dart | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Dart Jaguar client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/dart.md
+++ b/docs/generators/dart.md
@@ -10,6 +10,7 @@ title: Documentation for the dart Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Dart | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Dart 2.x client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/dynamic-html.md
+++ b/docs/generators/dynamic-html.md
@@ -9,6 +9,7 @@ title: Documentation for the dynamic-html Generator
 | generator name | dynamic-html | pass this to the generate command after -g |
 | generator stability | STABLE | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a dynamic HTML site. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/eiffel.md
+++ b/docs/generators/eiffel.md
@@ -10,6 +10,7 @@ title: Documentation for the eiffel Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Eiffel | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Eiffel client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/elixir.md
+++ b/docs/generators/elixir.md
@@ -10,6 +10,7 @@ title: Documentation for the elixir Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Elixir | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an elixir client library (alpha). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/elm.md
+++ b/docs/generators/elm.md
@@ -10,6 +10,7 @@ title: Documentation for the elm Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Elm | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Elm client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/erlang-client.md
+++ b/docs/generators/erlang-client.md
@@ -10,6 +10,7 @@ title: Documentation for the erlang-client Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Erlang | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Erlang client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/erlang-proper.md
+++ b/docs/generators/erlang-proper.md
@@ -10,6 +10,7 @@ title: Documentation for the erlang-proper Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Erlang | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Erlang library with PropEr generators (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/erlang-server.md
+++ b/docs/generators/erlang-server.md
@@ -10,6 +10,7 @@ title: Documentation for the erlang-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Erlang | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Erlang server library (beta) using OpenAPI Generator (https://openapi-generator.tech). By default, it will also generate service classes, which can be disabled with the `-Dnoservice` environment variable. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/flash-deprecated.md
+++ b/docs/generators/flash-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the flash-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | CLIENT | |
 | generator language | Flash | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Flash (ActionScript) client library (beta). IMPORTANT: this generator has been deprecated in v5.x | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/fsharp-functions.md
+++ b/docs/generators/fsharp-functions.md
@@ -10,6 +10,7 @@ title: Documentation for the fsharp-functions Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | F# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a fsharp-functions server (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/fsharp-giraffe-server.md
+++ b/docs/generators/fsharp-giraffe-server.md
@@ -10,6 +10,7 @@ title: Documentation for the fsharp-giraffe-server Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | F# | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a F# Giraffe server (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/go-deprecated.md
+++ b/docs/generators/go-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the go-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | CLIENT | |
 | generator language | Go | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Go client library (beta). NOTE: this generator has been deprecated. Please use `go` client generator instead. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/go-echo-server.md
+++ b/docs/generators/go-echo-server.md
@@ -10,6 +10,7 @@ title: Documentation for the go-echo-server Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | Go | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a go-echo server. (Beta) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/go-gin-server.md
+++ b/docs/generators/go-gin-server.md
@@ -10,6 +10,7 @@ title: Documentation for the go-gin-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Go | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Go server library with the gin framework using OpenAPI-Generator.By default, it will also generate service classes. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/go-server.md
+++ b/docs/generators/go-server.md
@@ -10,6 +10,7 @@ title: Documentation for the go-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Go | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Go server library using OpenAPI-Generator. By default, it will also generate service classes -- which you can disable with the `-Dnoservice` environment variable. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -10,6 +10,7 @@ title: Documentation for the go Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Go | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Go client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/graphql-nodejs-express-server.md
+++ b/docs/generators/graphql-nodejs-express-server.md
@@ -10,6 +10,7 @@ title: Documentation for the graphql-nodejs-express-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Javascript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a GraphQL Node.js Express server (beta) including it's types, queries, mutations, (resolvers) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/graphql-schema.md
+++ b/docs/generators/graphql-schema.md
@@ -10,6 +10,7 @@ title: Documentation for the graphql-schema Generator
 | generator stability | STABLE | |
 | generator type | SCHEMA | |
 | generator language | GraphQL | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates GraphQL schema files (beta) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/groovy.md
+++ b/docs/generators/groovy.md
@@ -10,6 +10,7 @@ title: Documentation for the groovy Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Groovy | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Groovy API client. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/haskell-http-client.md
+++ b/docs/generators/haskell-http-client.md
@@ -10,6 +10,7 @@ title: Documentation for the haskell-http-client Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Haskell | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Haskell http-client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/haskell-yesod.md
+++ b/docs/generators/haskell-yesod.md
@@ -10,6 +10,7 @@ title: Documentation for the haskell-yesod Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | Haskell | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a haskell-yesod server. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/haskell.md
+++ b/docs/generators/haskell.md
@@ -10,6 +10,7 @@ title: Documentation for the haskell Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Haskell | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Haskell server and client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/html.md
+++ b/docs/generators/html.md
@@ -9,6 +9,7 @@ title: Documentation for the html Generator
 | generator name | html | pass this to the generate command after -g |
 | generator stability | STABLE | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a static HTML file. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/html2.md
+++ b/docs/generators/html2.md
@@ -9,6 +9,7 @@ title: Documentation for the html2 Generator
 | generator name | html2 | pass this to the generate command after -g |
 | generator stability | STABLE | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a static HTML file. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -10,6 +10,7 @@ title: Documentation for the java-camel Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java Camel server (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -10,6 +10,7 @@ title: Documentation for the java-inflector Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java Inflector Server application. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -10,6 +10,7 @@ title: Documentation for the java-micronaut-client Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java Micronaut Client. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-msf4j.md
+++ b/docs/generators/java-msf4j.md
@@ -10,6 +10,7 @@ title: Documentation for the java-msf4j Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java Micro Service based on WSO2 Microservices Framework for Java (MSF4J) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-pkmst.md
+++ b/docs/generators/java-pkmst.md
@@ -10,6 +10,7 @@ title: Documentation for the java-pkmst Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PKMST SpringBoot Server application using the SpringFox integration. Also enables EurekaServerClient / Zipkin / Spring-Boot admin | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-play-framework.md
+++ b/docs/generators/java-play-framework.md
@@ -10,6 +10,7 @@ title: Documentation for the java-play-framework Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java Play Framework Server application. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-undertow-server.md
+++ b/docs/generators/java-undertow-server.md
@@ -10,6 +10,7 @@ title: Documentation for the java-undertow-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java Undertow Server application (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-vertx-web.md
+++ b/docs/generators/java-vertx-web.md
@@ -10,6 +10,7 @@ title: Documentation for the java-vertx-web Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java Vert.x-Web Server (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java-vertx.md
+++ b/docs/generators/java-vertx.md
@@ -10,6 +10,7 @@ title: Documentation for the java-vertx Generator
 | generator stability | DEPRECATED | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a java-Vert.X Server library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -10,6 +10,7 @@ title: Documentation for the java Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java client library (HTTP lib: Jersey (1.x, 2.x), Retrofit (2.x), OpenFeign (10.x) and more. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/javascript-apollo.md
+++ b/docs/generators/javascript-apollo.md
@@ -10,6 +10,7 @@ title: Documentation for the javascript-apollo Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | Javascript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a JavaScript client library (beta) using Apollo RESTDatasource. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/javascript-closure-angular.md
+++ b/docs/generators/javascript-closure-angular.md
@@ -10,6 +10,7 @@ title: Documentation for the javascript-closure-angular Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Javascript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Javascript AngularJS client library (beta) annotated with Google Closure Compiler annotations(https://developers.google.com/closure/compiler/docs/js-for-compiler?hl=en) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/javascript-flowtyped.md
+++ b/docs/generators/javascript-flowtyped.md
@@ -10,6 +10,7 @@ title: Documentation for the javascript-flowtyped Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Javascript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Javascript client library (beta) using Flow types and Fetch API. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/javascript.md
+++ b/docs/generators/javascript.md
@@ -10,6 +10,7 @@ title: Documentation for the javascript Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Javascript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a JavaScript client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-cxf-cdi Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java JAXRS Server according to JAXRS 2.0 specification, assuming an Apache CXF runtime and a Java EE runtime with CDI enabled. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-cxf-client Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java JAXRS Client based on Apache CXF framework. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-cxf-extended.md
+++ b/docs/generators/jaxrs-cxf-extended.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-cxf-extended Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Extends jaxrs-cxf with options to generate a functional mock server. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-cxf.md
+++ b/docs/generators/jaxrs-cxf.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-cxf Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java JAXRS Server application based on Apache CXF framework. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-jersey.md
+++ b/docs/generators/jaxrs-jersey.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-jersey Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java JAXRS Server application based on Jersey framework. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-resteasy-eap.md
+++ b/docs/generators/jaxrs-resteasy-eap.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-resteasy-eap Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java JAXRS-Resteasy Server application. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-resteasy.md
+++ b/docs/generators/jaxrs-resteasy.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-resteasy Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java JAXRS-Resteasy Server application. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -10,6 +10,7 @@ title: Documentation for the jaxrs-spec Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java JAXRS Server according to JAXRS 2.0 specification. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/jmeter.md
+++ b/docs/generators/jmeter.md
@@ -10,6 +10,7 @@ title: Documentation for the jmeter Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a JMeter .jmx file. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/k6.md
+++ b/docs/generators/k6.md
@@ -10,6 +10,7 @@ title: Documentation for the k6 Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | k6 | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a k6 script (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/kotlin-server-deprecated.md
+++ b/docs/generators/kotlin-server-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the kotlin-server-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | SERVER | |
 | generator language | Kotlin | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Kotlin server (Ktor v1.1.3). IMPORTANT: this generator has been deprecated. Please migrate to `kotlin-server` which supports Ktor v1.5.2+. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/kotlin-server.md
+++ b/docs/generators/kotlin-server.md
@@ -10,6 +10,7 @@ title: Documentation for the kotlin-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Kotlin | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Kotlin server. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/kotlin-spring.md
+++ b/docs/generators/kotlin-spring.md
@@ -10,6 +10,7 @@ title: Documentation for the kotlin-spring Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Kotlin | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Kotlin Spring application. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/kotlin-vertx.md
+++ b/docs/generators/kotlin-vertx.md
@@ -10,6 +10,7 @@ title: Documentation for the kotlin-vertx Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | Kotlin | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a kotlin-vertx server. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/kotlin.md
+++ b/docs/generators/kotlin.md
@@ -10,6 +10,7 @@ title: Documentation for the kotlin Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Kotlin | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Kotlin client. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/ktorm-schema.md
+++ b/docs/generators/ktorm-schema.md
@@ -10,6 +10,7 @@ title: Documentation for the ktorm-schema Generator
 | generator stability | BETA | |
 | generator type | SCHEMA | |
 | generator language | Ktorm | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a kotlin-ktorm schema (beta) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/lua.md
+++ b/docs/generators/lua.md
@@ -10,6 +10,7 @@ title: Documentation for the lua Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | Lua | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Lua client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/markdown.md
+++ b/docs/generators/markdown.md
@@ -9,6 +9,7 @@ title: Documentation for the markdown Generator
 | generator name | markdown | pass this to the generate command after -g |
 | generator stability | BETA | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a markdown documentation. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/mysql-schema.md
+++ b/docs/generators/mysql-schema.md
@@ -10,6 +10,7 @@ title: Documentation for the mysql-schema Generator
 | generator stability | STABLE | |
 | generator type | SCHEMA | |
 | generator language | Mysql | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a MySQL schema based on the model or schema defined in the OpenAPI specification (v2, v3). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/nim.md
+++ b/docs/generators/nim.md
@@ -10,6 +10,7 @@ title: Documentation for the nim Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | Nim | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a nim client (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/nodejs-express-server.md
+++ b/docs/generators/nodejs-express-server.md
@@ -10,6 +10,7 @@ title: Documentation for the nodejs-express-server Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | Javascript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a NodeJS Express server (alpha). IMPORTANT: this generator may subject to breaking changes without further notice). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/objc.md
+++ b/docs/generators/objc.md
@@ -10,6 +10,7 @@ title: Documentation for the objc Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Objective-C | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an Objective-C client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/ocaml.md
+++ b/docs/generators/ocaml.md
@@ -10,6 +10,7 @@ title: Documentation for the ocaml Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | OCaml | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates an OCaml client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/openapi-yaml.md
+++ b/docs/generators/openapi-yaml.md
@@ -9,6 +9,7 @@ title: Documentation for the openapi-yaml Generator
 | generator name | openapi-yaml | pass this to the generate command after -g |
 | generator stability | STABLE | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Creates a static openapi.yaml file (OpenAPI spec v3). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/openapi.md
+++ b/docs/generators/openapi.md
@@ -9,6 +9,7 @@ title: Documentation for the openapi Generator
 | generator name | openapi | pass this to the generate command after -g |
 | generator stability | STABLE | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Creates a static openapi.json file (OpenAPI spec v3.0). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/perl.md
+++ b/docs/generators/perl.md
@@ -10,6 +10,7 @@ title: Documentation for the perl Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Perl | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Perl client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-dt.md
+++ b/docs/generators/php-dt.md
@@ -10,6 +10,7 @@ title: Documentation for the php-dt Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP client relying on Data Transfer ( https://github.com/Articus/DataTransfer ) and compliant with PSR-7, PSR-11, PSR-17 and PSR-18. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-laravel.md
+++ b/docs/generators/php-laravel.md
@@ -10,6 +10,7 @@ title: Documentation for the php-laravel Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP laravel server library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-lumen.md
+++ b/docs/generators/php-lumen.md
@@ -10,6 +10,7 @@ title: Documentation for the php-lumen Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP Lumen server library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-mezzio-ph.md
+++ b/docs/generators/php-mezzio-ph.md
@@ -10,6 +10,7 @@ title: Documentation for the php-mezzio-ph Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates PHP server stub using Mezzio ( https://docs.mezzio.dev/mezzio/ ) and Path Handler ( https://github.com/Articus/PathHandler ). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-silex-deprecated.md
+++ b/docs/generators/php-silex-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the php-silex-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | SERVER | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP Silex server library. IMPORTANT NOTE: this generator is no longer actively maintained. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-slim-deprecated.md
+++ b/docs/generators/php-slim-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the php-slim-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | SERVER | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP Slim Framework server library. IMPORTANT NOTE: this generator (Slim 3.x)  is no longer actively maintained so please use 'php-slim4' generator instead. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-slim4.md
+++ b/docs/generators/php-slim4.md
@@ -10,6 +10,7 @@ title: Documentation for the php-slim4 Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP Slim 4 Framework server library(with Mock server). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php-symfony.md
+++ b/docs/generators/php-symfony.md
@@ -10,6 +10,7 @@ title: Documentation for the php-symfony Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP Symfony server bundle. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -10,6 +10,7 @@ title: Documentation for the php Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | PHP | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PHP client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/plantuml.md
+++ b/docs/generators/plantuml.md
@@ -9,6 +9,7 @@ title: Documentation for the plantuml Generator
 | generator name | plantuml | pass this to the generate command after -g |
 | generator stability | BETA | |
 | generator type | DOCUMENTATION | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a plantuml documentation. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/powershell.md
+++ b/docs/generators/powershell.md
@@ -10,6 +10,7 @@ title: Documentation for the powershell Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | PowerShell | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a PowerShell API client (beta) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/protobuf-schema.md
+++ b/docs/generators/protobuf-schema.md
@@ -10,6 +10,7 @@ title: Documentation for the protobuf-schema Generator
 | generator stability | BETA | |
 | generator type | SCHEMA | |
 | generator language | Protocol Buffers (Protobuf) | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates gRPC and protocol buffer schema files (beta) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/python-aiohttp.md
+++ b/docs/generators/python-aiohttp.md
@@ -11,6 +11,7 @@ title: Documentation for the python-aiohttp Generator
 | generator type | SERVER | |
 | generator language | Python | |
 | generator language version | 3.5.2+ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Python server library using the Connexion project. By default, it will also generate service classes -- which you can disable with the `-Dnoservice` environment variable. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/python-blueplanet.md
+++ b/docs/generators/python-blueplanet.md
@@ -11,6 +11,7 @@ title: Documentation for the python-blueplanet Generator
 | generator type | SERVER | |
 | generator language | Python | |
 | generator language version | 2.7+ and 3.5.2+ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Python server library using the Connexion project. By default, it will also generate service classes -- which you can disable with the `-Dnoservice` environment variable. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/python-experimental.md
+++ b/docs/generators/python-experimental.md
@@ -11,6 +11,7 @@ title: Documentation for the python-experimental Generator
 | generator type | CLIENT | |
 | generator language | Python | |
 | generator language version | >=3.9 | |
+| generator default templating engine | handlebars | |
 | helpTxt | Generates a Python client library<br /><br />Features in this generator:<br />- type hints on endpoints and model creation<br />- model parameter names use the spec defined keys and cases<br />- robust composition (oneOf/anyOf/allOf) where paload data is stored in one instance only<br />- endpoint parameter names use the spec defined keys and cases<br />- inline schemas are supported at any location including composition<br />- multiple content types supported in request body and response bodies<br />- run time type checking<br />- Sending/receiving decimals as strings supported with type:string format: number -> DecimalSchema<br />- quicker load time for python modules (a single endpoint can be imported and used without loading others)<br />- all instances of schemas dynamically inherit from all matching schemas so one can use isinstance to check if validation passed<br />- composed schemas with type constraints supported (type:object + oneOf/anyOf/allOf)<br />- schemas are not coerced/cast. For example string + date are both stored as string, and there is a date accessor<br />    - Exceptions: int/float is stored as Decimal, When receiving data from headers it will start as str and may need to be cast for example to int | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/python-fastapi.md
+++ b/docs/generators/python-fastapi.md
@@ -11,6 +11,7 @@ title: Documentation for the python-fastapi Generator
 | generator type | SERVER | |
 | generator language | Python | |
 | generator language version | 3.7 | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Python FastAPI server (beta). Models are defined with the pydantic library | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/python-flask.md
+++ b/docs/generators/python-flask.md
@@ -11,6 +11,7 @@ title: Documentation for the python-flask Generator
 | generator type | SERVER | |
 | generator language | Python | |
 | generator language version | 2.7 and 3.5.2+ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Python server library using the Connexion project. By default, it will also generate service classes -- which you can disable with the `-Dnoservice` environment variable. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/python-legacy.md
+++ b/docs/generators/python-legacy.md
@@ -11,6 +11,7 @@ title: Documentation for the python-legacy Generator
 | generator type | CLIENT | |
 | generator language | Python | |
 | generator language version | 2.7 and 3.4+ | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Python client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/python.md
+++ b/docs/generators/python.md
@@ -11,6 +11,7 @@ title: Documentation for the python Generator
 | generator type | CLIENT | |
 | generator language | Python | |
 | generator language version | >=3.6 | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Python client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/r.md
+++ b/docs/generators/r.md
@@ -10,6 +10,7 @@ title: Documentation for the r Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | R | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a R client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/ruby-on-rails.md
+++ b/docs/generators/ruby-on-rails.md
@@ -10,6 +10,7 @@ title: Documentation for the ruby-on-rails Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Ruby | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Ruby on Rails (v5) server library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/ruby-sinatra.md
+++ b/docs/generators/ruby-sinatra.md
@@ -10,6 +10,7 @@ title: Documentation for the ruby-sinatra Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Ruby | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Ruby Sinatra server library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/ruby.md
+++ b/docs/generators/ruby.md
@@ -10,6 +10,7 @@ title: Documentation for the ruby Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Ruby | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Ruby client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/rust-server.md
+++ b/docs/generators/rust-server.md
@@ -10,6 +10,7 @@ title: Documentation for the rust-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Rust | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Rust client/server library (beta) using the openapi-generator project. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/rust.md
+++ b/docs/generators/rust.md
@@ -10,6 +10,7 @@ title: Documentation for the rust Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Rust | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Rust client library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-akka-http-server.md
+++ b/docs/generators/scala-akka-http-server.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-akka-http-server Generator
 | generator stability | BETA | |
 | generator type | SERVER | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a scala-akka-http server (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-akka.md
+++ b/docs/generators/scala-akka.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-akka Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Scala client library (beta) base on Akka/Spray. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-finch.md
+++ b/docs/generators/scala-finch.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-finch Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Scala server application with Finch. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-gatling.md
+++ b/docs/generators/scala-gatling.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-gatling Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a gatling simulation library (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-httpclient-deprecated.md
+++ b/docs/generators/scala-httpclient-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-httpclient-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | CLIENT | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Scala client library (beta). IMPORTANT: This generator is no longer actively maintained and will be deprecated. PLease use 'scala-akka' generator instead. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-lagom-server.md
+++ b/docs/generators/scala-lagom-server.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-lagom-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Lagom API server (Beta) in scala | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-play-server.md
+++ b/docs/generators/scala-play-server.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-play-server Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Scala server application (beta) with Play Framework. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scala-sttp.md
+++ b/docs/generators/scala-sttp.md
@@ -10,6 +10,7 @@ title: Documentation for the scala-sttp Generator
 | generator stability | BETA | |
 | generator type | CLIENT | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Scala client library (beta) based on Sttp. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scalatra.md
+++ b/docs/generators/scalatra.md
@@ -10,6 +10,7 @@ title: Documentation for the scalatra Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Scala server application with Scalatra. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/scalaz.md
+++ b/docs/generators/scalaz.md
@@ -10,6 +10,7 @@ title: Documentation for the scalaz Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Scala | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Scalaz client library (beta) that uses http4s | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -10,6 +10,7 @@ title: Documentation for the spring Generator
 | generator stability | STABLE | |
 | generator type | SERVER | |
 | generator language | Java | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Java SpringBoot Server application using the SpringFox integration. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/swift4-deprecated.md
+++ b/docs/generators/swift4-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the swift4-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | CLIENT | |
 | generator language | Swift | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Swift 4.x client library (Deprecated and will be removed in 5.x releases. Please use `swift5` instead.) | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/swift5.md
+++ b/docs/generators/swift5.md
@@ -10,6 +10,7 @@ title: Documentation for the swift5 Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Swift | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a Swift 5.x client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-angular.md
+++ b/docs/generators/typescript-angular.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-angular Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript Angular (6.x - 13.x) client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-angularjs-deprecated.md
+++ b/docs/generators/typescript-angularjs-deprecated.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-angularjs-deprecated Generator
 | generator stability | DEPRECATED | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript AngularJS client library. This generator has been deprecated and will be removed in the future release. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-aurelia.md
+++ b/docs/generators/typescript-aurelia.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-aurelia Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript client library for the Aurelia framework (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-axios.md
+++ b/docs/generators/typescript-axios.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-axios Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript client library using axios. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-fetch.md
+++ b/docs/generators/typescript-fetch.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-fetch Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript client library using Fetch API (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-inversify.md
+++ b/docs/generators/typescript-inversify.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-inversify Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates Typescript services using Inversify IOC | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-jquery.md
+++ b/docs/generators/typescript-jquery.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-jquery Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript jquery client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-nestjs.md
+++ b/docs/generators/typescript-nestjs.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-nestjs Generator
 | generator stability | EXPERIMENTAL | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript Nestjs 6.x client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-node.md
+++ b/docs/generators/typescript-node.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-node Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript NodeJS client library. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-redux-query.md
+++ b/docs/generators/typescript-redux-query.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-redux-query Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript client library using redux-query API (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript-rxjs.md
+++ b/docs/generators/typescript-rxjs.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript-rxjs Generator
 | generator stability | STABLE | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript client library using Rxjs API. | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/typescript.md
+++ b/docs/generators/typescript.md
@@ -10,6 +10,7 @@ title: Documentation for the typescript Generator
 | generator stability | EXPERIMENTAL | |
 | generator type | CLIENT | |
 | generator language | Typescript | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates a TypeScript client library using Fetch API (beta). | |
 
 ## CONFIG OPTIONS

--- a/docs/generators/wsdl-schema.md
+++ b/docs/generators/wsdl-schema.md
@@ -10,6 +10,7 @@ title: Documentation for the wsdl-schema Generator
 | generator stability | BETA | |
 | generator type | SCHEMA | |
 | generator language | Web Services Description Language (WSDL) | |
+| generator default templating engine | mustache | |
 | helpTxt | Generates WSDL files. | |
 
 ## CONFIG OPTIONS

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
@@ -311,6 +311,7 @@ public class ConfigHelp extends OpenApiGeneratorCommand {
         if (config.generatorLanguageVersion() != null) {
             sb.append("| generator language version | "+config.generatorLanguageVersion()+" | |").append(newline);
         }
+        sb.append("| generator default templating engine | "+config.defaultTemplatingEngine()+" | |").append(newline);
         sb.append("| helpTxt | "+config.getHelp()+" | |").append(newline);
 
         sb.append(newline);

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -46,7 +46,7 @@ public class WorkflowSettings {
     public static final boolean DEFAULT_ENABLE_MINIMAL_UPDATE = false;
     public static final boolean DEFAULT_STRICT_SPEC_BEHAVIOR = true;
     public static final boolean DEFAULT_GENERATE_ALIAS_AS_MODEL = false;
-    public static final String DEFAULT_TEMPLATING_ENGINE_NAME = "mustache";
+    public static final String DEFAULT_TEMPLATING_ENGINE_NAME = null; // this is set by the generator
     public static final Map<String, String> DEFAULT_GLOBAL_PROPERTIES = Collections.unmodifiableMap(new HashMap<>());
 
     private String inputSpec;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -305,6 +305,8 @@ public interface CodegenConfig {
 
     Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings);
 
+    public String defaultTemplatingEngine();
+
     public GeneratorLanguage generatorLanguage();
 
     /*

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7385,6 +7385,11 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     @Override
+    public String defaultTemplatingEngine() {
+        return "mustache";
+    }
+
+    @Override
     public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.JAVA; }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -91,20 +91,11 @@ public class CodegenConfigurator {
             WorkflowSettings workflowSettings = settings.getWorkflowSettings();
             List<TemplateDefinition> userDefinedTemplateSettings = settings.getFiles();
 
-            String generatorName = generatorSettings.getGeneratorName();
-            String templatingEngineName = workflowSettings.getTemplatingEngineName();
-
-            if (isEmpty(templatingEngineName) && !isEmpty(generatorName)) {
-                // if templatingEngineName is empty and generatorName exists, use the config defaultTemplatingEngine
-                CodegenConfig config = CodegenConfigLoader.forName(generatorName);
-                templatingEngineName = config.defaultTemplatingEngine();
-            }
-
             // We copy "cached" properties into configurator so it is appropriately configured with all settings in external files.
             // FIXME: target is to eventually move away from CodegenConfigurator properties except gen/workflow settings.
-            configurator.generatorName = generatorName;
+            configurator.generatorName = generatorSettings.getGeneratorName();
             configurator.inputSpec = workflowSettings.getInputSpec();
-            configurator.templatingEngineName = templatingEngineName;
+            configurator.templatingEngineName = workflowSettings.getTemplatingEngineName();
             if (workflowSettings.getGlobalProperties() != null) {
                 configurator.globalProperties.putAll(workflowSettings.getGlobalProperties());
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -79,8 +79,8 @@ public class CodegenConfigurator {
 
     }
 
-    @SuppressWarnings("DuplicatedCode")
     public static CodegenConfigurator fromFile(String configFile, Module... modules) {
+        // NOTE: some config parameters may be missing from the configFile and may be passed in as command line args
 
         if (isNotEmpty(configFile)) {
             DynamicSettings settings = readDynamicSettings(configFile, modules);
@@ -91,16 +91,18 @@ public class CodegenConfigurator {
             WorkflowSettings workflowSettings = settings.getWorkflowSettings();
             List<TemplateDefinition> userDefinedTemplateSettings = settings.getFiles();
 
-            CodegenConfig config = CodegenConfigLoader.forName(generatorSettings.getGeneratorName());
+            String generatorName = generatorSettings.getGeneratorName();
             String templatingEngineName = workflowSettings.getTemplatingEngineName();
-            if (isEmpty(templatingEngineName)) {
-                // if templatingEngineName is empty check the config for a default
+
+            if (isEmpty(templatingEngineName) && !isEmpty(generatorName)) {
+                // if templatingEngineName is empty and generatorName exists, use the config defaultTemplatingEngine
+                CodegenConfig config = CodegenConfigLoader.forName(generatorName);
                 templatingEngineName = config.defaultTemplatingEngine();
             }
 
             // We copy "cached" properties into configurator so it is appropriately configured with all settings in external files.
             // FIXME: target is to eventually move away from CodegenConfigurator properties except gen/workflow settings.
-            configurator.generatorName = generatorSettings.getGeneratorName();
+            configurator.generatorName = generatorName;
             configurator.inputSpec = workflowSettings.getInputSpec();
             configurator.templatingEngineName = templatingEngineName;
             if (workflowSettings.getGlobalProperties() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
@@ -2087,5 +2087,10 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
     }
 
     @Override
+    public String defaultTemplatingEngine() {
+        return "handlebars";
+    }
+
+    @Override
     public String generatorLanguageVersion() { return ">=3.9"; };
 }


### PR DESCRIPTION
Adds generator default template engine
Once this is merged, one will not need to pass in `-e handlebars` when running the python-experimental generator

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
