### PR TITLE
[C++] Simplify forward declaration detection

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -418,13 +418,10 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
                 if( !childPropertyType.equals(childModel.classname) || childPropertyType.equals(parentModel.classname) || !childModel.hasVars ){
                     continue;
                 }
-                for(CodegenProperty p : childModel.vars) {
-                    if(((p.isModel && p.dataType.equals(parentModel.classname)) || (p.isContainer && p.mostInnerItems.baseType.equals(parentModel.classname)))) {
-                        String forwardDecl = "class " + childModel.classname + ";";
-                        if(!forwardDeclarations.contains(forwardDecl)) {
-                            forwardDeclarations.add(forwardDecl);
-                        }
-                    }
+
+                String forwardDecl = "class " + childPropertyType + ";";
+                if(!forwardDeclarations.contains(forwardDecl)) {
+                    forwardDeclarations.add(forwardDecl);
                 }
             }
         }

--- a/samples/client/petstore/cpp-qt/client/PFXPet.h
+++ b/samples/client/petstore/cpp-qt/client/PFXPet.h
@@ -29,6 +29,8 @@
 #include "PFXObject.h"
 
 namespace test_namespace {
+class PFXCategory;
+class PFXTag;
 
 class PFXPet : public PFXObject {
 public:

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
@@ -31,6 +31,8 @@ namespace openapitools {
 namespace client {
 namespace model {
 
+class Category;
+class Tag;
 
 /// <summary>
 /// A pet for sale in the pet store


### PR DESCRIPTION
This makes sure all model classes are added to the forward declarations which makes it possible to create templates without any model includes.
This helps to resolve circular inclusion issues.

This adds more forward declarations of which a lot are not strictly needed by the current templates, but they don't harm either. Trying to detect in which case declarations are needed or not or making it configurable does not seem to be worth the effort and would add a lot of complexity.

If you have a spec like this:
``` 
openapi: 3.0.1
info:
  title: Libre Graph API
  version: v0.9.0
  license:
    name: Apache 2.0
    url: https://www.apache.org/licenses/LICENSE-2.0.html
servers:
  - url: https://ocis.ocis-traefik.latest.owncloud.works/
    description: ownCloud Infinite Scale Latest
paths: {}
components:
  schemas:
    drive:
      description: Storage Space. Read-only.
      readOnly: true
      type: object
      properties:
        root:
          $ref: '#/components/schemas/driveItem'
    user:
      description: Represents an Active Directory user object.
      type: object
      properties:
        drive:
          $ref: '#/components/schemas/drive'
    driveItem:
      description: Reprensents a resource inside a drive. Read-only.
      readOnly: true
      type: object
      properties:
        lastModifiedByUser:
          $ref: '#/components/schemas/user'
          description: Identity of the user who last modified the item. Read-only.
          readOnly: true
```

(excerpt from https://github.com/owncloud/libre-graph-api/blob/main/api/openapi-spec/v0.0.yaml)

You get issues with circular `#include`s: `Drive` requires `DriveItem` requires `User` requires `Drive`  💥 
To solve this issue a template may only use forward declarations and must use pointers to model objects or a pimple implementation.

I'm working on templates based on the `cpp-qt-client`, but with the current implementation (without this PR) required forward declarations are missing: e.g., `Drive` only has a `User` forward declaration, the `DriveItem` forward declaration is missing. With this PR all models used in the header are added to the forward declarations.

I found the old code hard to reason about so i'm not 100% sure this does not remove any forward declarations in some edge case, but it works for me for the original spec that my excerpt is from and it's not completely trivial.

Attention: This change alone is not enough to make the generator produce compilable code for the spec above, but it's all that's needed to create working templates. Templates are still work in progress because I've still got runtime issues to resolve.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

