### PR TITLE
[PHP] Allows setting extra request options via config

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php/Configuration.mustache
@@ -105,6 +105,13 @@ class Configuration
     protected $tempFolderPath;
 
     /**
+     * Holds any extra request options you want to send
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -499,5 +506,27 @@ class Configuration
         }
 
         return $url;
+    }
+
+    /**
+     * Set extra request options
+     *
+     * @param array $options
+     * @return $this
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    /**
+     * Get extra request options
+     *
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
     }
 }

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -686,7 +686,7 @@ use {{invokerPackage}}\ObjectSerializer;
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -392,7 +392,7 @@ class AnotherFakeApi
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -367,7 +367,7 @@ class DefaultApi
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -4691,7 +4691,7 @@ class FakeApi
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -397,7 +397,7 @@ class FakeClassnameTags123Api
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -2556,7 +2556,7 @@ class PetApi
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -1153,7 +1153,7 @@ class StoreApi
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -2038,7 +2038,7 @@ class UserApi
      */
     protected function createHttpClientOption()
     {
-        $options = [];
+        $options = $this->config->getOptions();
         if ($this->config->getDebug()) {
             $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
             if (!$options[RequestOptions::DEBUG]) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -114,6 +114,13 @@ class Configuration
     protected $tempFolderPath;
 
     /**
+     * Holds any extra request options you want to send
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -519,5 +526,27 @@ class Configuration
         }
 
         return $url;
+    }
+
+    /**
+     * Set extra request options
+     *
+     * @param array $options
+     * @return $this
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    /**
+     * Get extra request options
+     *
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
@@ -5,6 +5,9 @@ namespace OpenAPI\Client;
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass \OpenAPI\Client\Configuration
+ */
 class ConfigurationTest extends TestCase
 {
     /**
@@ -63,5 +66,34 @@ class ConfigurationTest extends TestCase
         $config = new Configuration();
         $url = $config->getHostFromSettings(0, array("server" => "dev-petstore", "port" => "8"));
         $this->assertSame("http://dev-petstore.swagger.io:8080/v2", $url);
+    }
+
+    /**
+     * Tests additional http client options.
+     *
+     * @see https://github.com/OpenAPITools/openapi-generator/pull/11431
+     * @covers ::setOptions
+     * @covers ::getOptions
+     */
+    public function testHttpClientOptions()
+    {
+        $config = Configuration::getDefaultConfiguration();
+        // default is array and empty
+        $this->assertIsArray($config->getOptions());
+        $this->assertEmpty($config->getOptions());
+
+        // example from PR itself
+        $cookie = \GuzzleHttp\Cookie\CookieJar::fromArray([
+            'XDEBUG_SESSION' => 'xdebug',
+        ], 'example.com');
+
+        $self = $config->setOptions(['cookies' => $cookie]);
+        // assert method is chainable
+        $this->assertInstanceOf(Configuration::class, $self);
+
+        // still array, not empty
+        $options = $config->getOptions();
+        $this->assertIsArray($options);
+        $this->assertArrayHasKey('cookies', $options);
     }
 }


### PR DESCRIPTION
Allows setting extra headers in request. One use case is setting xdebug cookie for debugging locally.

```php
$config = Configuration::getDefaultConfiguration();

$cookie = GuzzleHttp\Cookie\CookieJar::fromArray([
    'XDEBUG_SESSION' => 'xdebug',
], 'example.com');

$config->setOptions(['cookies' => $cookie]);
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon
