### PR TITLE
Optional outputAsLibrary, onlyInterfaces parameters

### DIFF
--- a/docs/generators/go-server.md
+++ b/docs/generators/go-server.md
@@ -22,6 +22,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |enumClassPrefix|Prefix enum with class name| |false|
 |featureCORS|Enable Cross-Origin Resource Sharing middleware| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
+|onlyInterfaces|Exclude default service creators from output; only generate interfaces| |false|
+|outputAsLibrary|Exclude main.go, go.mod, and Dockerfile from output| |false|
 |packageName|Go package name (convention: lowercase).| |openapi|
 |packageVersion|Go package version.| |1.0.0|
 |router|Specify the router which should be used.|<dl><dt>**mux**</dt><dd>mux</dd><dt>**chi**</dt><dd>chi</dd></dl>|mux|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -53,6 +53,8 @@ public class GoServerCodegen extends AbstractGoCodegen {
     protected String sourceFolder = "go";
     protected Boolean corsFeatureEnabled = false;
     protected Boolean addResponseHeaders = false;
+    protected Boolean outputAsLibrary = false;
+    protected Boolean onlyInterfaces = false;
 
 
     public GoServerCodegen() {
@@ -109,6 +111,18 @@ public class GoServerCodegen extends AbstractGoCodegen {
         optAddResponseHeaders.defaultValue(addResponseHeaders.toString());
         cliOptions.add(optAddResponseHeaders);
 
+        
+        // option to exclude service factories; only interfaces are rendered
+        CliOption optOnlyInterfaces = new CliOption("onlyInterfaces", "Exclude default service creators from output; only generate interfaces");
+        optOnlyInterfaces.setType("bool");
+        optOnlyInterfaces.defaultValue(onlyInterfaces.toString());
+        cliOptions.add(optOnlyInterfaces);
+
+        // option to exclude main package (main.go), Dockerfile, and go.mod files
+        CliOption optOutputAsLibrary = new CliOption("outputAsLibrary", "Exclude main.go, go.mod, and Dockerfile from output");
+        optOutputAsLibrary.setType("bool");
+        optOutputAsLibrary.defaultValue(outputAsLibrary.toString());
+        cliOptions.add(optOutputAsLibrary);
         /*
          * Models.  You can write model files using the modelTemplateFiles map.
          * if you want to create one template for file, you can do so here.
@@ -214,6 +228,22 @@ public class GoServerCodegen extends AbstractGoCodegen {
             additionalProperties.put("addResponseHeaders", addResponseHeaders);
         }
 
+        if (additionalProperties.containsKey("onlyInterfaces")) {
+            this.setOnlyInterfaces(convertPropertyToBooleanAndWriteBack("onlyInterfaces"));
+        } else {
+            additionalProperties.put("onlyInterfaces", onlyInterfaces);
+        }
+
+        if (this.onlyInterfaces) {
+          apiTemplateFiles.remove("service.mustache");
+        }
+
+        if (additionalProperties.containsKey("outputAsLibrary")) {
+            this.setOutputAsLibrary(convertPropertyToBooleanAndWriteBack("outputAsLibrary"));
+        } else {
+            additionalProperties.put("outputAsLibrary", outputAsLibrary);
+        }
+
         if (additionalProperties.containsKey(CodegenConstants.ENUM_CLASS_PREFIX)) {
             setEnumClassPrefix(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.ENUM_CLASS_PREFIX).toString()));
             if (enumClassPrefix) {
@@ -238,10 +268,12 @@ public class GoServerCodegen extends AbstractGoCodegen {
          * entire object tree available.  If the input file has a suffix of `.mustache
          * it will be processed by the template engine.  Otherwise, it will be copied
          */
+        if (!outputAsLibrary) {
+          supportingFiles.add(new SupportingFile("main.mustache", "", "main.go"));
+          supportingFiles.add(new SupportingFile("Dockerfile.mustache", "", "Dockerfile"));
+          supportingFiles.add(new SupportingFile("go.mod.mustache", "", "go.mod"));
+        }
         supportingFiles.add(new SupportingFile("openapi.mustache", "api", "openapi.yaml"));
-        supportingFiles.add(new SupportingFile("main.mustache", "", "main.go"));
-        supportingFiles.add(new SupportingFile("Dockerfile.mustache", "", "Dockerfile"));
-        supportingFiles.add(new SupportingFile("go.mod.mustache", "", "go.mod"));
         supportingFiles.add(new SupportingFile("routers.mustache", sourceFolder, "routers.go"));
         supportingFiles.add(new SupportingFile("logger.mustache", sourceFolder, "logger.go"));
         supportingFiles.add(new SupportingFile("impl.mustache",sourceFolder, "impl.go"));
@@ -361,6 +393,14 @@ public class GoServerCodegen extends AbstractGoCodegen {
 
     public void setAddResponseHeaders(Boolean addResponseHeaders) {
         this.addResponseHeaders = addResponseHeaders;
+    }
+
+    public void setOnlyInterfaces(Boolean onlyInterfaces) {
+        this.onlyInterfaces = onlyInterfaces;
+    }
+
+    public void setOutputAsLibrary(Boolean outputAsLibrary) {
+        this.outputAsLibrary = outputAsLibrary;
     }
 
     @Override


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
In response to the ongoing conversation in https://github.com/OpenAPITools/openapi-generator/issues/3547, I added two flags to the `go-server` generator.

`outputAsLibrary` generates output intended to be included in a larger go project. It removes the `Dockerfile`, `main.go`, and `go.mod` from the rendered output.

`onlyInterfaces` removes the factory functions `New{{classname}}Service`, which expects implementations to be added to the generated templates, and those templates to be added to `.openapi-generator-ignore`.

Using both flags together will create a package that can be incorporated in an existing project, and whose service must be implemented in the composition root of the larger project, rather than in the generated output files.

This is a small step towards the larger goal of #3547, which is to bring the output more in line with a standard go project structure, and to provide more flexibility around how the generated files are used.

I propose this as an intermediate change, because it allows consumers to effectively use the generated code within a larger project, but should not create breaking changes for users of the current behavior.

<!-- Please check the completed items below -->
### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @wing328 