### PR TITLE
#8961: add @ts-ignore to the lines before an unused import or value is or might be

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -4,15 +4,9 @@
 
 import * as runtime from '../runtime';
 {{#imports.0}}
-import {
-    {{#imports}}
-    {{className}},
-    {{^withoutRuntimeChecks}}
-    {{className}}FromJSON,
-    {{className}}ToJSON,
-    {{/withoutRuntimeChecks}}
-    {{/imports}}
-} from '../models';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{#imports}}{{className}}{{^withoutRuntimeChecks}}, {{className}}FromJSON, {{className}}ToJSON{{/withoutRuntimeChecks}}{{^-last}}, {{/-last}}{{/imports}} } from '../models';
 {{/imports.0}}
 
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -4,8 +4,7 @@
 
 import * as runtime from '../runtime';
 {{#imports.0}}
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{#imports}}{{className}}{{^withoutRuntimeChecks}}, {{className}}FromJSON, {{className}}ToJSON{{/withoutRuntimeChecks}}{{^-last}}, {{/-last}}{{/imports}} } from '../models';
 {{/imports.0}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -4,8 +4,7 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
     return {{classname}}FromJSONTyped(json, false);
 }
 
-// ignoreDiscriminator not used
-// @ts-ignore
+// @ts-ignore: ignoreDiscriminator not used
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
     return json as {{classname}};
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -4,6 +4,8 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
     return {{classname}}FromJSONTyped(json, false);
 }
 
+// ignoreDiscriminator not used
+// @ts-ignore
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
     return json as {{classname}};
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -1,17 +1,14 @@
-// Some or all imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 {{#hasImports}}
 {{#imports}}
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{{.}}}, {{.}}FromJSON, {{.}}FromJSONTyped, {{.}}ToJSON } from './{{.}}';
 {{/imports}}
 
 {{/hasImports}}
 {{#discriminator}}
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{#discriminator.mappedModels}}{{modelName}}FromJSONTyped{{^-last}}, {{/-last}}{{/discriminator.mappedModels}} } from './';
 
 {{/discriminator}}
@@ -21,8 +18,7 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
     return {{classname}}FromJSONTyped(json, false);
 }
 
-// ignoreDiscriminator not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: ignoreDiscriminator may be unused
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
     {{#hasVars}}
     if ((json === undefined) || (json === null)) {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -1,21 +1,18 @@
+// Some or all imports not used depending on template conditions
+// @ts-ignore
 import { exists, mapValues } from '../runtime';
 {{#hasImports}}
 {{#imports}}
-import {
-    {{{.}}},
-    {{.}}FromJSON,
-    {{.}}FromJSONTyped,
-    {{.}}ToJSON,
-} from './{{.}}';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{{.}}}, {{.}}FromJSON, {{.}}FromJSONTyped, {{.}}ToJSON } from './{{.}}';
 {{/imports}}
 
 {{/hasImports}}
 {{#discriminator}}
-import {
-{{#discriminator.mappedModels}}
-     {{modelName}}FromJSONTyped{{^-last}},{{/-last}}
-{{/discriminator.mappedModels}}
-} from './';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{#discriminator.mappedModels}}{{modelName}}FromJSONTyped{{^-last}}, {{/-last}}{{/discriminator.mappedModels}} } from './';
 
 {{/discriminator}}
 {{>modelGenericInterfaces}}
@@ -24,6 +21,8 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
     return {{classname}}FromJSONTyped(json, false);
 }
 
+// ignoreDiscriminator not used depending on template conditions
+// @ts-ignore
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
     {{#hasVars}}
     if ((json === undefined) || (json === null)) {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -1,11 +1,8 @@
 {{#hasImports}}
 {{#oneOf}}
-import {
-    {{{.}}},
-    {{{.}}}FromJSON,
-    {{{.}}}FromJSONTyped,
-    {{{.}}}ToJSON,
-} from './{{.}}';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{{.}}}, {{{.}}}FromJSON, {{{.}}}FromJSONTyped, {{{.}}}ToJSON, } from './{{.}}';
 {{/oneOf}}
 
 {{/hasImports}}
@@ -15,6 +12,8 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
     return {{classname}}FromJSONTyped(json, false);
 }
 
+// ignoreDiscriminator not used depending on template conditions
+// @ts-ignore
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -1,7 +1,6 @@
 {{#hasImports}}
 {{#oneOf}}
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{{.}}}, {{{.}}}FromJSON, {{{.}}}FromJSONTyped, {{{.}}}ToJSON, } from './{{.}}';
 {{/oneOf}}
 
@@ -12,8 +11,7 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
     return {{classname}}FromJSONTyped(json, false);
 }
 
-// ignoreDiscriminator not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: ignoreDiscriminator may be unused
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
@@ -1,30 +1,23 @@
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories{{#returnPassthrough}}, appFromJS, NormalizedRecordEntities{{/returnPassthrough}}} from "../runtimeSagasAndRecords";
-// Import not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{classname}}{{#vars}}{{#isEnum}}, {{classname}}{{enumName}}{{/isEnum}}{{/vars}} } from './{{classname}}';
 
 {{#imports}}
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{{.}}} } from './{{{.}}}';
 {{/imports}}
 
 {{#modelImports}}
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{{.}}}Record, {{#lambda.camelcase}}{{.}}{{/lambda.camelcase}}RecordUtils } from './{{{.}}}Record';
 {{/modelImports}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
@@ -1,29 +1,31 @@
+// Some imports not used depending on template conditions
+// @ts-ignore
 import {ApiRecordUtils, knownRecordFactories{{#returnPassthrough}}, appFromJS, NormalizedRecordEntities{{/returnPassthrough}}} from "../runtimeSagasAndRecords";
+// Import not used depending on template conditions
+// @ts-ignore
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// Some imports not used depending on template conditions
+// @ts-ignore
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// Some imports not used depending on template conditions
+// @ts-ignore
 import {select, call} from "redux-saga/effects";
 
-import {
-    {{classname}},
-{{#vars}}
-{{#isEnum}}
-    {{classname}}{{enumName}},
-{{/isEnum}}
-{{/vars}}
-} from './{{classname}}';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{classname}}{{#vars}}{{#isEnum}}, {{classname}}{{enumName}}{{/isEnum}}{{/vars}} } from './{{classname}}';
 
 {{#imports}}
-import {
-    {{{.}}},
-} from './{{{.}}}';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{{.}}} } from './{{{.}}}';
 {{/imports}}
 
 {{#modelImports}}
-import {
-    {{{.}}}Record,
-    {{#lambda.camelcase}}{{.}}{{/lambda.camelcase}}RecordUtils
-} from './{{{.}}}Record';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{{.}}}Record, {{#lambda.camelcase}}{{.}}{{/lambda.camelcase}}RecordUtils } from './{{{.}}}Record';
 {{/modelImports}}
 
 export const {{classname}}RecordProps = {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtimeSagasAndRecords.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtimeSagasAndRecords.mustache
@@ -1,6 +1,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+// Some imports not used depending on template conditions
+// @ts-ignore
 import {fromJS as originalFromJS, isIndexed, List, Map as ImmMap, RecordOf} from 'immutable';
 import {normalize, NormalizedSchema, schema, Schema} from "normalizr";
 import {ActionDefinition, createAction} from "redux-ts-simple";

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtimeSagasAndRecords.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtimeSagasAndRecords.mustache
@@ -1,9 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-// Some imports not used depending on template conditions
-// @ts-ignore
-import {fromJS as originalFromJS, isIndexed, List, Map as ImmMap, RecordOf} from 'immutable';
+import {fromJS as originalFromJS, isIndexed, List, RecordOf} from 'immutable';
 import {normalize, NormalizedSchema, schema, Schema} from "normalizr";
 import {ActionDefinition, createAction} from "redux-ts-simple";
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/sagaApiManager.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/sagaApiManager.mustache
@@ -1,9 +1,7 @@
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { Configuration, ConfigurationParameters } from "../";
 
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{#apiInfo}}{{#apis}}{{classFilename}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}} } from "./";
 
 export class Api {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/sagaApiManager.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/sagaApiManager.mustache
@@ -1,15 +1,10 @@
-import {
-    Configuration,
-    ConfigurationParameters,
-} from "../";
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { Configuration, ConfigurationParameters } from "../";
 
-import {
-{{#apiInfo}}
-{{#apis}}
-    {{classFilename}},
-{{/apis}}
-{{/apiInfo}}
-} from "./";
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{#apiInfo}}{{#apis}}{{classFilename}}{{^-last}}, {{/-last}}{{/apis}}{{/apiInfo}} } from "./";
 
 export class Api {
 {{#apiInfo}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
@@ -2,25 +2,19 @@
 /* eslint-disable */
 {{>licenseInfo}}
 
-// Import not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: import may be unused
 import {Api} from './';
-// Import not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: import may be unused
 import {List} from 'immutable';
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import {all, fork, put, takeLatest} from "redux-saga/effects";
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import {apiCall, createSagaAction as originalCreateSagaAction, BaseEntitySupportPayloadApiAction, BasePayloadApiAction, NormalizedRecordEntities, normalizedEntities} from "../runtimeSagasAndRecords";
-// Import not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: import may be unused
 import {Action} from "redux-ts-simple";
 
 {{#imports.0}}
-// Some imports not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: some imports may be unused
 import { {{#imports}}{{className}}, {{className}}Record, {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}RecordUtils{{^-last}}, {{/-last}}{{/imports}}{{#passthroughImports}}, {{.}}{{/passthroughImports}} } from '../models';
 {{/imports.0}}
 {{#hasEnums}}
@@ -29,8 +23,7 @@ import { {{#imports}}{{className}}, {{className}}Record, {{#lambda.camelcase}}{{
 {{#allParams}}
 {{#isEnum}}
 
-// Import not used depending on template conditions
-// @ts-ignore
+// @ts-ignore: import may be unused
 import { {{operationIdCamelCase}}{{enumName}} } from './{{classname}}';
 {{/isEnum}}
 {{/allParams}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/sagas.mustache
@@ -2,23 +2,26 @@
 /* eslint-disable */
 {{>licenseInfo}}
 
+// Import not used depending on template conditions
+// @ts-ignore
 import {Api} from './';
+// Import not used depending on template conditions
+// @ts-ignore
 import {List} from 'immutable';
+// Some imports not used depending on template conditions
+// @ts-ignore
 import {all, fork, put, takeLatest} from "redux-saga/effects";
+// Some imports not used depending on template conditions
+// @ts-ignore
 import {apiCall, createSagaAction as originalCreateSagaAction, BaseEntitySupportPayloadApiAction, BasePayloadApiAction, NormalizedRecordEntities, normalizedEntities} from "../runtimeSagasAndRecords";
+// Import not used depending on template conditions
+// @ts-ignore
 import {Action} from "redux-ts-simple";
 
 {{#imports.0}}
-import {
-    {{#imports}}
-    {{className}},
-    {{className}}Record,
-    {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}RecordUtils,
-    {{/imports}}
-    {{#passthroughImports}}
-    {{.}},
-    {{/passthroughImports}}
-} from '../models';
+// Some imports not used depending on template conditions
+// @ts-ignore
+import { {{#imports}}{{className}}, {{className}}Record, {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}RecordUtils{{^-last}}, {{/-last}}{{/imports}}{{#passthroughImports}}, {{.}}{{/passthroughImports}} } from '../models';
 {{/imports.0}}
 {{#hasEnums}}
 {{#operations}}
@@ -26,9 +29,9 @@ import {
 {{#allParams}}
 {{#isEnum}}
 
-import {
-    {{operationIdCamelCase}}{{enumName}},
-} from './{{classname}}';
+// Import not used depending on template conditions
+// @ts-ignore
+import { {{operationIdCamelCase}}{{enumName}} } from './{{classname}}';
 {{/isEnum}}
 {{/allParams}}
 {{/operation}}

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Client,
-    ClientFromJSON,
-    ClientToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Client, ClientFromJSON, ClientToJSON } from '../models';
 
 export interface 123testSpecialTagsRequest {
     client: Client;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    InlineResponseDefault,
-    InlineResponseDefaultFromJSON,
-    InlineResponseDefaultToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { InlineResponseDefault, InlineResponseDefaultFromJSON, InlineResponseDefaultToJSON } from '../models';
 
 /**
  * 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -14,29 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Client,
-    ClientFromJSON,
-    ClientToJSON,
-    FileSchemaTestClass,
-    FileSchemaTestClassFromJSON,
-    FileSchemaTestClassToJSON,
-    HealthCheckResult,
-    HealthCheckResultFromJSON,
-    HealthCheckResultToJSON,
-    OuterComposite,
-    OuterCompositeFromJSON,
-    OuterCompositeToJSON,
-    OuterObjectWithEnumProperty,
-    OuterObjectWithEnumPropertyFromJSON,
-    OuterObjectWithEnumPropertyToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Client, ClientFromJSON, ClientToJSON, FileSchemaTestClass, FileSchemaTestClassFromJSON, FileSchemaTestClassToJSON, HealthCheckResult, HealthCheckResultFromJSON, HealthCheckResultToJSON, OuterComposite, OuterCompositeFromJSON, OuterCompositeToJSON, OuterObjectWithEnumProperty, OuterObjectWithEnumPropertyFromJSON, OuterObjectWithEnumPropertyToJSON, Pet, PetFromJSON, PetToJSON, User, UserFromJSON, UserToJSON } from '../models';
 
 export interface FakeHttpSignatureTestRequest {
     pet: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Client,
-    ClientFromJSON,
-    ClientToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Client, ClientFromJSON, ClientToJSON } from '../models';
 
 export interface TestClassnameRequest {
     client: Client;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface AddPetRequest {
     pet: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     user: User;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -37,6 +38,7 @@ export function AdditionalPropertiesClassFromJSON(json: any): AdditionalProperti
     return AdditionalPropertiesClassFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): AdditionalPropertiesClass {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -12,11 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-     CatFromJSONTyped,
-     DogFromJSONTyped
-} from './';
+// @ts-ignore: some imports may be unused
+import { CatFromJSONTyped, DogFromJSONTyped } from './';
 
 /**
  * 
@@ -42,6 +41,7 @@ export function AnimalFromJSON(json: any): Animal {
     return AnimalFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): Animal {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function ArrayOfArrayOfNumberOnlyFromJSON(json: any): ArrayOfArrayOfNumbe
     return ArrayOfArrayOfNumberOnlyFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayOfArrayOfNumberOnly {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function ArrayOfNumberOnlyFromJSON(json: any): ArrayOfNumberOnly {
     return ArrayOfNumberOnlyFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayOfNumberOnly {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    ReadOnlyFirst,
-    ReadOnlyFirstFromJSON,
-    ReadOnlyFirstFromJSONTyped,
-    ReadOnlyFirstToJSON,
-} from './ReadOnlyFirst';
+// @ts-ignore: some imports may be unused
+import { ReadOnlyFirst, ReadOnlyFirstFromJSON, ReadOnlyFirstFromJSONTyped, ReadOnlyFirstToJSON } from './ReadOnlyFirst';
 
 /**
  * 
@@ -50,6 +47,7 @@ export function ArrayTestFromJSON(json: any): ArrayTest {
     return ArrayTestFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayTest {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -61,6 +62,7 @@ export function CapitalizationFromJSON(json: any): Capitalization {
     return CapitalizationFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: boolean): Capitalization {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Animal,
-    AnimalFromJSON,
-    AnimalFromJSONTyped,
-    AnimalToJSON,
-} from './Animal';
-import {
-    CatAllOf,
-    CatAllOfFromJSON,
-    CatAllOfFromJSONTyped,
-    CatAllOfToJSON,
-} from './CatAllOf';
+// @ts-ignore: some imports may be unused
+import { Animal, AnimalFromJSON, AnimalFromJSONTyped, AnimalToJSON } from './Animal';
+// @ts-ignore: some imports may be unused
+import { CatAllOf, CatAllOfFromJSON, CatAllOfFromJSONTyped, CatAllOfToJSON } from './CatAllOf';
 
 /**
  * 
@@ -44,6 +37,7 @@ export function CatFromJSON(json: any): Cat {
     return CatFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/CatAllOf.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/CatAllOf.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function CatAllOfFromJSON(json: any): CatAllOf {
     return CatAllOfFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CatAllOfFromJSONTyped(json: any, ignoreDiscriminator: boolean): CatAllOf {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Model for testing model with "_class" property
@@ -31,6 +32,7 @@ export function ClassModelFromJSON(json: any): ClassModel {
     return ClassModelFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean): ClassModel {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function ClientFromJSON(json: any): Client {
     return ClientFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Client {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function DeprecatedObjectFromJSON(json: any): DeprecatedObject {
     return DeprecatedObjectFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): DeprecatedObject {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Animal,
-    AnimalFromJSON,
-    AnimalFromJSONTyped,
-    AnimalToJSON,
-} from './Animal';
-import {
-    DogAllOf,
-    DogAllOfFromJSON,
-    DogAllOfFromJSONTyped,
-    DogAllOfToJSON,
-} from './DogAllOf';
+// @ts-ignore: some imports may be unused
+import { Animal, AnimalFromJSON, AnimalFromJSONTyped, AnimalToJSON } from './Animal';
+// @ts-ignore: some imports may be unused
+import { DogAllOf, DogAllOfFromJSON, DogAllOfFromJSONTyped, DogAllOfToJSON } from './DogAllOf';
 
 /**
  * 
@@ -44,6 +37,7 @@ export function DogFromJSON(json: any): Dog {
     return DogFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DogAllOf.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DogAllOf.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function DogAllOfFromJSON(json: any): DogAllOf {
     return DogAllOfFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function DogAllOfFromJSONTyped(json: any, ignoreDiscriminator: boolean): DogAllOf {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -53,6 +54,7 @@ export function EnumArraysFromJSON(json: any): EnumArrays {
     return EnumArraysFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumArrays {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -27,6 +27,7 @@ export function EnumClassFromJSON(json: any): EnumClass {
     return EnumClassFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function EnumClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumClass {
     return json as EnumClass;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -12,31 +12,16 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    OuterEnum,
-    OuterEnumFromJSON,
-    OuterEnumFromJSONTyped,
-    OuterEnumToJSON,
-} from './OuterEnum';
-import {
-    OuterEnumDefaultValue,
-    OuterEnumDefaultValueFromJSON,
-    OuterEnumDefaultValueFromJSONTyped,
-    OuterEnumDefaultValueToJSON,
-} from './OuterEnumDefaultValue';
-import {
-    OuterEnumInteger,
-    OuterEnumIntegerFromJSON,
-    OuterEnumIntegerFromJSONTyped,
-    OuterEnumIntegerToJSON,
-} from './OuterEnumInteger';
-import {
-    OuterEnumIntegerDefaultValue,
-    OuterEnumIntegerDefaultValueFromJSON,
-    OuterEnumIntegerDefaultValueFromJSONTyped,
-    OuterEnumIntegerDefaultValueToJSON,
-} from './OuterEnumIntegerDefaultValue';
+// @ts-ignore: some imports may be unused
+import { OuterEnum, OuterEnumFromJSON, OuterEnumFromJSONTyped, OuterEnumToJSON } from './OuterEnum';
+// @ts-ignore: some imports may be unused
+import { OuterEnumDefaultValue, OuterEnumDefaultValueFromJSON, OuterEnumDefaultValueFromJSONTyped, OuterEnumDefaultValueToJSON } from './OuterEnumDefaultValue';
+// @ts-ignore: some imports may be unused
+import { OuterEnumInteger, OuterEnumIntegerFromJSON, OuterEnumIntegerFromJSONTyped, OuterEnumIntegerToJSON } from './OuterEnumInteger';
+// @ts-ignore: some imports may be unused
+import { OuterEnumIntegerDefaultValue, OuterEnumIntegerDefaultValueFromJSON, OuterEnumIntegerDefaultValueFromJSONTyped, OuterEnumIntegerDefaultValueToJSON } from './OuterEnumIntegerDefaultValue';
 
 /**
  * 
@@ -130,6 +115,7 @@ export function EnumTestFromJSON(json: any): EnumTest {
     return EnumTestFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumTest {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -37,6 +38,7 @@ export function FileSchemaTestClassFromJSON(json: any): FileSchemaTestClass {
     return FileSchemaTestClassFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): FileSchemaTestClass {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function FooFromJSON(json: any): Foo {
     return FooFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Decimal,
-    DecimalFromJSON,
-    DecimalFromJSONTyped,
-    DecimalToJSON,
-} from './Decimal';
+// @ts-ignore: some imports may be unused
+import { Decimal, DecimalFromJSON, DecimalFromJSONTyped, DecimalToJSON } from './Decimal';
 
 /**
  * 
@@ -128,6 +125,7 @@ export function FormatTestFromJSON(json: any): FormatTest {
     return FormatTestFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): FormatTest {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -37,6 +38,7 @@ export function HasOnlyReadOnlyFromJSON(json: any): HasOnlyReadOnly {
     return HasOnlyReadOnlyFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): HasOnlyReadOnly {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
@@ -31,6 +32,7 @@ export function HealthCheckResultFromJSON(json: any): HealthCheckResult {
     return HealthCheckResultFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: boolean): HealthCheckResult {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/InlineResponseDefault.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/InlineResponseDefault.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Foo,
-    FooFromJSON,
-    FooFromJSONTyped,
-    FooToJSON,
-} from './Foo';
+// @ts-ignore: some imports may be unused
+import { Foo, FooFromJSON, FooFromJSONTyped, FooToJSON } from './Foo';
 
 /**
  * 
@@ -38,6 +35,7 @@ export function InlineResponseDefaultFromJSON(json: any): InlineResponseDefault 
     return InlineResponseDefaultFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function InlineResponseDefaultFromJSONTyped(json: any, ignoreDiscriminator: boolean): InlineResponseDefault {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function ListFromJSON(json: any): List {
     return ListFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -58,6 +59,7 @@ export function MapTestFromJSON(json: any): MapTest {
     return MapTestFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): MapTest {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Animal,
-    AnimalFromJSON,
-    AnimalFromJSONTyped,
-    AnimalToJSON,
-} from './Animal';
+// @ts-ignore: some imports may be unused
+import { Animal, AnimalFromJSON, AnimalFromJSONTyped, AnimalToJSON } from './Animal';
 
 /**
  * 
@@ -50,6 +47,7 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSON(json: any): 
     return MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): MixedPropertiesAndAdditionalPropertiesClass {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Model for testing model name starting with number
@@ -37,6 +38,7 @@ export function Model200ResponseFromJSON(json: any): Model200Response {
     return Model200ResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): Model200Response {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Must be named `File` for test.
@@ -31,6 +32,7 @@ export function ModelFileFromJSON(json: any): ModelFile {
     return ModelFileFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelFile {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Model for testing model name same as property name
@@ -49,6 +50,7 @@ export function NameFromJSON(json: any): Name {
     return NameFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -98,6 +99,7 @@ export function NullableClassFromJSON(json: any): NullableClass {
     return NullableClassFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): NullableClass {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function NumberOnlyFromJSON(json: any): NumberOnly {
     return NumberOnlyFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): NumberOnly {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    DeprecatedObject,
-    DeprecatedObjectFromJSON,
-    DeprecatedObjectFromJSONTyped,
-    DeprecatedObjectToJSON,
-} from './DeprecatedObject';
+// @ts-ignore: some imports may be unused
+import { DeprecatedObject, DeprecatedObjectFromJSON, DeprecatedObjectFromJSONTyped, DeprecatedObjectToJSON } from './DeprecatedObject';
 
 /**
  * 
@@ -59,6 +56,7 @@ export function ObjectWithDeprecatedFieldsFromJSON(json: any): ObjectWithDepreca
     return ObjectWithDeprecatedFieldsFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscriminator: boolean): ObjectWithDeprecatedFields {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -43,6 +44,7 @@ export function OuterCompositeFromJSON(json: any): OuterComposite {
     return OuterCompositeFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterComposite {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -27,6 +27,7 @@ export function OuterEnumFromJSON(json: any): OuterEnum {
     return OuterEnumFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function OuterEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterEnum {
     return json as OuterEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -27,6 +27,7 @@ export function OuterEnumDefaultValueFromJSON(json: any): OuterEnumDefaultValue 
     return OuterEnumDefaultValueFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function OuterEnumDefaultValueFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
     return json as OuterEnumDefaultValue;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -27,6 +27,7 @@ export function OuterEnumIntegerFromJSON(json: any): OuterEnumInteger {
     return OuterEnumIntegerFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function OuterEnumIntegerFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterEnumInteger {
     return json as OuterEnumInteger;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -27,6 +27,7 @@ export function OuterEnumIntegerDefaultValueFromJSON(json: any): OuterEnumIntege
     return OuterEnumIntegerDefaultValueFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function OuterEnumIntegerDefaultValueFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
     return json as OuterEnumIntegerDefaultValue;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    OuterEnumInteger,
-    OuterEnumIntegerFromJSON,
-    OuterEnumIntegerFromJSONTyped,
-    OuterEnumIntegerToJSON,
-} from './OuterEnumInteger';
+// @ts-ignore: some imports may be unused
+import { OuterEnumInteger, OuterEnumIntegerFromJSON, OuterEnumIntegerFromJSONTyped, OuterEnumIntegerToJSON } from './OuterEnumInteger';
 
 /**
  * 
@@ -38,6 +35,7 @@ export function OuterObjectWithEnumPropertyFromJSON(json: any): OuterObjectWithE
     return OuterObjectWithEnumPropertyFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterObjectWithEnumProperty {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * 
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -37,6 +38,7 @@ export function ReadOnlyFirstFromJSON(json: any): ReadOnlyFirst {
     return ReadOnlyFirstFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boolean): ReadOnlyFirst {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Model for testing reserved words
@@ -31,6 +32,7 @@ export function ReturnFromJSON(json: any): Return {
     return ReturnFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Return {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -31,6 +32,7 @@ export function SpecialModelNameFromJSON(json: any): SpecialModelName {
     return SpecialModelNameFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: boolean): SpecialModelName {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface AddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * A pet for sale in the pet store
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -14,23 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    EnumPatternObject,
-    EnumPatternObjectFromJSON,
-    EnumPatternObjectToJSON,
-    InlineObject,
-    InlineObjectFromJSON,
-    InlineObjectToJSON,
-    InlineResponse200,
-    InlineResponse200FromJSON,
-    InlineResponse200ToJSON,
-    NumberEnum,
-    NumberEnumFromJSON,
-    NumberEnumToJSON,
-    StringEnum,
-    StringEnumFromJSON,
-    StringEnumToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { EnumPatternObject, EnumPatternObjectFromJSON, EnumPatternObjectToJSON, InlineObject, InlineObjectFromJSON, InlineObjectToJSON, InlineResponse200, InlineResponse200FromJSON, InlineResponse200ToJSON, NumberEnum, NumberEnumFromJSON, NumberEnumToJSON, StringEnum, StringEnumFromJSON, StringEnumToJSON } from '../models';
 
 export interface FakeEnumRequestGetInlineRequest {
     stringEnum?: FakeEnumRequestGetInlineStringEnumEnum;

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    NumberEnum,
-    NumberEnumFromJSON,
-    NumberEnumFromJSONTyped,
-    NumberEnumToJSON,
-} from './NumberEnum';
-import {
-    StringEnum,
-    StringEnumFromJSON,
-    StringEnumFromJSONTyped,
-    StringEnumToJSON,
-} from './StringEnum';
+// @ts-ignore: some imports may be unused
+import { NumberEnum, NumberEnumFromJSON, NumberEnumFromJSONTyped, NumberEnumToJSON } from './NumberEnum';
+// @ts-ignore: some imports may be unused
+import { StringEnum, StringEnumFromJSON, StringEnumFromJSONTyped, StringEnumToJSON } from './StringEnum';
 
 /**
  * 
@@ -62,6 +55,7 @@ export function EnumPatternObjectFromJSON(json: any): EnumPatternObject {
     return EnumPatternObjectFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumPatternObject {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/InlineObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/InlineObject.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -67,6 +68,7 @@ export function InlineObjectFromJSON(json: any): InlineObject {
     return InlineObjectFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function InlineObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): InlineObject {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/InlineResponse200.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/InlineResponse200.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * 
@@ -67,6 +68,7 @@ export function InlineResponse200FromJSON(json: any): InlineResponse200 {
     return InlineResponse200FromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function InlineResponse200FromJSONTyped(json: any, ignoreDiscriminator: boolean): InlineResponse200 {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -27,6 +27,7 @@ export function NumberEnumFromJSON(json: any): NumberEnum {
     return NumberEnumFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function NumberEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean): NumberEnum {
     return json as NumberEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -27,6 +27,7 @@ export function StringEnumFromJSON(json: any): StringEnum {
     return StringEnumFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function StringEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean): StringEnum {
     return json as StringEnum;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface AddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * A pet for sale in the pet store
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface AddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * A pet for sale in the pet store
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface PetApiAddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface StoreApiDeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface UserApiCreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * A pet for sale in the pet store
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    GetBehaviorPermissionsResponse,
-    GetBehaviorPermissionsResponseFromJSON,
-    GetBehaviorPermissionsResponseToJSON,
-    GetBehaviorTypeResponse,
-    GetBehaviorTypeResponseFromJSON,
-    GetBehaviorTypeResponseToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { GetBehaviorPermissionsResponse, GetBehaviorPermissionsResponseFromJSON, GetBehaviorPermissionsResponseToJSON, GetBehaviorTypeResponse, GetBehaviorTypeResponseFromJSON, GetBehaviorTypeResponseToJSON } from '../models';
 
 export interface GetBehaviorPermissionsRequest {
     behaviorId: number;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApiSagas.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApiSagas.ts
@@ -13,21 +13,19 @@
  */
 
 
+// @ts-ignore: import may be unused
 import {Api} from './';
+// @ts-ignore: import may be unused
 import {List} from 'immutable';
+// @ts-ignore: some imports may be unused
 import {all, fork, put, takeLatest} from "redux-saga/effects";
+// @ts-ignore: some imports may be unused
 import {apiCall, createSagaAction as originalCreateSagaAction, BaseEntitySupportPayloadApiAction, BasePayloadApiAction, NormalizedRecordEntities, normalizedEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {Action} from "redux-ts-simple";
 
-import {
-    GetBehaviorPermissionsResponse,
-    GetBehaviorPermissionsResponseRecord,
-    getBehaviorPermissionsResponseRecordUtils,
-    GetBehaviorTypeResponse,
-    GetBehaviorTypeResponseRecord,
-    getBehaviorTypeResponseRecordUtils,
-    BehaviorType,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { GetBehaviorPermissionsResponse, GetBehaviorPermissionsResponseRecord, getBehaviorPermissionsResponseRecordUtils, GetBehaviorTypeResponse, GetBehaviorTypeResponseRecord, getBehaviorTypeResponseRecordUtils, BehaviorType } from '../models';
 
 const createSagaAction = <T>(type: string) => originalCreateSagaAction<T>(type, {namespace: "api_behaviorApi"});
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -14,26 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryToJSON,
-    FindPetsByStatusResponse,
-    FindPetsByStatusResponseFromJSON,
-    FindPetsByStatusResponseToJSON,
-    FindPetsByUserResponse,
-    FindPetsByUserResponseFromJSON,
-    FindPetsByUserResponseToJSON,
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-    PetRegionsResponse,
-    PetRegionsResponseFromJSON,
-    PetRegionsResponseToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryToJSON, FindPetsByStatusResponse, FindPetsByStatusResponseFromJSON, FindPetsByStatusResponseToJSON, FindPetsByUserResponse, FindPetsByUserResponseFromJSON, FindPetsByUserResponseToJSON, ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON, PetRegionsResponse, PetRegionsResponseFromJSON, PetRegionsResponseToJSON } from '../models';
 
 export interface AddPetRequest {
     dummyCat: Category;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApiSagas.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApiSagas.ts
@@ -13,37 +13,22 @@
  */
 
 
+// @ts-ignore: import may be unused
 import {Api} from './';
+// @ts-ignore: import may be unused
 import {List} from 'immutable';
+// @ts-ignore: some imports may be unused
 import {all, fork, put, takeLatest} from "redux-saga/effects";
+// @ts-ignore: some imports may be unused
 import {apiCall, createSagaAction as originalCreateSagaAction, BaseEntitySupportPayloadApiAction, BasePayloadApiAction, NormalizedRecordEntities, normalizedEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {Action} from "redux-ts-simple";
 
-import {
-    Category,
-    CategoryRecord,
-    categoryRecordUtils,
-    FindPetsByStatusResponse,
-    FindPetsByStatusResponseRecord,
-    findPetsByStatusResponseRecordUtils,
-    FindPetsByUserResponse,
-    FindPetsByUserResponseRecord,
-    findPetsByUserResponseRecordUtils,
-    ModelApiResponse,
-    ModelApiResponseRecord,
-    modelApiResponseRecordUtils,
-    Pet,
-    PetRecord,
-    petRecordUtils,
-    PetRegionsResponse,
-    PetRegionsResponseRecord,
-    petRegionsResponseRecordUtils,
-    UserRecord,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryRecord, categoryRecordUtils, FindPetsByStatusResponse, FindPetsByStatusResponseRecord, findPetsByStatusResponseRecordUtils, FindPetsByUserResponse, FindPetsByUserResponseRecord, findPetsByUserResponseRecordUtils, ModelApiResponse, ModelApiResponseRecord, modelApiResponseRecordUtils, Pet, PetRecord, petRecordUtils, PetRegionsResponse, PetRegionsResponseRecord, petRegionsResponseRecordUtils, UserRecord } from '../models';
 
-import {
-    FindPetsByStatusStatusEnum,
-} from './PetApi';
+// @ts-ignore: import may be unused
+import { FindPetsByStatusStatusEnum } from './PetApi';
 
 const createSagaAction = <T>(type: string) => originalCreateSagaAction<T>(type, {namespace: "api_petApi"});
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    GetMatchingPartsResponse,
-    GetMatchingPartsResponseFromJSON,
-    GetMatchingPartsResponseToJSON,
-    GetPetPartTypeResponse,
-    GetPetPartTypeResponseFromJSON,
-    GetPetPartTypeResponseToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { GetMatchingPartsResponse, GetMatchingPartsResponseFromJSON, GetMatchingPartsResponseToJSON, GetPetPartTypeResponse, GetPetPartTypeResponseFromJSON, GetPetPartTypeResponseToJSON } from '../models';
 
 export interface GetFakePetPartTypeRequest {
     fakePetPartId: number;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApiSagas.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApiSagas.ts
@@ -13,22 +13,19 @@
  */
 
 
+// @ts-ignore: import may be unused
 import {Api} from './';
+// @ts-ignore: import may be unused
 import {List} from 'immutable';
+// @ts-ignore: some imports may be unused
 import {all, fork, put, takeLatest} from "redux-saga/effects";
+// @ts-ignore: some imports may be unused
 import {apiCall, createSagaAction as originalCreateSagaAction, BaseEntitySupportPayloadApiAction, BasePayloadApiAction, NormalizedRecordEntities, normalizedEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {Action} from "redux-ts-simple";
 
-import {
-    GetMatchingPartsResponse,
-    GetMatchingPartsResponseRecord,
-    getMatchingPartsResponseRecordUtils,
-    GetPetPartTypeResponse,
-    GetPetPartTypeResponseRecord,
-    getPetPartTypeResponseRecordUtils,
-    MatchingPartsRecord,
-    PetPartType,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { GetMatchingPartsResponse, GetMatchingPartsResponseRecord, getMatchingPartsResponseRecordUtils, GetPetPartTypeResponse, GetPetPartTypeResponseRecord, getPetPartTypeResponseRecordUtils, MatchingPartsRecord, PetPartType } from '../models';
 
 const createSagaAction = <T>(type: string) => originalCreateSagaAction<T>(type, {namespace: "api_petPartApi"});
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/SagaApiManager.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/SagaApiManager.ts
@@ -1,15 +1,8 @@
-import {
-    Configuration,
-    ConfigurationParameters,
-} from "../";
+// @ts-ignore: some imports may be unused
+import { Configuration, ConfigurationParameters } from "../";
 
-import {
-    BehaviorApi,
-    PetApi,
-    PetPartApi,
-    StoreApi,
-    UserApi,
-} from "./";
+// @ts-ignore: some imports may be unused
+import { BehaviorApi, PetApi, PetPartApi, StoreApi, UserApi } from "./";
 
 export class Api {
     public static behaviorApi: BehaviorApi;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApiSagas.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApiSagas.ts
@@ -13,17 +13,19 @@
  */
 
 
+// @ts-ignore: import may be unused
 import {Api} from './';
+// @ts-ignore: import may be unused
 import {List} from 'immutable';
+// @ts-ignore: some imports may be unused
 import {all, fork, put, takeLatest} from "redux-saga/effects";
+// @ts-ignore: some imports may be unused
 import {apiCall, createSagaAction as originalCreateSagaAction, BaseEntitySupportPayloadApiAction, BasePayloadApiAction, NormalizedRecordEntities, normalizedEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {Action} from "redux-ts-simple";
 
-import {
-    Order,
-    OrderRecord,
-    orderRecordUtils,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderRecord, orderRecordUtils } from '../models';
 
 const createSagaAction = <T>(type: string) => originalCreateSagaAction<T>(type, {namespace: "api_storeApi"});
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    DefaultMetaOnlyResponse,
-    DefaultMetaOnlyResponseFromJSON,
-    DefaultMetaOnlyResponseToJSON,
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { DefaultMetaOnlyResponse, DefaultMetaOnlyResponseFromJSON, DefaultMetaOnlyResponseToJSON, User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApiSagas.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApiSagas.ts
@@ -13,20 +13,19 @@
  */
 
 
+// @ts-ignore: import may be unused
 import {Api} from './';
+// @ts-ignore: import may be unused
 import {List} from 'immutable';
+// @ts-ignore: some imports may be unused
 import {all, fork, put, takeLatest} from "redux-saga/effects";
+// @ts-ignore: some imports may be unused
 import {apiCall, createSagaAction as originalCreateSagaAction, BaseEntitySupportPayloadApiAction, BasePayloadApiAction, NormalizedRecordEntities, normalizedEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {Action} from "redux-ts-simple";
 
-import {
-    DefaultMetaOnlyResponse,
-    DefaultMetaOnlyResponseRecord,
-    defaultMetaOnlyResponseRecordUtils,
-    User,
-    UserRecord,
-    userRecordUtils,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { DefaultMetaOnlyResponse, DefaultMetaOnlyResponseRecord, defaultMetaOnlyResponseRecordUtils, User, UserRecord, userRecordUtils } from '../models';
 
 const createSagaAction = <T>(type: string) => originalCreateSagaAction<T>(type, {namespace: "api_userApi"});
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -27,6 +27,7 @@ export function BehaviorTypeFromJSON(json: any): BehaviorType {
     return BehaviorTypeFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function BehaviorTypeFromJSONTyped(json: any, ignoreDiscriminator: boolean): BehaviorType {
     return json as BehaviorType;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/CategoryRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/CategoryRecord.ts
@@ -12,15 +12,18 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    Category,
-} from './Category';
+// @ts-ignore: some imports may be unused
+import { Category } from './Category';
 
 
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
 
 /**
  * 
@@ -38,6 +35,7 @@ export function DefaultMetaOnlyResponseFromJSON(json: any): DefaultMetaOnlyRespo
     return DefaultMetaOnlyResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): DefaultMetaOnlyResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponseRecord.ts
@@ -12,24 +12,24 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    DefaultMetaOnlyResponse,
-} from './DefaultMetaOnlyResponse';
+// @ts-ignore: some imports may be unused
+import { DefaultMetaOnlyResponse } from './DefaultMetaOnlyResponse';
 
-import {
-    ResponseMeta,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
 
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
 
 export const DefaultMetaOnlyResponseRecordProps = {
     recType: "DefaultMetaOnlyResponseApiRecord" as "DefaultMetaOnlyResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -36,6 +36,7 @@ export function DeploymentRequestStatusFromJSON(json: any): DeploymentRequestSta
     return DeploymentRequestStatusFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function DeploymentRequestStatusFromJSONTyped(json: any, ignoreDiscriminator: boolean): DeploymentRequestStatus {
     return json as DeploymentRequestStatus;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -42,6 +42,7 @@ export function ErrorCodeFromJSON(json: any): ErrorCode {
     return ErrorCodeFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function ErrorCodeFromJSONTyped(json: any, ignoreDiscriminator: boolean): ErrorCode {
     return json as ErrorCode;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Pet,
-    PetFromJSON,
-    PetFromJSONTyped,
-    PetToJSON,
-} from './Pet';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { Pet, PetFromJSON, PetFromJSONTyped, PetToJSON } from './Pet';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
 
 /**
  * 
@@ -50,6 +43,7 @@ export function FindPetsByStatusResponseFromJSON(json: any): FindPetsByStatusRes
     return FindPetsByStatusResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function FindPetsByStatusResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FindPetsByStatusResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponseRecord.ts
@@ -12,31 +12,28 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories, appFromJS, NormalizedRecordEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    FindPetsByStatusResponse,
-} from './FindPetsByStatusResponse';
+// @ts-ignore: some imports may be unused
+import { FindPetsByStatusResponse } from './FindPetsByStatusResponse';
 
-import {
-    Pet,
-} from './Pet';
-import {
-    ResponseMeta,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { Pet } from './Pet';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
 
-import {
-    PetRecord,
-    petRecordUtils
-} from './PetRecord';
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { PetRecord, petRecordUtils } from './PetRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
 
 export const FindPetsByStatusResponseRecordProps = {
     recType: "FindPetsByStatusResponseApiRecord" as "FindPetsByStatusResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
-import {
-    User,
-    UserFromJSON,
-    UserFromJSONTyped,
-    UserToJSON,
-} from './User';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserFromJSONTyped, UserToJSON } from './User';
 
 /**
  * 
@@ -50,6 +43,7 @@ export function FindPetsByUserResponseFromJSON(json: any): FindPetsByUserRespons
     return FindPetsByUserResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function FindPetsByUserResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FindPetsByUserResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponseRecord.ts
@@ -12,31 +12,28 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories, appFromJS, NormalizedRecordEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    FindPetsByUserResponse,
-} from './FindPetsByUserResponse';
+// @ts-ignore: some imports may be unused
+import { FindPetsByUserResponse } from './FindPetsByUserResponse';
 
-import {
-    ResponseMeta,
-} from './ResponseMeta';
-import {
-    User,
-} from './User';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { User } from './User';
 
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
-import {
-    UserRecord,
-    userRecordUtils
-} from './UserRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { UserRecord, userRecordUtils } from './UserRecord';
 
 export const FindPetsByUserResponseRecordProps = {
     recType: "FindPetsByUserResponseApiRecord" as "FindPetsByUserResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
 
 /**
  * 
@@ -44,6 +41,7 @@ export function GetBehaviorPermissionsResponseFromJSON(json: any): GetBehaviorPe
     return GetBehaviorPermissionsResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function GetBehaviorPermissionsResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetBehaviorPermissionsResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponseRecord.ts
@@ -12,24 +12,24 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories, appFromJS, NormalizedRecordEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    GetBehaviorPermissionsResponse,
-} from './GetBehaviorPermissionsResponse';
+// @ts-ignore: some imports may be unused
+import { GetBehaviorPermissionsResponse } from './GetBehaviorPermissionsResponse';
 
-import {
-    ResponseMeta,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
 
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
 
 export const GetBehaviorPermissionsResponseRecordProps = {
     recType: "GetBehaviorPermissionsResponseApiRecord" as "GetBehaviorPermissionsResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    BehaviorType,
-    BehaviorTypeFromJSON,
-    BehaviorTypeFromJSONTyped,
-    BehaviorTypeToJSON,
-} from './BehaviorType';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { BehaviorType, BehaviorTypeFromJSON, BehaviorTypeFromJSONTyped, BehaviorTypeToJSON } from './BehaviorType';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
 
 /**
  * 
@@ -50,6 +43,7 @@ export function GetBehaviorTypeResponseFromJSON(json: any): GetBehaviorTypeRespo
     return GetBehaviorTypeResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function GetBehaviorTypeResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetBehaviorTypeResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponseRecord.ts
@@ -12,27 +12,26 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories, appFromJS, NormalizedRecordEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    GetBehaviorTypeResponse,
-} from './GetBehaviorTypeResponse';
+// @ts-ignore: some imports may be unused
+import { GetBehaviorTypeResponse } from './GetBehaviorTypeResponse';
 
-import {
-    BehaviorType,
-} from './BehaviorType';
-import {
-    ResponseMeta,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { BehaviorType } from './BehaviorType';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
 
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
 
 export const GetBehaviorTypeResponseRecordProps = {
     recType: "GetBehaviorTypeResponseApiRecord" as "GetBehaviorTypeResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    MatchingParts,
-    MatchingPartsFromJSON,
-    MatchingPartsFromJSONTyped,
-    MatchingPartsToJSON,
-} from './MatchingParts';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { MatchingParts, MatchingPartsFromJSON, MatchingPartsFromJSONTyped, MatchingPartsToJSON } from './MatchingParts';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
 
 /**
  * 
@@ -50,6 +43,7 @@ export function GetMatchingPartsResponseFromJSON(json: any): GetMatchingPartsRes
     return GetMatchingPartsResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function GetMatchingPartsResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetMatchingPartsResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponseRecord.ts
@@ -12,31 +12,28 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories, appFromJS, NormalizedRecordEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    GetMatchingPartsResponse,
-} from './GetMatchingPartsResponse';
+// @ts-ignore: some imports may be unused
+import { GetMatchingPartsResponse } from './GetMatchingPartsResponse';
 
-import {
-    MatchingParts,
-} from './MatchingParts';
-import {
-    ResponseMeta,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { MatchingParts } from './MatchingParts';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
 
-import {
-    MatchingPartsRecord,
-    matchingPartsRecordUtils
-} from './MatchingPartsRecord';
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { MatchingPartsRecord, matchingPartsRecordUtils } from './MatchingPartsRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
 
 export const GetMatchingPartsResponseRecordProps = {
     recType: "GetMatchingPartsResponseApiRecord" as "GetMatchingPartsResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    PetPartType,
-    PetPartTypeFromJSON,
-    PetPartTypeFromJSONTyped,
-    PetPartTypeToJSON,
-} from './PetPartType';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { PetPartType, PetPartTypeFromJSON, PetPartTypeFromJSONTyped, PetPartTypeToJSON } from './PetPartType';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
 
 /**
  * 
@@ -50,6 +43,7 @@ export function GetPetPartTypeResponseFromJSON(json: any): GetPetPartTypeRespons
     return GetPetPartTypeResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function GetPetPartTypeResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetPetPartTypeResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponseRecord.ts
@@ -12,27 +12,26 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories, appFromJS, NormalizedRecordEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    GetPetPartTypeResponse,
-} from './GetPetPartTypeResponse';
+// @ts-ignore: some imports may be unused
+import { GetPetPartTypeResponse } from './GetPetPartTypeResponse';
 
-import {
-    PetPartType,
-} from './PetPartType';
-import {
-    ResponseMeta,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { PetPartType } from './PetPartType';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
 
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
 
 export const GetPetPartTypeResponseRecordProps = {
     recType: "GetPetPartTypeResponseApiRecord" as "GetPetPartTypeResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Simplified identifier of an item
@@ -37,6 +38,7 @@ export function ItemIdFromJSON(json: any): ItemId {
     return ItemIdFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): ItemId {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemIdRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemIdRecord.ts
@@ -12,15 +12,18 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    ItemId,
-} from './ItemId';
+// @ts-ignore: some imports may be unused
+import { ItemId } from './ItemId';
 
 
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Part,
-    PartFromJSON,
-    PartFromJSONTyped,
-    PartToJSON,
-} from './Part';
+// @ts-ignore: some imports may be unused
+import { Part, PartFromJSON, PartFromJSONTyped, PartToJSON } from './Part';
 
 /**
  * Contains all the matching parts
@@ -44,6 +41,7 @@ export function MatchingPartsFromJSON(json: any): MatchingParts {
     return MatchingPartsFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boolean): MatchingParts {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingPartsRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingPartsRecord.ts
@@ -12,24 +12,24 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    MatchingParts,
-} from './MatchingParts';
+// @ts-ignore: some imports may be unused
+import { MatchingParts } from './MatchingParts';
 
-import {
-    Part,
-} from './Part';
+// @ts-ignore: some imports may be unused
+import { Part } from './Part';
 
-import {
-    PartRecord,
-    partRecordUtils
-} from './PartRecord';
+// @ts-ignore: some imports may be unused
+import { PartRecord, partRecordUtils } from './PartRecord';
 
 export const MatchingPartsRecordProps = {
     recType: "MatchingPartsApiRecord" as "MatchingPartsApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponseRecord.ts
@@ -12,15 +12,18 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    ModelApiResponse,
-} from './ModelApiResponse';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse } from './ModelApiResponse';
 
 
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    ItemId,
-    ItemIdFromJSON,
-    ItemIdFromJSONTyped,
-    ItemIdToJSON,
-} from './ItemId';
+// @ts-ignore: some imports may be unused
+import { ItemId, ItemIdFromJSON, ItemIdFromJSONTyped, ItemIdToJSON } from './ItemId';
 
 /**
  * This represent an error normally linked to a specific item from a previous request
@@ -56,6 +53,7 @@ export function ModelErrorFromJSON(json: any): ModelError {
     return ModelErrorFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelError {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelErrorRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelErrorRecord.ts
@@ -12,24 +12,24 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    ModelError,
-} from './ModelError';
+// @ts-ignore: some imports may be unused
+import { ModelError } from './ModelError';
 
-import {
-    ItemId,
-} from './ItemId';
+// @ts-ignore: some imports may be unused
+import { ItemId } from './ItemId';
 
-import {
-    ItemIdRecord,
-    itemIdRecordUtils
-} from './ItemIdRecord';
+// @ts-ignore: some imports may be unused
+import { ItemIdRecord, itemIdRecordUtils } from './ItemIdRecord';
 
 export const ModelErrorRecordProps = {
     recType: "ModelErrorApiRecord" as "ModelErrorApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/OrderRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/OrderRecord.ts
@@ -12,16 +12,18 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    Order,
-    OrderStatusEnum,
-} from './Order';
+// @ts-ignore: some imports may be unused
+import { Order, OrderStatusEnum } from './Order';
 
 
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Contains all the info about a pet part
@@ -37,6 +38,7 @@ export function PartFromJSON(json: any): Part {
     return PartFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PartRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PartRecord.ts
@@ -12,15 +12,18 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    Part,
-} from './Part';
+// @ts-ignore: some imports may be unused
+import { Part } from './Part';
 
 
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -12,31 +12,16 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    DeploymentRequestStatus,
-    DeploymentRequestStatusFromJSON,
-    DeploymentRequestStatusFromJSONTyped,
-    DeploymentRequestStatusToJSON,
-} from './DeploymentRequestStatus';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
-import {
-    WarningCode,
-    WarningCodeFromJSON,
-    WarningCodeFromJSONTyped,
-    WarningCodeToJSON,
-} from './WarningCode';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { DeploymentRequestStatus, DeploymentRequestStatusFromJSON, DeploymentRequestStatusFromJSONTyped, DeploymentRequestStatusToJSON } from './DeploymentRequestStatus';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
+// @ts-ignore: some imports may be unused
+import { WarningCode, WarningCodeFromJSON, WarningCodeFromJSONTyped, WarningCodeToJSON } from './WarningCode';
 
 /**
  * A pet for sale in the pet store
@@ -186,6 +171,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -27,6 +27,7 @@ export function PetPartTypeFromJSON(json: any): PetPartType {
     return PetPartTypeFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function PetPartTypeFromJSONTyped(json: any, ignoreDiscriminator: boolean): PetPartType {
     return json as PetPartType;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRecord.ts
@@ -12,38 +12,32 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    Pet,
-    PetStatusEnum,
-} from './Pet';
+// @ts-ignore: some imports may be unused
+import { Pet, PetStatusEnum } from './Pet';
 
-import {
-    Category,
-} from './Category';
-import {
-    DeploymentRequestStatus,
-} from './DeploymentRequestStatus';
-import {
-    Tag,
-} from './Tag';
-import {
-    WarningCode,
-} from './WarningCode';
+// @ts-ignore: some imports may be unused
+import { Category } from './Category';
+// @ts-ignore: some imports may be unused
+import { DeploymentRequestStatus } from './DeploymentRequestStatus';
+// @ts-ignore: some imports may be unused
+import { Tag } from './Tag';
+// @ts-ignore: some imports may be unused
+import { WarningCode } from './WarningCode';
 
-import {
-    CategoryRecord,
-    categoryRecordUtils
-} from './CategoryRecord';
-import {
-    TagRecord,
-    tagRecordUtils
-} from './TagRecord';
+// @ts-ignore: some imports may be unused
+import { CategoryRecord, categoryRecordUtils } from './CategoryRecord';
+// @ts-ignore: some imports may be unused
+import { TagRecord, tagRecordUtils } from './TagRecord';
 
 export const PetRecordProps = {
     recType: "PetApiRecord" as "PetApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    ResponseMeta,
-    ResponseMetaFromJSON,
-    ResponseMetaFromJSONTyped,
-    ResponseMetaToJSON,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaFromJSON, ResponseMetaFromJSONTyped, ResponseMetaToJSON } from './ResponseMeta';
 
 /**
  * 
@@ -44,6 +41,7 @@ export function PetRegionsResponseFromJSON(json: any): PetRegionsResponse {
     return PetRegionsResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetRegionsResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): PetRegionsResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponseRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponseRecord.ts
@@ -12,24 +12,24 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories, appFromJS, NormalizedRecordEntities} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    PetRegionsResponse,
-} from './PetRegionsResponse';
+// @ts-ignore: some imports may be unused
+import { PetRegionsResponse } from './PetRegionsResponse';
 
-import {
-    ResponseMeta,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta } from './ResponseMeta';
 
-import {
-    ResponseMetaRecord,
-    responseMetaRecordUtils
-} from './ResponseMetaRecord';
+// @ts-ignore: some imports may be unused
+import { ResponseMetaRecord, responseMetaRecordUtils } from './ResponseMetaRecord';
 
 export const PetRegionsResponseRecordProps = {
     recType: "PetRegionsResponseApiRecord" as "PetRegionsResponseApiRecord",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -12,13 +12,10 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    ErrorCode,
-    ErrorCodeFromJSON,
-    ErrorCodeFromJSONTyped,
-    ErrorCodeToJSON,
-} from './ErrorCode';
+// @ts-ignore: some imports may be unused
+import { ErrorCode, ErrorCodeFromJSON, ErrorCodeFromJSONTyped, ErrorCodeToJSON } from './ErrorCode';
 
 /**
  * Mandatory part of each response given by our API
@@ -98,6 +95,7 @@ export function ResponseMetaFromJSON(json: any): ResponseMeta {
     return ResponseMetaFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ResponseMetaFromJSONTyped(json: any, ignoreDiscriminator: boolean): ResponseMeta {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMetaRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMetaRecord.ts
@@ -12,20 +12,21 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    ResponseMeta,
-    ResponseMetaCodeEnum,
-} from './ResponseMeta';
+// @ts-ignore: some imports may be unused
+import { ResponseMeta, ResponseMetaCodeEnum } from './ResponseMeta';
 
-import {
-    ErrorCode,
-} from './ErrorCode';
+// @ts-ignore: some imports may be unused
+import { ErrorCode } from './ErrorCode';
 
 
 export const ResponseMetaRecordProps = {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/TagRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/TagRecord.ts
@@ -12,15 +12,18 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    Tag,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Tag } from './Tag';
 
 
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -85,6 +86,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/UserRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/UserRecord.ts
@@ -12,15 +12,18 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some imports may be unused
 import {ApiRecordUtils, knownRecordFactories} from "../runtimeSagasAndRecords";
+// @ts-ignore: import may be unused
 import {getApiEntitiesState} from "../ApiEntitiesSelectors"
+// @ts-ignore: some imports may be unused
 import {List, Record, RecordOf, Map} from 'immutable';
 import {Schema, schema, NormalizedSchema} from "normalizr";
+// @ts-ignore: some imports may be unused
 import {select, call} from "redux-saga/effects";
 
-import {
-    User,
-} from './User';
+// @ts-ignore: some imports may be unused
+import { User } from './User';
 
 
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -27,6 +27,7 @@ export function WarningCodeFromJSON(json: any): WarningCode {
     return WarningCodeFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator not used
 export function WarningCodeFromJSONTyped(json: any, ignoreDiscriminator: boolean): WarningCode {
     return json as WarningCode;
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtimeSagasAndRecords.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtimeSagasAndRecords.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import {fromJS as originalFromJS, isIndexed, List, Map as ImmMap, RecordOf} from 'immutable';
+import {fromJS as originalFromJS, isIndexed, List, RecordOf} from 'immutable';
 import {normalize, NormalizedSchema, schema, Schema} from "normalizr";
 import {ActionDefinition, createAction} from "redux-ts-simple";
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface AddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * A pet for sale in the pet store
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface AddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * A pet for sale in the pet store
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -14,14 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    ModelApiResponseFromJSON,
-    ModelApiResponseToJSON,
-    Pet,
-    PetFromJSON,
-    PetToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, ModelApiResponseFromJSON, ModelApiResponseToJSON, Pet, PetFromJSON, PetToJSON } from '../models';
 
 export interface AddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-    OrderFromJSON,
-    OrderToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order, OrderFromJSON, OrderToJSON } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -14,11 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-    UserFromJSON,
-    UserToJSON,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User, UserFromJSON, UserToJSON } from '../models';
 
 export interface CreateUserRequest {
     body: User;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
@@ -37,6 +38,7 @@ export function CategoryFromJSON(json: any): Category {
     return CategoryFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
@@ -43,6 +44,7 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
     return ModelApiResponseFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
@@ -71,6 +72,7 @@ export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -12,19 +12,12 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
-import {
-    Category,
-    CategoryFromJSON,
-    CategoryFromJSONTyped,
-    CategoryToJSON,
-} from './Category';
-import {
-    Tag,
-    TagFromJSON,
-    TagFromJSONTyped,
-    TagToJSON,
-} from './Tag';
+// @ts-ignore: some imports may be unused
+import { Category, CategoryFromJSON, CategoryFromJSONTyped, CategoryToJSON } from './Category';
+// @ts-ignore: some imports may be unused
+import { Tag, TagFromJSON, TagFromJSONTyped, TagToJSON } from './Tag';
 
 /**
  * A pet for sale in the pet store
@@ -84,6 +77,7 @@ export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
@@ -37,6 +38,7 @@ export function TagFromJSON(json: any): Tag {
     return TagFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+// @ts-ignore: some or all imports may be unused
 import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
@@ -73,6 +74,7 @@ export function UserFromJSON(json: any): User {
     return UserFromJSONTyped(json, false);
 }
 
+// @ts-ignore: ignoreDiscriminator may be unused
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
     if ((json === undefined) || (json === null)) {
         return json;

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
@@ -14,10 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    Pet,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { ModelApiResponse, Pet } from '../models';
 
 export interface AddPetRequest {
     body: Pet;

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
@@ -14,9 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { Order } from '../models';
 
 export interface DeleteOrderRequest {
     orderId: string;

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
@@ -14,9 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
-} from '../models';
+// @ts-ignore: some imports may be unused
+import { User } from '../models';
 
 export interface CreateUserRequest {
     body: User;


### PR DESCRIPTION
fix #8961

Generated typescript files for the generators ``typescript-fetch`` do not compile with activated type-checks in typescript.
There are plenty of errors like:

    error TS6133: 'petDiscriminator' is declared but its value is never read.
    error TS6192: All imports in import declaration are unused.

As it is very hard to distinguish between used and unused imports and values, a ``// @ts-ignore`` is added to every line before such error appears or might appear.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  # ./bin/utils/export_docs_generators.sh # no docs changed
  ``` 
- [X]  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
- [ ]  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/). # No Windows user
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

I welcome the technical committee:
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov