### PR TITLE
[JavaSpring] Fixed hardcoded media type for Swagger 3 annotation in Spring templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -137,7 +137,7 @@ public interface {{classname}} {
         {{/vendorExtensions.x-tags}}
         responses = {
             {{#responses}}
-            @ApiResponse(responseCode = "{{{code}}}", description = "{{{message}}}"{{#baseType}}, content = { {{#produces}}@Content(mediaType = "{{{mediaType}}}", schema = @Schema(implementation =  {{{baseType}}}.class)){{^-last}},{{/-last}}{{/produces}} } {{/baseType}}){{^-last}},{{/-last}}
+            @ApiResponse(responseCode = "{{{code}}}", description = "{{{message}}}"{{#baseType}}, content = { {{#produces}}@Content(mediaType = "{{{mediaType}}}", schema = @Schema(implementation =  {{{baseType}}}.class)){{^-last}}, {{/-last}}{{/produces}} } {{/baseType}}){{^-last}},{{/-last}}
             {{/responses}}
         }{{#hasAuthMethods}},
         security = {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -137,7 +137,7 @@ public interface {{classname}} {
         {{/vendorExtensions.x-tags}}
         responses = {
             {{#responses}}
-            @ApiResponse(responseCode = "{{{code}}}", description = "{{{message}}}"{{#baseType}}, content = @Content(mediaType = "application/json", schema = @Schema(implementation =  {{{baseType}}}.class)){{/baseType}}){{^-last}},{{/-last}}
+            @ApiResponse(responseCode = "{{{code}}}", description = "{{{message}}}"{{#baseType}}, content = { {{#produces}}@Content(mediaType = "{{{mediaType}}}", schema = @Schema(implementation =  {{{baseType}}}.class)){{^-last}},{{/-last}}{{/produces}} } {{/baseType}}){{^-last}},{{/-last}}
             {{/responses}}
         }{{#hasAuthMethods}},
         security = {

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
@@ -104,7 +104,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -135,7 +135,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -166,7 +166,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
@@ -104,7 +104,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -135,7 +135,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -166,7 +166,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -259,7 +259,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -103,7 +103,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -130,7 +130,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -73,7 +73,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -103,7 +103,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -130,7 +130,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -146,7 +146,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -174,7 +174,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -146,7 +146,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -174,7 +174,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -46,7 +46,7 @@ public interface AnotherFakeApi {
         summary = "To test special tags",
         tags = { "$another-fake?" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
@@ -79,7 +79,7 @@ public interface FakeApi {
         operationId = "fakeOuterBooleanSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output boolean", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Boolean.class)))
+            @ApiResponse(responseCode = "200", description = "Output boolean", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  Boolean.class)) } )
         }
     )
     @RequestMapping(
@@ -103,7 +103,7 @@ public interface FakeApi {
         operationId = "fakeOuterCompositeSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output composite", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  OuterComposite.class)))
+            @ApiResponse(responseCode = "200", description = "Output composite", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  OuterComposite.class)) } )
         }
     )
     @RequestMapping(
@@ -127,7 +127,7 @@ public interface FakeApi {
         operationId = "fakeOuterNumberSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output number", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  BigDecimal.class)))
+            @ApiResponse(responseCode = "200", description = "Output number", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  BigDecimal.class)) } )
         }
     )
     @RequestMapping(
@@ -151,7 +151,7 @@ public interface FakeApi {
         operationId = "fakeOuterStringSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output string", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)))
+            @ApiResponse(responseCode = "200", description = "Output string", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  String.class)) } )
         }
     )
     @RequestMapping(
@@ -225,7 +225,7 @@ public interface FakeApi {
         summary = "To test \"client\" model",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -46,7 +46,7 @@ public interface FakeClassnameTags123Api {
         summary = "To test class name in snake case",
         tags = { "fake_classname_tags 123#$%^" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key_query")

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
@@ -108,7 +108,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -139,7 +139,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -170,7 +170,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
@@ -108,7 +108,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -139,7 +139,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -170,7 +170,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -265,7 +265,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })
@@ -297,7 +297,7 @@ public interface PetApi {
         summary = "uploads an image (required)",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
@@ -102,7 +102,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -129,7 +129,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
@@ -72,7 +72,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -102,7 +102,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -129,7 +129,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
@@ -145,7 +145,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -173,7 +173,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
@@ -145,7 +145,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -173,7 +173,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
@@ -105,7 +105,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -137,7 +137,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -169,7 +169,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -262,7 +262,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
@@ -105,7 +105,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -137,7 +137,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -169,7 +169,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
@@ -102,7 +102,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -129,7 +129,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
@@ -72,7 +72,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -102,7 +102,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -129,7 +129,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -145,7 +145,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -173,7 +173,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -145,7 +145,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -173,7 +173,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -47,7 +47,7 @@ public interface PetApi {
         summary = "Add a new pet to the store",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "405", description = "Invalid input")
         },
         security = {
@@ -106,7 +106,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -137,7 +137,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -168,7 +168,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -200,7 +200,7 @@ public interface PetApi {
         summary = "Update an existing pet",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found"),
             @ApiResponse(responseCode = "405", description = "Validation exception")

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -47,7 +47,7 @@ public interface PetApi {
         summary = "Add a new pet to the store",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "405", description = "Invalid input")
         },
         security = {
@@ -106,7 +106,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -137,7 +137,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -168,7 +168,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -200,7 +200,7 @@ public interface PetApi {
         summary = "Update an existing pet",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found"),
             @ApiResponse(responseCode = "405", description = "Validation exception")
@@ -264,7 +264,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -102,7 +102,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -129,7 +129,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -72,7 +72,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -102,7 +102,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -129,7 +129,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -160,7 +160,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -188,7 +188,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -160,7 +160,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -188,7 +188,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
@@ -113,7 +113,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -161,7 +161,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -209,7 +209,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -325,7 +325,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
@@ -113,7 +113,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -161,7 +161,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -209,7 +209,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
@@ -79,7 +79,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
@@ -161,7 +161,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -206,7 +206,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
@@ -161,7 +161,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -206,7 +206,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
@@ -51,7 +51,7 @@ public interface PetApi {
         summary = "Add a new pet to the store",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "405", description = "Invalid input")
         },
         security = {
@@ -130,7 +130,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -178,7 +178,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -226,7 +226,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -275,7 +275,7 @@ public interface PetApi {
         summary = "Update an existing pet",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found"),
             @ApiResponse(responseCode = "405", description = "Validation exception")

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
@@ -51,7 +51,7 @@ public interface PetApi {
         summary = "Add a new pet to the store",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "405", description = "Invalid input")
         },
         security = {
@@ -130,7 +130,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -178,7 +178,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -226,7 +226,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -275,7 +275,7 @@ public interface PetApi {
         summary = "Update an existing pet",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found"),
             @ApiResponse(responseCode = "405", description = "Validation exception")
@@ -359,7 +359,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
@@ -79,7 +79,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
@@ -176,7 +176,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -221,7 +221,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
@@ -176,7 +176,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -221,7 +221,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -42,7 +42,7 @@ public interface AnotherFakeApi {
         summary = "To test special tags",
         tags = { "$another-fake?" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeApi.java
@@ -76,7 +76,7 @@ public interface FakeApi {
         operationId = "fakeOuterBooleanSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output boolean", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Boolean.class)))
+            @ApiResponse(responseCode = "200", description = "Output boolean", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  Boolean.class)) } )
         }
     )
     @RequestMapping(
@@ -100,7 +100,7 @@ public interface FakeApi {
         operationId = "fakeOuterCompositeSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output composite", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  OuterComposite.class)))
+            @ApiResponse(responseCode = "200", description = "Output composite", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  OuterComposite.class)) } )
         }
     )
     @RequestMapping(
@@ -124,7 +124,7 @@ public interface FakeApi {
         operationId = "fakeOuterNumberSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output number", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  BigDecimal.class)))
