### PR TITLE
Bug Fix: Cast from QByteArray to std::runtime_error

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/ServerConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/ServerConfiguration.mustache
@@ -46,7 +46,7 @@ public:
                 QString value = serverVariable._defaultValue;
 
                 if (!serverVariable._enumValues.empty() && !serverVariable._enumValues.contains(value)) {
-                    throw std::runtime_error(QString("The variable " + name + " in the server URL has invalid value " + value + ".").toUtf8());
+                    throw std::runtime_error(QString("The variable " + name + " in the server URL has invalid value " + value + ".").toUtf8().toStdString());
                 }
                 QRegularExpression regex(QString("\\{" + name + "\\}"));
                 url = url.replace(regex, value);


### PR DESCRIPTION
I am compiling this on a sligthtly older Qt version (Qt 5.6) with a slightly older compiler and I encounter the following error:

```
error: no matching conversion for functional-style cast from 'QByteArray' to 'std::runtime_error'
```

This is easily mitigated and the solution is forward-compatible. The problem is simply because of mising cast operator from `QByteArray` to `std::string` on older Qt version. This solution should support all Qt versions.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd