### PR TITLE
[PHP] Fix deprecations in PHP 8.1

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php/README.mustache
@@ -13,7 +13,7 @@ For more information, please visit [{{{infoUrl}}}]({{{infoUrl}}}).
 ### Requirements
 
 PHP 7.3 and later.
-Should also work with PHP 8.0 but has not been tested.
+Should also work with PHP 8.0 or 8.1 but has not been tested.
 
 ### Composer
 

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -371,7 +371,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -371,7 +371,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -383,6 +383,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -396,7 +397,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -412,7 +413,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -424,6 +425,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/README.md
@@ -8,7 +8,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 ### Requirements
 
 PHP 7.3 and later.
-Should also work with PHP 8.0 but has not been tested.
+Should also work with PHP 8.0 or 8.1 but has not been tested.
 
 ### Composer
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -265,7 +265,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -265,7 +265,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -277,6 +277,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +291,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -306,7 +307,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -318,6 +319,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -271,7 +271,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -271,7 +271,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -283,6 +283,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -296,7 +297,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -312,7 +313,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -324,6 +325,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -295,7 +295,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -307,6 +307,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +321,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -336,7 +337,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -348,6 +349,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -295,7 +295,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -235,7 +235,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -235,7 +235,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -235,7 +235,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -235,7 +235,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -310,7 +310,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -310,7 +310,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -322,6 +322,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -335,7 +336,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -351,7 +352,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -363,6 +364,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -385,7 +385,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -397,6 +397,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -410,7 +411,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -426,7 +427,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -438,6 +439,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -385,7 +385,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -229,7 +229,7 @@ class Cat extends Animal
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -229,7 +229,7 @@ class Cat extends Animal
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -241,6 +241,7 @@ class Cat extends Animal
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -254,7 +255,7 @@ class Cat extends Animal
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -270,7 +271,7 @@ class Cat extends Animal
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -282,6 +283,7 @@ class Cat extends Animal
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -235,7 +235,7 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -235,7 +235,7 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -268,7 +268,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -268,7 +268,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -280,6 +280,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -293,7 +294,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -309,7 +310,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -321,6 +322,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -236,7 +236,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -248,6 +248,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,7 +262,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -277,7 +278,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -289,6 +290,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -236,7 +236,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -235,7 +235,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -235,7 +235,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
@@ -235,7 +235,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
@@ -235,7 +235,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -229,7 +229,7 @@ class Dog extends Animal
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -229,7 +229,7 @@ class Dog extends Animal
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -241,6 +241,7 @@ class Dog extends Animal
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -254,7 +255,7 @@ class Dog extends Animal
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -270,7 +271,7 @@ class Dog extends Animal
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -282,6 +283,7 @@ class Dog extends Animal
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -235,7 +235,7 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -235,7 +235,7 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -323,7 +323,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -323,7 +323,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -335,6 +335,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,7 +349,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +365,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -376,6 +377,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -588,7 +588,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -588,7 +588,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -600,6 +600,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -613,7 +614,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -629,7 +630,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -641,6 +642,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -236,7 +236,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -248,6 +248,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,7 +262,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -277,7 +278,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -289,6 +290,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -236,7 +236,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -265,7 +265,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -265,7 +265,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -277,6 +277,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +291,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -306,7 +307,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -318,6 +319,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -235,7 +235,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -235,7 +235,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -819,7 +819,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -819,7 +819,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -831,6 +831,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -844,7 +845,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -860,7 +861,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -872,6 +873,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -265,7 +265,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -265,7 +265,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -277,6 +277,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +291,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -306,7 +307,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -318,6 +319,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -236,7 +236,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -236,7 +236,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -248,6 +248,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,7 +262,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -277,7 +278,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -289,6 +290,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
@@ -235,7 +235,7 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
@@ -235,7 +235,7 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -349,7 +349,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -349,7 +349,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -361,6 +361,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +375,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -390,7 +391,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -402,6 +403,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -295,7 +295,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -295,7 +295,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -307,6 +307,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +321,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -336,7 +337,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -348,6 +349,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -266,7 +266,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -266,7 +266,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -278,6 +278,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,7 +292,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -307,7 +308,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -319,6 +320,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -235,7 +235,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -235,7 +235,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -236,7 +236,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -236,7 +236,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -248,6 +248,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,7 +262,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -277,7 +278,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -289,6 +290,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -329,7 +329,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -341,6 +341,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -354,7 +355,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -370,7 +371,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -382,6 +383,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -329,7 +329,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -565,7 +565,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -577,6 +577,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -590,7 +591,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -606,7 +607,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -618,6 +619,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -565,7 +565,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -235,7 +235,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -235,7 +235,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -331,7 +331,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -343,6 +343,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -356,7 +357,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -372,7 +373,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -384,6 +385,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -331,7 +331,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -421,7 +421,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -421,7 +421,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -433,6 +433,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -446,7 +447,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -462,7 +463,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -474,6 +475,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -295,7 +295,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -295,7 +295,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -307,6 +307,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +321,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -336,7 +337,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -348,6 +349,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
@@ -238,7 +238,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
@@ -238,7 +238,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -250,6 +250,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -263,7 +264,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -279,7 +280,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -291,6 +292,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -429,7 +429,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -441,6 +441,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -454,7 +455,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -470,7 +471,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -482,6 +483,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -429,7 +429,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -265,7 +265,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -277,6 +277,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +291,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -306,7 +307,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -318,6 +319,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -265,7 +265,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -235,7 +235,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -235,7 +235,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -247,6 +247,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +261,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -276,7 +277,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -288,6 +289,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -265,7 +265,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -277,6 +277,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +291,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -306,7 +307,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -318,6 +319,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -265,7 +265,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -445,7 +445,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): boolean
+    public function offsetExists($offset): bool
     {
         return isset($this->container[$offset]);
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -445,7 +445,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): boolean
     {
         return isset($this->container[$offset]);
     }
@@ -457,6 +457,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -470,7 +471,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -486,7 +487,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->container[$offset]);
     }
@@ -498,6 +499,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixed the following deprecations in PHP 8.1. This pull request resolves #11742.

> Deprecated: Return type of XXXX::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...

Added the `#[\ReturnTypeWillChange]` attribute or the same type hint as the internal interface to the return value of methods that implement PHP's internal interface `ArrayAccess`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) [❤️](https://www.patreon.com/ackintosh/overview), @ybelenko (2018/07), @renepardon (2018/12)