+            @ApiResponse(responseCode = "200", description = "Output number", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  BigDecimal.class)) } )
         }
     )
     @RequestMapping(
@@ -148,7 +148,7 @@ public interface FakeApi {
         operationId = "fakeOuterStringSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output string", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)))
+            @ApiResponse(responseCode = "200", description = "Output string", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  String.class)) } )
         }
     )
     @RequestMapping(
@@ -222,7 +222,7 @@ public interface FakeApi {
         summary = "To test \"client\" model",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(
@@ -461,7 +461,7 @@ public interface FakeApi {
         summary = "uploads an image (required)",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -42,7 +42,7 @@ public interface FakeClassnameTestApi {
         summary = "To test class name in snake case",
         tags = { "fake_classname_tags 123#$%^" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key_query")

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/PetApi.java
@@ -104,7 +104,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -135,7 +135,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -166,7 +166,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -261,7 +261,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/PetApi.java
@@ -104,7 +104,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -135,7 +135,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -166,7 +166,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/StoreApi.java
@@ -98,7 +98,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -125,7 +125,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/StoreApi.java
@@ -68,7 +68,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -98,7 +98,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -125,7 +125,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
@@ -141,7 +141,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -169,7 +169,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/UserApi.java
@@ -141,7 +141,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -169,7 +169,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -46,7 +46,7 @@ public interface AnotherFakeApi {
         summary = "To test special tags",
         tags = { "$another-fake?" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
@@ -82,7 +82,7 @@ public interface FakeApi {
         operationId = "fakeOuterBooleanSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output boolean", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Boolean.class)))
+            @ApiResponse(responseCode = "200", description = "Output boolean", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  Boolean.class)) } )
         }
     )
     @RequestMapping(
@@ -108,7 +108,7 @@ public interface FakeApi {
         operationId = "fakeOuterCompositeSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output composite", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  OuterComposite.class)))
