### PR TITLE
[Python] python regex validation generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonLegacyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonLegacyClientCodegen.java
@@ -329,13 +329,6 @@ public class PythonLegacyClientCodegen extends AbstractPythonCodegen implements 
                         + "/pattern/modifiers convention. " + pattern + " is not valid.");
             }
 
-        //check for instances of extra backslash that could cause compile issues and remove
-        int firstBackslash = pattern.indexOf("\\");
-            int bracket = pattern.indexOf("[");
-            if (firstBackslash == 0 || firstBackslash == 1 || firstBackslash == bracket+1) {
-                pattern = pattern.substring(0,firstBackslash)+pattern.substring(firstBackslash+1);
-            }
-
             String regex = pattern.substring(1, i).replace("'", "\\'");
             List<String> modifiers = new ArrayList<String>();
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -439,6 +439,20 @@ public class PythonClientTest {
         Assert.assertEquals((int) model.getMinProperties(), 1);
     }
 
+    @Test(description = "tests RegexObjects")
+    public void testRegexObjects() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_11521.yaml");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName = "DateTimeObject";
+        Schema modelSchema = ModelUtils.getSchema(openAPI, modelName);
+        final CodegenModel model = codegen.fromModel(modelName, modelSchema);
+        final CodegenProperty property1 = model.vars.get(0);
+        Assert.assertEquals(property1.baseName, "datetime");
+        Assert.assertEquals(property1.pattern, "/[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{1,2}:[\\d]{2}Z/");
+    }
+
     @Test(description = "tests RecursiveToExample")
     public void testRecursiveToExample() throws IOException {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_8052_recursive_model.yaml");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -451,6 +451,7 @@ public class PythonClientTest {
         final CodegenProperty property1 = model.vars.get(0);
         Assert.assertEquals(property1.baseName, "datetime");
         Assert.assertEquals(property1.pattern, "/[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{1,2}:[\\d]{2}Z/");
+        Assert.assertEquals(property1.vendorExtensions.get("x-regex"), "[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{1,2}:[\\d]{2}Z");
     }
 
     @Test(description = "tests RecursiveToExample")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonLegacyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonLegacyClientCodegenTest.java
@@ -93,7 +93,9 @@ public class PythonLegacyClientCodegenTest {
         Assert.assertEquals(op.allParams.get(5).pattern, "/^pattern\\d{3}$/i");
         // pattern_with_backslash_after_bracket '/^[\pattern\d{3}$/i'
         // added to test fix for issue #6675
-        Assert.assertEquals(op.allParams.get(6).pattern, "/^[\\pattern\\d{3}$/i");
+        // removed because "/^[\\pattern\\d{3}$/i" is invalid regex
+        // Assert.assertEquals(op.allParams.get(6).pattern, "/^[\\pattern\\d{3}$/i");
+        
     }
 
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonLegacyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonLegacyClientCodegenTest.java
@@ -93,7 +93,7 @@ public class PythonLegacyClientCodegenTest {
         Assert.assertEquals(op.allParams.get(5).pattern, "/^pattern\\d{3}$/i");
         // pattern_with_backslash_after_bracket '/^[\pattern\d{3}$/i'
         // added to test fix for issue #6675
-        // removed because "/^[\\pattern\\d{3}$/i" is invalid regex
+        // removed because "/^[\\pattern\\d{3}$/i" is invalid regex because [ is not escaped and there is no closing ]
         // Assert.assertEquals(op.allParams.get(6).pattern, "/^[\\pattern\\d{3}$/i");
         
     }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_11521.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_11521.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  description: a spec to test free form object models
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+tags: []
+paths: {}
+components:
+  schemas:
+    DateTimeObject:
+      properties:
+        datetime:
+          type: string
+          pattern: '[\d]{4}-[\d]{2}-[\d]{2}T[\d]{1,2}:[\d]{2}Z'


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This removes some code that was not correctly generating regex validation patterns. It's basically a revert of #10920 and fixes #11521.

Technical team: 
@taxpon 
@frol
@mbohlool 
@cbornet
@kenjones-cisco 
@tomplus 
@Jyhess 
@arun-nalla 
@spacether

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
