### PR TITLE
Fix oneOf discriminator lookup in java okhttp-gson client

### DIFF
--- a/bin/configs/java-okhttp-gson.yaml
+++ b/bin/configs/java-okhttp-gson.yaml
@@ -6,3 +6,4 @@ templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: petstore-okhttp-gson
   hideGenerationTimestamp: "true"
+  useOneOfDiscriminatorLookup: "true"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
@@ -76,16 +76,20 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     {{#discriminator}}
                     // use discriminator value for faster oneOf lookup
                     {{classname}} new{{classname}} = new {{classname}}();
-                    String discriminatorValue = elementAdapter.read(in).getAsJsonObject().get("{{{propertyBaseName}}}").getAsString();
-                    switch (discriminatorValue) {
-                    {{#mappedModels}}
-                        case "{{{mappingName}}}":
-                            deserialized = adapter{{modelName}}.fromJsonTree(jsonObject);
-                            new{{classname}}.setActualInstance(deserialized);
-                            return new{{classname}};
-                    {{/mappedModels}}
-                        default:
-                            log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", discriminatorValue));
+                    if (jsonObject.get("{{{propertyBaseName}}}") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for {{classname}} as `{{{propertyBaseName}}}` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `{{{propertyBaseName}}}`
+                        switch (jsonObject.get("{{{propertyBaseName}}}").getAsString()) {
+                        {{#mappedModels}}
+                            case "{{{mappingName}}}":
+                                deserialized = adapter{{modelName}}.fromJsonTree(jsonObject);
+                                new{{classname}}.setActualInstance(deserialized);
+                                return new{{classname}};
+                        {{/mappedModels}}
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", jsonObject.get("{{{propertyBaseName}}}").getAsString()));
+                        }
                     }
 
                     {{/discriminator}}

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Mammal.java
@@ -113,6 +113,30 @@ public class Mammal extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
 
+                    // use discriminator value for faster oneOf lookup
+                    Mammal newMammal = new Mammal();
+                    if (jsonObject.get("className") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for Mammal as `className` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `className`
+                        switch (jsonObject.get("className").getAsString()) {
+                            case "Pig":
+                                deserialized = adapterPig.fromJsonTree(jsonObject);
+                                newMammal.setActualInstance(deserialized);
+                                return newMammal;
+                            case "whale":
+                                deserialized = adapterWhale.fromJsonTree(jsonObject);
+                                newMammal.setActualInstance(deserialized);
+                                return newMammal;
+                            case "zebra":
+                                deserialized = adapterZebra.fromJsonTree(jsonObject);
+                                newMammal.setActualInstance(deserialized);
+                                return newMammal;
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for Mammal. Possible values: Pig whale zebra", jsonObject.get("className").getAsString()));
+                        }
+                    }
+
                     int match = 0;
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -104,6 +104,26 @@ public class NullableShape extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
 
+                    // use discriminator value for faster oneOf lookup
+                    NullableShape newNullableShape = new NullableShape();
+                    if (jsonObject.get("shapeType") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for NullableShape as `shapeType` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `shapeType`
+                        switch (jsonObject.get("shapeType").getAsString()) {
+                            case "Quadrilateral":
+                                deserialized = adapterQuadrilateral.fromJsonTree(jsonObject);
+                                newNullableShape.setActualInstance(deserialized);
+                                return newNullableShape;
+                            case "Triangle":
+                                deserialized = adapterTriangle.fromJsonTree(jsonObject);
+                                newNullableShape.setActualInstance(deserialized);
+                                return newNullableShape;
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for NullableShape. Possible values: Quadrilateral Triangle", jsonObject.get("shapeType").getAsString()));
+                        }
+                    }
+
                     int match = 0;
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pig.java
@@ -104,6 +104,26 @@ public class Pig extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
 
+                    // use discriminator value for faster oneOf lookup
+                    Pig newPig = new Pig();
+                    if (jsonObject.get("className") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for Pig as `className` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `className`
+                        switch (jsonObject.get("className").getAsString()) {
+                            case "BasquePig":
+                                deserialized = adapterBasquePig.fromJsonTree(jsonObject);
+                                newPig.setActualInstance(deserialized);
+                                return newPig;
+                            case "DanishPig":
+                                deserialized = adapterDanishPig.fromJsonTree(jsonObject);
+                                newPig.setActualInstance(deserialized);
+                                return newPig;
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for Pig. Possible values: BasquePig DanishPig", jsonObject.get("className").getAsString()));
+                        }
+                    }
+
                     int match = 0;
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -104,6 +104,26 @@ public class Quadrilateral extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
 
+                    // use discriminator value for faster oneOf lookup
+                    Quadrilateral newQuadrilateral = new Quadrilateral();
+                    if (jsonObject.get("quadrilateralType") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for Quadrilateral as `quadrilateralType` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `quadrilateralType`
+                        switch (jsonObject.get("quadrilateralType").getAsString()) {
+                            case "ComplexQuadrilateral":
+                                deserialized = adapterComplexQuadrilateral.fromJsonTree(jsonObject);
+                                newQuadrilateral.setActualInstance(deserialized);
+                                return newQuadrilateral;
+                            case "SimpleQuadrilateral":
+                                deserialized = adapterSimpleQuadrilateral.fromJsonTree(jsonObject);
+                                newQuadrilateral.setActualInstance(deserialized);
+                                return newQuadrilateral;
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for Quadrilateral. Possible values: ComplexQuadrilateral SimpleQuadrilateral", jsonObject.get("quadrilateralType").getAsString()));
+                        }
+                    }
+
                     int match = 0;
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Shape.java
@@ -104,6 +104,26 @@ public class Shape extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
 
+                    // use discriminator value for faster oneOf lookup
+                    Shape newShape = new Shape();
+                    if (jsonObject.get("shapeType") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for Shape as `shapeType` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `shapeType`
+                        switch (jsonObject.get("shapeType").getAsString()) {
+                            case "Quadrilateral":
+                                deserialized = adapterQuadrilateral.fromJsonTree(jsonObject);
+                                newShape.setActualInstance(deserialized);
+                                return newShape;
+                            case "Triangle":
+                                deserialized = adapterTriangle.fromJsonTree(jsonObject);
+                                newShape.setActualInstance(deserialized);
+                                return newShape;
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for Shape. Possible values: Quadrilateral Triangle", jsonObject.get("shapeType").getAsString()));
+                        }
+                    }
+
                     int match = 0;
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -104,6 +104,26 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
 
+                    // use discriminator value for faster oneOf lookup
+                    ShapeOrNull newShapeOrNull = new ShapeOrNull();
+                    if (jsonObject.get("shapeType") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for ShapeOrNull as `shapeType` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `shapeType`
+                        switch (jsonObject.get("shapeType").getAsString()) {
+                            case "Quadrilateral":
+                                deserialized = adapterQuadrilateral.fromJsonTree(jsonObject);
+                                newShapeOrNull.setActualInstance(deserialized);
+                                return newShapeOrNull;
+                            case "Triangle":
+                                deserialized = adapterTriangle.fromJsonTree(jsonObject);
+                                newShapeOrNull.setActualInstance(deserialized);
+                                return newShapeOrNull;
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for ShapeOrNull. Possible values: Quadrilateral Triangle", jsonObject.get("shapeType").getAsString()));
+                        }
+                    }
+
                     int match = 0;
                     TypeAdapter actualAdapter = elementAdapter;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Triangle.java
@@ -113,6 +113,30 @@ public class Triangle extends AbstractOpenApiSchema {
                     Object deserialized = null;
                     JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
 
+                    // use discriminator value for faster oneOf lookup
+                    Triangle newTriangle = new Triangle();
+                    if (jsonObject.get("triangleType") == null) {
+                        log.log(Level.WARNING, "Failed to lookup discriminator value for Triangle as `triangleType` was not found in the payload or the payload is empty.");
+                    } else  {
+                        // look up the discriminator value in the field `triangleType`
+                        switch (jsonObject.get("triangleType").getAsString()) {
+                            case "EquilateralTriangle":
+                                deserialized = adapterEquilateralTriangle.fromJsonTree(jsonObject);
+                                newTriangle.setActualInstance(deserialized);
+                                return newTriangle;
+                            case "IsoscelesTriangle":
+                                deserialized = adapterIsoscelesTriangle.fromJsonTree(jsonObject);
+                                newTriangle.setActualInstance(deserialized);
+                                return newTriangle;
+                            case "ScaleneTriangle":
+                                deserialized = adapterScaleneTriangle.fromJsonTree(jsonObject);
+                                newTriangle.setActualInstance(deserialized);
+                                return newTriangle;
+                            default:
+                                log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for Triangle. Possible values: EquilateralTriangle IsoscelesTriangle ScaleneTriangle", jsonObject.get("triangleType").getAsString()));
+                        }
+                    }
+
                     int match = 0;
                     TypeAdapter actualAdapter = elementAdapter;
 


### PR DESCRIPTION
- Fix oneOf discriminator lookup in java okhttp-gson client
- Add tests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
