### PR TITLE
[haskell-http-client] Update haskell-http-client generator to Aeson 2.x

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-http-client/Core.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/Core.mustache
@@ -70,7 +70,7 @@ data {{configType}} = {{configType}}
   , configLogContext :: LogContext -- ^ Configures the logger
   , configAuthMethods :: [AnyAuthMethod] -- ^ List of configured auth methods
   , configValidateAuthMethods :: Bool -- ^ throw exceptions if auth methods are not configured
-  , configQueryExtraUnreserved :: B.ByteString -- ^ Configures additional querystring characters which must not be URI encoded, e.g. '+' or ':' 
+  , configQueryExtraUnreserved :: B.ByteString -- ^ Configures additional querystring characters which must not be URI encoded, e.g. '+' or ':'
   }
 
 -- | display the config
@@ -419,7 +419,7 @@ _applyAuthMethods req config@({{configType}} {configAuthMethods = as}) =
 -- * Utils
 
 -- | Removes Null fields.  (OpenAPI-Specification 2.0 does not allow Null in JSON)
-_omitNulls :: [(Text, A.Value)] -> A.Value
+_omitNulls :: [(A.Key, A.Value)] -> A.Value
 _omitNulls = A.object . P.filter notNull
   where
     notNull (_, A.Null) = False

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
@@ -39,7 +39,7 @@ library
       lib
   ghc-options: -Wall -funbox-strict-fields
   build-depends:
-      aeson >=1.0 && <2.0
+      aeson >=2.0 && <3.0
     , base >=4.7 && <5.0
     , base64-bytestring >1.0 && <2.0
     , bytestring >=0.10.0

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Core.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Core.hs
@@ -79,7 +79,7 @@ data OpenAPIPetstoreConfig = OpenAPIPetstoreConfig
   , configLogContext :: LogContext -- ^ Configures the logger
   , configAuthMethods :: [AnyAuthMethod] -- ^ List of configured auth methods
   , configValidateAuthMethods :: Bool -- ^ throw exceptions if auth methods are not configured
-  , configQueryExtraUnreserved :: B.ByteString -- ^ Configures additional querystring characters which must not be URI encoded, e.g. '+' or ':' 
+  , configQueryExtraUnreserved :: B.ByteString -- ^ Configures additional querystring characters which must not be URI encoded, e.g. '+' or ':'
   }
 
 -- | display the config
@@ -428,7 +428,7 @@ _applyAuthMethods req config@(OpenAPIPetstoreConfig {configAuthMethods = as}) =
 -- * Utils
 
 -- | Removes Null fields.  (OpenAPI-Specification 2.0 does not allow Null in JSON)
-_omitNulls :: [(Text, A.Value)] -> A.Value
+_omitNulls :: [(A.Key, A.Value)] -> A.Value
 _omitNulls = A.object . P.filter notNull
   where
     notNull (_, A.Null) = False

--- a/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
+++ b/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
@@ -35,7 +35,7 @@ library
       lib
   ghc-options: -Wall -funbox-strict-fields
   build-depends:
-      aeson >=1.0 && <2.0
+      aeson >=2.0 && <3.0
     , base >=4.7 && <5.0
     , base64-bytestring >1.0 && <2.0
     , bytestring >=0.10.0


### PR DESCRIPTION
Due to a [denial-of-service vulnerability](https://github.com/haskell/aeson/issues/864) of `aeson-1.x`, we would like to update to `aeson-2.x`.

This PR includes the 1-line change in `Core.hs` necessary to upgrade `aeson` to the new version.

If the PR points to the wrong branch, tell me and I will fix it.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
