### PR TITLE
Specify source encoding in java/kotlin sample poms templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
@@ -105,6 +105,7 @@
     </dependencies>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 {{#useBeanValidation}}
     	<beanvalidation-version>2.0.2</beanvalidation-version>
 {{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
@@ -187,6 +187,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pom.mustache
@@ -205,6 +205,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.22</swagger-core-version>
         <jackson-version>2.11.2</jackson-version>
         <jetty-version>9.2.9.v20150224</jetty-version>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/openliberty/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/openliberty/pom.mustache
@@ -50,6 +50,7 @@
     </dependencies>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -61,7 +62,7 @@
         <packaging.type>usr</packaging.type>
         <app.name>${project.artifactId}</app.name>
         <package.file>${project.build.directory}/${app.name}.zip</package.file>
-		<beanvalidation-version>2.0.2</beanvalidation-version>
+		    <beanvalidation-version>2.0.2</beanvalidation-version>
     </properties>
 
     <build>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -144,6 +144,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 {{/java8}}
     <jackson-version>2.9.9</jackson-version>
     <junit-version>4.13.1</junit-version>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -9,6 +9,7 @@
         <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         {{#springFoxDocumentationProvider}}
         <springfox.version>2.9.2</springfox.version>
         {{/springFoxDocumentationProvider}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -9,6 +9,7 @@
         <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         {{#springFoxDocumentationProvider}}
         <springfox.version>2.9.2</springfox.version>
         {{/springFoxDocumentationProvider}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -286,6 +286,7 @@
     </dependencies>
     <properties>
         <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/pom.mustache
@@ -52,6 +52,7 @@
     </plugins>
   </build>
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <swagger-annotations-version>1.5.8</swagger-annotations-version>
     <httpcomponents-httpmime-version>4.5.2</httpcomponents-httpmime-version>
     <google-code-gson-version>2.6.2</google-code-gson-version>

--- a/modules/openapi-generator/src/main/resources/java-camel-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-camel-server/pom.mustache
@@ -38,6 +38,7 @@ Do not edit the class manually.
     </developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.boot.version>2.6.2</org.springframework.boot.version>
         <org.apache.camel.version>3.14.0</org.apache.camel.version>
     </properties>

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/configuration/pom.xml.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/configuration/pom.xml.mustache
@@ -16,6 +16,7 @@
     <properties>
         <packaging>jar</packaging>
         <jdk.version>1.8</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- If you are building with JDK 9 or higher, you can uncomment the lines below to set the release version -->
         <!-- <release.version>8</release.version> -->
         <micronaut.version>{{{micronautVersion}}}</micronaut.version>

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/pom.mustache
@@ -5,6 +5,9 @@
     <version>{{artifactVersion}}</version>
     <name>{{appName}}</name>
     <packaging>pom</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
@@ -6,6 +6,7 @@
     <name>{{artifactId}}</name>
     <version>{{artifactVersion}}</version>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.30</kotlin.version>
         <kotlinx-coroutines.version>1.2.0</kotlinx-coroutines.version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/client/petstore/java-micronaut-client/pom.xml
+++ b/samples/client/petstore/java-micronaut-client/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <packaging>jar</packaging>
         <jdk.version>1.8</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- If you are building with JDK 9 or higher, you can uncomment the lines below to set the release version -->
         <!-- <release.version>8</release.version> -->
         <micronaut.version>3.2.6</micronaut.version>

--- a/samples/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/client/petstore/spring-cloud-async/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/client/petstore/spring-cloud-date-time/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/client/petstore/spring-stubs/pom.xml
+++ b/samples/client/petstore/spring-stubs/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/client/petstore/spring-cloud/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/client/petstore/spring-stubs/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.7</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/server/petstore/springboot-delegate/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-delegate/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/server/petstore/springboot-reactive/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-reactive/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-useoptional/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/openapi3/server/petstore/springboot/pom.xml
+++ b/samples/openapi3/server/petstore/springboot/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>
     <parent>

--- a/samples/server/petstore/java-camel/pom.xml
+++ b/samples/server/petstore/java-camel/pom.xml
@@ -38,6 +38,7 @@ Do not edit the class manually.
     </developers>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.springframework.boot.version>2.6.2</org.springframework.boot.version>
         <org.apache.camel.version>3.14.0</org.apache.camel.version>
     </properties>

--- a/samples/server/petstore/java-micronaut-server/pom.xml
+++ b/samples/server/petstore/java-micronaut-server/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <packaging>jar</packaging>
         <jdk.version>1.8</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- If you are building with JDK 9 or higher, you can uncomment the lines below to set the release version -->
         <!-- <release.version>8</release.version> -->
         <micronaut.version>3.2.6</micronaut.version>

--- a/samples/server/petstore/jaxrs-cxf-cdi-default-value/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-cdi-default-value/pom.xml
@@ -96,6 +96,7 @@
     </dependencies>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     	<beanvalidation-version>2.0.2</beanvalidation-version>
     </properties>
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
@@ -96,6 +96,7 @@
     </dependencies>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     	<beanvalidation-version>2.0.2</beanvalidation-version>
     </properties>
 

--- a/samples/server/petstore/jaxrs-resteasy/default-value/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/default-value/pom.xml
@@ -187,6 +187,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.22</swagger-core-version>
         <jackson-version>2.11.2</jackson-version>
         <jetty-version>9.2.9.v20150224</jetty-version>

--- a/samples/server/petstore/jaxrs-resteasy/default/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/default/pom.xml
@@ -187,6 +187,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.22</swagger-core-version>
         <jackson-version>2.11.2</jackson-version>
         <jetty-version>9.2.9.v20150224</jetty-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/pom.xml
@@ -164,6 +164,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
@@ -169,6 +169,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
@@ -169,6 +169,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>

--- a/samples/server/petstore/jaxrs-resteasy/java8/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/java8/pom.xml
@@ -182,6 +182,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.22</swagger-core-version>
         <jackson-version>2.11.2</jackson-version>
         <jetty-version>9.2.9.v20150224</jetty-version>

--- a/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
@@ -187,6 +187,7 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.22</swagger-core-version>
         <jackson-version>2.11.2</jackson-version>
         <jetty-version>9.2.9.v20150224</jetty-version>

--- a/samples/server/petstore/kotlin-springboot-delegate/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-delegate/pom.xml
@@ -6,6 +6,7 @@
     <name>openapi-spring</name>
     <version>1.0.0</version>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.30</kotlin.version>
         <kotlinx-coroutines.version>1.2.0</kotlinx-coroutines.version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
@@ -6,6 +6,7 @@
     <name>openapi-spring</name>
     <version>1.0.0</version>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.30</kotlin.version>
         <kotlinx-coroutines.version>1.2.0</kotlinx-coroutines.version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/kotlin-springboot-reactive/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-reactive/pom.xml
@@ -6,6 +6,7 @@
     <name>openapi-spring</name>
     <version>1.0.0</version>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.30</kotlin.version>
         <kotlinx-coroutines.version>1.2.0</kotlinx-coroutines.version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/kotlin-springboot/pom.xml
+++ b/samples/server/petstore/kotlin-springboot/pom.xml
@@ -6,6 +6,7 @@
     <name>openapi-spring</name>
     <version>1.0.0</version>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.30</kotlin.version>
         <kotlinx-coroutines.version>1.2.0</kotlinx-coroutines.version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/spring-mvc-default-value/pom.xml
+++ b/samples/server/petstore/spring-mvc-default-value/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/spring-mvc-j8-async/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-async/pom.xml
@@ -163,6 +163,7 @@
     </dependencies>
     <properties>
         <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
@@ -163,6 +163,7 @@
     </dependencies>
     <properties>
         <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/spring-mvc-no-nullable/pom.xml
+++ b/samples/server/petstore/spring-mvc-no-nullable/pom.xml
@@ -158,6 +158,7 @@
     </dependencies>
     <properties>
         <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/spring-mvc-spring-pageable/pom.xml
+++ b/samples/server/petstore/spring-mvc-spring-pageable/pom.xml
@@ -163,6 +163,7 @@
     </dependencies>
     <properties>
         <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/spring-mvc/pom.xml
+++ b/samples/server/petstore/spring-mvc/pom.xml
@@ -163,6 +163,7 @@
     </dependencies>
     <properties>
         <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.7</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-delegate/pom.xml
+++ b/samples/server/petstore/springboot-delegate/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/server/petstore/springboot-implicitHeaders/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.7</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.7</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-spring-pageable/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/server/petstore/springboot-useoptional/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot-virtualan/pom.xml
+++ b/samples/server/petstore/springboot-virtualan/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>

--- a/samples/server/petstore/springboot/pom.xml
+++ b/samples/server/petstore/springboot/pom.xml
@@ -9,6 +9,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <springfox.version>2.9.2</springfox.version>
     </properties>
     <parent>


### PR DESCRIPTION
Add the `<project.build.sourceEncoding>` property in some templates, so that the sample tests can be run independently of the host default file encoding.

This is an attempt to fix the circlesci builds that fail when generating the samples. See https://app.circleci.com/jobs/github/OpenAPITools/openapi-generator/29795?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link for a recent example: 
```
[ERROR] /home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeApi.java:308: error: unmappable character for encoding ANSI_X3.4-1968
[ERROR] * Fake endpoint for testing various parameters  ?????????  ???????????????????????????  ?????? ?????? ?????????
[ERROR] ^
[ERROR] 
[ERROR] Command line was: /usr/lib/jvm/java-8-openjdk-amd64/jre/../bin/javadoc @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/home/circleci/OpenAPITools/openapi-generator/samples/server/petstore/spring-mvc-j8-async/target/site/apidocs' dir.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :spring-mvc-server-j8-async
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
