### PR TITLE
PROPOSAL: Java AST-based Client

### DIFF
--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -429,6 +429,11 @@
             <version>3.19.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-symbol-solver-core</artifactId>
+            <version>3.24.0</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -17,7 +17,12 @@
 
 package org.openapitools.codegen;
 
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.google.common.collect.Sets;
+import com.google.common.io.Resources;
 import com.samskivert.mustache.Mustache.Lambda;
 
 import io.swagger.parser.OpenAPIParser;
@@ -36,6 +41,7 @@ import io.swagger.v3.parser.core.models.ParseOptions;
 
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.config.GlobalSettings;
+import org.openapitools.codegen.languages.PythonClientCodegen;
 import org.openapitools.codegen.templating.mustache.CamelCaseLambda;
 import org.openapitools.codegen.templating.mustache.IndentedLambda;
 import org.openapitools.codegen.templating.mustache.LowercaseLambda;
@@ -47,6 +53,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/modules/openapi-generator/src/test/resources/3_0/java_ast_client_example.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java_ast_client_example.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.0
+info:
+  version: 01.01.00
+  title: APITest API documentation.
+  termsOfService: http://api.apitest.com/party/tos/
+servers:
+  - url: https://api.apitest.com/v1
+paths:
+  /polygon:
+    get:
+      summary: Get the polygon!
+      operationId: ping
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Polygon
+        '400':
+          description: Bad Request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Polygon'
+      parameters: []
+components:
+  schemas:
+    Polygon:
+      title: Polygon
+      description: A Polygon!
+      type: object
+      properties:
+        name:
+          type: string
+        sides:
+          type: array
+          items:
+            $ref: '#/components/schemas/Side'
+    Side:
+      type: object
+      properties:
+        length:
+          $ref: '#/components/schemas/ValueWithUnits'
+    ValueWithUnits:
+      type: object
+      properties:
+        unit:
+          type: string
+        magnitude:
+          type: number
+
+
+
+

--- a/modules/openapi-generator/src/test/resources/3_0/java_ast_client_example_expected.txt
+++ b/modules/openapi-generator/src/test/resources/3_0/java_ast_client_example_expected.txt
@@ -1,0 +1,58 @@
+public class Polygon {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    private List<Side> sides;
+
+    public List<Side> getSides() {
+        return sides;
+    }
+
+    public void setSides(List<Side> sides) {
+        this.sides = sides;
+    }
+}
+
+public class Side {
+
+    private ValueWithUnits length;
+
+    public ValueWithUnits getLength() {
+        return length;
+    }
+
+    public void setLength(ValueWithUnits length) {
+        this.length = length;
+    }
+}
+
+public class ValueWithUnits {
+
+    private String unit;
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    private BigDecimal magnitude;
+
+    public BigDecimal getMagnitude() {
+        return magnitude;
+    }
+
+    public void setMagnitude(BigDecimal magnitude) {
+        this.magnitude = magnitude;
+    }
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR attempts to demonstrate the power, flexibility and maintainability of creating generated code using an AST parser instead of mustache templates. With a very readable 10 lines of code and no mustache templates, I was able to convert a collection of `CodeGenModel`s into valid Java classes with fields and getters and setters, with proper indentation and everything. This method completely outsources the burden of string manipulation, linting and a lot of the frustrating parts of maintaining and thinking about the code structure to the JavaParser package (for Java). I'd argue that reading and thinking about this code is far easier than trying to reason about the combination of Mustache templates and String wrangling that the generators currently use. A downside is that you have to use a different AST generator for each language. But on the other side, that allows for each generator to be written in the language of the generated code itself. This isn't really meant to replace the current generators at all, but rather demonstrate the power of working with the AST directly.
