### PR TITLE
[#4650] Fix StackOverflowError for recursive composite schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -629,14 +629,14 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
         }
         for (Schema sc : oneOfanyOfSchemas) {
             Schema refSchema = ModelUtils.getReferencedSchema(this.openAPI, sc);
-            addProperties(otherProperties, otherRequired, refSchema);
+            addProperties(otherProperties, otherRequired, refSchema, new HashSet<>());
         }
         Set<String> otherRequiredSet = new HashSet<>(otherRequired);
 
         List<Schema> allOf = cs.getAllOf();
         if ((schema.getProperties() != null && !schema.getProperties().isEmpty()) || allOf != null) {
             // NOTE: this function also adds the allOf properties inside schema
-            addProperties(selfProperties, selfRequired, schema);
+            addProperties(selfProperties, selfRequired, schema, new HashSet<>());
         }
         if (result.discriminator != null) {
             selfRequired.add(result.discriminator.getPropertyBaseName());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -744,4 +744,24 @@ public class DefaultGeneratorTest {
             templates.toFile().delete();
         }
     }
+
+    @Test
+    public void testRecursionBug4650() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/bugs/recursion-bug-4650.yaml");
+        ClientOptInput opts = new ClientOptInput();
+        opts.openAPI(openAPI);
+        DefaultCodegen config = new DefaultCodegen();
+        config.setStrictSpecBehavior(false);
+        opts.config(config);
+        final DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(opts);
+        generator.configureGeneratorProperties();
+
+        List<File> files = new ArrayList<>();
+        List<String> filteredSchemas = ModelUtils.getSchemasUsedOnlyInFormParam(openAPI);
+        List<Object> allModels = new ArrayList<>();
+        // The bug causes a StackOverflowError when calling generateModels
+        generator.generateModels(files, allModels, filteredSchemas);
+        // all fine, we have passed
+    }
 }

--- a/modules/openapi-generator/src/test/resources/bugs/recursion-bug-4650.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/recursion-bug-4650.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.1
+info:
+  title: Test
+  version: v1
+paths:
+  /api/v1/filters:
+    get:
+      responses:
+        '200':
+          description: default response
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Filter'
+components:
+  schemas:
+    AndFilter:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Filter'
+        - type: object
+          properties:
+            operator:
+              type: string
+              default: and
+              enum:
+                - and
+                - or
+            filters:
+              type: array
+              items:
+                $ref: '#/components/schemas/Filter'
+    Filter:
+      type: object
+      properties:
+        operator:
+          type: string
+          enum:
+            - and
+            - or
+      example:
+        operator: eq
+        field: name
+        value: john
+      discriminator:
+        propertyName: operator
+        mapping:
+          and: '#/components/schemas/AndFilter'
+          or: '#/components/schemas/OrFilter'
+      oneOf:
+        - $ref: '#/components/schemas/AndFilter'
+        - $ref: '#/components/schemas/OrFilter'
+    OrFilter:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Filter'
+        - type: object
+          properties:
+            operator:
+              type: string
+              default: or
+              enum:
+                - and
+                - or


### PR DESCRIPTION
The generator ran into a loop when a composite schema recursively added itself. This change provides a reproducing example and fixes the issue by extending DefaultCodegen#addProperties() by an additional circuit breaker parameter.

When additionalProperties() is called with a schema instance for which the properties have already been added, the method directly returns and does not run into the loop.

To fix #4650