+            @ApiResponse(responseCode = "200", description = "Output composite", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  OuterComposite.class)) } )
         }
     )
     @RequestMapping(
@@ -134,7 +134,7 @@ public interface FakeApi {
         operationId = "fakeOuterNumberSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output number", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  BigDecimal.class)))
+            @ApiResponse(responseCode = "200", description = "Output number", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  BigDecimal.class)) } )
         }
     )
     @RequestMapping(
@@ -160,7 +160,7 @@ public interface FakeApi {
         operationId = "fakeOuterStringSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output string", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)))
+            @ApiResponse(responseCode = "200", description = "Output string", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  String.class)) } )
         }
     )
     @RequestMapping(
@@ -240,7 +240,7 @@ public interface FakeApi {
         summary = "To test \"client\" model",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(
@@ -493,7 +493,7 @@ public interface FakeApi {
         summary = "uploads an image (required)",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -46,7 +46,7 @@ public interface FakeClassnameTestApi {
         summary = "To test class name in snake case",
         tags = { "fake_classname_tags 123#$%^" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key_query")

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
@@ -112,7 +112,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -145,7 +145,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -178,7 +178,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -279,7 +279,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
@@ -112,7 +112,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -145,7 +145,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -178,7 +178,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
@@ -74,7 +74,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -106,7 +106,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -135,7 +135,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
@@ -106,7 +106,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -135,7 +135,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
@@ -153,7 +153,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -183,7 +183,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
@@ -153,7 +153,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -183,7 +183,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -50,7 +50,7 @@ public interface AnotherFakeApi {
         summary = "To test special tags",
         tags = { "$another-fake?" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @Parameters({

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
@@ -89,7 +89,7 @@ public interface FakeApi {
         operationId = "fakeOuterBooleanSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output boolean", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Boolean.class)))
+            @ApiResponse(responseCode = "200", description = "Output boolean", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  Boolean.class)) } )
         }
     )
     @Parameters({
@@ -118,7 +118,7 @@ public interface FakeApi {
         operationId = "fakeOuterCompositeSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output composite", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  OuterComposite.class)))
+            @ApiResponse(responseCode = "200", description = "Output composite", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  OuterComposite.class)) } )
         }
     )
     @Parameters({
@@ -156,7 +156,7 @@ public interface FakeApi {
         operationId = "fakeOuterNumberSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output number", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  BigDecimal.class)))
+            @ApiResponse(responseCode = "200", description = "Output number", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  BigDecimal.class)) } )
         }
     )
     @Parameters({
@@ -185,7 +185,7 @@ public interface FakeApi {
         operationId = "fakeOuterStringSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output string", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)))
