### PR TITLE
[PHP] Allows passing filename to deserialize

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -20,6 +20,7 @@
 namespace {{invokerPackage}};
 
 use {{modelPackage}}\ModelInterface;
+use GuzzleHttp\Psr7;
 
 /**
  * ObjectSerializer Class Doc Comment
@@ -337,6 +338,8 @@ class ObjectSerializer
         }
 
         if ($class === '\SplFileObject') {
+            $data = Psr7\Utils::streamFor($data);
+
             /** @var \Psr\Http\Message\StreamInterface $data */
 
             // determine file name

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -20,7 +20,7 @@
 namespace {{invokerPackage}};
 
 use {{modelPackage}}\ModelInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * ObjectSerializer Class Doc Comment
@@ -338,7 +338,7 @@ class ObjectSerializer
         }
 
         if ($class === '\SplFileObject') {
-            $data = Psr7\Utils::streamFor($data);
+            $data = Utils::streamFor($data);
 
             /** @var \Psr\Http\Message\StreamInterface $data */
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -29,7 +29,7 @@
 namespace OpenAPI\Client;
 
 use OpenAPI\Client\Model\ModelInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * ObjectSerializer Class Doc Comment
@@ -347,7 +347,7 @@ class ObjectSerializer
         }
 
         if ($class === '\SplFileObject') {
-            $data = Psr7\Utils::streamFor($data);
+            $data = Utils::streamFor($data);
 
             /** @var \Psr\Http\Message\StreamInterface $data */
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -29,6 +29,7 @@
 namespace OpenAPI\Client;
 
 use OpenAPI\Client\Model\ModelInterface;
+use GuzzleHttp\Psr7;
 
 /**
  * ObjectSerializer Class Doc Comment
@@ -346,6 +347,8 @@ class ObjectSerializer
         }
 
         if ($class === '\SplFileObject') {
+            $data = Psr7\Utils::streamFor($data);
+
             /** @var \Psr\Http\Message\StreamInterface $data */
 
             // determine file name

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -4,7 +4,6 @@ namespace OpenAPI\Client;
 
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\StreamInterface;
 
 // test object serializer
 class ObjectSerializerTest extends TestCase
@@ -34,7 +33,7 @@ class ObjectSerializerTest extends TestCase
      * @covers ObjectSerializer::serialize
      * @dataProvider provideFileStreams
      */
-    public function testDeserializeFile(StreamInterface $stream, ?array $httpHeaders = null, ?string $expectedFilename = null): void
+    public function testDeserializeFile($stream, ?array $httpHeaders = null, ?string $expectedFilename = null): void
     {
         $s = new ObjectSerializer();
 
@@ -61,6 +60,11 @@ class ObjectSerializerTest extends TestCase
                 Utils::streamFor(\fopen(__FILE__, 'r')),
                 ['Content-Disposition' => 'inline; filename=\'foobar.php\''],
                 'foobar.php',
+            ],
+            'File path' => [
+                __FILE__,
+                null,
+                null,
             ],
         ];
     }


### PR DESCRIPTION
Currently the `ObjectSerializer::deserialize()` does not work when passing a filename string for a `SplFileObject` type.

The `\GuzzleHttp\Psr7\Utils::streamFor()` has support for a wide-range of data, including strings, and converts them to a stream resource.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
