### PR TITLE
[php-symfony] Allow non mandatory array value in Symfony

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -87,6 +87,11 @@ class JmsSerializer implements SerializerInterface
 
     private function deserializeArrayString($format, $type, $data)
     {
+        if($data === null)
+        {
+            return [];
+        }
+
         // Parse the string using the correct separator
         switch ($format) {
             case 'csv':

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
@@ -87,6 +87,11 @@ class JmsSerializer implements SerializerInterface
 
     private function deserializeArrayString($format, $type, $data)
     {
+        if($data === null)
+        {
+            return [];
+        }
+
         // Parse the string using the correct separator
         switch ($format) {
             case 'csv':


### PR DESCRIPTION
Hello,

We have an issue when a parameter is not set in a get query.
In file Service/JmsSerializer.php, the `deserializeArrayString` method does not check for null value.

If value is null, the returned data is an array with 1 element:
```
array(1) {
[0]=>
string(0) ""
}
```
This value the fails validation.

Returning null for a null input corrects the issue.

Mentionning contributors as requested:
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @ybelenko, @renepardon