+            @ApiResponse(responseCode = "200", description = "Output string", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  String.class)) } )
         }
     )
     @Parameters({
@@ -274,7 +274,7 @@ public interface FakeApi {
         summary = "To test \"client\" model",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @Parameters({
@@ -553,7 +553,7 @@ public interface FakeApi {
         summary = "uploads an image (required)",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -50,7 +50,7 @@ public interface FakeClassnameTestApi {
         summary = "To test class name in snake case",
         tags = { "fake_classname_tags 123#$%^" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key_query")

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
@@ -121,7 +121,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -171,7 +171,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -221,7 +221,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -345,7 +345,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
@@ -121,7 +121,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -171,7 +171,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -221,7 +221,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
@@ -81,7 +81,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -116,7 +116,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -162,7 +162,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
@@ -116,7 +116,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -162,7 +162,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
@@ -169,7 +169,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -216,7 +216,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
@@ -169,7 +169,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -216,7 +216,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -50,7 +50,7 @@ public interface AnotherFakeApi {
         summary = "To test special tags",
         tags = { "$another-fake?" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
@@ -87,7 +87,7 @@ public interface FakeApi {
         operationId = "fakeOuterBooleanSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output boolean", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Boolean.class)))
+            @ApiResponse(responseCode = "200", description = "Output boolean", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  Boolean.class)) } )
         }
     )
     @RequestMapping(
@@ -114,7 +114,7 @@ public interface FakeApi {
         operationId = "fakeOuterCompositeSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output composite", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  OuterComposite.class)))
+            @ApiResponse(responseCode = "200", description = "Output composite", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  OuterComposite.class)) } )
         }
     )
     @RequestMapping(
@@ -141,7 +141,7 @@ public interface FakeApi {
         operationId = "fakeOuterNumberSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output number", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  BigDecimal.class)))
+            @ApiResponse(responseCode = "200", description = "Output number", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  BigDecimal.class)) } )
         }
     )
     @RequestMapping(
@@ -168,7 +168,7 @@ public interface FakeApi {
         operationId = "fakeOuterStringSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output string", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)))
+            @ApiResponse(responseCode = "200", description = "Output string", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  String.class)) } )
         }
     )
     @RequestMapping(
@@ -251,7 +251,7 @@ public interface FakeApi {
         summary = "To test \"client\" model",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(
@@ -511,7 +511,7 @@ public interface FakeApi {
         summary = "uploads an image (required)",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -50,7 +50,7 @@ public interface FakeClassnameTestApi {
         summary = "To test class name in snake case",
         tags = { "fake_classname_tags 123#$%^" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key_query")

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
@@ -118,7 +118,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -152,7 +152,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -186,7 +186,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -290,7 +290,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
@@ -118,7 +118,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -152,7 +152,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -186,7 +186,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
@@ -79,7 +79,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -111,7 +111,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -141,7 +141,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
@@ -111,7 +111,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -141,7 +141,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -161,7 +161,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -192,7 +192,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -161,7 +161,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -192,7 +192,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -50,7 +50,7 @@ public interface AnotherFakeApi {
         summary = "To test special tags",
         tags = { "$another-fake?" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
@@ -87,7 +87,7 @@ public interface FakeApi {
         operationId = "fakeOuterBooleanSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output boolean", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Boolean.class)))
+            @ApiResponse(responseCode = "200", description = "Output boolean", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  Boolean.class)) } )
         }
     )
     @RequestMapping(
@@ -114,7 +114,7 @@ public interface FakeApi {
         operationId = "fakeOuterCompositeSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output composite", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  OuterComposite.class)))
+            @ApiResponse(responseCode = "200", description = "Output composite", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  OuterComposite.class)) } )
         }
     )
     @RequestMapping(
@@ -150,7 +150,7 @@ public interface FakeApi {
         operationId = "fakeOuterNumberSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output number", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  BigDecimal.class)))
+            @ApiResponse(responseCode = "200", description = "Output number", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  BigDecimal.class)) } )
         }
     )
     @RequestMapping(
@@ -177,7 +177,7 @@ public interface FakeApi {
         operationId = "fakeOuterStringSerialize",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "Output string", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)))
