### PR TITLE
[C++][Pistache] fix float literals in C++ Pistache codegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -408,7 +408,15 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         } else if (ModelUtils.isNumberSchema(p)) {
             if (ModelUtils.isFloatSchema(p)) { // float
                 if (p.getDefault() != null) {
-                    return p.getDefault().toString() + "f";
+                    // We have to ensure that our default value has a decimal point,
+                    // because in C++ the 'f' suffix is not valid on integer literals
+                    // i.e. 374.0f is a valid float but 374 isn't.
+                    String defaultStr = p.getDefault().toString();
+                    if (defaultStr.indexOf('.') < 0) {
+                        return defaultStr + ".0f";
+                    } else {
+                        return defaultStr + "f";
+                    }
                 } else {
                     return "0.0f";
                 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Small fix that ensures the float literals (written for default values) in the generated C++ code are suffixed with an `f`. 
Before, this could cause a compile break because the literal would be interpreted as for example an integer before.
_Note: this might be different for certain C++ compilers, I've encountered this with GCC 10.2.1._

It's a bit of a hack but hey it works.

Also: I ran the generate-samples script and did not encounter any changed files, so maybe this is an edge case not caught by the examples.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
Cc @ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @martindelille (2018/03) @muttleyxd (2019/08)
