### PR TITLE
Remove deprecated options in Java client generator

### DIFF
--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -62,7 +62,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |parentGroupId|parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |parentVersion|parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |performBeanValidation|Perform BeanValidation| |false|
-|playVersion|Version of Play! Framework (possible values &quot;play24&quot; (Deprecated), &quot;play25&quot; (Deprecated), &quot;play26&quot; (Default))| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |scmConnection|SCM connection in generated pom.xml| |scm:git:git@github.com:openapitools/openapi-generator.git|
 |scmDeveloperConnection|SCM developer connection in generated pom.xml| |scm:git:git@github.com:openapitools/openapi-generator.git|
@@ -81,9 +80,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |usePlayWS|Use Play! Async HTTP client (Play WS API)| |false|
 |useReflectionEqualsHashCode|Use org.apache.commons.lang3.builder for equals and hashCode in the models. WARNING: This will fail under a security manager, unless the appropriate permissions are set up correctly and also there's potential performance impact.| |false|
 |useRuntimeException|Use RuntimeException instead of Exception| |false|
-|useRxJava|Whether to use the RxJava adapter with the retrofit2 library. IMPORTANT: this option has been deprecated and will be removed in the 5.x release.| |false|
-|useRxJava2|Whether to use the RxJava2 adapter with the retrofit2 library.| |false|
-|useRxJava3|Whether to use the RxJava3 adapter with the retrofit2 library.| |false|
+|useRxJava2|Whether to use the RxJava2 adapter with the retrofit2 library. IMPORTANT: This option has been deprecated.| |false|
+|useRxJava3|Whether to use the RxJava3 adapter with the retrofit2 library. IMPORTANT: This option has been deprecated.| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -49,12 +49,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
     private final Logger LOGGER = LoggerFactory.getLogger(JavaClientCodegen.class);
 
-    public static final String USE_RX_JAVA = "useRxJava";
     public static final String USE_RX_JAVA2 = "useRxJava2";
     public static final String USE_RX_JAVA3 = "useRxJava3";
     public static final String DO_NOT_USE_RX = "doNotUseRx";
     public static final String USE_PLAY_WS = "usePlayWS";
-    public static final String PLAY_VERSION = "playVersion";
     public static final String ASYNC_NATIVE = "asyncNative";
     public static final String CONFIG_KEY = "configKey";
     public static final String PARCELABLE_MODEL = "parcelableModel";
@@ -68,10 +66,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     public static final String GRADLE_PROPERTIES= "gradleProperties";
     public static final String ERROR_OBJECT_TYPE= "errorObjectType";
     public static final String ERROR_OBJECT_SUBTYPE= "errorObjectSubtype";
-
-    public static final String PLAY_24 = "play24";
-    public static final String PLAY_25 = "play25";
-    public static final String PLAY_26 = "play26";
 
     public static final String MICROPROFILE_DEFAULT = "default";
     public static final String MICROPROFILE_KUMULUZEE = "kumuluzee";
@@ -104,7 +98,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     // (mustache does not allow for boolean operators so we need this extra field)
     protected boolean doNotUseRx = true;
     protected boolean usePlayWS = false;
-    protected String playVersion = PLAY_26;
     protected String microprofileFramework = MICROPROFILE_DEFAULT;
     protected String configKey = null;
 
@@ -149,12 +142,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
         modelTestTemplateFiles.put("model_test.mustache", ".java");
 
