### PR TITLE
[kotlin-spring] fix #9902 use coroutine Flow for arrays in delegate when reactive=true

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiDelegate.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiDelegate.mustache
@@ -9,9 +9,6 @@ import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.core.io.Resource
 {{#reactive}}
 import kotlinx.coroutines.flow.Flow
-import org.springframework.web.server.ServerWebExchange
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 {{/reactive}}
 
 import java.util.Optional
@@ -33,7 +30,7 @@ interface {{classname}}Delegate {
     /**
      * @see {{classname}}#{{operationId}}
      */
-    {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{paramName}}: {{^isFile}}{{>optionalDataType}}{{/isFile}}{{#isFile}}Resource?{{/isFile}}{{^-last}},
+    {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{paramName}}: {{^isFile}}{{^reactive}}{{>optionalDataType}}{{/reactive}}{{#reactive}}{{^isArray}}{{>optionalDataType}}{{/isArray}}{{#isArray}}Flow<{{{baseType}}}>{{/isArray}}{{/reactive}}{{/isFile}}{{#isFile}}Resource?{{/isFile}}{{^-last}},
         {{/-last}}{{/allParams}}): {{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {
         {{>methodBody}}
     }

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiDelegate.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiDelegate.mustache
@@ -30,7 +30,7 @@ interface {{classname}}Delegate {
     /**
      * @see {{classname}}#{{operationId}}
      */
-    {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{paramName}}: {{^isFile}}{{^reactive}}{{>optionalDataType}}{{/reactive}}{{#reactive}}{{^isArray}}{{>optionalDataType}}{{/isArray}}{{#isArray}}Flow<{{{baseType}}}>{{/isArray}}{{/reactive}}{{/isFile}}{{#isFile}}Resource?{{/isFile}}{{^-last}},
+    {{#reactive}}{{^isArray}}suspend {{/isArray}}{{/reactive}}fun {{operationId}}({{#allParams}}{{paramName}}: {{^isFile}}{{^reactive}}{{>optionalDataType}}{{/reactive}}{{#reactive}}{{^isArray}}{{>optionalDataType}}{{/isArray}}{{#isArray}}{{#isBodyParam}}Flow<{{{baseType}}}>{{/isBodyParam}}{{^isBodyParam}}{{>optionalDataType}}{{/isBodyParam}}{{/isArray}}{{/reactive}}{{/isFile}}{{#isFile}}Resource?{{/isFile}}{{^-last}},
         {{/-last}}{{/allParams}}): {{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {
         {{>methodBody}}
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -1,11 +1,17 @@
 package org.openapitools.codegen.kotlin.spring;
 
+import static org.openapitools.codegen.TestUtils.assertFileContains;
+import static org.openapitools.codegen.TestUtils.assertFileNotContains;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
 import com.google.common.collect.testing.Helpers;
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.parser.core.models.ParseOptions;
+
 import org.apache.commons.io.FileUtils;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
@@ -17,15 +23,11 @@ import org.openapitools.codegen.languages.features.CXFServerFeatures;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-
-import static org.openapitools.codegen.TestUtils.assertFileContains;
-import static org.openapitools.codegen.TestUtils.assertFileNotContains;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.parser.core.models.ParseOptions;
 
 public class KotlinSpringServerCodegenTest {
 
@@ -236,7 +238,10 @@ public class KotlinSpringServerCodegenTest {
                 new File(output, "src/main/kotlin/org/openapitools/api/TestV1ApiDelegate.kt"),
                 new File(output, "src/main/kotlin/org/openapitools/api/TestV2Api.kt"),
                 new File(output, "src/main/kotlin/org/openapitools/api/TestV2ApiController.kt"),
-                new File(output, "src/main/kotlin/org/openapitools/api/TestV2ApiDelegate.kt")
+                new File(output, "src/main/kotlin/org/openapitools/api/TestV2ApiDelegate.kt"),
+                new File(output, "src/main/kotlin/org/openapitools/api/TestV3Api.kt"),
+                new File(output, "src/main/kotlin/org/openapitools/api/TestV3ApiController.kt"),
+                new File(output, "src/main/kotlin/org/openapitools/api/TestV3ApiDelegate.kt")
         );
 
         assertFileContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV1Api.kt"),
@@ -253,9 +258,18 @@ public class KotlinSpringServerCodegenTest {
         assertFileNotContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV2Api.kt"),
                 "exchange");
         assertFileContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV2ApiDelegate.kt"),
-                "import kotlinx.coroutines.flow.Flow");
+                "import kotlinx.coroutines.flow.Flow", "ResponseEntity<Flow<kotlin.String>>");
         assertFileNotContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV2ApiDelegate.kt"),
                 "suspend fun", "ApiUtil");
+
+        assertFileContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV3Api.kt"),
+                "import kotlinx.coroutines.flow.Flow", "requestBody: Flow<kotlin.Long>");
+        assertFileNotContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV3Api.kt"),
+                "exchange");
+        assertFileContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV3ApiDelegate.kt"),
+                "import kotlinx.coroutines.flow.Flow", "suspend fun", "requestBody: Flow<kotlin.Long>");
+        assertFileNotContains(Paths.get(output + "/src/main/kotlin/org/openapitools/api/TestV3ApiDelegate.kt"),
+                "ApiUtil");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/issue7325-use-delegate-reactive-tags-kotlin.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/issue7325-use-delegate-reactive-tags-kotlin.yaml
@@ -32,4 +32,18 @@ paths:
                 items:
                   type: string
 
-
+  /api/v3/test:
+    post:
+      tags: [Test v3]
+      operationId: test3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                format: int64
+                type: integer
+      responses:
+        202:
+          description: OK


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR fixes the problem described in issue [#9902](https://github.com/OpenAPITools/openapi-generator/issues/9902), which I'll summarize here:
* For the `kotlin-spring` generator, with `delegatePattern` and `reactive` set to true, the generated API file should use a Kotlin coroutine-type `Flow` when dealing with an OpenAPI `array` data type.
* For a `requestBody` parameter, it does this for a generated API class, but _not_ for a generated Delegate class. In generated Delegate classes, an array type that is the request body is generated as a `kotlin.collections.List` instead of a `Flow`.
* This is not only incorrect, it also means the generated code does not compile, as the API class is attempting to pass a `Flow` to a Delegate that is expecting a `kotlin.collections.List`.

To fix this, I have made the following changes:
* I have updated the relevant Delegate Moustache template to use a `Flow` when the `requestBody` parameter is an array.
* I've also added some unit tests to cover this case.

#### How to validate
1. Using [this OpenAPI spec](https://gist.github.com/giveadamakick/11d65b51f951eb23150937ce225f4223), and using an openapi-generator-maven-plugin config with `delegatePattern` and `reactive` set to `true` (see [this example I used](https://gist.github.com/giveadamakick/b87fac47e6076a72c22dfe6bb10eeeef)), run a `mvn install` _without_ the changes in this PR. You'll see that the generated code does not compile.
2. Repeat the above using the generator including the changes in this PR. The code now compiles, and the delegate has the correct `Flow` type for the `requestBody` parameter.

After running both `./bin/generate-samples.sh` and `./bin/utils/export_docs_generators.sh`, no extra files were generated, so nothing extra to include in this PR.

Mentioning Kotlin technical committee members: @jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
