### PR TITLE
Add delete body to petstore.yaml spec v3.0

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -184,7 +184,7 @@ paths:
         '404':
           description: Pet not found
       security:
-        - api_key: []
+        - api_key: [ ]
     post:
       tags:
         - pet
@@ -224,6 +224,15 @@ paths:
       summary: Deletes a pet
       description: ''
       operationId: deletePet
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
       parameters:
         - name: api_key
           in: header
@@ -301,7 +310,7 @@ paths:
                   type: integer
                   format: int32
       security:
-        - api_key: []
+        - api_key: [ ]
   /store/order:
     post:
       tags:
@@ -392,7 +401,7 @@ paths:
         default:
           description: successful operation
       security:
-        - api_key: []
+        - api_key: [ ]
       requestBody:
         content:
           application/json:
@@ -411,7 +420,7 @@ paths:
         default:
           description: successful operation
       security:
-        - api_key: []
+        - api_key: [ ]
       requestBody:
         $ref: '#/components/requestBodies/UserArray'
   /user/createWithList:
@@ -425,7 +434,7 @@ paths:
         default:
           description: successful operation
       security:
-        - api_key: []
+        - api_key: [ ]
       requestBody:
         $ref: '#/components/requestBodies/UserArray'
   /user/login:
@@ -490,7 +499,7 @@ paths:
         default:
           description: successful operation
       security:
-        - api_key: []
+        - api_key: [ ]
   '/user/{username}':
     get:
       tags:
@@ -538,7 +547,7 @@ paths:
         '404':
           description: User not found
       security:
-        - api_key: []
+        - api_key: [ ]
       requestBody:
         content:
           application/json:
@@ -565,7 +574,7 @@ paths:
         '404':
           description: User not found
       security:
-        - api_key: []
+        - api_key: [ ]
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'

--- a/samples/client/petstore/apex/force-app/main/default/classes/OASPetApi.cls
+++ b/samples/client/petstore/apex/force-app/main/default/classes/OASPetApi.cls
@@ -54,12 +54,16 @@ public class OASPetApi {
      * 
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @throws OAS.ApiException if fails to make API call
      */
     public void deletePet(Map<String, Object> params) {
         client.assertNotNull(params.get('petId'), 'petId');
         List<OAS.Param> query = new List<OAS.Param>();
         List<OAS.Param> form = new List<OAS.Param>();
+
+        // cast form params to verify their expected type
+        form.addAll(client.makeParam('additionalMetadata', (String) params.get('additionalMetadata')));
 
         client.invoke(
             'DELETE', '/pet/{petId}', '',
@@ -71,7 +75,7 @@ public class OASPetApi {
                 'api_key' => (String) params.get('apiKey')
             },
             new List<String>(),
-            new List<String>(),
+            new List<String>{ 'application/x-www-form-urlencoded' },
             new List<String> { 'petstore_auth' },
             null
         );

--- a/samples/client/petstore/cpp-tiny/lib/service/PetApi.cpp
+++ b/samples/client/petstore/cpp-tiny/lib/service/PetApi.cpp
@@ -63,6 +63,9 @@ using namespace Tiny;
             , 
             
             std::string apiKey
+            , 
+            
+            std::string additionalMetadata
             
         )
         {
@@ -74,8 +77,10 @@ using namespace Tiny;
 
             // Query    | 
 
-            // Form     | 
+            // Form     | additionalMetadata 
+            addHeader("Content-Type", "application/x-www-form-urlencoded");
 
+            addFormParam("additionalMetadata",additionalMetadata);
 
 
                 std::string s_petId("{");

--- a/samples/client/petstore/cpp-tiny/lib/service/PetApi.h
+++ b/samples/client/petstore/cpp-tiny/lib/service/PetApi.h
@@ -44,6 +44,7 @@ public:
     * 
     * \param petId Pet id to delete *Required*
     * \param apiKey 
+    * \param additionalMetadata Additional data to pass to server
     */
     Response<
             String
@@ -54,6 +55,9 @@ public:
             , 
             
             std::string apiKey
+            , 
+            
+            std::string additionalMetadata
             
     );
     /**

--- a/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
@@ -82,8 +82,8 @@ module Petstore
     # 
     # @param pet_id [Int64] Pet id to delete
     # @return [nil]
-    def delete_pet(pet_id : Int64, api_key : String?)
-      delete_pet_with_http_info(pet_id, api_key)
+    def delete_pet(pet_id : Int64, api_key : String?, additional_metadata : String?)
+      delete_pet_with_http_info(pet_id, api_key, additional_metadata)
       nil
     end
 
@@ -91,7 +91,7 @@ module Petstore
     # 
     # @param pet_id [Int64] Pet id to delete
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def delete_pet_with_http_info(pet_id : Int64, api_key : String?)
+    def delete_pet_with_http_info(pet_id : Int64, api_key : String?, additional_metadata : String?)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.delete_pet ..."}
       end
@@ -107,10 +107,13 @@ module Petstore
 
       # header parameters
       header_params = Hash(String, String).new
+      # HTTP header "Content-Type"
+      header_params["Content-Type"] = @api_client.select_header_content_type(["application/x-www-form-urlencoded"])
       header_params["api_key"] = api_key
 
       # form parameters
       form_params = Hash(Symbol, (String | ::File)).new
+      form_params[:"additionalMetadata"] = additional_metadata unless additional_metadata.nil?
 
       # http body (model)
       post_body = nil

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/docs/PetApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/docs/PetApi.md
@@ -89,7 +89,7 @@ Name | Type | Description  | Notes
 
 <a name="deletepet"></a>
 # **DeletePet**
-> void DeletePet (long petId, string apiKey = null)
+> void DeletePet (long petId, string apiKey = null, string additionalMetadata = null)
 
 Deletes a pet
 
@@ -115,11 +115,12 @@ namespace Example
             var apiInstance = new PetApi(config);
             var petId = 789L;  // long | Pet id to delete
             var apiKey = "apiKey_example";  // string |  (optional) 
+            var additionalMetadata = "additionalMetadata_example";  // string | Additional data to pass to server (optional) 
 
             try
             {
                 // Deletes a pet
-                apiInstance.DeletePet(petId, apiKey);
+                apiInstance.DeletePet(petId, apiKey, additionalMetadata);
             }
             catch (ApiException  e)
             {
@@ -138,6 +139,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | **long**| Pet id to delete | 
  **apiKey** | **string**|  | [optional] 
+ **additionalMetadata** | **string**| Additional data to pass to server | [optional] 
 
 ### Return type
 
@@ -149,7 +151,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
@@ -52,9 +52,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns></returns>
-        void DeletePet(long petId, string apiKey = default(string), int operationIndex = 0);
+        void DeletePet(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0);
 
         /// <summary>
         /// Deletes a pet
@@ -65,9 +66,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> DeletePetWithHttpInfo(long petId, string apiKey = default(string), int operationIndex = 0);
+        ApiResponse<Object> DeletePetWithHttpInfo(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0);
         /// <summary>
         /// Finds Pets by status
         /// </summary>
@@ -250,10 +252,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task DeletePetAsync(long petId, string apiKey = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task DeletePetAsync(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Deletes a pet
@@ -264,10 +267,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> DeletePetWithHttpInfoAsync(long petId, string apiKey = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<Object>> DeletePetWithHttpInfoAsync(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Finds Pets by status
         /// </summary>
@@ -716,11 +720,12 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns></returns>
-        public void DeletePet(long petId, string apiKey = default(string), int operationIndex = 0)
+        public void DeletePet(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0)
         {
-            DeletePetWithHttpInfo(petId, apiKey);
+            DeletePetWithHttpInfo(petId, apiKey, additionalMetadata);
         }
 
         /// <summary>
@@ -729,13 +734,15 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Object> DeletePetWithHttpInfo(long petId, string apiKey = default(string), int operationIndex = 0)
+        public Org.OpenAPITools.Client.ApiResponse<Object> DeletePetWithHttpInfo(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
+                "application/x-www-form-urlencoded"
             };
 
             // to determine the Accept header
@@ -758,6 +765,10 @@ namespace Org.OpenAPITools.Api
             if (apiKey != null)
             {
                 localVarRequestOptions.HeaderParameters.Add("api_key", Org.OpenAPITools.Client.ClientUtils.ParameterToString(apiKey)); // header parameter
+            }
+            if (additionalMetadata != null)
+            {
+                localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
             }
 
             localVarRequestOptions.Operation = "PetApi.DeletePet";
@@ -790,12 +801,13 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeletePetAsync(long petId, string apiKey = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task DeletePetAsync(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            await DeletePetWithHttpInfoAsync(petId, apiKey, operationIndex, cancellationToken).ConfigureAwait(false);
+            await DeletePetWithHttpInfoAsync(petId, apiKey, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -804,15 +816,17 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
+        /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> DeletePetWithHttpInfoAsync(long petId, string apiKey = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> DeletePetWithHttpInfoAsync(long petId, string apiKey = default(string), string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
+                "application/x-www-form-urlencoded"
             };
 
             // to determine the Accept header
@@ -835,6 +849,10 @@ namespace Org.OpenAPITools.Api
             if (apiKey != null)
             {
                 localVarRequestOptions.HeaderParameters.Add("api_key", Org.OpenAPITools.Client.ClientUtils.ParameterToString(apiKey)); // header parameter
+            }
+            if (additionalMetadata != null)
+            {
+                localVarRequestOptions.FormParameters.Add("additionalMetadata", Org.OpenAPITools.Client.ClientUtils.ParameterToString(additionalMetadata)); // form parameter
             }
 
             localVarRequestOptions.Operation = "PetApi.DeletePet";

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/PetApi.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/PetApi.groovy
@@ -35,7 +35,7 @@ class PetApi {
 
     }
 
-    def deletePet ( Long petId, String apiKey, Closure onSuccess, Closure onFailure)  {
+    def deletePet ( Long petId, String apiKey, String additionalMetadata, Closure onSuccess, Closure onFailure)  {
         String resourcePath = "/pet/${petId}"
 
         // params
@@ -55,6 +55,8 @@ class PetApi {
         }
 
 
+        contentType = 'application/x-www-form-urlencoded';
+        bodyParams = additionalMetadata
 
         apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
                     "DELETE", "",

--- a/samples/client/petstore/lua/petstore/api/pet_api.lua
+++ b/samples/client/petstore/lua/petstore/api/pet_api.lua
@@ -101,7 +101,7 @@ function pet_api:add_pet(pet)
 	end
 end
 
-function pet_api:delete_pet(pet_id, api_key)
+function pet_api:delete_pet(pet_id, api_key, additional_metadata)
 	local req = http_request.new_from_uri({
 		scheme = self.default_scheme;
 		host = self.host;
@@ -112,9 +112,16 @@ function pet_api:delete_pet(pet_id, api_key)
 
 	-- set HTTP verb
 	req.headers:upsert(":method", "DELETE")
+	-- TODO: create a function to select proper accept
+	--local var_content_type = { "application/x-www-form-urlencoded" }
+	req.headers:upsert("accept", "application/x-www-form-urlencoded")
+
 	if api_key then
 		req.headers:upsert("api_key", api_key)
 	end
+	req:set_body(http_util.dict_to_query({
+		["additionalMetadata"] = additional_metadata;
+	}))
 	-- oAuth
 	if self.access_token then
 		req.headers:upsert("authorization", "Bearer " .. self.access_token)

--- a/samples/client/petstore/nim/petstore/apis/api_pet.nim
+++ b/samples/client/petstore/nim/petstore/apis/api_pet.nim
@@ -47,10 +47,14 @@ proc addPet*(httpClient: HttpClient, pet: Pet): (Option[Pet], Response) =
   constructResult[Pet](response)
 
 
-proc deletePet*(httpClient: HttpClient, petId: int64, apiKey: string): Response =
+proc deletePet*(httpClient: HttpClient, petId: int64, apiKey: string, additionalMetadata: string): Response =
   ## Deletes a pet
+  httpClient.headers["Content-Type"] = "application/x-www-form-urlencoded"
   httpClient.headers["api_key"] = apiKey
-  httpClient.delete(basepath & fmt"/pet/{petId}")
+  let query_for_api_call = encodeQuery([
+    ("additionalMetadata", $additionalMetadata), # Additional data to pass to server
+  ])
+  httpClient.delete(basepath & fmt"/pet/{petId}", $query_for_api_call)
 
 
 proc findPetsByStatus*(httpClient: HttpClient, status: seq[Status]): (Option[seq[Pet]], Response) =

--- a/samples/client/petstore/php-dt-modern/.openapi-generator/FILES
+++ b/samples/client/petstore/php-dt-modern/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/App/DTO/GetPetByIdParameterData.php
 src/App/DTO/GetUserByNameParameterData.php
 src/App/DTO/InlineObject.php
 src/App/DTO/InlineObject1.php
+src/App/DTO/InlineObject2.php
 src/App/DTO/LoginUserParameterData.php
 src/App/DTO/Order.php
 src/App/DTO/Pet.php

--- a/samples/client/petstore/php-dt-modern/src/App/ApiClient.php
+++ b/samples/client/petstore/php-dt-modern/src/App/ApiClient.php
@@ -374,18 +374,23 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * Deletes a pet
      * @param \App\DTO\DeletePetParameterData $parameters
+     * @param \App\DTO\InlineObject1 $requestContent
      * @param iterable|string[][] $security
+     * @param string $requestMediaType
      * @return ResponseInterface
      * @throws ClientExceptionInterface
      * @throws DT\Exception\InvalidData
      */
     public function deletePetRaw(
         \App\DTO\DeletePetParameterData $parameters,
-        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]]
+        \App\DTO\InlineObject1 $requestContent,
+        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
+        string $requestMediaType = 'application/x-www-form-urlencoded'
     ): ResponseInterface
     {
         $request = $this->createRequest('DELETE', '/pet/{petId}', $this->getPathParameters($parameters), []);
         $request = $this->addCustomHeaders($request, $parameters);
+        $request = $this->addBody($request, $requestMediaType, $requestContent);
         $request = $this->addSecurity($request, $security);
         return $this->httpClient->sendRequest($request);
     }
