### PR TITLE
Support validation for arrays for JavaJaxRS and a test to validate th…

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidatedType.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidatedType.mustache
@@ -1,0 +1,1 @@
+{{#isArray}}{{baseType}}<{{#items}}{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}{{>beanValidatedType}}{{/items}}>{{/isArray}}{{^isArray}}{{{datatypeWithEnum}}}{{/isArray}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   {{#vendorExtensions.x-extra-annotation}}{{{vendorExtensions.x-extra-annotation}}}{{/vendorExtensions.x-extra-annotation}}{{#useSwaggerAnnotations}}
   @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/useSwaggerAnnotations}}
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{>beanValidatedType}} {{getter}}() {
     return {{name}};
   }
 

--- a/modules/openapi-generator/src/test/resources/3_0/deepobject-array-with-pattern.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/deepobject-array-with-pattern.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.3
+info:
+  title: deepobject-array-with-pattern-test
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      operationId: test
+      parameters:
+        - name: options
+          in: query
+          required: false
+          style: deepObject
+          schema:
+            $ref: '#/components/schemas/Options'
+          explode: true
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Options:
+      type: object
+      properties:
+        a:
+          type: array
+          items:
+            type: string
+            pattern: '^[A-Z].*'


### PR DESCRIPTION
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)

This PR extends src/main/resources/JavaJaxRS/spec/pojo.mustache to handle patterns for arrays within deepObjects
Added file: src/main/resources/JavaJaxRS/spec/beanValidatedType.mustache
Extended test for validation: src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java

https://github.com/OpenAPITools/openapi-generator/issues/11707

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
