### PR TITLE
typescript-fetch: Support deprecated parameters, operations

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -46,6 +46,9 @@ export interface {{classname}}Interface {
      * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
      {{/allParams}}
      * @param {*} [options] Override http request option.
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      * @throws {RequiredError}
      * @memberof {{classname}}Interface
      */

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
@@ -12,6 +12,9 @@ export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
      * {{#lambda.indented_star_4}}{{{unescapedDescription}}}{{/lambda.indented_star_4}}
      * @type {{=<% %>=}}{<%&datatype%>}<%={{ }}=%>
      * @memberof {{classname}}
+    {{#deprecated}}
+     * @deprecated
+    {{/deprecated}}
      */
     {{#isReadOnly}}readonly {{/isReadOnly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
 {{/vars}}


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/11522

Similar to the `axios` and `angular` versions:
https://github.com/OpenAPITools/openapi-generator/pull/9505
https://github.com/OpenAPITools/openapi-generator/pull/6973
