### PR TITLE
fix: avoid generic NPE when refering to missing schema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -565,6 +565,9 @@ public class DefaultCodegen implements CodegenConfig {
                 parent.getChildren().add(cm);
                 parent.hasChildren = true;
                 Schema parentSchema = this.openAPI.getComponents().getSchemas().get(parent.name);
+                if (parentSchema == null) {
+                    throw new NullPointerException(parent.name+" in "+this.openAPI.getComponents().getSchemas());
+                }
                 if (parentSchema.getDiscriminator() == null) {
                     parent = allModels.get(parent.getParent());
                 } else {


### PR DESCRIPTION
I was getting a generic NPE that I was unable to analyze:

```
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
Caused by: java.lang.NullPointerException
        at org.openapitools.codegen.DefaultCodegen.updateAllModels(DefaultCodegen.java:568)
        at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:497)
        at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:888)
        at org.openapitools.generator.gradle.plugin.tasks.GenerateTask.doWork(GenerateTask.kt:716)
        ... 223 more
```

Here:
https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L568

This change gives me something to investigate.
