### PR TITLE
Fix ClassCastException if expected type is Object

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiResponseDecoder.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiResponseDecoder.mustache
@@ -25,7 +25,7 @@ public class ApiResponseDecoder extends JacksonDecoder {
     Map<String, Collection<String>> responseHeaders = Collections.unmodifiableMap(response.headers());
         //Detects if the type is an instance of the parameterized class ApiResponse
         Type responseBodyType;
-        if (Types.getRawType(type).isAssignableFrom(ApiResponse.class)) {
+        if (type instanceof ParameterizedType && Types.getRawType(type).isAssignableFrom(ApiResponse.class)) {
             //The ApiResponse class has a single type parameter, the Dto class itself
             responseBodyType = ((ParameterizedType) type).getActualTypeArguments()[0];
             Object body = super.decode(response, responseBodyType);


### PR DESCRIPTION
The currently generated code will throw a `ClassCastException` if `type` is `Object`. I'm not quite sure why `isAssignableFrom` is used here but I tried to keep the change minimal - in my understanding, the result would be the same if the line was 
```
if(Types.getRawType(type).equals(ApiResponse.class)) {
``` 
because the `ApiResponse` only extends `Object` and implements no interfaces. Maybe it was meant to be `ApiResponse.class.isAssignableFrom(Types.getRawType(type))`? This would also permit subclasses of `ApiResponse`, but then it would be more complicated to determine the actual type parameter (because `type` itself may not be parameterized) and to create the object to return (because it would have to be an instance of the subclass).

Fixes #11509

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).

___The build did not work locally, probably because I don't have Java 8 installed anyomore. As it's a really small change, I hope that will be ok...___
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)