### PR TITLE
tidy: [csharp-netcore] Remove redundant useWebRequest tag from templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/ApiClient.mustache
@@ -23,9 +23,6 @@ using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 using RestSharp;
 using RestSharp.Deserializers;
 using RestSharpMethod = RestSharp.Method;
-{{#useWebRequest}}
-using System.Net.Http;
-{{/useWebRequest}}
 {{#supportsRetry}}
 using Polly;
 {{/supportsRetry}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
@@ -20,9 +20,6 @@ using System.Web;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
-{{#useWebRequest}}
-using System.Net.Http;
-{{/useWebRequest}}
 using System.Net.Http;
 using System.Net.Http.Headers;
 {{#supportsRetry}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -23,9 +23,6 @@ using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 using RestSharp;
 using RestSharp.Deserializers;
 using RestSharpMethod = RestSharp.Method;
-{{#useWebRequest}}
-using System.Net.Http;
-{{/useWebRequest}}
 {{#supportsRetry}}
 using Polly;
 {{/supportsRetry}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -20,9 +20,6 @@ using System.Web;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
-{{#useWebRequest}}
-using System.Net.Http;
-{{/useWebRequest}}
 using System.Net.Http;
 using System.Net.Http.Headers;
 {{#supportsRetry}}


### PR DESCRIPTION
Tidy to remove redundant `useWebRequest` tag from template.  Does not appear to be used anywhere.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
