### PR TITLE
Added x-codegen-name for go mustache template

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -19,7 +19,7 @@ type {{classname}} struct {
 {{#deprecated}}
 	// Deprecated
 {{/deprecated}}
-	{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
 	AdditionalProperties map[string]interface{}
@@ -274,19 +274,19 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	{{#vendorExtensions.x-golang-is-container}}
 	{{! support for container fields is not ideal at this point because of lack of Nullable* types}}
 	if o.{{name}} != nil {
-		toSerialize["{{baseName}}"] = o.{{name}}
+		toSerialize["{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}"] = o.{{name}}
 	}
 	{{/vendorExtensions.x-golang-is-container}}
 	{{^vendorExtensions.x-golang-is-container}}
 	if {{#required}}true{{/required}}{{^required}}o.{{name}}.IsSet(){{/required}} {
-		toSerialize["{{baseName}}"] = o.{{name}}.Get()
+		toSerialize["{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}"] = o.{{name}}.Get()
 	}
 	{{/vendorExtensions.x-golang-is-container}}
 	{{/isNullable}}
 	{{! if argument is not nullable, don't set it if it is nil}}
 	{{^isNullable}}
 	if {{#required}}true{{/required}}{{^required}}o.{{name}} != nil{{/required}} {
-		toSerialize["{{baseName}}"] = o.{{name}}
+		toSerialize["{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}"] = o.{{name}}
 	}
 	{{/isNullable}}
 	{{/vars}}
@@ -314,7 +314,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 	{{#deprecated}}
 		// Deprecated
 	{{/deprecated}}
-		{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+		{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 	{{/vars}}
 	}
 
@@ -344,7 +344,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		{{#vars}}
-		delete(additionalProperties, "{{{baseName}}}")
+		delete(additionalProperties, "{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}")
 		{{/vars}}
 
 		// remove fields from embedded structs
@@ -381,7 +381,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		{{#vars}}
-		delete(additionalProperties, "{{{baseName}}}")
+		delete(additionalProperties, "{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}")
 		{{/vars}}
 		o.AdditionalProperties = additionalProperties
 	}
@@ -400,7 +400,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
 		{{#vars}}
-		delete(additionalProperties, "{{{baseName}}}")
+		delete(additionalProperties, "{{#vendorExtensions.x-codegen-name}}{{{.}}}{{/vendorExtensions.x-codegen-name}}{{^vendorExtensions.x-codegen-name}}{{baseName}}{{/vendorExtensions.x-codegen-name}}")
 		{{/vars}}
 		o.AdditionalProperties = additionalProperties
 	}


### PR DESCRIPTION
This allows to override json key name from open api using
x-codegen-name. This makes it possible to have  a field name that renders
a different json key. When not x-codegen-name exists it defaults back to
the original baseName naming (as earlier).

This applies to the go client generator.

Below open API spec defines two fields, one overridden and the other is normal.

```yaml
openapi: "3.0.1"
info:
  title: Building
  version: 1.0.0
  description: >
    Building model
  termsOfService: "http://www.crossbreed.se/terms/"
  contact:
    name: mario.toffia@crossbreed.se
  license:
    name: Apache 2.0
paths:
  /info:
    get:
      operationId: getInfo
      responses:
        200:
          description: Success
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Building'
components:
  schemas:
    Building:
      type: object
      properties:
        BuildingID:
          type: string          
          x-go-custom-tag: 'dynamodbav:"PK"'
          x-codegen-name: lid
        SK:
          type: string
          maxLength: 255
```

This generates the following

```golang
/*
Building

Building model 

API version: 1.0.0
*/

// Code generated by OpenAPI Generator (https://openapi-generator.tech); DO NOT EDIT.

package locationmodel

import (
	"encoding/json"
)

// Building struct for Building
type Building struct {
	BuildingID string `json:"lid" dynamodbav:"PK"`
	SK string `json:"SK"`
}

// NewBuilding instantiates a new Building object
// This constructor will assign default values to properties that have it defined,
// and makes sure properties required by API are set, but the set of arguments
// will change when the set of required properties is changed
func NewBuilding(buildingID string, sK string, name string, location map[string]string, params map[string]string, version int64, sign string) *Building {
	this := Building{}
	this.BuildingID = buildingID
	this.SK = sK
	this.Name = name
	this.Location = location
	this.Params = params
	this.Version = version
	this.Sign = sign
	return &this
}

// NewBuildingWithDefaults instantiates a new Building object
// This constructor will only assign default values to properties that have it defined,
// but it doesn't guarantee that properties required by API are set
func NewBuildingWithDefaults() *Building {
	this := Building{}
	return &this
}

// GetBuildingID returns the BuildingID field value
func (o *Building) GetBuildingID() string {
	if o == nil {
		var ret string
		return ret
	}

	return o.BuildingID
}

// GetBuildingIDOk returns a tuple with the BuildingID field value
// and a boolean to check if the value has been set.
func (o *Building) GetBuildingIDOk() (*string, bool) {
	if o == nil  {
		return nil, false
	}
	return &o.BuildingID, true
}

// SetBuildingID sets field value
func (o *Building) SetBuildingID(v string) {
	o.BuildingID = v
}

// GetSK returns the SK field value
func (o *Building) GetSK() string {
	if o == nil {
		var ret string
		return ret
	}

	return o.SK
}

// GetSKOk returns a tuple with the SK field value
// and a boolean to check if the value has been set.
func (o *Building) GetSKOk() (*string, bool) {
	if o == nil  {
		return nil, false
	}
	return &o.SK, true
}

// SetSK sets field value
func (o *Building) SetSK(v string) {
	o.SK = v
}

func (o Building) MarshalJSON() ([]byte, error) {
	toSerialize := map[string]interface{}{}
	if true {
		toSerialize["lid"] = o.BuildingID
	}
	if true {
		toSerialize["SK"] = o.SK
	}
	return json.Marshal(toSerialize)
}

type NullableBuilding struct {
	value *Building
	isSet bool
}

func (v NullableBuilding) Get() *Building {
	return v.value
}

func (v *NullableBuilding) Set(val *Building) {
	v.value = val
	v.isSet = true
}

func (v NullableBuilding) IsSet() bool {
	return v.isSet
}

func (v *NullableBuilding) Unset() {
	v.value = nil
	v.isSet = false
}

func NewNullableBuilding(val *Building) *NullableBuilding {
	return &NullableBuilding{value: val, isSet: true}
}

func (v NullableBuilding) MarshalJSON() ([]byte, error) {
	return json.Marshal(v.value)
}

func (v *NullableBuilding) UnmarshalJSON(src []byte) error {
	v.isSet = true
	return json.Unmarshal(src, &v.value)
}
```