@@ -393,7 +398,9 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * Deletes a pet
      * @param \App\DTO\DeletePetParameterData $parameters
+     * @param \App\DTO\InlineObject1 $requestContent
      * @param iterable|string[][] $security
+     * @param string $requestMediaType
      * @return array
      * @throws ClientExceptionInterface
      * @throws DT\Exception\InvalidData
@@ -401,10 +408,12 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function deletePet(
         \App\DTO\DeletePetParameterData $parameters,
-        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]]
+        \App\DTO\InlineObject1 $requestContent,
+        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
+        string $requestMediaType = 'application/x-www-form-urlencoded'
     ): array
     {
-        $response = $this->deletePetRaw($parameters, $security);
+        $response = $this->deletePetRaw($parameters, $requestContent, $security, $requestMediaType);
         $responseContent = null;
         switch ($response->getStatusCode())
         {
@@ -419,7 +428,9 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * Deletes a pet
      * @param \App\DTO\DeletePetParameterData $parameters
+     * @param \App\DTO\InlineObject1 $requestContent
      * @param iterable|string[][] $security
+     * @param string $requestMediaType
      * @return mixed
      * @throws ClientExceptionInterface
      * @throws DT\Exception\InvalidData
@@ -428,10 +439,12 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function deletePetResult(
         \App\DTO\DeletePetParameterData $parameters,
-        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]]
+        \App\DTO\InlineObject1 $requestContent,
+        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
+        string $requestMediaType = 'application/x-www-form-urlencoded'
     ): mixed
     {
-        return $this->getSuccessfulContent(...$this->deletePet($parameters, $security));
+        return $this->getSuccessfulContent(...$this->deletePet($parameters, $requestContent, $security, $requestMediaType));
     }
     //endregion
 
@@ -1387,7 +1400,7 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * uploads an image
      * @param \App\DTO\UploadFileParameterData $parameters
-     * @param \App\DTO\InlineObject1 $requestContent
+     * @param \App\DTO\InlineObject2 $requestContent
      * @param iterable|string[][] $security
      * @param string $requestMediaType
      * @param string $responseMediaType
@@ -1397,7 +1410,7 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function uploadFileRaw(
         \App\DTO\UploadFileParameterData $parameters,
-        \App\DTO\InlineObject1 $requestContent,
+        \App\DTO\InlineObject2 $requestContent,
         iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
         string $requestMediaType = 'multipart/form-data',
         string $responseMediaType = 'application/json'
@@ -1413,7 +1426,7 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * uploads an image
      * @param \App\DTO\UploadFileParameterData $parameters
-     * @param \App\DTO\InlineObject1 $requestContent
+     * @param \App\DTO\InlineObject2 $requestContent
      * @param iterable|string[][] $security
      * @param string $requestMediaType
      * @param string $responseMediaType
@@ -1424,7 +1437,7 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function uploadFile(
         \App\DTO\UploadFileParameterData $parameters,
-        \App\DTO\InlineObject1 $requestContent,
+        \App\DTO\InlineObject2 $requestContent,
         iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
         string $requestMediaType = 'multipart/form-data',
         string $responseMediaType = 'application/json'
@@ -1446,7 +1459,7 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * uploads an image
      * @param \App\DTO\UploadFileParameterData $parameters
-     * @param \App\DTO\InlineObject1 $requestContent
+     * @param \App\DTO\InlineObject2 $requestContent
      * @param iterable|string[][] $security
      * @param string $requestMediaType
      * @param string $responseMediaType
@@ -1458,7 +1471,7 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function uploadFileResult(
         \App\DTO\UploadFileParameterData $parameters,
-        \App\DTO\InlineObject1 $requestContent,
+        \App\DTO\InlineObject2 $requestContent,
         iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
         string $requestMediaType = 'multipart/form-data',
         string $responseMediaType = 'application/json'

--- a/samples/client/petstore/php-dt-modern/src/App/DTO/InlineObject2.php
+++ b/samples/client/petstore/php-dt-modern/src/App/DTO/InlineObject2.php
@@ -5,7 +5,7 @@ namespace App\DTO;
 
 use Articus\DataTransfer\PhpAttribute as DTA;
 
-class InlineObject1
+class InlineObject2
 {
     /**
      * Additional data to pass to server
@@ -13,5 +13,13 @@ class InlineObject1
     #[DTA\Data(field: "additionalMetadata", nullable: true)]
     #[DTA\Validator("Scalar", ["type" => "string"])]
     public string|null $additional_metadata = null;
+
+    /**
+     * file to upload
+     */
+    #[DTA\Data(field: "file", nullable: true)]
+    #[DTA\Strategy("Object", ["type" => \SplFileObject::class])]
+    #[DTA\Validator("TypeCompliant", ["type" => \SplFileObject::class])]
+    public \SplFileObject|null $file = null;
 
 }

--- a/samples/client/petstore/php-dt/.openapi-generator/FILES
+++ b/samples/client/petstore/php-dt/.openapi-generator/FILES
@@ -52,6 +52,7 @@ src/App/DTO/GetPetByIdParameterData.php
 src/App/DTO/GetUserByNameParameterData.php
 src/App/DTO/InlineObject.php
 src/App/DTO/InlineObject1.php
+src/App/DTO/InlineObject2.php
 src/App/DTO/LoginUserParameterData.php
 src/App/DTO/Order.php
 src/App/DTO/Pet.php

--- a/samples/client/petstore/php-dt/src/App/ApiClient.php
+++ b/samples/client/petstore/php-dt/src/App/ApiClient.php
@@ -374,18 +374,23 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * Deletes a pet
      * @param \App\DTO\DeletePetParameterData $parameters
+     * @param \App\DTO\InlineObject1 $requestContent
      * @param iterable|string[][] $security
+     * @param string $requestMediaType
      * @return ResponseInterface
      * @throws ClientExceptionInterface
      * @throws DT\Exception\InvalidData
      */
     public function deletePetRaw(
         \App\DTO\DeletePetParameterData $parameters,
-        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]]
+        \App\DTO\InlineObject1 $requestContent,
+        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
+        string $requestMediaType = 'application/x-www-form-urlencoded'
     ): ResponseInterface
     {
         $request = $this->createRequest('DELETE', '/pet/{petId}', $this->getPathParameters($parameters), []);
         $request = $this->addCustomHeaders($request, $parameters);
+        $request = $this->addBody($request, $requestMediaType, $requestContent);
         $request = $this->addSecurity($request, $security);
         return $this->httpClient->sendRequest($request);
     }
@@ -393,7 +398,9 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * Deletes a pet
      * @param \App\DTO\DeletePetParameterData $parameters
+     * @param \App\DTO\InlineObject1 $requestContent
      * @param iterable|string[][] $security
+     * @param string $requestMediaType
      * @return array
      * @throws ClientExceptionInterface
      * @throws DT\Exception\InvalidData
@@ -401,10 +408,12 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function deletePet(
         \App\DTO\DeletePetParameterData $parameters,
-        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]]
+        \App\DTO\InlineObject1 $requestContent,
+        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
+        string $requestMediaType = 'application/x-www-form-urlencoded'
     ): array
     {
-        $response = $this->deletePetRaw($parameters, $security);
+        $response = $this->deletePetRaw($parameters, $requestContent, $security, $requestMediaType);
         $responseContent = null;
         switch ($response->getStatusCode())
         {
@@ -419,7 +428,9 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * Deletes a pet
      * @param \App\DTO\DeletePetParameterData $parameters
+     * @param \App\DTO\InlineObject1 $requestContent
      * @param iterable|string[][] $security
+     * @param string $requestMediaType
      * @return mixed
      * @throws ClientExceptionInterface
      * @throws DT\Exception\InvalidData
@@ -428,10 +439,12 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function deletePetResult(
         \App\DTO\DeletePetParameterData $parameters,
-        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]]
+        \App\DTO\InlineObject1 $requestContent,
+        iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
+        string $requestMediaType = 'application/x-www-form-urlencoded'
     )
     {
-        return $this->getSuccessfulContent(...$this->deletePet($parameters, $security));
+        return $this->getSuccessfulContent(...$this->deletePet($parameters, $requestContent, $security, $requestMediaType));
     }
     //endregion
 
