### PR TITLE
fix: [csharp-netcore]: oneOf fixes for Primitive types

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
@@ -6,7 +6,7 @@
     [DataContract(Name = "{{{name}}}")]
     {{>visibility}} partial class {{classname}} : AbstractOpenAPISchema, {{#parent}}{{{.}}}, {{/parent}}IEquatable<{{classname}}>{{#validatable}}, IValidatableObject{{/validatable}}
     {
-{{#isNullable}}
+        {{#isNullable}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.
         /// </summary>
@@ -15,8 +15,10 @@
             this.IsNullable = true;
             this.SchemaType= "oneOf";
         }
-{{/isNullable}}
-{{#composedSchemas.oneOf}}{{^isNull}}
+
+        {{/isNullable}}
+        {{#composedSchemas.oneOf}}
+        {{^isNull}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class
         /// with the <see cref="{{dataType}}" /> class
@@ -28,7 +30,9 @@
             this.SchemaType= "oneOf";
             this.ActualInstance = actualInstance{{^model.isNullable}}{{^isPrimitiveType}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isPrimitiveType}}{{#isPrimitiveType}}{{#isArray}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isArray}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isFreeFormObject}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isFreeFormObject}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isString}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isString}}{{/isPrimitiveType}}{{/model.isNullable}};
         }
-{{/isNull}}{{/composedSchemas.oneOf}}
+
+        {{/isNull}}
+        {{/composedSchemas.oneOf}}
 
         private Object _actualInstance;
 
@@ -55,7 +59,8 @@
                 }
             }
         }
-        {{#composedSchemas.oneOf}}{{^isNull}}
+        {{#composedSchemas.oneOf}}
+        {{^isNull}}
 
         /// <summary>
         /// Get the actual instance of `{{dataType}}`. If the actual instance is not `{{dataType}}`,
@@ -65,7 +70,9 @@
         public {{{dataType}}} Get{{#lambda.titlecase}}{{baseType}}{{/lambda.titlecase}}{{#isArray}}{{#lambda.titlecase}}{{{dataFormat}}}{{/lambda.titlecase}}{{/isArray}}()
         {
             return ({{{dataType}}})this.ActualInstance;
-        }{{/isNull}}{{/composedSchemas.oneOf}}
+        }
+        {{/isNull}}
+        {{/composedSchemas.oneOf}}
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
@@ -1,3 +1,4 @@
+{{#model}}
     /// <summary>
     /// {{description}}{{^description}}{{classname}}{{/description}}
     /// </summary>
@@ -5,7 +6,7 @@
     [DataContract(Name = "{{{name}}}")]
     {{>visibility}} partial class {{classname}} : AbstractOpenAPISchema, {{#parent}}{{{.}}}, {{/parent}}IEquatable<{{classname}}>{{#validatable}}, IValidatableObject{{/validatable}}
     {
-        {{#isNullable}}
+{{#isNullable}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.
         /// </summary>
@@ -14,22 +15,20 @@
             this.IsNullable = true;
             this.SchemaType= "oneOf";
         }
-
-        {{/isNullable}}
-        {{#oneOf}}
+{{/isNullable}}
+{{#composedSchemas.oneOf}}{{^isNull}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class
-        /// with the <see cref="{{{.}}}" /> class
+        /// with the <see cref="{{dataType}}" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of {{{.}}}.</param>
-        public {{classname}}({{{.}}} actualInstance)
+        /// <param name="actualInstance">An instance of {{dataType}}.</param>
+        public {{classname}}({{{dataType}}} actualInstance)
         {
-            this.IsNullable = {{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}};
+            this.IsNullable = {{#model.isNullable}}true{{/model.isNullable}}{{^model.isNullable}}false{{/model.isNullable}};
             this.SchemaType= "oneOf";
-            this.ActualInstance = actualInstance{{^isNullable}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isNullable}};
+            this.ActualInstance = actualInstance{{^model.isNullable}}{{^isPrimitiveType}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isPrimitiveType}}{{#isPrimitiveType}}{{#isArray}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isArray}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isFreeFormObject}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isFreeFormObject}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isString}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isString}}{{/isPrimitiveType}}{{/model.isNullable}};
         }
-
-        {{/oneOf}}
+{{/isNull}}{{/composedSchemas.oneOf}}
 
         private Object _actualInstance;
 
@@ -56,18 +55,17 @@
                 }
             }
         }
-        {{#oneOf}}
+        {{#composedSchemas.oneOf}}{{^isNull}}
 
         /// <summary>
-        /// Get the actual instance of `{{{.}}}`. If the actual instance is not `{{{.}}}`,
+        /// Get the actual instance of `{{dataType}}`. If the actual instance is not `{{dataType}}`,
         /// the InvalidClassException will be thrown
         /// </summary>
-        /// <returns>An instance of {{{.}}}</returns>
-        public {{{.}}} Get{{{.}}}()
+        /// <returns>An instance of {{dataType}}</returns>
+        public {{{dataType}}} Get{{#lambda.titlecase}}{{baseType}}{{/lambda.titlecase}}{{#isArray}}{{#lambda.titlecase}}{{{dataFormat}}}{{/lambda.titlecase}}{{/isArray}}()
         {
-            return ({{{.}}})this.ActualInstance;
-        }
-        {{/oneOf}}
+            return ({{{dataType}}})this.ActualInstance;
+        }{{/isNull}}{{/composedSchemas.oneOf}}
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -272,3 +270,4 @@
             return false;
         }
     }
+{{/model}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Mammal.cs
@@ -37,18 +37,6 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
-        /// with the <see cref="Pig" /> class
-        /// </summary>
-        /// <param name="actualInstance">An instance of Pig.</param>
-        public Mammal(Pig actualInstance)
-        {
-            this.IsNullable = false;
-            this.SchemaType= "oneOf";
-            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Whale" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of Whale.</param>
@@ -65,6 +53,18 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="actualInstance">An instance of Zebra.</param>
         public Mammal(Zebra actualInstance)
+        {
+            this.IsNullable = false;
+            this.SchemaType= "oneOf";
+            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mammal" /> class
+        /// with the <see cref="Pig" /> class
+        /// </summary>
+        /// <param name="actualInstance">An instance of Pig.</param>
+        public Mammal(Pig actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -105,16 +105,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Pig</returns>
-        public Pig GetPig()
-        {
-            return (Pig)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Whale`. If the actual instance is not `Whale`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -132,6 +122,16 @@ namespace Org.OpenAPITools.Model
         public Zebra GetZebra()
         {
             return (Zebra)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Pig</returns>
+        public Pig GetPig()
+        {
+            return (Pig)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public NullableShape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public NullableShape(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public NullableShape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public NullableShape(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="ComplexQuadrilateral" /> class
+        /// with the <see cref="SimpleQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
-        public Quadrilateral(ComplexQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
+        public Quadrilateral(SimpleQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="SimpleQuadrilateral" /> class
+        /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
-        public Quadrilateral(SimpleQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
+        public Quadrilateral(ComplexQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of ComplexQuadrilateral</returns>
-        public ComplexQuadrilateral GetComplexQuadrilateral()
-        {
-            return (ComplexQuadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `SimpleQuadrilateral`. If the actual instance is not `SimpleQuadrilateral`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral GetSimpleQuadrilateral()
         {
             return (SimpleQuadrilateral)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of ComplexQuadrilateral</returns>
+        public ComplexQuadrilateral GetComplexQuadrilateral()
+        {
+            return (ComplexQuadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Shape.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public Shape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public Shape(Triangle actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public Shape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public Shape(Quadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public ShapeOrNull(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public ShapeOrNull(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public ShapeOrNull(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public ShapeOrNull(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Mammal.cs
@@ -38,18 +38,6 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
-        /// with the <see cref="Pig" /> class
-        /// </summary>
-        /// <param name="actualInstance">An instance of Pig.</param>
-        public Mammal(Pig actualInstance)
-        {
-            this.IsNullable = false;
-            this.SchemaType= "oneOf";
-            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Whale" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of Whale.</param>
@@ -66,6 +54,18 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="actualInstance">An instance of Zebra.</param>
         public Mammal(Zebra actualInstance)
+        {
+            this.IsNullable = false;
+            this.SchemaType= "oneOf";
+            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mammal" /> class
+        /// with the <see cref="Pig" /> class
+        /// </summary>
+        /// <param name="actualInstance">An instance of Pig.</param>
+        public Mammal(Pig actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -106,16 +106,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Pig</returns>
-        public Pig GetPig()
-        {
-            return (Pig)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Whale`. If the actual instance is not `Whale`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -133,6 +123,16 @@ namespace Org.OpenAPITools.Model
         public Zebra GetZebra()
         {
             return (Zebra)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Pig</returns>
+        public Pig GetPig()
+        {
+            return (Pig)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -47,10 +47,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public NullableShape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public NullableShape(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -59,10 +59,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public NullableShape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public NullableShape(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -99,16 +99,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -116,6 +106,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="ComplexQuadrilateral" /> class
+        /// with the <see cref="SimpleQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
-        public Quadrilateral(ComplexQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
+        public Quadrilateral(SimpleQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -50,10 +50,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="SimpleQuadrilateral" /> class
+        /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
-        public Quadrilateral(SimpleQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
+        public Quadrilateral(ComplexQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -90,16 +90,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of ComplexQuadrilateral</returns>
-        public ComplexQuadrilateral GetComplexQuadrilateral()
-        {
-            return (ComplexQuadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `SimpleQuadrilateral`. If the actual instance is not `SimpleQuadrilateral`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -107,6 +97,16 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral GetSimpleQuadrilateral()
         {
             return (SimpleQuadrilateral)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of ComplexQuadrilateral</returns>
+        public ComplexQuadrilateral GetComplexQuadrilateral()
+        {
+            return (ComplexQuadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Shape.cs
@@ -38,10 +38,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public Shape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public Shape(Triangle actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -50,10 +50,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public Shape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public Shape(Quadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -90,16 +90,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -107,6 +97,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -47,10 +47,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public ShapeOrNull(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public ShapeOrNull(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -59,10 +59,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public ShapeOrNull(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public ShapeOrNull(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -99,16 +99,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -116,6 +106,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Mammal.cs
@@ -37,18 +37,6 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
-        /// with the <see cref="Pig" /> class
-        /// </summary>
-        /// <param name="actualInstance">An instance of Pig.</param>
-        public Mammal(Pig actualInstance)
-        {
-            this.IsNullable = false;
-            this.SchemaType= "oneOf";
-            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Whale" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of Whale.</param>
@@ -65,6 +53,18 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="actualInstance">An instance of Zebra.</param>
         public Mammal(Zebra actualInstance)
+        {
+            this.IsNullable = false;
+            this.SchemaType= "oneOf";
+            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mammal" /> class
+        /// with the <see cref="Pig" /> class
+        /// </summary>
+        /// <param name="actualInstance">An instance of Pig.</param>
+        public Mammal(Pig actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -105,16 +105,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Pig</returns>
-        public Pig GetPig()
-        {
-            return (Pig)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Whale`. If the actual instance is not `Whale`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -132,6 +122,16 @@ namespace Org.OpenAPITools.Model
         public Zebra GetZebra()
         {
             return (Zebra)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Pig</returns>
+        public Pig GetPig()
+        {
+            return (Pig)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public NullableShape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public NullableShape(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public NullableShape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public NullableShape(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="ComplexQuadrilateral" /> class
+        /// with the <see cref="SimpleQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
-        public Quadrilateral(ComplexQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
+        public Quadrilateral(SimpleQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="SimpleQuadrilateral" /> class
+        /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
-        public Quadrilateral(SimpleQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
+        public Quadrilateral(ComplexQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of ComplexQuadrilateral</returns>
-        public ComplexQuadrilateral GetComplexQuadrilateral()
-        {
-            return (ComplexQuadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `SimpleQuadrilateral`. If the actual instance is not `SimpleQuadrilateral`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral GetSimpleQuadrilateral()
         {
             return (SimpleQuadrilateral)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of ComplexQuadrilateral</returns>
+        public ComplexQuadrilateral GetComplexQuadrilateral()
+        {
+            return (ComplexQuadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Shape.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public Shape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public Shape(Triangle actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public Shape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public Shape(Quadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public ShapeOrNull(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public ShapeOrNull(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public ShapeOrNull(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public ShapeOrNull(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Mammal.cs
@@ -37,18 +37,6 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
-        /// with the <see cref="Pig" /> class
-        /// </summary>
-        /// <param name="actualInstance">An instance of Pig.</param>
-        public Mammal(Pig actualInstance)
-        {
-            this.IsNullable = false;
-            this.SchemaType= "oneOf";
-            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Whale" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of Whale.</param>
@@ -65,6 +53,18 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="actualInstance">An instance of Zebra.</param>
         public Mammal(Zebra actualInstance)
+        {
+            this.IsNullable = false;
+            this.SchemaType= "oneOf";
+            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mammal" /> class
+        /// with the <see cref="Pig" /> class
+        /// </summary>
+        /// <param name="actualInstance">An instance of Pig.</param>
+        public Mammal(Pig actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -105,16 +105,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Pig</returns>
-        public Pig GetPig()
-        {
-            return (Pig)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Whale`. If the actual instance is not `Whale`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -132,6 +122,16 @@ namespace Org.OpenAPITools.Model
         public Zebra GetZebra()
         {
             return (Zebra)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Pig</returns>
+        public Pig GetPig()
+        {
+            return (Pig)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public NullableShape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public NullableShape(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public NullableShape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public NullableShape(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="ComplexQuadrilateral" /> class
+        /// with the <see cref="SimpleQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
-        public Quadrilateral(ComplexQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
+        public Quadrilateral(SimpleQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="SimpleQuadrilateral" /> class
+        /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
-        public Quadrilateral(SimpleQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
+        public Quadrilateral(ComplexQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of ComplexQuadrilateral</returns>
-        public ComplexQuadrilateral GetComplexQuadrilateral()
-        {
-            return (ComplexQuadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `SimpleQuadrilateral`. If the actual instance is not `SimpleQuadrilateral`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral GetSimpleQuadrilateral()
         {
             return (SimpleQuadrilateral)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of ComplexQuadrilateral</returns>
+        public ComplexQuadrilateral GetComplexQuadrilateral()
+        {
+            return (ComplexQuadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Shape.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public Shape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public Shape(Triangle actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public Shape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public Shape(Quadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public ShapeOrNull(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public ShapeOrNull(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public ShapeOrNull(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public ShapeOrNull(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
@@ -37,18 +37,6 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
-        /// with the <see cref="Pig" /> class
-        /// </summary>
-        /// <param name="actualInstance">An instance of Pig.</param>
-        public Mammal(Pig actualInstance)
-        {
-            this.IsNullable = false;
-            this.SchemaType= "oneOf";
-            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Whale" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of Whale.</param>
@@ -65,6 +53,18 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="actualInstance">An instance of Zebra.</param>
         public Mammal(Zebra actualInstance)
+        {
+            this.IsNullable = false;
+            this.SchemaType= "oneOf";
+            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mammal" /> class
+        /// with the <see cref="Pig" /> class
+        /// </summary>
+        /// <param name="actualInstance">An instance of Pig.</param>
+        public Mammal(Pig actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -105,16 +105,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Pig</returns>
-        public Pig GetPig()
-        {
-            return (Pig)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Whale`. If the actual instance is not `Whale`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -132,6 +122,16 @@ namespace Org.OpenAPITools.Model
         public Zebra GetZebra()
         {
             return (Zebra)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Pig</returns>
+        public Pig GetPig()
+        {
+            return (Pig)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public NullableShape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public NullableShape(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public NullableShape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public NullableShape(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="ComplexQuadrilateral" /> class
+        /// with the <see cref="SimpleQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
-        public Quadrilateral(ComplexQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
+        public Quadrilateral(SimpleQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="SimpleQuadrilateral" /> class
+        /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
-        public Quadrilateral(SimpleQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
+        public Quadrilateral(ComplexQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of ComplexQuadrilateral</returns>
-        public ComplexQuadrilateral GetComplexQuadrilateral()
-        {
-            return (ComplexQuadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `SimpleQuadrilateral`. If the actual instance is not `SimpleQuadrilateral`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral GetSimpleQuadrilateral()
         {
             return (SimpleQuadrilateral)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of ComplexQuadrilateral</returns>
+        public ComplexQuadrilateral GetComplexQuadrilateral()
+        {
+            return (ComplexQuadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public Shape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public Shape(Triangle actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public Shape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public Shape(Quadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public ShapeOrNull(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public ShapeOrNull(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public ShapeOrNull(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public ShapeOrNull(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -37,18 +37,6 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class
-        /// with the <see cref="Pig" /> class
-        /// </summary>
-        /// <param name="actualInstance">An instance of Pig.</param>
-        public Mammal(Pig actualInstance)
-        {
-            this.IsNullable = false;
-            this.SchemaType= "oneOf";
-            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Mammal" /> class
         /// with the <see cref="Whale" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of Whale.</param>
@@ -65,6 +53,18 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="actualInstance">An instance of Zebra.</param>
         public Mammal(Zebra actualInstance)
+        {
+            this.IsNullable = false;
+            this.SchemaType= "oneOf";
+            this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mammal" /> class
+        /// with the <see cref="Pig" /> class
+        /// </summary>
+        /// <param name="actualInstance">An instance of Pig.</param>
+        public Mammal(Pig actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -105,16 +105,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Pig</returns>
-        public Pig GetPig()
-        {
-            return (Pig)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Whale`. If the actual instance is not `Whale`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -132,6 +122,16 @@ namespace Org.OpenAPITools.Model
         public Zebra GetZebra()
         {
             return (Zebra)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Pig`. If the actual instance is not `Pig`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Pig</returns>
+        public Pig GetPig()
+        {
+            return (Pig)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public NullableShape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public NullableShape(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public NullableShape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public NullableShape(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="ComplexQuadrilateral" /> class
+        /// with the <see cref="SimpleQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
-        public Quadrilateral(ComplexQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
+        public Quadrilateral(SimpleQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class
-        /// with the <see cref="SimpleQuadrilateral" /> class
+        /// with the <see cref="ComplexQuadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of SimpleQuadrilateral.</param>
-        public Quadrilateral(SimpleQuadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of ComplexQuadrilateral.</param>
+        public Quadrilateral(ComplexQuadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of ComplexQuadrilateral</returns>
-        public ComplexQuadrilateral GetComplexQuadrilateral()
-        {
-            return (ComplexQuadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `SimpleQuadrilateral`. If the actual instance is not `SimpleQuadrilateral`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral GetSimpleQuadrilateral()
         {
             return (SimpleQuadrilateral)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `ComplexQuadrilateral`. If the actual instance is not `ComplexQuadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of ComplexQuadrilateral</returns>
+        public ComplexQuadrilateral GetComplexQuadrilateral()
+        {
+            return (ComplexQuadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
@@ -37,10 +37,10 @@ namespace Org.OpenAPITools.Model
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public Shape(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public Shape(Triangle actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -49,10 +49,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public Shape(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public Shape(Quadrilateral actualInstance)
         {
             this.IsNullable = false;
             this.SchemaType= "oneOf";
@@ -89,16 +89,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -106,6 +96,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -46,10 +46,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Quadrilateral" /> class
+        /// with the <see cref="Triangle" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Quadrilateral.</param>
-        public ShapeOrNull(Quadrilateral actualInstance)
+        /// <param name="actualInstance">An instance of Triangle.</param>
+        public ShapeOrNull(Triangle actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -58,10 +58,10 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class
-        /// with the <see cref="Triangle" /> class
+        /// with the <see cref="Quadrilateral" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of Triangle.</param>
-        public ShapeOrNull(Triangle actualInstance)
+        /// <param name="actualInstance">An instance of Quadrilateral.</param>
+        public ShapeOrNull(Quadrilateral actualInstance)
         {
             this.IsNullable = true;
             this.SchemaType= "oneOf";
@@ -98,16 +98,6 @@ namespace Org.OpenAPITools.Model
         }
 
         /// <summary>
-        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
-        /// the InvalidClassException will be thrown
-        /// </summary>
-        /// <returns>An instance of Quadrilateral</returns>
-        public Quadrilateral GetQuadrilateral()
-        {
-            return (Quadrilateral)this.ActualInstance;
-        }
-
-        /// <summary>
         /// Get the actual instance of `Triangle`. If the actual instance is not `Triangle`,
         /// the InvalidClassException will be thrown
         /// </summary>
@@ -115,6 +105,16 @@ namespace Org.OpenAPITools.Model
         public Triangle GetTriangle()
         {
             return (Triangle)this.ActualInstance;
+        }
+
+        /// <summary>
+        /// Get the actual instance of `Quadrilateral`. If the actual instance is not `Quadrilateral`,
+        /// the InvalidClassException will be thrown
+        /// </summary>
+        /// <returns>An instance of Quadrilateral</returns>
+        public Quadrilateral GetQuadrilateral()
+        {
+            return (Quadrilateral)this.ActualInstance;
         }
 
         /// <summary>


### PR DESCRIPTION
- Conditionals for string and Object to still throw ArgumentException but NOT for non nullable primitives
- Escape type in XML comment to avoid issues with types<T> rendering.
Relates to #11426 11426

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Part of schema causing challenges:

```yaml
PolymorphicProperty:
  oneOf:
  - type: boolean
  - type: string
  - type: object
  - type: array
     items:
  $ref: '#/components/schemas/StringArrayItem'
StringArrayItem:
  type: string
  format: string			
```

-An `oneOf` `notnullable` with primitives as options would generate non functioning code in the csharp-netcore generator.

### Issues encountered

#### Checking non nullable primitive for null.

existing (compile error)

```c#
public PolymorphicProperty(bool actualInstance)
{
	//...
	this.ActualInstance = actualInstance ?? throw new ArgumentException("Invalid instance found. Must not be null.");
}
```

change: (only for primitives, **Note**: I noticed that `Object` and `string` are returning isPrimitive:true in the model, so extra checks where made for these types)

```c#
public PolymorphicProperty(bool actualInstance)
{
	//...
	this.ActualInstance = actualInstance;
}
```



#### XML Comments should be escaped to accomodate to Generic <> Types

existing
```c#
/// <summary>
/// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
/// with the <see cref="List<string>" /> class
/// </summary>
/// <param name="actualInstance">An instance of List<string>.</param>
```

better
```c#
/// <summary>
/// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
/// with the <see cref="List&lt;string&gt;" /> class
/// </summary>
/// <param name="actualInstance">An instance of List&lt;string&gt;.</param>
```

### Getter for Generic Type has invalid method name

existing (won't compile)

```c#
public List<string> GetList<string>()
```

changes to:
```c#
public List<string> GetListString()
```



<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 

> **TRIED TO RUN `/bin/generate-sample.sh` but it errors with** 
> ```
> samples/openapi3/client/petstore/java/jersey2-java8-special-charactersCan't load config class with name 'java-micronaut-server'
> ```

**EDIT** : .Possibly misunderstood , was able to run and update generated code
```bash
/bin/generate-samples.sh ./bin/configs/csharp-netcore*
```


**_Please advise if there is anything more I should do for this PR, I am new to this repo and nill exposure to Java._**

<!--
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
-->
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.  @mandrean @frankyjuang @shibayan @Blackclaws @lucamazzanti

