### PR TITLE
Add Model Docs to scala-akka generator as defined in its README

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
@@ -43,6 +43,7 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
     protected String artifactId = "openapi-client";
     protected String artifactVersion = "1.0.0";
     protected String resourcesFolder = "src/main/resources";
+    protected String modelDocPath = "docs/";
     protected String configKey = "apiRequest";
     protected int defaultTimeoutInMs = 5000;
     protected String configKeyPath = mainPackage;
@@ -85,6 +86,7 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
         outputFolder = "generated-code/scala-akka";
         modelTemplateFiles.put("model.mustache", ".scala");
         apiTemplateFiles.put("api.mustache", ".scala");
+        modelDocTemplateFiles.put("model_doc.mustache", ".md");
         embeddedTemplateDir = templateDir = "scala-akka-client";
         apiPackage = mainPackage + ".api";
         modelPackage = mainPackage + ".model";
@@ -164,6 +166,7 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
             }
         }
         additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
+        additionalProperties.put("modelDocPath", modelDocPath);
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
@@ -359,5 +362,10 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
 
     public void setMainPackage(String mainPackage) {
         this.configKeyPath = this.mainPackage = mainPackage;
+    }
+
+    @Override
+    public String modelDocFileFolder() {
+        return (outputFolder + File.separator + modelDocPath).replace('/', File.separatorChar);
     }
 }

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/class_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/class_doc.mustache
@@ -1,0 +1,32 @@
+# {{#vendorExtensions.x-is-one-of-interface}}Trait {{/vendorExtensions.x-is-one-of-interface}}{{classname}}
+
+{{#description}}{{&description}}
+{{/description}}
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isContainer}}{{#isArray}}{{#items}}{{#isModel}}[{{/isModel}}{{/items}}**{{baseType}}{{#items}}&lt;{{dataType}}&gt;**{{#isModel}}]({{^baseType}}{{dataType}}{{/baseType}}{{baseType}}.md){{/isModel}}{{/items}}{{/isArray}}{{#isMap}}{{#items}}{{#isModel}}[{{/isModel}}**Map&lt;String, {{dataType}}&gt;**{{#isModel}}]({{^baseType}}{{dataType}}{{/baseType}}{{baseType}}.md){{/isModel}}{{/items}}{{/isMap}}{{/isContainer}}{{^isContainer}}{{#isModel}}[{{/isModel}}**{{dataType}}**{{#isModel}}]({{^baseType}}{{dataType}}{{/baseType}}{{baseType}}.md){{/isModel}}{{/isContainer}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}
+{{/vars}}
+{{#vars}}{{#isEnum}}
+
+## Enum: {{datatypeWithEnum}}
+Allowed values: {{#allowableValues}}[{{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}}
+
+{{/isEnum}}{{/vars}}
+{{#vendorExtensions.x-implements.0}}
+
+## Implemented Interfaces
+
+{{#vendorExtensions.x-implements}}
+* {{{.}}}
+{{/vendorExtensions.x-implements}}
+{{/vendorExtensions.x-implements.0}}
+{{#vendorExtensions.x-is-one-of-interface}}
+## Implementing Classes
+
+{{#oneOf}}
+* {{{.}}}
+{{/oneOf}}
+{{/vendorExtensions.x-is-one-of-interface}}

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/enum_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/enum_doc.mustache
@@ -1,0 +1,7 @@
+# {{classname}}
+
+## Enum
+
+{{#allowableValues}}{{#enumVars}}
+* `{{name}}` (value: `{{{value}}}`)
+{{/enumVars}}{{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/model_doc.mustache
@@ -1,0 +1,9 @@
+{{#models}}{{#model}}
+
+{{#isEnum}}
+{{>enum_doc}}
+{{/isEnum}}
+{{^isEnum}}
+{{>class_doc}}
+{{/isEnum}}
+{{/model}}{{/models}}

--- a/samples/client/petstore/scala-akka/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-akka/.openapi-generator/FILES
@@ -1,5 +1,11 @@
 README.md
 build.sbt
+docs/ApiResponse.md
+docs/Category.md
+docs/Order.md
+docs/Pet.md
+docs/Tag.md
+docs/User.md
 project/build.properties
 src/main/resources/reference.conf
 src/main/scala/org/openapitools/client/api/EnumsSerializers.scala

--- a/samples/client/petstore/scala-akka/README.md
+++ b/samples/client/petstore/scala-akka/README.md
@@ -89,12 +89,12 @@ Class | Method | HTTP request | Description
 
 ## Documentation for Models
 
- - [ApiResponse](ApiResponse.md)
- - [Category](Category.md)
- - [Order](Order.md)
- - [Pet](Pet.md)
- - [Tag](Tag.md)
- - [User](User.md)
+ - [ApiResponse](docs/ApiResponse.md)
+ - [Category](docs/Category.md)
+ - [Order](docs/Order.md)
+ - [Pet](docs/Pet.md)
+ - [Tag](docs/Tag.md)
+ - [User](docs/User.md)
 
 
 ## Documentation for Authorization

--- a/samples/client/petstore/scala-akka/docs/ApiResponse.md
+++ b/samples/client/petstore/scala-akka/docs/ApiResponse.md
@@ -1,0 +1,16 @@
+
+
+# ApiResponse
+
+Describes the result of uploading an image resource
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**code** | **Int** |  |  [optional]
+**`type`** | **String** |  |  [optional]
+**message** | **String** |  |  [optional]
+
+
+

--- a/samples/client/petstore/scala-akka/docs/Category.md
+++ b/samples/client/petstore/scala-akka/docs/Category.md
@@ -1,0 +1,15 @@
+
+
+# Category
+
+A category for a pet
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **Long** |  |  [optional]
+**name** | **String** |  |  [optional]
+
+
+

--- a/samples/client/petstore/scala-akka/docs/Order.md
+++ b/samples/client/petstore/scala-akka/docs/Order.md
@@ -1,0 +1,24 @@
+
+
+# Order
+
+An order for a pets from the pet store
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **Long** |  |  [optional]
+**petId** | **Long** |  |  [optional]
+**quantity** | **Int** |  |  [optional]
+**shipDate** | **OffsetDateTime** |  |  [optional]
+**status** | [**Status**](#Status) | Order Status |  [optional]
+**complete** | **Boolean** |  |  [optional]
+
+
+## Enum: Status
+Allowed values: [placed, approved, delivered]
+
+
+
+

--- a/samples/client/petstore/scala-akka/docs/Pet.md
+++ b/samples/client/petstore/scala-akka/docs/Pet.md
@@ -1,0 +1,24 @@
+
+
+# Pet
+
+A pet for sale in the pet store
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **Long** |  |  [optional]
+**category** | [**Category**](Category.md) |  |  [optional]
+**name** | **String** |  | 
+**photoUrls** | **Seq&lt;String&gt;** |  | 
+**tags** | [**Seq&lt;Tag&gt;**](Tag.md) |  |  [optional]
+**status** | [**Status**](#Status) | pet status in the store |  [optional]
+
+
+## Enum: Status
+Allowed values: [available, pending, sold]
+
+
+
+

--- a/samples/client/petstore/scala-akka/docs/Tag.md
+++ b/samples/client/petstore/scala-akka/docs/Tag.md
@@ -1,0 +1,15 @@
+
+
+# Tag
+
+A tag for a pet
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **Long** |  |  [optional]
+**name** | **String** |  |  [optional]
+
+
+

--- a/samples/client/petstore/scala-akka/docs/User.md
+++ b/samples/client/petstore/scala-akka/docs/User.md
@@ -1,0 +1,21 @@
+
+
+# User
+
+A User who is purchasing from the pet store
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **Long** |  |  [optional]
+**username** | **String** |  |  [optional]
+**firstName** | **String** |  |  [optional]
+**lastName** | **String** |  |  [optional]
+**email** | **String** |  |  [optional]
+**password** | **String** |  |  [optional]
+**phone** | **String** |  |  [optional]
+**userStatus** | **Int** | User Status |  [optional]
+
+
+


### PR DESCRIPTION
Scala Akka Client contains references to Model Docs that aren't present in the generated source code. This PR fixes that by adding those docs, resolving this issue #10242

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
