### PR TITLE
[typescript-fetch] / #8881: add ESM to npm builds

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -405,6 +405,10 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("package.mustache", "", "package.json"));
         supportingFiles.add(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
+        // in case ECMAScript 6 is supported add another tsconfig for an ESM (ECMAScript Module)
+        if (supportsES6) {
+            supportingFiles.add(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
+        }
         supportingFiles.add(new SupportingFile("npmignore.mustache", "", ".npmignore"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
     }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
@@ -9,10 +9,13 @@
 {{^packageAsSourceOnlyLibrary}}
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+{{#supportsES6}}
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
+{{/supportsES6}}
   "scripts": {
-    "build": "tsc"{{^sagasAndRecords}},
-    "prepare": "npm run build"
-{{/sagasAndRecords}}
+    "build": "tsc{{#supportsES6}} && tsc -p tsconfig.esm.json{{/supportsES6}}"{{^sagasAndRecords}},
+    "prepare": "npm run build"{{/sagasAndRecords}}
   },
 {{/packageAsSourceOnlyLibrary}}
   "devDependencies": {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/tsconfig.esm.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/tsconfig.esm.mustache
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -3,12 +3,14 @@ package org.openapitools.codegen.typescript.fetch;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeScriptFetchClientCodegenTest {
     @Test
@@ -102,4 +104,33 @@ public class TypeScriptFetchClientCodegenTest {
         Assert.assertEquals(codegen.getTypeDeclaration(parentSchema), "{ [key: string]: Child; }");
     }
 
+    @Test
+    public void containsESMTSConfigFileInCaseOfES6AndNPM() {
+        TypeScriptFetchClientCodegen codegen = new TypeScriptFetchClientCodegen();
+
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-fetch-petstore");
+        codegen.additionalProperties().put("snapshot", false);
+        codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
+        codegen.setSupportsES6(true);
+
+        codegen.processOpts();
+
+        assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
+        assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
+    }
+
+    @Test
+    public void doesNotContainESMTSConfigFileInCaseOfES5AndNPM() {
+        TypeScriptFetchClientCodegen codegen = new TypeScriptFetchClientCodegen();
+
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-fetch-petstore");
+        codegen.additionalProperties().put("snapshot", false);
+        codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
+        codegen.setSupportsES6(false);
+
+        codegen.processOpts();
+
+        assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
+        assertThat(codegen.supportingFiles()).doesNotContain(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
+    }
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/.openapi-generator/FILES
@@ -15,4 +15,5 @@ src/models/Tag.ts
 src/models/User.ts
 src/models/index.ts
 src/runtime.ts
+tsconfig.esm.json
 tsconfig.json

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
@@ -5,8 +5,10 @@
   "author": "OpenAPI-Generator",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "npm run build"
   },
   "devDependencies": {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/tsconfig.esm.json
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/.openapi-generator/FILES
@@ -70,4 +70,5 @@ src/models/WarningCodeRecord.ts
 src/models/index.ts
 src/runtime.ts
 src/runtimeSagasAndRecords.ts
+tsconfig.esm.json
 tsconfig.json

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/package.json
@@ -5,8 +5,11 @@
   "author": "OpenAPI-Generator",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc"  },
+    "build": "tsc && tsc -p tsconfig.esm.json"
+  },
   "devDependencies": {
     "immutable": "^4.0.0-rc.12",
     "normalizr": "^3.6.1",

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/tsconfig.esm.json
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}


### PR DESCRIPTION
fix #8881 

An additional ``tsconfig.esm.json`` is added to every generated typescript-fetch code having ``supportsES6`` and ``npmName``.
That will create an additional ECMAScript Module (ESM) to the npm build.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  # ./bin/utils/export_docs_generators.sh # no docs changed
  ``` 
- [X]  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh ./bin/configs/typescript-fetch-*`. 
- [ ]  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/). # No Windows user
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

I welcome the technical committee:
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov