### PR TITLE
php-laravel, enum models, nullable and default values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -404,6 +404,8 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             // return the name in camelCase style
             // phone_number => phoneNumber
             name = camelize(name, true);
+        } else if ("PascalCase".equals(variableNamingConvention)) {
+            name = camelize(name, false);
         } else { // default to snake case
             // return the name in underscore style
             // PhoneNumber => phone_number

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
@@ -18,9 +18,13 @@
 package org.openapitools.codegen.languages;
 
 import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.utils.ModelUtils;
+
+import io.swagger.v3.oas.models.media.Schema;
 
 import java.io.File;
 import java.util.*;
@@ -299,5 +303,97 @@ public class PhpLaravelServerCodegen extends AbstractPhpCodegen {
         }
 
         return camelize(name, false) + "Controller";
+    }
+
+    @Override
+    protected String getEnumDefaultValue(String defaultValue, String dataType) {
+        return defaultValue;
+    }
+
+    @Override
+    public CodegenProperty fromProperty(String name, Schema p) {
+        CodegenProperty property = super.fromProperty(name, p);
+        Schema referencedSchema = ModelUtils.getReferencedSchema(this.openAPI, p);
+
+        //Referenced enum case:
+        if (!property.isEnum && referencedSchema.getEnum() != null && !referencedSchema.getEnum().isEmpty()) {
+            property.dataType = this.getSchemaType(referencedSchema);
+            property.defaultValue = this.toDefaultValue(referencedSchema);
+            List<Object> _enum = referencedSchema.getEnum();
+
+            Map<String, Object> allowableValues = new HashMap<>();
+            allowableValues.put("values", _enum);
+            if (allowableValues.size() > 0) {
+                property.allowableValues = allowableValues;
+            }
+        }
+
+        return property;
+    }
+
+    @Override
+    public String toDefaultValue(Schema p) {
+        if (ModelUtils.isBooleanSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            } else if (!Boolean.TRUE.equals(p.getNullable())) {
+                return "false";
+            }
+        } else if (ModelUtils.isDateSchema(p)) {
+            // TODO
+        } else if (ModelUtils.isDateTimeSchema(p)) {
+            // TODO
+        } else if (ModelUtils.isFileSchema(p)) {
+            // TODO
+        } else if (ModelUtils.isNumberSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            } else if (!Boolean.TRUE.equals(p.getNullable())) {
+                return "0";
+            }
+        } else if (ModelUtils.isIntegerSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            } else if (!Boolean.TRUE.equals(p.getNullable())) {
+                return "0";
+            }
+        } else if (ModelUtils.isStringSchema(p)) {
+            if (p.getDefault() != null) {
+                return "'" + p.getDefault() + "'";
+            } else if (!Boolean.TRUE.equals(p.getNullable())) {
+                return "\"\"";
+            }
+        } else if (ModelUtils.isArraySchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            } else if (!Boolean.TRUE.equals(p.getNullable())) {
+                return "[]";
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public String toEnumDefaultValue(String value, String datatype) {
+        return datatype + "::" + value;
+    }
+
+    @Override
+    public String toEnumVarName(String value, String datatype) {
+        if (value.length() == 0) {
+            return super.toEnumVarName(value, datatype);
+        }
+
+        // number
+        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+            String varName = "NUMBER_" + value;
+            varName = varName.replaceAll("-", "MINUS_");
+            varName = varName.replaceAll("\\+", "PLUS_");
+            varName = varName.replaceAll("\\.", "_DOT_");
+            return varName;
+        }
+
+        return super.toEnumVarName(value, datatype);
     }
 }

--- a/modules/openapi-generator/src/main/resources/php-laravel/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/model.mustache
@@ -1,21 +1,17 @@
 <?php
-{{#models}}{{#model}}/**
+{{#models}}
+{{#model}}
+/**
  * {{classname}}
  */
 namespace {{modelPackage}};
 
 /**
  * {{classname}}
+{{#description}}
+ * @description {{{.}}}
+{{/description}}
  */
-class {{classname}} {
-
-    {{#vars}}
-    /** @var {{{dataType}}} ${{name}} {{description}}*/
-{{#deprecated}}
-    /** @deprecated */
-{{/deprecated}}
-    private ${{name}};
-
-    {{/vars}}
-}
-{{/model}}{{/models}}
+{{#isEnum}}{{>model_enum}}{{/isEnum}}{{^isEnum}}{{>model_generic}}{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/modules/openapi-generator/src/main/resources/php-laravel/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/model_enum.mustache
@@ -1,0 +1,28 @@
+class {{classname}}
+{
+    /**
+     * Possible values of this enum
+     */
+    {{#allowableValues}}
+    {{#enumVars}}
+    const {{{name}}} = {{{value}}};
+
+    {{/enumVars}}
+    {{/allowableValues}}
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public static function getAllowableEnumValues()
+    {
+        return [
+            {{#allowableValues}}
+            {{#enumVars}}
+            self::{{{name}}}{{^-last}},
+            {{/-last}}
+            {{/enumVars}}
+            {{/allowableValues}}
+
+        ];
+    }
+}

--- a/modules/openapi-generator/src/main/resources/php-laravel/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/model_generic.mustache
@@ -5,7 +5,7 @@ class {{classname}} {
 {{#deprecated}}
     /** @deprecated */
 {{/deprecated}}
-    private ${{name}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{#isNullable}} = null{{/isNullable}}{{/defaultValue}};
+    public ${{name}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{#isNullable}} = null{{/isNullable}}{{/defaultValue}};
 
     {{/vars}}
 }

--- a/modules/openapi-generator/src/main/resources/php-laravel/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/model_generic.mustache
@@ -1,0 +1,11 @@
+class {{classname}} {
+
+    {{#vars}}
+    /** @var {{{dataType}}}{{#isNullable}}|null{{/isNullable}} ${{name}} {{description}}*/
+{{#deprecated}}
+    /** @deprecated */
+{{/deprecated}}
+    private ${{name}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{#isNullable}} = null{{/isNullable}}{{/defaultValue}};
+
+    {{/vars}}
+}

--- a/samples/server/petstore/php-laravel/lib/app/Models/AdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/AdditionalPropertiesClass.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class AdditionalPropertiesClass {
 
     /** @var array<string,string> $mapProperty */
-    private $mapProperty;
+    public $mapProperty;
 
     /** @var array<string,array<string,string>> $mapOfMapProperty */
-    private $mapOfMapProperty;
+    public $mapOfMapProperty;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Animal.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Animal.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class Animal {
 
     /** @var string $className */
-    private $className;
+    private $className = "";
 
     /** @var string $color */
-    private $color;
+    private $color = 'red';
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Animal.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Animal.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class Animal {
 
     /** @var string $className */
-    private $className = "";
+    public $className = "";
 
     /** @var string $color */
-    private $color = 'red';
+    public $color = 'red';
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ApiResponse.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ApiResponse.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class ApiResponse {
 
     /** @var int $code */
-    private $code;
+    private $code = 0;
 
     /** @var string $type */
-    private $type;
+    private $type = "";
 
     /** @var string $message */
-    private $message;
+    private $message = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ApiResponse.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ApiResponse.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class ApiResponse {
 
     /** @var int $code */
-    private $code = 0;
+    public $code = 0;
 
     /** @var string $type */
-    private $type = "";
+    public $type = "";
 
     /** @var string $message */
-    private $message = "";
+    public $message = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfArrayOfNumberOnly.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class ArrayOfArrayOfNumberOnly {
 
     /** @var float[][] $arrayArrayNumber */
-    private $arrayArrayNumber;
+    private $arrayArrayNumber = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfArrayOfNumberOnly.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class ArrayOfArrayOfNumberOnly {
 
     /** @var float[][] $arrayArrayNumber */
-    private $arrayArrayNumber = [];
+    public $arrayArrayNumber = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfNumberOnly.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class ArrayOfNumberOnly {
 
     /** @var float[] $arrayNumber */
-    private $arrayNumber = [];
+    public $arrayNumber = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ArrayOfNumberOnly.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class ArrayOfNumberOnly {
 
     /** @var float[] $arrayNumber */
-    private $arrayNumber;
+    private $arrayNumber = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ArrayTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ArrayTest.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class ArrayTest {
 
     /** @var string[] $arrayOfString */
-    private $arrayOfString = [];
+    public $arrayOfString = [];
 
     /** @var int[][] $arrayArrayOfInteger */
-    private $arrayArrayOfInteger = [];
+    public $arrayArrayOfInteger = [];
 
     /** @var \app\Models\ReadOnlyFirst[][] $arrayArrayOfModel */
-    private $arrayArrayOfModel = [];
+    public $arrayArrayOfModel = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ArrayTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ArrayTest.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class ArrayTest {
 
     /** @var string[] $arrayOfString */
-    private $arrayOfString;
+    private $arrayOfString = [];
 
     /** @var int[][] $arrayArrayOfInteger */
-    private $arrayArrayOfInteger;
+    private $arrayArrayOfInteger = [];
 
     /** @var \app\Models\ReadOnlyFirst[][] $arrayArrayOfModel */
-    private $arrayArrayOfModel;
+    private $arrayArrayOfModel = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Capitalization.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Capitalization.php
@@ -10,21 +10,21 @@ namespace app\Models;
 class Capitalization {
 
     /** @var string $smallCamel */
-    private $smallCamel;
+    private $smallCamel = "";
 
     /** @var string $capitalCamel */
-    private $capitalCamel;
+    private $capitalCamel = "";
 
     /** @var string $smallSnake */
-    private $smallSnake;
+    private $smallSnake = "";
 
     /** @var string $capitalSnake */
-    private $capitalSnake;
+    private $capitalSnake = "";
 
     /** @var string $sCAETHFlowPoints */
-    private $sCAETHFlowPoints;
+    private $sCAETHFlowPoints = "";
 
     /** @var string $aTTNAME Name of the pet*/
-    private $aTTNAME;
+    private $aTTNAME = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Capitalization.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Capitalization.php
@@ -10,21 +10,21 @@ namespace app\Models;
 class Capitalization {
 
     /** @var string $smallCamel */
-    private $smallCamel = "";
+    public $smallCamel = "";
 
     /** @var string $capitalCamel */
-    private $capitalCamel = "";
+    public $capitalCamel = "";
 
     /** @var string $smallSnake */
-    private $smallSnake = "";
+    public $smallSnake = "";
 
     /** @var string $capitalSnake */
-    private $capitalSnake = "";
+    public $capitalSnake = "";
 
     /** @var string $sCAETHFlowPoints */
-    private $sCAETHFlowPoints = "";
+    public $sCAETHFlowPoints = "";
 
     /** @var string $aTTNAME Name of the pet*/
-    private $aTTNAME = "";
+    public $aTTNAME = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Cat.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Cat.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class Cat {
 
     /** @var string $className */
-    private $className;
+    private $className = "";
 
     /** @var string $color */
-    private $color;
+    private $color = 'red';
 
     /** @var bool $declawed */
-    private $declawed;
+    private $declawed = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Cat.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Cat.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class Cat {
 
     /** @var string $className */
-    private $className = "";
+    public $className = "";
 
     /** @var string $color */
-    private $color = 'red';
+    public $color = 'red';
 
     /** @var bool $declawed */
-    private $declawed = false;
+    public $declawed = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/CatAllOf.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/CatAllOf.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class CatAllOf {
 
     /** @var bool $declawed */
-    private $declawed = false;
+    public $declawed = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/CatAllOf.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/CatAllOf.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class CatAllOf {
 
     /** @var bool $declawed */
-    private $declawed;
+    private $declawed = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Category.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Category.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class Category {
 
     /** @var int $id */
-    private $id = 0;
+    public $id = 0;
 
     /** @var string $name */
-    private $name = 'default-name';
+    public $name = 'default-name';
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Category.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Category.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class Category {
 
     /** @var int $id */
-    private $id;
+    private $id = 0;
 
     /** @var string $name */
-    private $name;
+    private $name = 'default-name';
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ClassModel.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ClassModel.php
@@ -6,10 +6,11 @@ namespace app\Models;
 
 /**
  * ClassModel
+ * @description Model for testing model with \"_class\" property
  */
 class ClassModel {
 
     /** @var string $class */
-    private $class;
+    private $class = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ClassModel.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ClassModel.php
@@ -11,6 +11,6 @@ namespace app\Models;
 class ClassModel {
 
     /** @var string $class */
-    private $class = "";
+    public $class = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Client.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Client.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class Client {
 
     /** @var string $client */
-    private $client = "";
+    public $client = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Client.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Client.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class Client {
 
     /** @var string $client */
-    private $client;
+    private $client = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/DeprecatedObject.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/DeprecatedObject.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class DeprecatedObject {
 
     /** @var string $name */
-    private $name = "";
+    public $name = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/DeprecatedObject.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/DeprecatedObject.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class DeprecatedObject {
 
     /** @var string $name */
-    private $name;
+    private $name = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Dog.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Dog.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class Dog {
 
     /** @var string $className */
-    private $className;
+    private $className = "";
 
     /** @var string $color */
-    private $color;
+    private $color = 'red';
 
     /** @var string $breed */
-    private $breed;
+    private $breed = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Dog.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Dog.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class Dog {
 
     /** @var string $className */
-    private $className = "";
+    public $className = "";
 
     /** @var string $color */
-    private $color = 'red';
+    public $color = 'red';
 
     /** @var string $breed */
-    private $breed = "";
+    public $breed = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/DogAllOf.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/DogAllOf.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class DogAllOf {
 
     /** @var string $breed */
-    private $breed;
+    private $breed = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/DogAllOf.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/DogAllOf.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class DogAllOf {
 
     /** @var string $breed */
-    private $breed = "";
+    public $breed = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/EnumArrays.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/EnumArrays.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class EnumArrays {
 
     /** @var string $justSymbol */
-    private $justSymbol = "";
+    public $justSymbol = "";
 
     /** @var string[] $arrayEnum */
-    private $arrayEnum = [];
+    public $arrayEnum = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/EnumArrays.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/EnumArrays.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class EnumArrays {
 
     /** @var string $justSymbol */
-    private $justSymbol;
+    private $justSymbol = "";
 
     /** @var string[] $arrayEnum */
-    private $arrayEnum;
+    private $arrayEnum = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/EnumClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/EnumClass.php
@@ -7,6 +7,27 @@ namespace app\Models;
 /**
  * EnumClass
  */
-class EnumClass {
+class EnumClass
+{
+    /**
+     * Possible values of this enum
+     */
+    const ABC = '_abc';
 
+    const EFG = '-efg';
+
+    const XYZ = '(xyz)';
+
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public static function getAllowableEnumValues()
+    {
+        return [
+            self::ABC,
+            self::EFG,
+            self::XYZ
+        ];
+    }
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/EnumTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/EnumTest.php
@@ -10,27 +10,27 @@ namespace app\Models;
 class EnumTest {
 
     /** @var string $enumString */
-    private $enumString = "";
+    public $enumString = "";
 
     /** @var string $enumStringRequired */
-    private $enumStringRequired = "";
+    public $enumStringRequired = "";
 
     /** @var int $enumInteger */
-    private $enumInteger = 0;
+    public $enumInteger = 0;
 
     /** @var double $enumNumber */
-    private $enumNumber = 0;
+    public $enumNumber = 0;
 
     /** @var string|null $outerEnum */
-    private $outerEnum = null;
+    public $outerEnum = null;
 
     /** @var int $outerEnumInteger */
-    private $outerEnumInteger = \app\Models\OuterEnumInteger::NUMBER_0;
+    public $outerEnumInteger = \app\Models\OuterEnumInteger::NUMBER_0;
 
     /** @var string $outerEnumDefaultValue */
-    private $outerEnumDefaultValue = \app\Models\OuterEnumDefaultValue::PLACED;
+    public $outerEnumDefaultValue = \app\Models\OuterEnumDefaultValue::PLACED;
 
     /** @var int $outerEnumIntegerDefaultValue */
-    private $outerEnumIntegerDefaultValue = \app\Models\OuterEnumIntegerDefaultValue::NUMBER_0;
+    public $outerEnumIntegerDefaultValue = \app\Models\OuterEnumIntegerDefaultValue::NUMBER_0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/EnumTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/EnumTest.php
@@ -10,27 +10,27 @@ namespace app\Models;
 class EnumTest {
 
     /** @var string $enumString */
-    private $enumString;
+    private $enumString = "";
 
     /** @var string $enumStringRequired */
-    private $enumStringRequired;
+    private $enumStringRequired = "";
 
     /** @var int $enumInteger */
-    private $enumInteger;
+    private $enumInteger = 0;
 
     /** @var double $enumNumber */
-    private $enumNumber;
+    private $enumNumber = 0;
 
-    /** @var \app\Models\OuterEnum $outerEnum */
-    private $outerEnum;
+    /** @var string|null $outerEnum */
+    private $outerEnum = null;
 
-    /** @var \app\Models\OuterEnumInteger $outerEnumInteger */
-    private $outerEnumInteger;
+    /** @var int $outerEnumInteger */
+    private $outerEnumInteger = \app\Models\OuterEnumInteger::NUMBER_0;
 
-    /** @var \app\Models\OuterEnumDefaultValue $outerEnumDefaultValue */
-    private $outerEnumDefaultValue;
+    /** @var string $outerEnumDefaultValue */
+    private $outerEnumDefaultValue = \app\Models\OuterEnumDefaultValue::PLACED;
 
-    /** @var \app\Models\OuterEnumIntegerDefaultValue $outerEnumIntegerDefaultValue */
-    private $outerEnumIntegerDefaultValue;
+    /** @var int $outerEnumIntegerDefaultValue */
+    private $outerEnumIntegerDefaultValue = \app\Models\OuterEnumIntegerDefaultValue::NUMBER_0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/File.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/File.php
@@ -11,6 +11,6 @@ namespace app\Models;
 class File {
 
     /** @var string $sourceURI Test capitalization*/
-    private $sourceURI = "";
+    public $sourceURI = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/File.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/File.php
@@ -6,10 +6,11 @@ namespace app\Models;
 
 /**
  * File
+ * @description Must be named `File` for test.
  */
 class File {
 
     /** @var string $sourceURI Test capitalization*/
-    private $sourceURI;
+    private $sourceURI = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/FileSchemaTestClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/FileSchemaTestClass.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class FileSchemaTestClass {
 
     /** @var \app\Models\File $file */
-    private $file;
+    public $file;
 
     /** @var \app\Models\File[] $files */
-    private $files = [];
+    public $files = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/FileSchemaTestClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/FileSchemaTestClass.php
@@ -13,6 +13,6 @@ class FileSchemaTestClass {
     private $file;
 
     /** @var \app\Models\File[] $files */
-    private $files;
+    private $files = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Foo.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Foo.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class Foo {
 
     /** @var string $bar */
-    private $bar = 'bar';
+    public $bar = 'bar';
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Foo.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Foo.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class Foo {
 
     /** @var string $bar */
-    private $bar;
+    private $bar = 'bar';
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/FormatTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/FormatTest.php
@@ -10,51 +10,51 @@ namespace app\Models;
 class FormatTest {
 
     /** @var int $integer */
-    private $integer = 0;
+    public $integer = 0;
 
     /** @var int $int32 */
-    private $int32 = 0;
+    public $int32 = 0;
 
     /** @var int $int64 */
-    private $int64 = 0;
+    public $int64 = 0;
 
     /** @var float $number */
-    private $number = 0;
+    public $number = 0;
 
     /** @var float $float */
-    private $float = 0;
+    public $float = 0;
 
     /** @var double $double */
-    private $double = 0;
+    public $double = 0;
 
     /** @var float $decimal */
-    private $decimal = "";
+    public $decimal = "";
 
     /** @var string $string */
-    private $string = "";
+    public $string = "";
 
     /** @var string $byte */
-    private $byte = "";
+    public $byte = "";
 
     /** @var \SplFileObject $binary */
-    private $binary;
+    public $binary;
 
     /** @var \DateTime $date */
-    private $date;
+    public $date;
 
     /** @var \DateTime $dateTime */
-    private $dateTime;
+    public $dateTime;
 
     /** @var string $uuid */
-    private $uuid = "";
+    public $uuid = "";
 
     /** @var string $password */
-    private $password = "";
+    public $password = "";
 
     /** @var string $patternWithDigits A string that is a 10 digit number. Can have leading zeros.*/
-    private $patternWithDigits = "";
+    public $patternWithDigits = "";
 
     /** @var string $patternWithDigitsAndDelimiter A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.*/
-    private $patternWithDigitsAndDelimiter = "";
+    public $patternWithDigitsAndDelimiter = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/FormatTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/FormatTest.php
@@ -10,31 +10,31 @@ namespace app\Models;
 class FormatTest {
 
     /** @var int $integer */
-    private $integer;
+    private $integer = 0;
 
     /** @var int $int32 */
-    private $int32;
+    private $int32 = 0;
 
     /** @var int $int64 */
-    private $int64;
+    private $int64 = 0;
 
     /** @var float $number */
-    private $number;
+    private $number = 0;
 
     /** @var float $float */
-    private $float;
+    private $float = 0;
 
     /** @var double $double */
-    private $double;
+    private $double = 0;
 
     /** @var float $decimal */
-    private $decimal;
+    private $decimal = "";
 
     /** @var string $string */
-    private $string;
+    private $string = "";
 
     /** @var string $byte */
-    private $byte;
+    private $byte = "";
 
     /** @var \SplFileObject $binary */
     private $binary;
@@ -46,15 +46,15 @@ class FormatTest {
     private $dateTime;
 
     /** @var string $uuid */
-    private $uuid;
+    private $uuid = "";
 
     /** @var string $password */
-    private $password;
+    private $password = "";
 
     /** @var string $patternWithDigits A string that is a 10 digit number. Can have leading zeros.*/
-    private $patternWithDigits;
+    private $patternWithDigits = "";
 
     /** @var string $patternWithDigitsAndDelimiter A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.*/
-    private $patternWithDigitsAndDelimiter;
+    private $patternWithDigitsAndDelimiter = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/HasOnlyReadOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/HasOnlyReadOnly.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class HasOnlyReadOnly {
 
     /** @var string $bar */
-    private $bar;
+    private $bar = "";
 
     /** @var string $foo */
-    private $foo;
+    private $foo = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/HasOnlyReadOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/HasOnlyReadOnly.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class HasOnlyReadOnly {
 
     /** @var string $bar */
-    private $bar = "";
+    public $bar = "";
 
     /** @var string $foo */
-    private $foo = "";
+    public $foo = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/HealthCheckResult.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/HealthCheckResult.php
@@ -6,10 +6,11 @@ namespace app\Models;
 
 /**
  * HealthCheckResult
+ * @description Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
  */
 class HealthCheckResult {
 
-    /** @var string $nullableMessage */
-    private $nullableMessage;
+    /** @var string|null $nullableMessage */
+    private $nullableMessage = null;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/HealthCheckResult.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/HealthCheckResult.php
@@ -11,6 +11,6 @@ namespace app\Models;
 class HealthCheckResult {
 
     /** @var string|null $nullableMessage */
-    private $nullableMessage = null;
+    public $nullableMessage = null;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/InlineResponseDefault.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/InlineResponseDefault.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class InlineResponseDefault {
 
     /** @var \app\Models\Foo $string */
-    private $string;
+    public $string;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/MapTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/MapTest.php
@@ -10,15 +10,15 @@ namespace app\Models;
 class MapTest {
 
     /** @var array<string,array<string,string>> $mapMapOfString */
-    private $mapMapOfString;
+    public $mapMapOfString;
 
     /** @var array<string,string> $mapOfEnumString */
-    private $mapOfEnumString;
+    public $mapOfEnumString;
 
     /** @var array<string,bool> $directMap */
-    private $directMap;
+    public $directMap;
 
     /** @var array<string,bool> $indirectMap */
-    private $indirectMap;
+    public $indirectMap;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -10,7 +10,7 @@ namespace app\Models;
 class MixedPropertiesAndAdditionalPropertiesClass {
 
     /** @var string $uuid */
-    private $uuid;
+    private $uuid = "";
 
     /** @var \DateTime $dateTime */
     private $dateTime;

--- a/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class MixedPropertiesAndAdditionalPropertiesClass {
 
     /** @var string $uuid */
-    private $uuid = "";
+    public $uuid = "";
 
     /** @var \DateTime $dateTime */
-    private $dateTime;
+    public $dateTime;
 
     /** @var array<string,\app\Models\Animal> $map */
-    private $map;
+    public $map;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Model200Response.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Model200Response.php
@@ -6,13 +6,14 @@ namespace app\Models;
 
 /**
  * Model200Response
+ * @description Model for testing model name starting with number
  */
 class Model200Response {
 
     /** @var int $name */
-    private $name;
+    private $name = 0;
 
     /** @var string $class */
-    private $class;
+    private $class = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Model200Response.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Model200Response.php
@@ -11,9 +11,9 @@ namespace app\Models;
 class Model200Response {
 
     /** @var int $name */
-    private $name = 0;
+    public $name = 0;
 
     /** @var string $class */
-    private $class = "";
+    public $class = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ModelList.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ModelList.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class ModelList {
 
     /** @var string $_123list */
-    private $_123list;
+    private $_123list = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ModelList.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ModelList.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class ModelList {
 
     /** @var string $_123list */
-    private $_123list = "";
+    public $_123list = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ModelReturn.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ModelReturn.php
@@ -6,10 +6,11 @@ namespace app\Models;
 
 /**
  * ModelReturn
+ * @description Model for testing reserved words
  */
 class ModelReturn {
 
     /** @var int $return */
-    private $return;
+    private $return = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ModelReturn.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ModelReturn.php
@@ -11,6 +11,6 @@ namespace app\Models;
 class ModelReturn {
 
     /** @var int $return */
-    private $return = 0;
+    public $return = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Name.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Name.php
@@ -6,19 +6,20 @@ namespace app\Models;
 
 /**
  * Name
+ * @description Model for testing model name same as property name
  */
 class Name {
 
     /** @var int $name */
-    private $name;
+    private $name = 0;
 
     /** @var int $snakeCase */
-    private $snakeCase;
+    private $snakeCase = 0;
 
     /** @var string $property */
-    private $property;
+    private $property = "";
 
     /** @var int $_123number */
-    private $_123number;
+    private $_123number = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Name.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Name.php
@@ -11,15 +11,15 @@ namespace app\Models;
 class Name {
 
     /** @var int $name */
-    private $name = 0;
+    public $name = 0;
 
     /** @var int $snakeCase */
-    private $snakeCase = 0;
+    public $snakeCase = 0;
 
     /** @var string $property */
-    private $property = "";
+    public $property = "";
 
     /** @var int $_123number */
-    private $_123number = 0;
+    public $_123number = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
@@ -9,38 +9,38 @@ namespace app\Models;
  */
 class NullableClass {
 
-    /** @var int $integerProp */
-    private $integerProp;
+    /** @var int|null $integerProp */
+    private $integerProp = null;
 
-    /** @var float $numberProp */
-    private $numberProp;
+    /** @var float|null $numberProp */
+    private $numberProp = null;
 
-    /** @var bool $booleanProp */
-    private $booleanProp;
+    /** @var bool|null $booleanProp */
+    private $booleanProp = null;
 
-    /** @var string $stringProp */
-    private $stringProp;
+    /** @var string|null $stringProp */
+    private $stringProp = null;
 
-    /** @var \DateTime $dateProp */
-    private $dateProp;
+    /** @var \DateTime|null $dateProp */
+    private $dateProp = null;
 
-    /** @var \DateTime $datetimeProp */
-    private $datetimeProp;
+    /** @var \DateTime|null $datetimeProp */
+    private $datetimeProp = null;
 
-    /** @var object[] $arrayNullableProp */
-    private $arrayNullableProp;
+    /** @var object[]|null $arrayNullableProp */
+    private $arrayNullableProp = null;
 
-    /** @var object[] $arrayAndItemsNullableProp */
-    private $arrayAndItemsNullableProp;
+    /** @var object[]|null $arrayAndItemsNullableProp */
+    private $arrayAndItemsNullableProp = null;
 
     /** @var object[] $arrayItemsNullable */
-    private $arrayItemsNullable;
+    private $arrayItemsNullable = [];
 
-    /** @var array<string,object> $objectNullableProp */
-    private $objectNullableProp;
+    /** @var array<string,object>|null $objectNullableProp */
+    private $objectNullableProp = null;
 
-    /** @var array<string,object> $objectAndItemsNullableProp */
-    private $objectAndItemsNullableProp;
+    /** @var array<string,object>|null $objectAndItemsNullableProp */
+    private $objectAndItemsNullableProp = null;
 
     /** @var array<string,object> $objectItemsNullable */
     private $objectItemsNullable;

--- a/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
@@ -10,39 +10,39 @@ namespace app\Models;
 class NullableClass {
 
     /** @var int|null $integerProp */
-    private $integerProp = null;
+    public $integerProp = null;
 
     /** @var float|null $numberProp */
-    private $numberProp = null;
+    public $numberProp = null;
 
     /** @var bool|null $booleanProp */
-    private $booleanProp = null;
+    public $booleanProp = null;
 
     /** @var string|null $stringProp */
-    private $stringProp = null;
+    public $stringProp = null;
 
     /** @var \DateTime|null $dateProp */
-    private $dateProp = null;
+    public $dateProp = null;
 
     /** @var \DateTime|null $datetimeProp */
-    private $datetimeProp = null;
+    public $datetimeProp = null;
 
     /** @var object[]|null $arrayNullableProp */
-    private $arrayNullableProp = null;
+    public $arrayNullableProp = null;
 
     /** @var object[]|null $arrayAndItemsNullableProp */
-    private $arrayAndItemsNullableProp = null;
+    public $arrayAndItemsNullableProp = null;
 
     /** @var object[] $arrayItemsNullable */
-    private $arrayItemsNullable = [];
+    public $arrayItemsNullable = [];
 
     /** @var array<string,object>|null $objectNullableProp */
-    private $objectNullableProp = null;
+    public $objectNullableProp = null;
 
     /** @var array<string,object>|null $objectAndItemsNullableProp */
-    private $objectAndItemsNullableProp = null;
+    public $objectAndItemsNullableProp = null;
 
     /** @var array<string,object> $objectItemsNullable */
-    private $objectItemsNullable;
+    public $objectItemsNullable;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/NumberOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/NumberOnly.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class NumberOnly {
 
     /** @var float $justNumber */
-    private $justNumber = 0;
+    public $justNumber = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/NumberOnly.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/NumberOnly.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class NumberOnly {
 
     /** @var float $justNumber */
-    private $justNumber;
+    private $justNumber = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ObjectWithDeprecatedFields.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ObjectWithDeprecatedFields.php
@@ -10,11 +10,11 @@ namespace app\Models;
 class ObjectWithDeprecatedFields {
 
     /** @var string $uuid */
-    private $uuid;
+    private $uuid = "";
 
     /** @var float $id */
     /** @deprecated */
-    private $id;
+    private $id = 0;
 
     /** @var \app\Models\DeprecatedObject $deprecatedRef */
     /** @deprecated */
@@ -22,6 +22,6 @@ class ObjectWithDeprecatedFields {
 
     /** @var string[] $bars */
     /** @deprecated */
-    private $bars;
+    private $bars = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ObjectWithDeprecatedFields.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ObjectWithDeprecatedFields.php
@@ -10,18 +10,18 @@ namespace app\Models;
 class ObjectWithDeprecatedFields {
 
     /** @var string $uuid */
-    private $uuid = "";
+    public $uuid = "";
 
     /** @var float $id */
     /** @deprecated */
-    private $id = 0;
+    public $id = 0;
 
     /** @var \app\Models\DeprecatedObject $deprecatedRef */
     /** @deprecated */
-    private $deprecatedRef;
+    public $deprecatedRef;
 
     /** @var string[] $bars */
     /** @deprecated */
-    private $bars = [];
+    public $bars = [];
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Order.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Order.php
@@ -10,21 +10,21 @@ namespace app\Models;
 class Order {
 
     /** @var int $id */
-    private $id = 0;
+    public $id = 0;
 
     /** @var int $petId */
-    private $petId = 0;
+    public $petId = 0;
 
     /** @var int $quantity */
-    private $quantity = 0;
+    public $quantity = 0;
 
     /** @var \DateTime $shipDate */
-    private $shipDate;
+    public $shipDate;
 
     /** @var string $status Order Status*/
-    private $status = "";
+    public $status = "";
 
     /** @var bool $complete */
-    private $complete = false;
+    public $complete = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Order.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Order.php
@@ -10,21 +10,21 @@ namespace app\Models;
 class Order {
 
     /** @var int $id */
-    private $id;
+    private $id = 0;
 
     /** @var int $petId */
-    private $petId;
+    private $petId = 0;
 
     /** @var int $quantity */
-    private $quantity;
+    private $quantity = 0;
 
     /** @var \DateTime $shipDate */
     private $shipDate;
 
     /** @var string $status Order Status*/
-    private $status;
+    private $status = "";
 
     /** @var bool $complete */
-    private $complete;
+    private $complete = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterComposite.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterComposite.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class OuterComposite {
 
     /** @var float $myNumber */
-    private $myNumber;
+    private $myNumber = 0;
 
     /** @var string $myString */
-    private $myString;
+    private $myString = "";
 
     /** @var bool $myBoolean */
-    private $myBoolean;
+    private $myBoolean = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterComposite.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterComposite.php
@@ -10,12 +10,12 @@ namespace app\Models;
 class OuterComposite {
 
     /** @var float $myNumber */
-    private $myNumber = 0;
+    public $myNumber = 0;
 
     /** @var string $myString */
-    private $myString = "";
+    public $myString = "";
 
     /** @var bool $myBoolean */
-    private $myBoolean = false;
+    public $myBoolean = false;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterEnum.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterEnum.php
@@ -7,6 +7,27 @@ namespace app\Models;
 /**
  * OuterEnum
  */
-class OuterEnum {
+class OuterEnum
+{
+    /**
+     * Possible values of this enum
+     */
+    const PLACED = 'placed';
 
+    const APPROVED = 'approved';
+
+    const DELIVERED = 'delivered';
+
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public static function getAllowableEnumValues()
+    {
+        return [
+            self::PLACED,
+            self::APPROVED,
+            self::DELIVERED
+        ];
+    }
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterEnumDefaultValue.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterEnumDefaultValue.php
@@ -7,6 +7,27 @@ namespace app\Models;
 /**
  * OuterEnumDefaultValue
  */
-class OuterEnumDefaultValue {
+class OuterEnumDefaultValue
+{
+    /**
+     * Possible values of this enum
+     */
+    const PLACED = 'placed';
 
+    const APPROVED = 'approved';
+
+    const DELIVERED = 'delivered';
+
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public static function getAllowableEnumValues()
+    {
+        return [
+            self::PLACED,
+            self::APPROVED,
+            self::DELIVERED
+        ];
+    }
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterEnumInteger.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterEnumInteger.php
@@ -7,6 +7,27 @@ namespace app\Models;
 /**
  * OuterEnumInteger
  */
-class OuterEnumInteger {
+class OuterEnumInteger
+{
+    /**
+     * Possible values of this enum
+     */
+    const NUMBER_0 = 0;
 
+    const NUMBER_1 = 1;
+
+    const NUMBER_2 = 2;
+
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public static function getAllowableEnumValues()
+    {
+        return [
+            self::NUMBER_0,
+            self::NUMBER_1,
+            self::NUMBER_2
+        ];
+    }
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterEnumIntegerDefaultValue.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterEnumIntegerDefaultValue.php
@@ -7,6 +7,27 @@ namespace app\Models;
 /**
  * OuterEnumIntegerDefaultValue
  */
-class OuterEnumIntegerDefaultValue {
+class OuterEnumIntegerDefaultValue
+{
+    /**
+     * Possible values of this enum
+     */
+    const NUMBER_0 = 0;
 
+    const NUMBER_1 = 1;
+
+    const NUMBER_2 = 2;
+
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public static function getAllowableEnumValues()
+    {
+        return [
+            self::NUMBER_0,
+            self::NUMBER_1,
+            self::NUMBER_2
+        ];
+    }
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterObjectWithEnumProperty.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterObjectWithEnumProperty.php
@@ -9,7 +9,7 @@ namespace app\Models;
  */
 class OuterObjectWithEnumProperty {
 
-    /** @var \app\Models\OuterEnumInteger $value */
-    private $value;
+    /** @var int $value */
+    private $value = \app\Models\OuterEnumInteger::NUMBER_0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/OuterObjectWithEnumProperty.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/OuterObjectWithEnumProperty.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class OuterObjectWithEnumProperty {
 
     /** @var int $value */
-    private $value = \app\Models\OuterEnumInteger::NUMBER_0;
+    public $value = \app\Models\OuterEnumInteger::NUMBER_0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Pet.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Pet.php
@@ -10,21 +10,21 @@ namespace app\Models;
 class Pet {
 
     /** @var int $id */
-    private $id = 0;
+    public $id = 0;
 
     /** @var \app\Models\Category $category */
-    private $category;
+    public $category;
 
     /** @var string $name */
-    private $name = "";
+    public $name = "";
 
     /** @var string[] $photoUrls */
-    private $photoUrls = [];
+    public $photoUrls = [];
 
     /** @var \app\Models\Tag[] $tags */
-    private $tags = [];
+    public $tags = [];
 
     /** @var string $status pet status in the store*/
-    private $status = "";
+    public $status = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Pet.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Pet.php
@@ -10,21 +10,21 @@ namespace app\Models;
 class Pet {
 
     /** @var int $id */
-    private $id;
+    private $id = 0;
 
     /** @var \app\Models\Category $category */
     private $category;
 
     /** @var string $name */
-    private $name;
+    private $name = "";
 
     /** @var string[] $photoUrls */
-    private $photoUrls;
+    private $photoUrls = [];
 
     /** @var \app\Models\Tag[] $tags */
-    private $tags;
+    private $tags = [];
 
     /** @var string $status pet status in the store*/
-    private $status;
+    private $status = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ReadOnlyFirst.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ReadOnlyFirst.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class ReadOnlyFirst {
 
     /** @var string $bar */
-    private $bar = "";
+    public $bar = "";
 
     /** @var string $baz */
-    private $baz = "";
+    public $baz = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/ReadOnlyFirst.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ReadOnlyFirst.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class ReadOnlyFirst {
 
     /** @var string $bar */
-    private $bar;
+    private $bar = "";
 
     /** @var string $baz */
-    private $baz;
+    private $baz = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/SpecialModelName.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/SpecialModelName.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class SpecialModelName {
 
     /** @var int $specialPropertyName */
-    private $specialPropertyName;
+    private $specialPropertyName = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/SpecialModelName.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/SpecialModelName.php
@@ -10,6 +10,6 @@ namespace app\Models;
 class SpecialModelName {
 
     /** @var int $specialPropertyName */
-    private $specialPropertyName = 0;
+    public $specialPropertyName = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Tag.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Tag.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class Tag {
 
     /** @var int $id */
-    private $id = 0;
+    public $id = 0;
 
     /** @var string $name */
-    private $name = "";
+    public $name = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/Tag.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/Tag.php
@@ -10,9 +10,9 @@ namespace app\Models;
 class Tag {
 
     /** @var int $id */
-    private $id;
+    private $id = 0;
 
     /** @var string $name */
-    private $name;
+    private $name = "";
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/User.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/User.php
@@ -10,27 +10,27 @@ namespace app\Models;
 class User {
 
     /** @var int $id */
-    private $id = 0;
+    public $id = 0;
 
     /** @var string $username */
-    private $username = "";
+    public $username = "";
 
     /** @var string $firstName */
-    private $firstName = "";
+    public $firstName = "";
 
     /** @var string $lastName */
-    private $lastName = "";
+    public $lastName = "";
 
     /** @var string $email */
-    private $email = "";
+    public $email = "";
 
     /** @var string $password */
-    private $password = "";
+    public $password = "";
 
     /** @var string $phone */
-    private $phone = "";
+    public $phone = "";
 
     /** @var int $userStatus User Status*/
-    private $userStatus = 0;
+    public $userStatus = 0;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/User.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/User.php
@@ -10,27 +10,27 @@ namespace app\Models;
 class User {
 
     /** @var int $id */
-    private $id;
+    private $id = 0;
 
     /** @var string $username */
-    private $username;
+    private $username = "";
 
     /** @var string $firstName */
-    private $firstName;
+    private $firstName = "";
 
     /** @var string $lastName */
-    private $lastName;
+    private $lastName = "";
 
     /** @var string $email */
-    private $email;
+    private $email = "";
 
     /** @var string $password */
-    private $password;
+    private $password = "";
 
     /** @var string $phone */
-    private $phone;
+    private $phone = "";
 
     /** @var int $userStatus User Status*/
-    private $userStatus;
+    private $userStatus = 0;
 
 }


### PR DESCRIPTION
+ support for enum models & separating mustache templates for enums and generics
+ extract property 'type' and 'default value' from a #ref to an enum model
+ support for `PascalCase` naming convention for PHP generators
+ use a default value for known basic types when they are not nullable
+ use 'null' as default value for nullable types when they do not specify the default value
+ use defined constant path as enum default value when found

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee] @sgadouar @wing328 