+            @ApiResponse(responseCode = "200", description = "Output string", content = { @Content(mediaType = "*/*", schema = @Schema(implementation =  String.class)) } )
         }
     )
     @RequestMapping(
@@ -260,7 +260,7 @@ public interface FakeApi {
         summary = "To test \"client\" model",
         tags = { "fake" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         }
     )
     @RequestMapping(
@@ -529,7 +529,7 @@ public interface FakeApi {
         summary = "uploads an image (required)",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -50,7 +50,7 @@ public interface FakeClassnameTestApi {
         summary = "To test class name in snake case",
         tags = { "fake_classname_tags 123#$%^" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Client.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key_query")

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
@@ -118,7 +118,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -166,7 +166,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -214,7 +214,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -332,7 +332,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApi.java
@@ -118,7 +118,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -166,7 +166,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -214,7 +214,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
@@ -79,7 +79,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApi.java
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
@@ -161,7 +161,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -206,7 +206,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApi.java
@@ -161,7 +161,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -206,7 +206,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
@@ -51,7 +51,7 @@ public interface PetApi {
         summary = "Add a new pet to the store",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "405", description = "Invalid input")
         },
         security = {
@@ -130,7 +130,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -178,7 +178,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -226,7 +226,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -275,7 +275,7 @@ public interface PetApi {
         summary = "Update an existing pet",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found"),
             @ApiResponse(responseCode = "405", description = "Validation exception")

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
@@ -51,7 +51,7 @@ public interface PetApi {
         summary = "Add a new pet to the store",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "405", description = "Invalid input")
         },
         security = {
@@ -130,7 +130,7 @@ public interface PetApi {
         summary = "Finds Pets by status",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid status value")
         },
         security = {
@@ -178,7 +178,7 @@ public interface PetApi {
         summary = "Finds Pets by tags",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid tag value")
         },
         security = {
@@ -226,7 +226,7 @@ public interface PetApi {
         summary = "Find pet by ID",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found")
         },
@@ -275,7 +275,7 @@ public interface PetApi {
         summary = "Update an existing pet",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Pet.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Pet.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Pet not found"),
             @ApiResponse(responseCode = "405", description = "Validation exception")
@@ -359,7 +359,7 @@ public interface PetApi {
         summary = "uploads an image",
         tags = { "pet" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  ModelApiResponse.class)) } )
         },
         security = {
             @SecurityRequirement(name = "petstore_auth", scopes={ "write:pets", "read:pets" })

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
@@ -79,7 +79,7 @@ public interface StoreApi {
         summary = "Returns pet inventories by status",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)))
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/json", schema = @Schema(implementation =  Map.class)) } )
         },
         security = {
             @SecurityRequirement(name = "api_key")
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
@@ -112,7 +112,7 @@ public interface StoreApi {
         summary = "Find purchase order by ID",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid ID supplied"),
             @ApiResponse(responseCode = "404", description = "Order not found")
         }
@@ -156,7 +156,7 @@ public interface StoreApi {
         summary = "Place an order for a pet",
         tags = { "store" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  Order.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  Order.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid Order")
         }
     )

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
@@ -176,7 +176,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -221,7 +221,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class))),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
@@ -176,7 +176,7 @@ public interface UserApi {
         summary = "Get user by user name",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  User.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  User.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username supplied"),
             @ApiResponse(responseCode = "404", description = "User not found")
         }
@@ -221,7 +221,7 @@ public interface UserApi {
         summary = "Logs user into the system",
         tags = { "user" },
         responses = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)),@Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = { @Content(mediaType = "application/xml", schema = @Schema(implementation =  String.class)), @Content(mediaType = "application/json", schema = @Schema(implementation =  String.class)) } ),
             @ApiResponse(responseCode = "400", description = "Invalid username/password supplied")
         }
     )


### PR DESCRIPTION
### PR checklist
* [x]  Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
* [x]  Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
* [x]  Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ```
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
* [x]  File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
* [x]  If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Description

Solved this issue:
https://github.com/OpenAPITools/openapi-generator/issues/11511