### PR TITLE
[typescript-fetch] date=string type mapping

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -975,6 +975,14 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             return TypeScriptFetchClientCodegen.getItemsDataType(this.items);
         }
 
+        public boolean isDateType() {
+            return isDate && "Date".equals(dataType);
+        }
+
+        public boolean isDateTimeType() {
+            return isDateTime && "Date".equals(dataType);
+        }
+
         public ExtendedCodegenParameter(CodegenParameter cp) {
             super();
 
@@ -1104,6 +1112,14 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
 
         public String getItemsDataType() {
             return TypeScriptFetchClientCodegen.getItemsDataType(this.items);
+        }
+
+        public boolean isDateType() {
+            return isDate && "Date".equals(dataType);
+        }
+
+        public boolean isDateTimeType() {
+            return isDateTime && "Date".equals(dataType);
         }
 
         public ExtendedCodegenProperty(CodegenProperty cp) {
@@ -1344,6 +1360,14 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         public boolean isEntity; // Is a model containing an "id" property marked as isUniqueId
         public String returnPassthrough;
         public boolean hasReturnPassthroughVoid;
+
+        public boolean isDateType() {
+            return isDate && "Date".equals(dataType);
+        }
+
+        public boolean isDateTimeType() {
+            return isDateTime && "Date".equals(dataType);
+        }
 
         public ExtendedCodegenModel(CodegenModel cm) {
             super();

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -116,17 +116,17 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isArray}}
         {{^isArray}}
         if (requestParameters.{{paramName}} !== undefined) {
-            {{#isDateTime}}
+            {{#isDateTimeType}}
             queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString();
-            {{/isDateTime}}
-            {{^isDateTime}}
-            {{#isDate}}
+            {{/isDateTimeType}}
+            {{^isDateTimeType}}
+            {{#isDateType}}
             queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substr(0,10);
-            {{/isDate}}
-            {{^isDate}}
+            {{/isDateType}}
+            {{^isDateType}}
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
-            {{/isDate}}
-            {{/isDateTime}}
+            {{/isDateType}}
+            {{/isDateTimeType}}
         }
 
         {{/isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -45,17 +45,17 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{/additionalPropertiesType}}
         {{#vars}}
         {{#isPrimitiveType}}
-        {{#isDate}}
+        {{#isDateType}}
         '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
-        {{/isDate}}
-        {{#isDateTime}}
+        {{/isDateType}}
+        {{#isDateTimeType}}
         '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
-        {{/isDateTime}}
-        {{^isDate}}
-        {{^isDateTime}}
+        {{/isDateTimeType}}
+        {{^isDateType}}
+        {{^isDateTimeType}}
         '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
-        {{/isDateTime}}
-        {{/isDate}}
+        {{/isDateTimeType}}
+        {{/isDateType}}
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}
@@ -104,7 +104,7 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
         {{#vars}}
         {{^isReadOnly}}
         {{#isPrimitiveType}}
-        '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString().substr(0,10)){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString()){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
+        '{{baseName}}': {{#isDateType}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString().substr(0,10)){{/isDateType}}{{#isDateTimeType}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString()){{/isDateTimeType}}{{^isDateType}}{{^isDateTimeType}}value.{{name}}{{/isDateTimeType}}{{/isDateType}},
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -116,6 +116,76 @@ public class TypeScriptFetchModelTest {
         Assert.assertFalse(property5.isContainer);
     }
 
+    @Test(description = "convert a simple TypeScript Angular model; overwrite date/DateTime type mapping")
+    public void simpleModelWithStringDateTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
+                .addProperties("name", new StringSchema())
+                .addProperties("createdAt", new DateTimeSchema())
+                .addProperties("birthDate", new DateSchema())
+                .addProperties("active", new BooleanSchema())
+                .addRequiredItem("id")
+                .addRequiredItem("name");
+
+        final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        codegen.typeMapping().put("date", "string");
+        codegen.typeMapping().put("DateTime", "string");
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 5);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.dataType, "number");
+        Assert.assertEquals(property1.name, "id");
+        Assert.assertEquals(property1.defaultValue, "undefined");
+        Assert.assertEquals(property1.baseType, "number");
+        Assert.assertTrue(property1.required);
+        Assert.assertFalse(property1.isContainer);
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "name");
+        Assert.assertEquals(property2.dataType, "string");
+        Assert.assertEquals(property2.name, "name");
+        Assert.assertEquals(property2.defaultValue, "undefined");
+        Assert.assertEquals(property2.baseType, "string");
+        Assert.assertTrue(property2.required);
+        Assert.assertFalse(property2.isContainer);
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.complexType, null);
+        Assert.assertEquals(property3.dataType, "string");
+        Assert.assertEquals(property3.name, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "undefined");
+        Assert.assertFalse(property3.required);
+        Assert.assertFalse(property3.isContainer);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.complexType, null);
+        Assert.assertEquals(property4.dataType, "string");
+        Assert.assertEquals(property4.name, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "undefined");
+        Assert.assertFalse(property4.required);
+        Assert.assertFalse(property4.isContainer);
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        Assert.assertEquals(property5.baseName, "active");
+        Assert.assertEquals(property5.complexType, null);
+        Assert.assertEquals(property5.dataType, "boolean");
+        Assert.assertEquals(property5.name, "active");
+        Assert.assertEquals(property5.defaultValue, "undefined");
+        Assert.assertFalse(property5.required);
+        Assert.assertFalse(property5.isContainer);
+    }
+
     @Test(description = "convert and check default values for a simple TypeScript Angular model")
     public void simpleModelDefaultValuesTest() throws ParseException {
         IntegerSchema integerSchema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);


### PR DESCRIPTION
The typescript-fetch use `Date` typed properties for date and date-time fields.
The generated interface and factory function looks like this:

```typescript
export interface TheModel {
    /**
     * 
     * @type {Date}
     * @memberof TheModel
     */
    mandatoryDate: Date;
    /**
     * 
     * @type {Date}
     * @memberof TheModel
     */
    optionalDate?: Date;
}

export function TheModelFromJSONTyped(json: any, ignoreDiscriminator: boolean): TheModel {
    if ((json === undefined) || (json === null)) {
        return json;
    }
    return {
        'mandatoryDate': (new Date(json['updateDateTime'])),
        'optionalDate': !exists(json, 'publicationDateTime') ? undefined : (new Date(json['publicationDateTime'])),
    };
}
```

When changing the type mapping with `--type-mappings=date=string,DateTime=string` only the interface changes:

```typescript
export interface TheModel {
    /**
     * 
     * @type {string}
     * @memberof TheModel
     */
    mandatoryDate: string;
    /**
     * 
     * @type {string}
     * @memberof TheModel
     */
    optionalDate?: string;
}

export function TheModelFromJSONTyped(json: any, ignoreDiscriminator: boolean): TheModel {
    if ((json === undefined) || (json === null)) {
        return json;
    }
    return {
        'mandatoryDate': (new Date(json['updateDateTime'])),
        'optionalDate': !exists(json, 'publicationDateTime') ? undefined : (new Date(json['publicationDateTime'])),
    };
}
```

But the factory function still converts all values to dates.
This is wrong and results in a typescript compile error.

With the change, the generated code looks like this (when remap `date=string,DateTime=string`):

```typescript
export interface TheModel {
    /**
     * 
     * @type {string}
     * @memberof TheModel
     */
    mandatoryDate: string;
    /**
     * 
     * @type {string}
     * @memberof TheModel
     */
    optionalDate?: string;
}

export function TheModelFromJSONTyped(json: any, ignoreDiscriminator: boolean): TheModel {
    if ((json === undefined) || (json === null)) {
        return json;
    }
    return {
        'mandatoryDate': json['updateDateTime'],
        'optionalDate': !exists(json, 'publicationDateTime') ? undefined : json['publicationDateTime'],
    };
}
```


<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

I just don't know how to cover that in the UnitTests. Which is why I didn't add any new tests :roll_eyes: 
It might make sense to set `CodegenParameter#isDate` & `#isDateTime`, `CodegenProperty#isDate` & `#isDateTime` and `CodegenModel#isDate` & `#isDateTime` to false instead. But that would be a more serious intervention.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov

Relates to #11308 #10088