-        cliOptions.add(CliOption.newBoolean(USE_RX_JAVA, "Whether to use the RxJava adapter with the retrofit2 library. IMPORTANT: this option has been deprecated and will be removed in the 5.x release."));
-        cliOptions.add(CliOption.newBoolean(USE_RX_JAVA2, "Whether to use the RxJava2 adapter with the retrofit2 library."));
-        cliOptions.add(CliOption.newBoolean(USE_RX_JAVA3, "Whether to use the RxJava3 adapter with the retrofit2 library."));
+        cliOptions.add(CliOption.newBoolean(USE_RX_JAVA2, "Whether to use the RxJava2 adapter with the retrofit2 library. IMPORTANT: This option has been deprecated."));
+        cliOptions.add(CliOption.newBoolean(USE_RX_JAVA3, "Whether to use the RxJava3 adapter with the retrofit2 library. IMPORTANT: This option has been deprecated."));
         cliOptions.add(CliOption.newBoolean(PARCELABLE_MODEL, "Whether to generate models for Android that implement Parcelable with the okhttp-gson library."));
         cliOptions.add(CliOption.newBoolean(USE_PLAY_WS, "Use Play! Async HTTP client (Play WS API)"));
-        cliOptions.add(CliOption.newString(PLAY_VERSION, "Version of Play! Framework (possible values \"play24\" (Deprecated), \"play25\" (Deprecated), \"play26\" (Default))"));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
         cliOptions.add(CliOption.newBoolean(PERFORM_BEANVALIDATION, "Perform BeanValidation"));
         cliOptions.add(CliOption.newBoolean(USE_GZIP_FEATURE, "Send gzip-encoded requests"));
@@ -241,23 +232,14 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         super.processOpts();
 
         // RxJava