@@ -1387,7 +1400,7 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * uploads an image
      * @param \App\DTO\UploadFileParameterData $parameters
-     * @param \App\DTO\InlineObject1 $requestContent
+     * @param \App\DTO\InlineObject2 $requestContent
      * @param iterable|string[][] $security
      * @param string $requestMediaType
      * @param string $responseMediaType
@@ -1397,7 +1410,7 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function uploadFileRaw(
         \App\DTO\UploadFileParameterData $parameters,
-        \App\DTO\InlineObject1 $requestContent,
+        \App\DTO\InlineObject2 $requestContent,
         iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
         string $requestMediaType = 'multipart/form-data',
         string $responseMediaType = 'application/json'
@@ -1413,7 +1426,7 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * uploads an image
      * @param \App\DTO\UploadFileParameterData $parameters
-     * @param \App\DTO\InlineObject1 $requestContent
+     * @param \App\DTO\InlineObject2 $requestContent
      * @param iterable|string[][] $security
      * @param string $requestMediaType
      * @param string $responseMediaType
@@ -1424,7 +1437,7 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function uploadFile(
         \App\DTO\UploadFileParameterData $parameters,
-        \App\DTO\InlineObject1 $requestContent,
+        \App\DTO\InlineObject2 $requestContent,
         iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
         string $requestMediaType = 'multipart/form-data',
         string $responseMediaType = 'application/json'
@@ -1446,7 +1459,7 @@ class ApiClient extends OAGAC\AbstractApiClient
     /**
      * uploads an image
      * @param \App\DTO\UploadFileParameterData $parameters
-     * @param \App\DTO\InlineObject1 $requestContent
+     * @param \App\DTO\InlineObject2 $requestContent
      * @param iterable|string[][] $security
      * @param string $requestMediaType
      * @param string $responseMediaType
@@ -1458,7 +1471,7 @@ class ApiClient extends OAGAC\AbstractApiClient
      */
     public function uploadFileResult(
         \App\DTO\UploadFileParameterData $parameters,
-        \App\DTO\InlineObject1 $requestContent,
+        \App\DTO\InlineObject2 $requestContent,
         iterable $security = ['petstore_auth' => ['write:pets', 'read:pets', ]],
         string $requestMediaType = 'multipart/form-data',
         string $responseMediaType = 'application/json'

--- a/samples/client/petstore/php-dt/src/App/DTO/InlineObject2.php
+++ b/samples/client/petstore/php-dt/src/App/DTO/InlineObject2.php
@@ -7,7 +7,7 @@ use Articus\DataTransfer\Annotation as DTA;
 
 /**
  */
-class InlineObject1
+class InlineObject2
 {
     /**
      * Additional data to pass to server
@@ -16,5 +16,14 @@ class InlineObject1
      * @var string|null
      */
     public $additional_metadata;
+
+    /**
+     * file to upload
+     * @DTA\Data(field="file", nullable=true)
+     * @DTA\Strategy(name="Object", options={"type":\SplFileObject::class})
+     * @DTA\Validator(name="TypeCompliant", options={"type":\SplFileObject::class})
+     * @var \SplFileObject|null
+     */
+    public $file;
 
 }

--- a/samples/client/petstore/rust/hyper/petstore/docs/PetApi.md
+++ b/samples/client/petstore/rust/hyper/petstore/docs/PetApi.md
@@ -47,7 +47,7 @@ Name | Type | Description  | Required | Notes
 
 ## delete_pet
 
-> delete_pet(pet_id, api_key)
+> delete_pet(pet_id, api_key, additional_metadata)
 Deletes a pet
 
 
@@ -59,6 +59,7 @@ Name | Type | Description  | Required | Notes
 ------------- | ------------- | ------------- | ------------- | -------------
 **pet_id** | **i64** | Pet id to delete | [required] |
 **api_key** | Option<**String**> |  |  |
+**additional_metadata** | Option<**String**> | Additional data to pass to server |  |
 
 ### Return type
 
@@ -70,7 +71,7 @@ Name | Type | Description  | Required | Notes
 
 ### HTTP request headers
 
-- **Content-Type**: Not defined
+- **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/pet_api.rs
@@ -36,7 +36,7 @@ impl<C: hyper::client::connect::Connect> PetApiClient<C>
 
 pub trait PetApi {
     fn add_pet(&self, pet: crate::models::Pet) -> Pin<Box<dyn Future<Output = Result<crate::models::Pet, Error>>>>;
-    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), Error>>>>;
+    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>, additional_metadata: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), Error>>>>;
     fn find_pets_by_status(&self, status: Vec<String>) -> Pin<Box<dyn Future<Output = Result<Vec<crate::models::Pet>, Error>>>>;
     fn find_pets_by_tags(&self, tags: Vec<String>) -> Pin<Box<dyn Future<Output = Result<Vec<crate::models::Pet>, Error>>>>;
     fn get_pet_by_id(&self, pet_id: i64) -> Pin<Box<dyn Future<Output = Result<crate::models::Pet, Error>>>>;
@@ -58,13 +58,16 @@ impl<C: hyper::client::connect::Connect>PetApi for PetApiClient<C>
     }
 
     #[allow(unused_mut)]
-    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {
+    fn delete_pet(&self, pet_id: i64, api_key: Option<&str>, additional_metadata: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {
         let mut req = __internal_request::Request::new(hyper::Method::DELETE, "/pet/{petId}".to_string())
             .with_auth(__internal_request::Auth::Oauth)
         ;
         req = req.with_path_param("petId".to_string(), pet_id.to_string());
         if let Some(param_value) = api_key {
             req = req.with_header_param("api_key".to_string(), param_value.to_string());
+        }
+        if let Some(param_value) = additional_metadata {
+            req = req.with_form_param("additionalMetadata".to_string(), param_value.to_string());
         }
         req = req.returns_nothing();
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/docs/PetApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async/docs/PetApi.md
@@ -47,7 +47,7 @@ Name | Type | Description  | Required | Notes
 
 ## delete_pet
 
-> delete_pet(pet_id, api_key)
+> delete_pet(pet_id, api_key, additional_metadata)
 Deletes a pet
 
 
@@ -59,6 +59,7 @@ Name | Type | Description  | Required | Notes
 ------------- | ------------- | ------------- | ------------- | -------------
 **pet_id** | **i64** | Pet id to delete | [required] |
 **api_key** | Option<**String**> |  |  |
+**additional_metadata** | Option<**String**> | Additional data to pass to server |  |
 
 ### Return type
 
@@ -70,7 +71,7 @@ Name | Type | Description  | Required | Notes
 
 ### HTTP request headers
 
-- **Content-Type**: Not defined
+- **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
@@ -26,7 +26,9 @@ pub struct AddPetParams {
 pub struct DeletePetParams {
     /// Pet id to delete
     pub pet_id: i64,
-    pub api_key: Option<String>
+    pub api_key: Option<String>,
+    /// Additional data to pass to server
+    pub additional_metadata: Option<String>
 }
 
 /// struct for passing parameters to the method [`find_pets_by_status`]
@@ -254,6 +256,7 @@ pub async fn delete_pet(configuration: &configuration::Configuration, params: De
     // unbox the parameters
     let pet_id = params.pet_id;
     let api_key = params.api_key;
+    let additional_metadata = params.additional_metadata;
 
 
     let local_var_client = &local_var_configuration.client;
@@ -270,6 +273,11 @@ pub async fn delete_pet(configuration: &configuration::Configuration, params: De
     if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
+    let mut local_var_form_params = std::collections::HashMap::new();
+    if let Some(local_var_param_value) = additional_metadata {
+        local_var_form_params.insert("additionalMetadata", local_var_param_value.to_string());
+    }
+    local_var_req_builder = local_var_req_builder.form(&local_var_form_params);
 
     let local_var_req = local_var_req_builder.build()?;
     let local_var_resp = local_var_client.execute(local_var_req).await?;

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/PetApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/PetApi.md
@@ -47,7 +47,7 @@ Name | Type | Description  | Required | Notes
 
 ## delete_pet
 
-> delete_pet(pet_id, api_key)
+> delete_pet(pet_id, api_key, additional_metadata)
 Deletes a pet
 
 
@@ -59,6 +59,7 @@ Name | Type | Description  | Required | Notes
 ------------- | ------------- | ------------- | ------------- | -------------
 **pet_id** | **i64** | Pet id to delete | [required] |
 **api_key** | Option<**String**> |  |  |
+**additional_metadata** | Option<**String**> | Additional data to pass to server |  |
 
 ### Return type
 
@@ -70,7 +71,7 @@ Name | Type | Description  | Required | Notes
 
 ### HTTP request headers
 
-- **Content-Type**: Not defined
+- **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
@@ -128,7 +128,7 @@ pub fn add_pet(configuration: &configuration::Configuration, pet: crate::models:
 }
 
 /// 
-pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api_key: Option<&str>) -> Result<(), Error<DeletePetError>> {
+pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api_key: Option<&str>, additional_metadata: Option<&str>) -> Result<(), Error<DeletePetError>> {
     let local_var_configuration = configuration;
 
     let local_var_client = &local_var_configuration.client;
@@ -158,6 +158,11 @@ pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api
     if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
+    let mut local_var_form_params = std::collections::HashMap::new();
+    if let Some(local_var_param_value) = additional_metadata {
+        local_var_form_params.insert("additionalMetadata", local_var_param_value.to_string());
+    }
+    local_var_req_builder = local_var_req_builder.form(&local_var_form_params);
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;

--- a/samples/client/petstore/rust/reqwest/petstore/docs/PetApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore/docs/PetApi.md
@@ -47,7 +47,7 @@ Name | Type | Description  | Required | Notes
 
 ## delete_pet
 
-> delete_pet(pet_id, api_key)
+> delete_pet(pet_id, api_key, additional_metadata)
 Deletes a pet
 
 
@@ -59,6 +59,7 @@ Name | Type | Description  | Required | Notes
 ------------- | ------------- | ------------- | ------------- | -------------
 **pet_id** | **i64** | Pet id to delete | [required] |
 **api_key** | Option<**String**> |  |  |
+**additional_metadata** | Option<**String**> | Additional data to pass to server |  |
 
 ### Return type
 
@@ -70,7 +71,7 @@ Name | Type | Description  | Required | Notes
 
 ### HTTP request headers
 
-- **Content-Type**: Not defined
+- **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
@@ -115,7 +115,7 @@ pub fn add_pet(configuration: &configuration::Configuration, pet: crate::models:
 }
 
 /// 
-pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api_key: Option<&str>) -> Result<(), Error<DeletePetError>> {
+pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api_key: Option<&str>, additional_metadata: Option<&str>) -> Result<(), Error<DeletePetError>> {
     let local_var_configuration = configuration;
 
     let local_var_client = &local_var_configuration.client;
@@ -132,6 +132,11 @@ pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api
     if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
+    let mut local_var_form_params = std::collections::HashMap::new();
+    if let Some(local_var_param_value) = additional_metadata {
+        local_var_form_params.insert("additionalMetadata", local_var_param_value.to_string());
+    }
+    local_var_req_builder = local_var_req_builder.form(&local_var_form_params);
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;

--- a/samples/client/petstore/scala-httpclient-deprecated/src/main/scala/org/openapitools/example/api/PetApi.scala
+++ b/samples/client/petstore/scala-httpclient-deprecated/src/main/scala/org/openapitools/example/api/PetApi.scala
@@ -108,10 +108,11 @@ class PetApi(
    *
    * @param petId Pet id to delete 
    * @param apiKey  (optional)
+   * @param additionalMetadata Additional data to pass to server (optional)
    * @return void
    */
-  def deletePet(petId: Long, apiKey: Option[String] = None) = {
-    val await = Try(Await.result(deletePetAsync(petId, apiKey), Duration.Inf))
+  def deletePet(petId: Long, apiKey: Option[String] = None, additionalMetadata: Option[String] = None) = {
+    val await = Try(Await.result(deletePetAsync(petId, apiKey, additionalMetadata), Duration.Inf))
     await match {
       case Success(i) => Some(await.get)
       case Failure(t) => None
@@ -124,10 +125,11 @@ class PetApi(
    *
    * @param petId Pet id to delete 
    * @param apiKey  (optional)
+   * @param additionalMetadata Additional data to pass to server (optional)
    * @return Future(void)
    */
-  def deletePetAsync(petId: Long, apiKey: Option[String] = None) = {
-      helper.deletePet(petId, apiKey)
+  def deletePetAsync(petId: Long, apiKey: Option[String] = None, additionalMetadata: Option[String] = None) = {
+      helper.deletePet(petId, apiKey, additionalMetadata)
   }
 
   /**
@@ -319,7 +321,8 @@ class PetApiAsyncHelper(client: TransportClient, config: SwaggerConfig) extends 
   }
 
   def deletePet(petId: Long,
-    apiKey: Option[String] = None
+    apiKey: Option[String] = None,
+    additionalMetadata: Option[String] = None
     )(implicit reader: ClientResponseReader[Unit]): Future[Unit] = {
     // create path and map variables
     val path = (addFmt("/pet/{petId}")

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -50,13 +50,17 @@ class PetApi(baseUrl: String) {
    * 
    * @param petId Pet id to delete
    * @param apiKey 
+   * @param additionalMetadata Additional data to pass to server
    */
-  def deletePet(petId: Long, apiKey: Option[String] = None
+  def deletePet(petId: Long, apiKey: Option[String] = None, additionalMetadata: Option[String] = None
 ): Request[Either[ResponseException[String, Exception], Unit], Nothing] =
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
-      .contentType("application/json")
+      .contentType("application/x-www-form-urlencoded")
       .header("api_key", apiKey.toString)
+      .body(Map(
+        "additionalMetadata" -> additionalMetadata
+      ))
       .response(asJson[Unit])
 
   /**

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -70,6 +70,7 @@ public interface PetApi {
      *
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @return Invalid pet value (status code 400)
      */
     @ApiOperation(
@@ -89,11 +90,13 @@ public interface PetApi {
     })
     @RequestMapping(
         method = RequestMethod.DELETE,
-        value = "/pet/{petId}"
+        value = "/pet/{petId}",
+        consumes = "application/x-www-form-urlencoded"
     )
     ResponseEntity<Void> deletePet(
         @ApiParam(value = "Pet id to delete", required = true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "") @RequestHeader(value = "api_key", required = false) String apiKey
+        @ApiParam(value = "") @RequestHeader(value = "api_key", required = false) String apiKey,
+        @ApiParam(value = "Additional data to pass to server") @Valid @RequestParam(value = "additionalMetadata", required = false) String additionalMetadata
     );
 
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -96,15 +96,17 @@ export class PetService {
      * 
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public deletePet(petId: number, apiKey?: string, ): Observable<AxiosResponse<any>>;
-    public deletePet(petId: number, apiKey?: string, ): Observable<any> {
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, ): Observable<AxiosResponse<any>>;
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, ): Observable<any> {
 
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
+
 
 
         let headers = this.defaultHeaders;
@@ -130,7 +132,24 @@ export class PetService {
 
         // to determine the Content-Type header
         const consumes: string[] = [
+            'application/x-www-form-urlencoded'
         ];
+
+        const canConsumeForm = this.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): void; };
+        let useForm = false;
+        let convertFormParamsToString = false;
+        if (useForm) {
+            formParams = new FormData();
+        } else {
+            // formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        }
+
+        if (additionalMetadata !== undefined) {
+            formParams.append('additionalMetadata', <any>additionalMetadata);
+        }
+
         return this.httpClient.delete<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 withCredentials: this.configuration.withCredentials,

--- a/samples/config/petstore/protobuf-schema/services/pet_service.proto
+++ b/samples/config/petstore/protobuf-schema/services/pet_service.proto
@@ -45,6 +45,8 @@ message DeletePetRequest {
   // Pet id to delete
   int64 petId = 1;
   string apiKey = 2;
+  // Additional data to pass to server
+  string additionalMetadata = 3;
 
 }
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/doc/PetApi.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/doc/PetApi.md
@@ -65,7 +65,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **deletePet**
-> deletePet(petId, apiKey)
+> deletePet(petId, apiKey, additionalMetadata)
 
 Deletes a pet
 
@@ -80,9 +80,10 @@ import 'package:openapi/api.dart';
 final api_instance = PetApi();
 final petId = 789; // int | Pet id to delete
 final apiKey = apiKey_example; // String | 
+final additionalMetadata = additionalMetadata_example; // String | Additional data to pass to server
 
 try {
-    api_instance.deletePet(petId, apiKey);
+    api_instance.deletePet(petId, apiKey, additionalMetadata);
 } catch (e) {
     print('Exception when calling PetApi->deletePet: $e\n');
 }
@@ -94,6 +95,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | **int**| Pet id to delete | 
  **apiKey** | **String**|  | [optional] 
+ **additionalMetadata** | **String**| Additional data to pass to server | [optional] 
 
 ### Return type
 
@@ -105,7 +107,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -88,7 +88,10 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, }) async {
+  ///
+  /// * [String] additionalMetadata:
+  ///   Additional data to pass to server
+  Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, String? additionalMetadata, }) async {
     // ignore: prefer_const_declarations
     final path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
@@ -105,8 +108,11 @@ class PetApi {
     }
 
     const authNames = <String>['petstore_auth'];
-    const contentTypes = <String>[];
+    const contentTypes = <String>['application/x-www-form-urlencoded'];
 
+    if (additionalMetadata != null) {
+      formParams[r'additionalMetadata'] = parameterToString(additionalMetadata);
+    }
 
     return apiClient.invokeAPI(
       path,
@@ -130,8 +136,11 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future<void> deletePet(int petId, { String? apiKey, }) async {
-    final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, );
+  ///
+  /// * [String] additionalMetadata:
+  ///   Additional data to pass to server
+  Future<void> deletePet(int petId, { String? apiKey, String? additionalMetadata, }) async {
+    final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, additionalMetadata: additionalMetadata, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -75,6 +75,7 @@ public interface PetApi {
      *
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @return Invalid pet value (status code 400)
      */
     @Operation(
@@ -90,11 +91,13 @@ public interface PetApi {
     )
     @RequestMapping(
         method = RequestMethod.DELETE,
-        value = "/pet/{petId}"
+        value = "/pet/{petId}",
+        consumes = "application/x-www-form-urlencoded"
     )
     ResponseEntity<Void> deletePet(
         @Parameter(name = "petId", description = "Pet id to delete", required = true) @PathVariable("petId") Long petId,
-        @Parameter(name = "api_key", description = "") @RequestHeader(value = "api_key", required = false) String apiKey
+        @Parameter(name = "api_key", description = "") @RequestHeader(value = "api_key", required = false) String apiKey,
+        @Parameter(name = "additionalMetadata", description = "Additional data to pass to server") @Valid @RequestParam(value = "additionalMetadata", required = false) String additionalMetadata
     );
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/PetApi.md
@@ -106,6 +106,8 @@ let body:petstore.PetApiDeletePetRequest = {
   petId: 1,
   // string (optional)
   apiKey: "api_key_example",
+  // string | Additional data to pass to server (optional)
+  additionalMetadata: "additionalMetadata_example",
 };
 
 apiInstance.deletePet(body).then((data:any) => {
@@ -120,6 +122,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | [**number**] | Pet id to delete | defaults to undefined
  **apiKey** | [**string**] |  | (optional) defaults to undefined
+ **additionalMetadata** | [**string**] | Additional data to pass to server | (optional) defaults to undefined
 
 
 ### Return type
@@ -132,7 +135,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
@@ -71,14 +71,16 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new RequiredError("PetApi", "deletePet", "petId");
         }
+
 
 
 
@@ -93,6 +95,31 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         // Header Params
         requestContext.setHeaderParam("api_key", ObjectSerializer.serialize(apiKey, "string", ""));
 
+        // Form Params
+        const useForm = canConsumeForm([
+            'application/x-www-form-urlencoded',
+        ]);
+
+        let localVarFormParams
+        if (useForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new URLSearchParams();
+        }
+
+        if (additionalMetadata !== undefined) {
+             // TODO: replace .append with .set
+             localVarFormParams.append('additionalMetadata', additionalMetadata as any);
+        }
+
+        requestContext.setBody(localVarFormParams);
+
+        if(!useForm) {
+            const contentType = ObjectSerializer.getPreferredMediaType([
+                "application/x-www-form-urlencoded"
+            ]);
+            requestContext.setHeaderParam("Content-Type", contentType);
+        }
 
         let authMethod: SecurityAuthentication | undefined;
         // Apply auth methods

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObjectParamAPI.ts
@@ -34,6 +34,12 @@ export interface PetApiDeletePetRequest {
      * @memberof PetApideletePet
      */
     apiKey?: string
+    /**
+     * Additional data to pass to server
+     * @type string
+     * @memberof PetApideletePet
+     */
+    additionalMetadata?: string
 }
 
 export interface PetApiFindPetsByStatusRequest {
@@ -136,7 +142,7 @@ export class ObjectPetApi {
      * @param param the request object
      */
     public deletePet(param: PetApiDeletePetRequest, options?: Configuration): Promise<void> {
-        return this.api.deletePet(param.petId, param.apiKey,  options).toPromise();
+        return this.api.deletePet(param.petId, param.apiKey, param.additionalMetadata,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
@@ -55,9 +55,10 @@ export class ObservablePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, additionalMetadata, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/PromiseAPI.ts
@@ -37,9 +37,10 @@ export class PromisePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, additionalMetadata, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/default/PetApi.md
@@ -106,6 +106,8 @@ let body:petstore.PetApiDeletePetRequest = {
   petId: 1,
   // string (optional)
   apiKey: "api_key_example",
+  // string | Additional data to pass to server (optional)
+  additionalMetadata: "additionalMetadata_example",
 };
 
 apiInstance.deletePet(body).then((data:any) => {
@@ -120,6 +122,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | [**number**] | Pet id to delete | defaults to undefined
  **apiKey** | [**string**] |  | (optional) defaults to undefined
+ **additionalMetadata** | [**string**] | Additional data to pass to server | (optional) defaults to undefined
 
 
 ### Return type
@@ -132,7 +135,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -73,14 +73,16 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new RequiredError("PetApi", "deletePet", "petId");
         }
+
 
 
 
@@ -95,6 +97,31 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         // Header Params
         requestContext.setHeaderParam("api_key", ObjectSerializer.serialize(apiKey, "string", ""));
 
+        // Form Params
+        const useForm = canConsumeForm([
+            'application/x-www-form-urlencoded',
+        ]);
+
+        let localVarFormParams
+        if (useForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new URLSearchParams();
+        }
+
+        if (additionalMetadata !== undefined) {
+             // TODO: replace .append with .set
+             localVarFormParams.append('additionalMetadata', additionalMetadata as any);
+        }
+
+        requestContext.setBody(localVarFormParams);
+
+        if(!useForm) {
+            const contentType = ObjectSerializer.getPreferredMediaType([
+                "application/x-www-form-urlencoded"
+            ]);
+            requestContext.setHeaderParam("Content-Type", contentType);
+        }
 
         let authMethod: SecurityAuthentication | undefined;
         // Apply auth methods

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObjectParamAPI.ts
@@ -34,6 +34,12 @@ export interface PetApiDeletePetRequest {
      * @memberof PetApideletePet
      */
     apiKey?: string
+    /**
+     * Additional data to pass to server
+     * @type string
+     * @memberof PetApideletePet
+     */
+    additionalMetadata?: string
 }
 
 export interface PetApiFindPetsByStatusRequest {
@@ -136,7 +142,7 @@ export class ObjectPetApi {
      * @param param the request object
      */
     public deletePet(param: PetApiDeletePetRequest, options?: Configuration): Promise<void> {
-        return this.api.deletePet(param.petId, param.apiKey,  options).toPromise();
+        return this.api.deletePet(param.petId, param.apiKey, param.additionalMetadata,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
@@ -55,9 +55,10 @@ export class ObservablePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, additionalMetadata, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
@@ -37,9 +37,10 @@ export class PromisePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, additionalMetadata, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/PetApi.md
@@ -106,6 +106,8 @@ let body:petstore.PetApiDeletePetRequest = {
   petId: 1,
   // string (optional)
   apiKey: "api_key_example",
+  // string | Additional data to pass to server (optional)
+  additionalMetadata: "additionalMetadata_example",
 };
 
 apiInstance.deletePet(body).then((data:any) => {
@@ -120,6 +122,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | [**number**] | Pet id to delete | defaults to undefined
  **apiKey** | [**string**] |  | (optional) defaults to undefined
+ **additionalMetadata** | [**string**] | Additional data to pass to server | (optional) defaults to undefined
 
 
 ### Return type
@@ -132,7 +135,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -71,14 +71,16 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new RequiredError("PetApi", "deletePet", "petId");
         }
+
 
 
 
@@ -93,6 +95,31 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         // Header Params
         requestContext.setHeaderParam("api_key", ObjectSerializer.serialize(apiKey, "string", ""));
 
+        // Form Params
+        const useForm = canConsumeForm([
+            'application/x-www-form-urlencoded',
+        ]);
+
+        let localVarFormParams
+        if (useForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new URLSearchParams();
+        }
+
+        if (additionalMetadata !== undefined) {
+             // TODO: replace .append with .set
+             localVarFormParams.append('additionalMetadata', additionalMetadata as any);
+        }
+
+        requestContext.setBody(localVarFormParams);
+
+        if(!useForm) {
+            const contentType = ObjectSerializer.getPreferredMediaType([
+                "application/x-www-form-urlencoded"
+            ]);
+            requestContext.setHeaderParam("Content-Type", contentType);
+        }
 
         let authMethod: SecurityAuthentication | undefined;
         // Apply auth methods

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObjectParamAPI.ts
@@ -34,6 +34,12 @@ export interface PetApiDeletePetRequest {
      * @memberof PetApideletePet
      */
     apiKey?: string
+    /**
+     * Additional data to pass to server
+     * @type string
+     * @memberof PetApideletePet
+     */
+    additionalMetadata?: string
 }
 
 export interface PetApiFindPetsByStatusRequest {
@@ -136,7 +142,7 @@ export class ObjectPetApi {
      * @param param the request object
      */
     public deletePet(param: PetApiDeletePetRequest, options?: Configuration): Promise<void> {
-        return this.api.deletePet(param.petId, param.apiKey,  options).toPromise();
+        return this.api.deletePet(param.petId, param.apiKey, param.additionalMetadata,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
@@ -55,9 +55,10 @@ export class ObservablePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, additionalMetadata, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
@@ -37,9 +37,10 @@ export class PromisePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, additionalMetadata, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/PetApi.md
@@ -106,6 +106,8 @@ let body:petstore.PetApiDeletePetRequest = {
   petId: 1,
   // string (optional)
   apiKey: "api_key_example",
+  // string | Additional data to pass to server (optional)
+  additionalMetadata: "additionalMetadata_example",
 };
 
 apiInstance.deletePet(body).then((data:any) => {
@@ -120,6 +122,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | [**number**] | Pet id to delete | defaults to undefined
  **apiKey** | [**string**] |  | (optional) defaults to undefined
+ **additionalMetadata** | [**string**] | Additional data to pass to server | (optional) defaults to undefined
 
 
 ### Return type
@@ -132,7 +135,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.service.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.service.ts
@@ -7,7 +7,7 @@ import { Pet } from "../models/Pet";
 export abstract class AbstractPetApiRequestFactory {
     public abstract addPet(pet: Pet, options?: Configuration): Promise<RequestContext>;
 
-    public abstract deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext>;
+    public abstract deletePet(petId: number, apiKey?: string, additionalMetadata?: string, options?: Configuration): Promise<RequestContext>;
 
     public abstract findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext>;
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -71,14 +71,16 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new RequiredError("PetApi", "deletePet", "petId");
         }
+
 
 
 
@@ -93,6 +95,31 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         // Header Params
         requestContext.setHeaderParam("api_key", ObjectSerializer.serialize(apiKey, "string", ""));
 
+        // Form Params
+        const useForm = canConsumeForm([
+            'application/x-www-form-urlencoded',
+        ]);
+
+        let localVarFormParams
+        if (useForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new URLSearchParams();
+        }
+
+        if (additionalMetadata !== undefined) {
+             // TODO: replace .append with .set
+             localVarFormParams.append('additionalMetadata', additionalMetadata as any);
+        }
+
+        requestContext.setBody(localVarFormParams);
+
+        if(!useForm) {
+            const contentType = ObjectSerializer.getPreferredMediaType([
+                "application/x-www-form-urlencoded"
+            ]);
+            requestContext.setHeaderParam("Content-Type", contentType);
+        }
 
         let authMethod: SecurityAuthentication | undefined;
         // Apply auth methods

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/services/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/services/ObservableAPI.ts
@@ -13,7 +13,7 @@ import { User } from "../models/User";
 export abstract class AbstractObservablePetApi {
     public abstract addPet(pet: Pet, options?: Configuration): Observable<Pet>;
 
-    public abstract deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void>;
+    public abstract deletePet(petId: number, apiKey?: string, additionalMetadata?: string, options?: Configuration): Observable<void>;
 
     public abstract findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>>;
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/services/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/services/PromiseAPI.ts
@@ -12,7 +12,7 @@ import { User } from "../models/User";
 export abstract class AbstractPromisePetApi {
     public abstract addPet(pet: Pet, options?: Configuration): Promise<Pet>;
 
-    public abstract deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<void>;
+    public abstract deletePet(petId: number, apiKey?: string, additionalMetadata?: string, options?: Configuration): Promise<void>;
 
     public abstract findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<Array<Pet>>;
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObjectParamAPI.ts
@@ -34,6 +34,12 @@ export interface PetApiDeletePetRequest {
      * @memberof PetApideletePet
      */
     apiKey?: string
+    /**
+     * Additional data to pass to server
+     * @type string
+     * @memberof PetApideletePet
+     */
+    additionalMetadata?: string
 }
 
 export interface PetApiFindPetsByStatusRequest {
@@ -136,7 +142,7 @@ export class ObjectPetApi {
      * @param param the request object
      */
     public deletePet(param: PetApiDeletePetRequest, options?: Configuration): Promise<void> {
-        return this.api.deletePet(param.petId, param.apiKey,  options).toPromise();
+        return this.api.deletePet(param.petId, param.apiKey, param.additionalMetadata,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
@@ -60,9 +60,10 @@ export class ObservablePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, additionalMetadata, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
@@ -42,9 +42,10 @@ export class PromisePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, additionalMetadata, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/PetApi.md
@@ -106,6 +106,8 @@ let body:petstore.PetApiDeletePetRequest = {
   petId: 1,
   // string (optional)
   apiKey: "api_key_example",
+  // string | Additional data to pass to server (optional)
+  additionalMetadata: "additionalMetadata_example",
 };
 
 apiInstance.deletePet(body).then((data:any) => {
@@ -120,6 +122,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | [**number**] | Pet id to delete | defaults to undefined
  **apiKey** | [**string**] |  | (optional) defaults to undefined
+ **additionalMetadata** | [**string**] | Additional data to pass to server | (optional) defaults to undefined
 
 
 ### Return type
@@ -132,7 +135,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -71,14 +71,16 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new RequiredError("PetApi", "deletePet", "petId");
         }
+
 
 
 
@@ -93,6 +95,31 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         // Header Params
         requestContext.setHeaderParam("api_key", ObjectSerializer.serialize(apiKey, "string", ""));
 
+        // Form Params
+        const useForm = canConsumeForm([
+            'application/x-www-form-urlencoded',
+        ]);
+
+        let localVarFormParams
+        if (useForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new URLSearchParams();
+        }
+
+        if (additionalMetadata !== undefined) {
+             // TODO: replace .append with .set
+             localVarFormParams.append('additionalMetadata', additionalMetadata as any);
+        }
+
+        requestContext.setBody(localVarFormParams);
+
+        if(!useForm) {
+            const contentType = ObjectSerializer.getPreferredMediaType([
+                "application/x-www-form-urlencoded"
+            ]);
+            requestContext.setHeaderParam("Content-Type", contentType);
+        }
 
         let authMethod: SecurityAuthentication | undefined;
         // Apply auth methods

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObjectParamAPI.ts
@@ -34,6 +34,12 @@ export interface PetApiDeletePetRequest {
      * @memberof PetApideletePet
      */
     apiKey?: string
+    /**
+     * Additional data to pass to server
+     * @type string
+     * @memberof PetApideletePet
+     */
+    additionalMetadata?: string
 }
 
 export interface PetApiFindPetsByStatusRequest {
@@ -136,7 +142,7 @@ export class ObjectPetApi {
      * @param param the request object
      */
     public deletePet(param: PetApiDeletePetRequest, options?: Configuration): Promise<void> {
-        return this.api.deletePet(param.petId, param.apiKey,  options).toPromise();
+        return this.api.deletePet(param.petId, param.apiKey, param.additionalMetadata,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
@@ -55,9 +55,10 @@ export class ObservablePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, additionalMetadata, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
@@ -37,9 +37,10 @@ export class PromisePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, additionalMetadata, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/PetApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/PetApi.md
@@ -106,6 +106,8 @@ let body:petstore.PetApiDeletePetRequest = {
   petId: 1,
   // string (optional)
   apiKey: "api_key_example",
+  // string | Additional data to pass to server (optional)
+  additionalMetadata: "additionalMetadata_example",
 };
 
 apiInstance.deletePet(body).then((data:any) => {
@@ -120,6 +122,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | [**number**] | Pet id to delete | defaults to undefined
  **apiKey** | [**string**] |  | (optional) defaults to undefined
+ **additionalMetadata** | [**string**] | Additional data to pass to server | (optional) defaults to undefined
 
 
 ### Return type
@@ -132,7 +135,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -73,14 +73,16 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new RequiredError("PetApi", "deletePet", "petId");
         }
+
 
 
 
@@ -95,6 +97,31 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         // Header Params
         requestContext.setHeaderParam("api_key", ObjectSerializer.serialize(apiKey, "string", ""));
 
+        // Form Params
+        const useForm = canConsumeForm([
+            'application/x-www-form-urlencoded',
+        ]);
+
+        let localVarFormParams
+        if (useForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new URLSearchParams();
+        }
+
+        if (additionalMetadata !== undefined) {
+             // TODO: replace .append with .set
+             localVarFormParams.append('additionalMetadata', additionalMetadata as any);
+        }
+
+        requestContext.setBody(localVarFormParams);
+
+        if(!useForm) {
+            const contentType = ObjectSerializer.getPreferredMediaType([
+                "application/x-www-form-urlencoded"
+            ]);
+            requestContext.setHeaderParam("Content-Type", contentType);
+        }
 
         let authMethod: SecurityAuthentication | undefined;
         // Apply auth methods

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObjectParamAPI.ts
@@ -34,6 +34,12 @@ export interface PetApiDeletePetRequest {
      * @memberof PetApideletePet
      */
     apiKey?: string
+    /**
+     * Additional data to pass to server
+     * @type string
+     * @memberof PetApideletePet
+     */
+    additionalMetadata?: string
 }
 
 export interface PetApiFindPetsByStatusRequest {
@@ -136,7 +142,7 @@ export class ObjectPetApi {
      * @param param the request object
      */
     public deletePet(param: PetApiDeletePetRequest, options?: Configuration): Promise<void> {
-        return this.api.deletePet(param.petId, param.apiKey,  options).toPromise();
+        return this.api.deletePet(param.petId, param.apiKey, param.additionalMetadata,  options).toPromise();
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
@@ -55,9 +55,10 @@ export class ObservablePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, additionalMetadata, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
@@ -37,9 +37,10 @@ export class PromisePetApi {
      * Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param additionalMetadata Additional data to pass to server
      */
-    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, _options);
+    public deletePet(petId: number, apiKey?: string, additionalMetadata?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, additionalMetadata, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
@@ -96,6 +96,7 @@ public interface PetApi {
      *
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @return Invalid pet value (status code 400)
      */
     @Operation(
@@ -111,11 +112,13 @@ public interface PetApi {
     )
     @RequestMapping(
         method = RequestMethod.DELETE,
-        value = "/pet/{petId}"
+        value = "/pet/{petId}",
+        consumes = { "application/x-www-form-urlencoded" }
     )
     default ResponseEntity<Void> deletePet(
         @Parameter(name = "petId", description = "Pet id to delete", required = true) @PathVariable("petId") Long petId,
-        @Parameter(name = "api_key", description = "") @RequestHeader(value = "api_key", required = false) String apiKey
+        @Parameter(name = "api_key", description = "") @RequestHeader(value = "api_key", required = false) String apiKey,
+        @Parameter(name = "additionalMetadata", description = "Additional data to pass to server") @Valid @RequestParam(value = "additionalMetadata", required = false) String additionalMetadata
     ) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/resources/openapi.yaml
@@ -190,6 +190,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -200,6 +210,7 @@ paths:
       summary: Deletes a pet
       tags:
       - pet
+      x-content-type: application/x-www-form-urlencoded
       x-accepts: application/json
       x-tags:
       - tag: pet
@@ -293,7 +304,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -693,9 +704,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -880,6 +896,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/api/PetApi.java
@@ -72,15 +72,18 @@ public interface PetApi {
      *
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @return Invalid pet value (status code 400)
      */
     @RequestMapping(
         method = RequestMethod.DELETE,
-        value = "/pet/{petId}"
+        value = "/pet/{petId}",
+        consumes = { "application/x-www-form-urlencoded" }
     )
     default ResponseEntity<Void> deletePet(
          @PathVariable("petId") Long petId,
-         @RequestHeader(value = "api_key", required = false) String apiKey
+         @RequestHeader(value = "api_key", required = false) String apiKey,
+         @Valid @RequestParam(value = "additionalMetadata", required = false) String additionalMetadata
     ) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 

--- a/samples/openapi3/server/petstore/springboot-source/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/resources/openapi.yaml
@@ -190,6 +190,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -200,6 +210,7 @@ paths:
       summary: Deletes a pet
       tags:
       - pet
+      x-content-type: application/x-www-form-urlencoded
       x-accepts: application/json
       x-tags:
       - tag: pet
@@ -293,7 +304,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -693,9 +704,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -880,6 +896,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
@@ -96,6 +96,7 @@ public interface PetApi {
      *
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @return Invalid pet value (status code 400)
      */
     @Operation(
@@ -111,11 +112,13 @@ public interface PetApi {
     )
     @RequestMapping(
         method = RequestMethod.DELETE,
-        value = "/pet/{petId}"
+        value = "/pet/{petId}",
+        consumes = { "application/x-www-form-urlencoded" }
     )
     default ResponseEntity<Void> deletePet(
         @Parameter(name = "petId", description = "Pet id to delete", required = true) @PathVariable("petId") Long petId,
-        @Parameter(name = "api_key", description = "") @RequestHeader(value = "api_key", required = false) String apiKey
+        @Parameter(name = "api_key", description = "") @RequestHeader(value = "api_key", required = false) String apiKey,
+        @Parameter(name = "additionalMetadata", description = "Additional data to pass to server") @Valid @RequestParam(value = "additionalMetadata", required = false) String additionalMetadata
     ) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 

--- a/samples/openapi3/server/petstore/springboot/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot/src/main/resources/openapi.yaml
@@ -190,6 +190,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -200,6 +210,7 @@ paths:
       summary: Deletes a pet
       tags:
       - pet
+      x-content-type: application/x-www-form-urlencoded
       x-accepts: application/json
       x-tags:
       - tag: pet
@@ -293,7 +304,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -693,9 +704,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -880,6 +896,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -63,12 +63,14 @@ namespace Org.OpenAPITools.Controllers
         /// </summary>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"></param>
+        /// <param name="additionalMetadata">Additional data to pass to server</param>
         /// <response code="400">Invalid pet value</response>
         [HttpDelete]
         [Route("/v2/pet/{petId}")]
+        [Consumes("application/x-www-form-urlencoded")]
         [ValidateModelState]
         [SwaggerOperation("DeletePet")]
-        public virtual IActionResult DeletePet([FromRoute (Name = "petId")][Required]long petId, [FromHeader]string apiKey)
+        public virtual IActionResult DeletePet([FromRoute (Name = "petId")][Required]long petId, [FromHeader]string apiKey, [FromForm (Name = "additionalMetadata")]string additionalMetadata)
         {
 
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/wwwroot/openapi-original.json
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/wwwroot/openapi-original.json
@@ -230,6 +230,22 @@
           },
           "style" : "simple"
         } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/inline_object_1",
+          "content" : {
+            "application/x-www-form-urlencoded" : {
+              "schema" : {
+                "properties" : {
+                  "additionalMetadata" : {
+                    "description" : "Additional data to pass to server",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              }
+            }
+          }
+        },
         "responses" : {
           "400" : {
             "description" : "Invalid pet value"
@@ -349,7 +365,7 @@
           "style" : "simple"
         } ],
         "requestBody" : {
-          "$ref" : "#/components/requestBodies/inline_object_1",
+          "$ref" : "#/components/requestBodies/inline_object_2",
           "content" : {
             "multipart/form-data" : {
               "schema" : {
@@ -837,9 +853,18 @@
       },
       "inline_object_1" : {
         "content" : {
-          "multipart/form-data" : {
+          "application/x-www-form-urlencoded" : {
             "schema" : {
               "$ref" : "#/components/schemas/inline_object_1"
+            }
+          }
+        }
+      },
+      "inline_object_2" : {
+        "content" : {
+          "multipart/form-data" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/inline_object_2"
             }
           }
         }
@@ -1080,6 +1105,15 @@
         "type" : "object"
       },
       "inline_object_1" : {
+        "properties" : {
+          "additionalMetadata" : {
+            "description" : "Additional data to pass to server",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "inline_object_2" : {
         "properties" : {
           "additionalMetadata" : {
             "description" : "Additional data to pass to server",

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -63,12 +63,14 @@ namespace Org.OpenAPITools.Controllers
         /// </summary>
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"></param>
+        /// <param name="additionalMetadata">Additional data to pass to server</param>
         /// <response code="400">Invalid pet value</response>
         [HttpDelete]
         [Route("/v2/pet/{petId}")]
+        [Consumes("application/x-www-form-urlencoded")]
         [ValidateModelState]
         [SwaggerOperation("DeletePet")]
-        public virtual IActionResult DeletePet([FromRoute (Name = "petId")][Required]long petId, [FromHeader]string apiKey)
+        public virtual IActionResult DeletePet([FromRoute (Name = "petId")][Required]long petId, [FromHeader]string apiKey, [FromForm (Name = "additionalMetadata")]string additionalMetadata)
         {
 
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...

--- a/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/wwwroot/openapi-original.json
+++ b/samples/server/petstore/aspnetcore-6.0/src/Org.OpenAPITools/wwwroot/openapi-original.json
@@ -230,6 +230,22 @@
           },
           "style" : "simple"
         } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/inline_object_1",
+          "content" : {
+            "application/x-www-form-urlencoded" : {
+              "schema" : {
+                "properties" : {
+                  "additionalMetadata" : {
+                    "description" : "Additional data to pass to server",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              }
+            }
+          }
+        },
         "responses" : {
           "400" : {
             "description" : "Invalid pet value"
@@ -349,7 +365,7 @@
           "style" : "simple"
         } ],
         "requestBody" : {
-          "$ref" : "#/components/requestBodies/inline_object_1",
+          "$ref" : "#/components/requestBodies/inline_object_2",
           "content" : {
             "multipart/form-data" : {
               "schema" : {
@@ -837,9 +853,18 @@
       },
       "inline_object_1" : {
         "content" : {
-          "multipart/form-data" : {
+          "application/x-www-form-urlencoded" : {
             "schema" : {
               "$ref" : "#/components/schemas/inline_object_1"
+            }
+          }
+        }
+      },
+      "inline_object_2" : {
+        "content" : {
+          "multipart/form-data" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/inline_object_2"
             }
           }
         }
@@ -1080,6 +1105,15 @@
         "type" : "object"
       },
       "inline_object_1" : {
+        "properties" : {
+          "additionalMetadata" : {
+            "description" : "Additional data to pass to server",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "inline_object_2" : {
         "properties" : {
           "additionalMetadata" : {
             "description" : "Additional data to pass to server",

--- a/samples/server/petstore/erlang-server/priv/openapi.json
+++ b/samples/server/petstore/erlang-server/priv/openapi.json
@@ -230,6 +230,22 @@
           },
           "style" : "simple"
         } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/inline_object_1",
+          "content" : {
+            "application/x-www-form-urlencoded" : {
+              "schema" : {
+                "properties" : {
+                  "additionalMetadata" : {
+                    "description" : "Additional data to pass to server",
+                    "type" : "string"
+                  }
+                },
+                "type" : "object"
+              }
+            }
+          }
+        },
         "responses" : {
           "400" : {
             "description" : "Invalid pet value"
@@ -349,7 +365,7 @@
           "style" : "simple"
         } ],
         "requestBody" : {
-          "$ref" : "#/components/requestBodies/inline_object_1",
+          "$ref" : "#/components/requestBodies/inline_object_2",
           "content" : {
             "multipart/form-data" : {
               "schema" : {
@@ -837,9 +853,18 @@
       },
       "inline_object_1" : {
         "content" : {
-          "multipart/form-data" : {
+          "application/x-www-form-urlencoded" : {
             "schema" : {
               "$ref" : "#/components/schemas/inline_object_1"
+            }
+          }
+        }
+      },
+      "inline_object_2" : {
+        "content" : {
+          "multipart/form-data" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/inline_object_2"
             }
           }
         }
@@ -1080,6 +1105,15 @@
         "type" : "object"
       },
       "inline_object_1" : {
+        "properties" : {
+          "additionalMetadata" : {
+            "description" : "Additional data to pass to server",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "inline_object_2" : {
         "properties" : {
           "additionalMetadata" : {
             "description" : "Additional data to pass to server",

--- a/samples/server/petstore/erlang-server/src/openapi_api.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_api.erl
@@ -23,7 +23,8 @@ request_params('AddPet') ->
 request_params('DeletePet') ->
     [
         'petId',
-        'api_key'
+        'api_key',
+        'additionalMetadata'
     ];
 
 request_params('FindPetsByStatus') ->
@@ -173,6 +174,15 @@ request_param_info('DeletePet', 'petId') ->
 request_param_info('DeletePet', 'api_key') ->
     #{
         source =>   header,
+        rules => [
+            {type, 'binary'},
+            not_required
+        ]
+    };
+
+request_param_info('DeletePet', 'additionalMetadata') ->
+    #{
+        source =>   body,
         rules => [
             {type, 'binary'},
             not_required

--- a/samples/server/petstore/go-api-server/api/openapi.yaml
+++ b/samples/server/petstore/go-api-server/api/openapi.yaml
@@ -176,6 +176,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -269,7 +279,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -624,9 +634,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -811,6 +826,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -61,7 +61,7 @@ type UserApiRouter interface {
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
 	AddPet(context.Context, Pet) (ImplResponse, error)
-	DeletePet(context.Context, int64, string) (ImplResponse, error)
+	DeletePet(context.Context, int64, string, string) (ImplResponse, error)
 	FindPetsByStatus(context.Context, []string) (ImplResponse, error)
 	// Deprecated
 	FindPetsByTags(context.Context, []string) (ImplResponse, error)

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -127,6 +127,10 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 
 // DeletePet - Deletes a pet
 func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
 	params := mux.Vars(r)
 	petIdParam, err := parseInt64Parameter(params["petId"], true)
 	if err != nil {
@@ -135,7 +139,8 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apiKeyParam := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
+				additionalMetadataParam := r.FormValue("additionalMetadata")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam, additionalMetadataParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -42,7 +42,7 @@ func (s *PetApiService) AddPet(ctx context.Context, pet Pet) (ImplResponse, erro
 }
 
 // DeletePet - Deletes a pet
-func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
+func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string, additionalMetadata string) (ImplResponse, error) {
 	// TODO - update DeletePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/samples/server/petstore/go-chi-server/api/openapi.yaml
+++ b/samples/server/petstore/go-chi-server/api/openapi.yaml
@@ -176,6 +176,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -269,7 +279,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -624,9 +634,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -811,6 +826,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/server/petstore/go-chi-server/go/api.go
+++ b/samples/server/petstore/go-chi-server/go/api.go
@@ -61,7 +61,7 @@ type UserApiRouter interface {
 // and updated with the logic required for the API.
 type PetApiServicer interface { 
 	AddPet(context.Context, Pet) (ImplResponse, error)
-	DeletePet(context.Context, int64, string) (ImplResponse, error)
+	DeletePet(context.Context, int64, string, string) (ImplResponse, error)
 	FindPetsByStatus(context.Context, []string) (ImplResponse, error)
 	// Deprecated
 	FindPetsByTags(context.Context, []string) (ImplResponse, error)

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -127,6 +127,10 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 
 // DeletePet - Deletes a pet
 func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
 	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -134,7 +138,8 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apiKeyParam := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
+				additionalMetadataParam := r.FormValue("additionalMetadata")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam, additionalMetadataParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet_service.go
@@ -42,7 +42,7 @@ func (s *PetApiService) AddPet(ctx context.Context, pet Pet) (ImplResponse, erro
 }
 
 // DeletePet - Deletes a pet
-func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string) (ImplResponse, error) {
+func (s *PetApiService) DeletePet(ctx context.Context, petId int64, apiKey string, additionalMetadata string) (ImplResponse, error) {
 	// TODO - update DeletePet with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/samples/server/petstore/go-echo-server/.docs/api/openapi.yaml
+++ b/samples/server/petstore/go-echo-server/.docs/api/openapi.yaml
@@ -176,6 +176,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -269,7 +279,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -624,9 +634,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -811,6 +826,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/server/petstore/go-gin-api-server/api/openapi.yaml
+++ b/samples/server/petstore/go-gin-api-server/api/openapi.yaml
@@ -176,6 +176,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -269,7 +279,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -624,9 +634,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -811,6 +826,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/api/PetApi.java
@@ -67,6 +67,10 @@ public class PetApi extends RouteBuilder {
             .delete("/pet/{petId}")
                 .description("Deletes a pet")
                 .id("deletePetApi")
+                .clientRequestValidation(false)
+                .bindingMode(RestBindingMode.off)
+                .consumes("application/x-www-form-urlencoded")
+                
                 .param()
                     .name("petId")
                     .type(RestParamType.path)
@@ -77,6 +81,12 @@ public class PetApi extends RouteBuilder {
                     .name("apiKey")
                     .type(RestParamType.header)
                     .required(false)
+                .endParam()
+                .param()
+                    .name("additionalMetadata")
+                    .type(RestParamType.formData)
+                    .required(false)
+                    .description("Additional data to pass to server")
                 .endParam()
                 .to("direct:validate-deletePet");
         

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/api/PetApiValidator.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/api/PetApiValidator.java
@@ -26,6 +26,7 @@ public class PetApiValidator extends RouteBuilder {
         
         from("direct:validate-deletePet")
             .id("validate-deletePet")
+            .to("bean-validator://validate-request")
             .to("direct:deletePet");
         
         from("direct:validate-findPetsByStatus")

--- a/samples/server/petstore/java-micronaut-server/docs/controllers/PetController.md
+++ b/samples/server/petstore/java-micronaut-server/docs/controllers/PetController.md
@@ -43,7 +43,7 @@ Name | Type | Description  | Notes
 <a name="deletePet"></a>
 # **deletePet**
 ```java
-Mono<Object> PetController.deletePet(petIdapiKey)
+Mono<Object> PetController.deletePet(petIdapiKeyadditionalMetadata)
 ```
 
 Deletes a pet
@@ -55,13 +55,14 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **petId** | `Long` | Pet id to delete |
 **apiKey** | `String` |  | [optional parameter]
+**additionalMetadata** | `String` | Additional data to pass to server | [optional parameter]
 
 
 ### Authorization
 * **petstore_auth**, scopes: `write:pets`, `read:pets`
 
 ### HTTP request headers
- - **Accepts Content-Type**: Not defined
+ - **Accepts Content-Type**: `application/x-www-form-urlencoded`
  - **Produces Content-Type**: Not defined
 
 <a name="findPetsByStatus"></a>

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/PetController.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/PetController.java
@@ -70,6 +70,7 @@ public class PetController {
      *
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param additionalMetadata Additional data to pass to server (optional)
      */
     @ApiOperation(
         value = "Deletes a pet",
@@ -86,9 +87,11 @@ public class PetController {
         @ApiResponse(code = 400, message = "Invalid pet value")})
     @Delete(uri="/pet/{petId}")
     @Produces(value = {})
+    @Consumes(value = {"application/x-www-form-urlencoded"})
     public Mono<Object> deletePet(
         @PathVariable(value="petId") @NotNull Long petId, 
-        @Header(value="api_key") @Nullable String apiKey
+        @Header(value="api_key") @Nullable String apiKey, 
+        @Nullable String additionalMetadata
     ) {
         // TODO implement deletePet() body;
         Mono<Object> result = Mono.empty();

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApi.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApi.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public interface PetApi  {
     Future<ApiResponse<Pet>> addPet(Pet pet);
-    Future<ApiResponse<Void>> deletePet(Long petId, String apiKey);
+    Future<ApiResponse<Void>> deletePet(Long petId, String apiKey, JsonObject formBody);
     Future<ApiResponse<List<Pet>>> findPetsByStatus(List<String> status);
     Future<ApiResponse<List<Pet>>> findPetsByTags(List<String> tags);
     Future<ApiResponse<Pet>> getPetById(Long petId);

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
@@ -75,11 +75,14 @@ public class PetApiHandler {
 
         Long petId = requestParameters.pathParameter("petId") != null ? requestParameters.pathParameter("petId").getLong() : null;
         String apiKey = requestParameters.headerParameter("api_key") != null ? requestParameters.headerParameter("api_key").getString() : null;
+        RequestParameter body = requestParameters.body();
+        JsonObject formBody = body != null ? body.getJsonObject() : null;
 
         logger.debug("Parameter petId is {}", petId);
         logger.debug("Parameter apiKey is {}", apiKey);
+        logger.debug("Parameter formBody is {}", formBody);
 
-        api.deletePet(petId, apiKey)
+        api.deletePet(petId, apiKey, formBody)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiImpl.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiImpl.java
@@ -20,7 +20,7 @@ public class PetApiImpl implements PetApi {
         return Future.failedFuture(new HttpException(501));
     }
 
-    public Future<ApiResponse<Void>> deletePet(Long petId, String apiKey) {
+    public Future<ApiResponse<Void>> deletePet(Long petId, String apiKey, JsonObject formBody) {
         return Future.failedFuture(new HttpException(501));
     }
 

--- a/samples/server/petstore/java-vertx-web/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/java-vertx-web/src/main/resources/openapi.yaml
@@ -182,6 +182,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -192,6 +202,7 @@ paths:
       summary: Deletes a pet
       tags:
       - pet
+      x-content-type: application/x-www-form-urlencoded
       x-accepts: application/json
     get:
       description: Returns a single pet
@@ -279,7 +290,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -653,9 +664,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -840,6 +856,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -71,12 +71,14 @@ interface PetApi {
         value = [ApiResponse(code = 400, message = "Invalid pet value")])
     @RequestMapping(
             method = [RequestMethod.DELETE],
-            value = ["/pet/{petId}"]
+            value = ["/pet/{petId}"],
+            consumes = ["application/x-www-form-urlencoded"]
     )
     fun deletePet(@ApiParam(value = "Pet id to delete", required=true) @PathVariable("petId") petId: kotlin.Long
 ,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) apiKey: kotlin.String?
+,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: kotlin.String? 
 ): ResponseEntity<Unit> {
-        return getDelegate().deletePet(petId, apiKey);
+        return getDelegate().deletePet(petId, apiKey, additionalMetadata);
     }
 
     @ApiOperation(

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiDelegate.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiDelegate.kt
@@ -44,7 +44,8 @@ interface PetApiDelegate {
      * @see PetApi#deletePet
      */
     fun deletePet(petId: kotlin.Long,
-        apiKey: kotlin.String?): ResponseEntity<Unit> {
+        apiKey: kotlin.String?,
+        additionalMetadata: kotlin.String?): ResponseEntity<Unit> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
     }

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
@@ -77,6 +77,8 @@ abstract class AbstractPetApi
     ): ResponseInterface {
         $headers = $request->getHeaders();
         $apiKey = $request->hasHeader('api_key') ? $headers['api_key'] : null;
+        $body = $request->getParsedBody();
+        $additionalMetadata = (isset($body['additionalMetadata'])) ? $body['additionalMetadata'] : null;
         $message = "How about implementing deletePet as a DELETE method in OpenAPIServer\Api\PetApi class?";
         throw new HttpNotImplementedException($request, $message);
     }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
@@ -90,12 +90,13 @@ interface PetApiInterface
      *
      * @param  \int $petId  Pet id to delete (required)
      * @param  \string $apiKey   (optional)
+     * @param  \string $additionalMetadata  Additional data to pass to server (optional)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
      */
-    public function deletePet($petId, $apiKey = null, &$responseCode, array &$responseHeaders);
+    public function deletePet($petId, $apiKey = null, $additionalMetadata = null, &$responseCode, array &$responseHeaders);
 
     /**
      * Operation findPetsByStatus

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -162,6 +162,7 @@ class PetController extends Controller
 
         // Read out all input parameter values into variables
         $apiKey = $request->headers->get('api_key');
+        $additionalMetadata = $request->request->get('additionalMetadata');
 
         // Use the default value if no value was provided
 
@@ -169,6 +170,7 @@ class PetController extends Controller
         try {
             $petId = $this->deserialize($petId, 'int', 'string');
             $apiKey = $this->deserialize($apiKey, 'string', 'string');
+            $additionalMetadata = $this->deserialize($additionalMetadata, 'string', 'string');
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
         }
@@ -187,6 +189,12 @@ class PetController extends Controller
         if ($response instanceof Response) {
             return $response;
         }
+        $asserts = [];
+        $asserts[] = new Assert\Type("string");
+        $response = $this->validate($additionalMetadata, $asserts);
+        if ($response instanceof Response) {
+            return $response;
+        }
 
 
         try {
@@ -198,7 +206,7 @@ class PetController extends Controller
             // Make the call to the business logic
             $responseCode = 204;
             $responseHeaders = [];
-            $result = $handler->deletePet($petId, $apiKey, $responseCode, $responseHeaders);
+            $result = $handler->deletePet($petId, $apiKey, $additionalMetadata, $responseCode, $responseHeaders);
 
             // Find default response message
             $message = '';

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/PetApiInterface.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/PetApiInterface.md
@@ -89,7 +89,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
 ## **deletePet**
-> deletePet($petId, $apiKey)
+> deletePet($petId, $apiKey, $additionalMetadata)
 
 Deletes a pet
 
@@ -120,7 +120,7 @@ class PetApi implements PetApiInterface
     /**
      * Implementation of PetApiInterface#deletePet
      */
-    public function deletePet($petId, $apiKey = null)
+    public function deletePet($petId, $apiKey = null, $additionalMetadata = null)
     {
         // Implement the operation ...
     }
@@ -135,6 +135,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **petId** | **int**| Pet id to delete |
  **apiKey** | **string**|  | [optional]
+ **additionalMetadata** | **string**| Additional data to pass to server | [optional]
 
 ### Return type
 
@@ -146,7 +147,7 @@ void (empty response body)
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
+ - **Content-Type**: application/x-www-form-urlencoded
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)

--- a/samples/server/petstore/python-fastapi/openapi.yaml
+++ b/samples/server/petstore/python-fastapi/openapi.yaml
@@ -176,6 +176,16 @@ paths:
           format: int64
           type: integer
         style: simple
+      requestBody:
+        $ref: '#/components/requestBodies/inline_object_1'
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                additionalMetadata:
+                  description: Additional data to pass to server
+                  type: string
+              type: object
       responses:
         "400":
           description: Invalid pet value
@@ -269,7 +279,7 @@ paths:
           type: integer
         style: simple
       requestBody:
-        $ref: '#/components/requestBodies/inline_object_1'
+        $ref: '#/components/requestBodies/inline_object_2'
         content:
           multipart/form-data:
             schema:
@@ -624,9 +634,14 @@ components:
             $ref: '#/components/schemas/inline_object'
     inline_object_1:
       content:
-        multipart/form-data:
+        application/x-www-form-urlencoded:
           schema:
             $ref: '#/components/schemas/inline_object_1'
+    inline_object_2:
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/inline_object_2'
   schemas:
     Order:
       description: An order for a pets from the pet store
@@ -837,6 +852,12 @@ components:
           type: string
       type: object
     inline_object_1:
+      properties:
+        additionalMetadata:
+          description: Additional data to pass to server
+          type: string
+      type: object
+    inline_object_2:
       properties:
         additionalMetadata:
           description: Additional data to pass to server

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
@@ -54,6 +54,7 @@ async def add_pet(
 async def delete_pet(
     petId: int = Path(None, description="Pet id to delete"),
     api_key: str = Header(None, description=""),
+    additional_metadata: str = Form(None, description="Additional data to pass to server"),
     token_petstore_auth: TokenModel = Security(
         get_token_petstore_auth, scopes=["write:pets", "read:pets"]
     ),


### PR DESCRIPTION
The openapi specification (v3.0.3 https://swagger.io/specification/#operation-object) specifies that the request body `shall` be ignored where the RFC7231 method semantics are not clearly defined.

It appears request bodies for DELETE method are used and supported by thirdparty libraries such as angular. This prompted support for it in some generators. However, the petstore test spec does not define any request body, and these features were not tested.

This change includes a request body for the deletePet operation. Since consumers are suggested to ignore it, I thought it would make more sense to provide it in a specification that is used across many generators to ensure none of them would throw an error or fail to compile rather than ignoring it.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
