### PR TITLE
[#11323] Fixed wrong clearing of CodegenModel#hasEnum field

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5181,7 +5181,6 @@ public class DefaultCodegen implements CodegenConfig {
         m.hasRequired = false;
         if (properties != null && !properties.isEmpty()) {
             m.hasVars = true;
-            m.hasEnums = false; // TODO need to fix as its false in both cases
 
             Set<String> mandatory = required == null ? Collections.emptySet()
                     : new TreeSet<>(required);
@@ -5192,7 +5191,7 @@ public class DefaultCodegen implements CodegenConfig {
         } else {
             m.emptyVars = true;
             m.hasVars = false;
-            m.hasEnums = false; // TODO need to fix as its false in both cases
+            m.hasEnums = false;
         }
 
         if (allProperties != null) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -938,5 +938,33 @@ public class SpringCodegenTest {
         Assert.assertTrue(codegen.apiTemplateFiles().isEmpty());
     }
 
+    @Test
+    public void testIssue11323() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
 
+        OpenAPI openAPI = new OpenAPIParser()
+              .readLocation("src/test/resources/3_0/spring/issue_11323.yml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        //codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Address.java"),
+              "@JsonValue", "import com.fasterxml.jackson.annotation.JsonValue;");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_11323.yml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_11323.yml
@@ -1,0 +1,41 @@
+openapi: 3.0.1
+info:
+  title: Test Issue #11323
+  version: v1
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: default response
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Address'
+components:
+  schemas:
+    Address:
+      type: object
+      properties:
+        locationType:
+          type: string
+          enum:
+            - VILLAGE
+            - SMALL_TOWN
+            - BIG_CITY
+      allOf:
+        - $ref: '#/components/schemas/BasicAddress'
+
+    BasicAddress:
+      type: object
+      properties:
+        street:
+          type: string
+        housenumber:
+          type: string
+        zip:
+          type: string
+        city:
+          type: string
+        country:
+          type: string


### PR DESCRIPTION
A CodegenModel's hasEnum property is set in addVars:
  cm.hasEnums = true;
This state was cleared afterwards again.

As one of its results the import for @JsonValue was not added for the model class in the Spring code generator, where 'model.hasEnums' was evaluated to false where it should be true.

Added a test case with the model provided in the issue that reproduces the problem.