-        if (additionalProperties.containsKey(USE_RX_JAVA) && additionalProperties.containsKey(USE_RX_JAVA2) && additionalProperties.containsKey(USE_RX_JAVA3)) {
-            LOGGER.warn("You specified all RxJava versions 1, 2 and 3 but they are mutually exclusive. Defaulting to v3.");
+        if (additionalProperties.containsKey(USE_RX_JAVA2) && additionalProperties.containsKey(USE_RX_JAVA3)) {
+            LOGGER.warn("You specified all RxJava versions 2 and 3 but they are mutually exclusive. Defaulting to v3.");
             this.setUseRxJava3(Boolean.parseBoolean(additionalProperties.get(USE_RX_JAVA3).toString()));
         } else {
-            if (additionalProperties.containsKey(USE_RX_JAVA) && additionalProperties.containsKey(USE_RX_JAVA2)) {
-                LOGGER.warn("You specified both RxJava versions 1 and 2 but they are mutually exclusive. Defaulting to v2.");
-                this.setUseRxJava2(Boolean.parseBoolean(additionalProperties.get(USE_RX_JAVA2).toString()));
-            } else if (additionalProperties.containsKey(USE_RX_JAVA) && additionalProperties.containsKey(USE_RX_JAVA3)) {
-                LOGGER.warn("You specified both RxJava versions 1 and 3 but they are mutually exclusive. Defaulting to v3.");
-                this.setUseRxJava3(Boolean.parseBoolean(additionalProperties.get(USE_RX_JAVA3).toString()));
-            } else if (additionalProperties.containsKey(USE_RX_JAVA2) && additionalProperties.containsKey(USE_RX_JAVA3)) {
+            if (additionalProperties.containsKey(USE_RX_JAVA2) && additionalProperties.containsKey(USE_RX_JAVA3)) {
                 LOGGER.warn("You specified both RxJava versions 2 and 3 but they are mutually exclusive. Defaulting to v3.");
                 this.setUseRxJava3(Boolean.parseBoolean(additionalProperties.get(USE_RX_JAVA3).toString()));
             } else {
-                if (additionalProperties.containsKey(USE_RX_JAVA)) {
-                    this.setUseRxJava(Boolean.parseBoolean(additionalProperties.get(USE_RX_JAVA).toString()));
-                }
                 if (additionalProperties.containsKey(USE_RX_JAVA2)) {
                     this.setUseRxJava2(Boolean.parseBoolean(additionalProperties.get(USE_RX_JAVA2).toString()));
                 }
@@ -276,11 +258,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             this.setUsePlayWS(Boolean.parseBoolean(additionalProperties.get(USE_PLAY_WS).toString()));
         }
         additionalProperties.put(USE_PLAY_WS, usePlayWS);
-
-        if (additionalProperties.containsKey(PLAY_VERSION)) {
-            this.setPlayVersion(additionalProperties.get(PLAY_VERSION).toString());
-        }
-        additionalProperties.put(PLAY_VERSION, playVersion);
 
         // Microprofile framework
         if (additionalProperties.containsKey(MICROPROFILE_FRAMEWORK)) {
@@ -560,40 +537,13 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             }
 
             apiTemplateFiles.remove("api.mustache");
+            apiTemplateFiles.put("play26/api.mustache", ".java");
 
-            if (PLAY_24.equals(playVersion)) {
-                LOGGER.warn("`play24` option has been deprecated and will be removed in the 5.x release. Please use `play26` instead.");
-                additionalProperties.put(PLAY_24, true);
-                apiTemplateFiles.put("play24/api.mustache", ".java");
-
-                supportingFiles.add(new SupportingFile("play24/ApiClient.mustache", invokerFolder, "ApiClient.java"));
-                supportingFiles.add(new SupportingFile("play24/Play24CallFactory.mustache", invokerFolder, "Play24CallFactory.java"));
-                supportingFiles.add(new SupportingFile("play24/Play24CallAdapterFactory.mustache", invokerFolder,
-                        "Play24CallAdapterFactory.java"));
-            }
-
-            if (PLAY_25.equals(playVersion)) {
-                LOGGER.warn("`play25` option has been deprecated and will be removed in the 5.x release. Please use `play26` instead.");
-                additionalProperties.put(PLAY_25, true);
-                apiTemplateFiles.put("play25/api.mustache", ".java");
-
-                supportingFiles.add(new SupportingFile("play25/ApiClient.mustache", invokerFolder, "ApiClient.java"));
-                supportingFiles.add(new SupportingFile("play25/Play25CallFactory.mustache", invokerFolder, "Play25CallFactory.java"));
-                supportingFiles.add(new SupportingFile("play25/Play25CallAdapterFactory.mustache", invokerFolder,
-                        "Play25CallAdapterFactory.java"));
-                setJava8ModeAndAdditionalProperties(true);
-            }
-
-            if (PLAY_26.equals(playVersion)) {
-                additionalProperties.put(PLAY_26, true);
-                apiTemplateFiles.put("play26/api.mustache", ".java");
-
-                supportingFiles.add(new SupportingFile("play26/ApiClient.mustache", invokerFolder, "ApiClient.java"));
-                supportingFiles.add(new SupportingFile("play26/Play26CallFactory.mustache", invokerFolder, "Play26CallFactory.java"));
-                supportingFiles.add(new SupportingFile("play26/Play26CallAdapterFactory.mustache", invokerFolder,
-                        "Play26CallAdapterFactory.java"));
-                setJava8ModeAndAdditionalProperties(true);
-            }
+            supportingFiles.add(new SupportingFile("play26/ApiClient.mustache", invokerFolder, "ApiClient.java"));
+            supportingFiles.add(new SupportingFile("play26/Play26CallFactory.mustache", invokerFolder, "Play26CallFactory.java"));
+            supportingFiles.add(new SupportingFile("play26/Play26CallAdapterFactory.mustache", invokerFolder,
+                    "Play26CallAdapterFactory.java"));
+            setJava8ModeAndAdditionalProperties(true);
 
             supportingFiles.add(new SupportingFile("play-common/auth/ApiKeyAuth.mustache", authFolder, "ApiKeyAuth.java"));
             supportingFiles.add(new SupportingFile("auth/Authentication.mustache", authFolder, "Authentication.java"));
@@ -987,10 +937,6 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
     public void setUsePlayWS(boolean usePlayWS) {
         this.usePlayWS = usePlayWS;
-    }
-
-    public void setPlayVersion(String playVersion) {
-        this.playVersion = playVersion;
     }
 
     public void setAsyncNative(boolean asyncNative) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -19,9 +19,6 @@ import org.threeten.bp.format.DateTimeFormatter;
 {{/threetenbp}}
 import retrofit2.Converter;
 import retrofit2.Retrofit;
-{{#useRxJava}}
-import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
-{{/useRxJava}}
 {{#useRxJava2}}
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 {{/useRxJava2}}
@@ -157,9 +154,6 @@ public class ApiClient {
     adapterBuilder = new Retrofit
       .Builder()
       .baseUrl(baseUrl)
-      {{#useRxJava}}
-      .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-      {{/useRxJava}}
       {{#useRxJava2}}
       .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
       {{/useRxJava2}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -2,9 +2,6 @@ package {{package}};
 
 import {{invokerPackage}}.CollectionFormats.*;
 
-{{#useRxJava}}
-import rx.Observable;
-{{/useRxJava}}
 {{#useRxJava2}}
 import io.reactivex.Observable;
 {{/useRxJava2}}
@@ -47,7 +44,7 @@ public interface {{classname}} {
 {{#allParams}}
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
 {{/allParams}}
-   * @return {{^doNotUseRx}}{{#useRxJava}}Observable&lt;{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{returnType}}{{^returnType}}Void{{/returnType}}{{/isResponseFile}}&gt;{{/useRxJava}}{{#useRxJava2}}{{#returnType}}Observable&lt;{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{returnType}}{{/isResponseFile}}&gt;{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava2}}{{#useRxJava3}}{{#returnType}}Observable&lt;{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{returnType}}{{/isResponseFile}}&gt;{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava3}}{{/doNotUseRx}}{{#doNotUseRx}}Call&lt;{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{returnType}}{{^returnType}}Void{{/returnType}}{{/isResponseFile}}&gt;{{/doNotUseRx}}
+   * @return {{^doNotUseRx}}{{#useRxJava2}}{{#returnType}}Observable&lt;{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{returnType}}{{/isResponseFile}}&gt;{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava2}}{{#useRxJava3}}{{#returnType}}Observable&lt;{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{returnType}}{{/isResponseFile}}&gt;{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava3}}{{/doNotUseRx}}{{#doNotUseRx}}Call&lt;{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{returnType}}{{^returnType}}Void{{/returnType}}{{/isResponseFile}}&gt;{{/doNotUseRx}}
 {{#isDeprecated}}
    * @deprecated
 {{/isDeprecated}}
@@ -74,7 +71,7 @@ public interface {{classname}} {
   {{/prioritizedContentTypes}}
   {{/formParams}}
   @{{httpMethod}}("{{{path}}}")
-  {{^doNotUseRx}}{{#useRxJava}}Observable<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{{returnType}}}{{^returnType}}Void{{/returnType}}{{/isResponseFile}}>{{/useRxJava}}{{#useRxJava2}}{{#returnType}}Observable<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{{returnType}}}{{/isResponseFile}}>{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava2}}{{#useRxJava3}}{{#returnType}}Observable<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{{returnType}}}{{/isResponseFile}}>{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava3}}{{/doNotUseRx}}{{#doNotUseRx}}Call<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{{returnType}}}{{^returnType}}Void{{/returnType}}{{/isResponseFile}}>{{/doNotUseRx}} {{operationId}}({{^allParams}});{{/allParams}}
+  {{^doNotUseRx}}{{#useRxJava2}}{{#returnType}}Observable<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{{returnType}}}{{/isResponseFile}}>{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava2}}{{#useRxJava3}}{{#returnType}}Observable<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{{returnType}}}{{/isResponseFile}}>{{/returnType}}{{^returnType}}Completable{{/returnType}}{{/useRxJava3}}{{/doNotUseRx}}{{#doNotUseRx}}Call<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{{returnType}}}{{^returnType}}Void{{/returnType}}{{/isResponseFile}}>{{/doNotUseRx}} {{operationId}}({{^allParams}});{{/allParams}}
     {{#allParams}}{{>libraries/retrofit2/queryParams}}{{>libraries/retrofit2/pathParams}}{{>libraries/retrofit2/headerParams}}{{>libraries/retrofit2/bodyParams}}{{>libraries/retrofit2/formParams}}{{^-last}}, {{/-last}}{{#-last}}
   );{{/-last}}{{/allParams}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -118,21 +118,10 @@ ext {
     jackson_databind_nullable_version = "0.2.2"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
-    {{#play24}}
-    play_version = "2.4.11"
-    {{/play24}}
-    {{#play25}}
-    play_version = "2.5.14"
-    {{/play25}}
-    {{#play26}}
     play_version = "2.6.7"
-    {{/play26}}
     {{/usePlayWS}}
     swagger_annotations_version = "1.5.22"
     junit_version = "4.13.1"
-    {{#useRxJava}}
-    rx_java_version = "1.3.0"
-    {{/useRxJava}}
     {{#useRxJava2}}
     rx_java_version = "2.1.1"
     {{/useRxJava2}}
@@ -152,10 +141,6 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
-    {{#useRxJava}}
-    implementation "com.squareup.retrofit2:adapter-rxjava:$retrofit_version"
-    implementation "io.reactivex:rxjava:$rx_java_version"
-    {{/useRxJava}}
     {{#useRxJava2}}
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
     implementation "io.reactivex.rxjava2:rxjava:$rx_java_version"
@@ -177,13 +162,8 @@ dependencies {
     implementation "org.threeten:threetenbp:$threetenbp_version"
     {{/threetenbp}}
     {{#usePlayWS}}
-    {{#play26}}
     implementation "com.typesafe.play:play-ahc-ws_2.12:$play_version"
     implementation "jakarta.validation:jakarta.validation-api:2.0.2"
-    {{/play26}}
-    {{^play26}}
-    implementation "com.typesafe.play:play-java-ws_2.11:$play_version"
-    {{/play26}}
     implementation "com.squareup.retrofit2:converter-jackson:$retrofit_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
@@ -15,25 +15,13 @@ lazy val root = (project in file(".")).
       "com.squareup.retrofit2" % "converter-gson" % "2.3.0" % "compile",
       {{/usePlayWS}}
       {{#usePlayWS}}
-      {{#play24}}
-      "com.typesafe.play" % "play-java-ws_2.11" % "2.4.11" % "compile",
-      {{/play24}}
-      {{#play25}}
-      "com.typesafe.play" % "play-java-ws_2.11" % "2.5.15" % "compile",
-      {{/play25}}
-      {{#play26}}
       "com.typesafe.play" % "play-ahc-ws_2.12" % "2.6.7" % "compile",
       "jakarta.validation" % "jakarta.validation-api" % "2.0.2" % "compile",
-      {{/play26}}
       "com.squareup.retrofit2" % "converter-jackson" % "2.3.0" % "compile",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.10.5" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.5" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5.1" % "compile",
       {{/usePlayWS}}
-      {{#useRxJava}}
-      "com.squareup.retrofit2" % "adapter-rxjava" % "2.3.0" % "compile",
-      "io.reactivex" % "rxjava" % "1.3.0" % "compile",
-      {{/useRxJava}}
       {{#useRxJava2}}
       "com.squareup.retrofit2" % "adapter-rxjava2" % "2.3.0" % "compile",
       "io.reactivex.rxjava2" % "rxjava" % "2.1.1" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/api.mustache
@@ -2,9 +2,12 @@ package {{package}};
 
 import {{invokerPackage}}.CollectionFormats.*;
 
-{{#useRxJava}}import rx.Observable;{{/useRxJava}}
-{{#useRxJava2}}import io.reactivex.Observable;{{/useRxJava2}}
-{{#doNotUseRx}}import retrofit2.Call;{{/doNotUseRx}}
+{{#useRxJava2}}
+import io.reactivex.Observable;
+{{/useRxJava2}}
+{{#doNotUseRx}}
+import retrofit2.Call;
+{{/doNotUseRx}}
 import retrofit2.http.*;
 
 import okhttp3.RequestBody;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -273,18 +273,6 @@
                 <version>${threetenbp-version}</version>
             </dependency>
         {{/threetenbp}}
-        {{#useRxJava}}
-            <dependency>
-                <groupId>io.reactivex</groupId>
-                <artifactId>rxjava</artifactId>
-                <version>${rxjava-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.retrofit2</groupId>
-                <artifactId>adapter-rxjava</artifactId>
-                <version>${retrofit-version}</version>
-            </dependency>
-        {{/useRxJava}}
         {{#useRxJava2}}
             <dependency>
                 <groupId>io.reactivex.rxjava2</groupId>
@@ -351,21 +339,6 @@
                     <version>${jackson-version}</version>
                 </dependency>
             {{/withXml}}
-            {{#play24}}
-            <dependency>
-                <groupId>com.typesafe.play</groupId>
-                <artifactId>play-java-ws_2.11</artifactId>
-                <version>${play-version}</version>
-            </dependency>
-            {{/play24}}
-            {{#play25}}
-            <dependency>
-                <groupId>com.typesafe.play</groupId>
-                <artifactId>play-java-ws_2.11</artifactId>
-                <version>${play-version}</version>
-            </dependency>
-            {{/play25}}
-            {{#play26}}
             <dependency>
                 <groupId>com.typesafe.play</groupId>
                 <artifactId>play-ahc-ws_2.12</artifactId>
@@ -376,7 +349,6 @@
                 <artifactId>jakarta.validation-api</artifactId>
                 <version>${beanvalidation-version}</version>
             </dependency>
-            {{/play26}}
         {{/usePlayWS}}
         {{#parcelableModel}}
             <!-- Needed for Parcelable support-->
@@ -410,23 +382,12 @@
         <swagger-annotations-version>1.6.3</swagger-annotations-version>
         {{#usePlayWS}}
         <jackson-version>2.12.1</jackson-version>
-        {{#play24}}
-        <play-version>2.4.11</play-version>
-        {{/play24}}
-        {{#play25}}
-        <play-version>2.5.15</play-version>
-        {{/play25}}
-        {{#play26}}
         <play-version>2.6.7</play-version>
-        {{/play26}}
         {{#openApiNullable}}
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         {{/openApiNullable}}
         {{/usePlayWS}}
         <retrofit-version>2.5.0</retrofit-version>
-        {{#useRxJava}}
-        <rxjava-version>1.3.0</rxjava-version>
-        {{/useRxJava}}
         {{#useRxJava2}}
         <rxjava-version>2.1.1</rxjava-version>
         {{/useRxJava2}}

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -2,8 +2,6 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.CollectionFormats.*;
 
-
-
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -2,8 +2,6 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.CollectionFormats.*;
 
-
-
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -2,8 +2,6 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.CollectionFormats.*;
 
-
-
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/PetApi.java
@@ -2,8 +2,6 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.CollectionFormats.*;
 
-
-
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -2,8 +2,6 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.CollectionFormats.*;
 
-
-
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/UserApi.java
@@ -2,8 +2,6 @@ package org.openapitools.client.api;
 
 import org.openapitools.client.CollectionFormats.*;
 
-
-
 import retrofit2.Call;
 import retrofit2.http.*;
 


### PR DESCRIPTION
Remove options that have been marked as deprecated: `useRxJava`, `playVersion`

`useRxJava2`, `useRxJava3` have been marked as deprecated and will be removed in 6.x version (default to RxJava3 after that)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
