### PR TITLE
[java native] Support arrays in QueryParameters deepObject style

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -313,7 +313,12 @@ public class {{classname}} {
         {{#isDeepObject}}
     if ({{paramName}} != null) {
           {{#items.vars}}
+              {{#isArray}}
+      localVarQueryParams.addAll(ApiClient.parameterToPairs("csv", "{{baseName}}", {{paramName}}.{{getter}}()));
+              {{/isArray}}
+              {{^isArray}}
       localVarQueryParams.addAll(ApiClient.parameterToPairs("{{baseName}}", {{paramName}}.{{getter}}()));
+              {{/isArray}}
           {{/items.vars}}
     }
         {{/isDeepObject}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientDeepObjectTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientDeepObjectTest.java
@@ -58,6 +58,6 @@ public class JavaClientDeepObjectTest {
         generator.opts(input).generate();
 
         assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
-                "options[a]", "options[b]");
+                "options[a]", "options[b]", "\"csv\", \"options[c]\"");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/deepobject.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/deepobject.yaml
@@ -34,3 +34,7 @@ components:
           type: string
           nullable: true
           format: date-time
+        c:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)

This PR extends src/main/resources/Java/libraries/native/api.mustache to handle arrays within deepObject
#11697

Please have a look at the extended test class and test document:
* modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientDeepObjectTest.java
* modules/openapi-generator/src/test/resources/3_0/deepobject.yaml

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
