### PR TITLE
[kotlin-spring] Add beanQualifiers switch to populate RestController / Controller annotations with FQCN

### DIFF
--- a/docs/generators/kotlin-spring.md
+++ b/docs/generators/kotlin-spring.md
@@ -23,6 +23,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |artifactId|Generated artifact id (name of jar).| |openapi-spring|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |basePackage|base package (invokerPackage) for generated code| |org.openapitools|
+|beanQualifiers|Whether to add fully-qualifier class names as bean qualifiers in @Component and @RestController annotations. May be used to prevent bean names clash if multiple generated libraries (contexts) added to single project.| |false|
 |delegatePattern|Whether to generate the server files using the delegate pattern| |false|
 |enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |camelCase|
 |exceptionHandler|generate default global exception handlers (not compatible with reactive. enabling reactive will disable exceptionHandler )| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -66,6 +66,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     public static final String INTERFACE_ONLY = "interfaceOnly";
     public static final String DELEGATE_PATTERN = "delegatePattern";
     public static final String USE_TAGS = "useTags";
+    public static final String BEAN_QUALIFIERS = "beanQualifiers";
 
     private String basePackage;
     private String invokerPackage;
@@ -82,6 +83,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     private boolean interfaceOnly = false;
     private boolean delegatePattern = false;
     protected boolean useTags = false;
+    private boolean beanQualifiers = false;
 
     public KotlinSpringServerCodegen() {
         super();
@@ -146,6 +148,9 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         addSwitch(INTERFACE_ONLY, "Whether to generate only API interface stubs without the server files.", interfaceOnly);
         addSwitch(DELEGATE_PATTERN, "Whether to generate the server files using the delegate pattern", delegatePattern);
         addSwitch(USE_TAGS, "Whether to use tags for creating interface and controller class names", useTags);
+        addSwitch(BEAN_QUALIFIERS, "Whether to add fully-qualifier class names as bean qualifiers in @Component and " +
+                "@RestController annotations. May be used to prevent bean names clash if multiple generated libraries" +
+                " (contexts) added to single project.", beanQualifiers);
         supportedLibraries.put(SPRING_BOOT, "Spring-boot Server application.");
         setLibrary(SPRING_BOOT);
 
@@ -256,6 +261,14 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         this.reactive = reactive;
     }
 
+    public boolean isBeanQualifiers() {
+        return beanQualifiers;
+    }
+
+    public void setBeanQualifiers(boolean beanQualifiers) {
+        this.beanQualifiers = beanQualifiers;
+    }
+
     @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
@@ -362,6 +375,11 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         }
         writePropertyBack(REACTIVE, reactive);
         writePropertyBack(EXCEPTION_HANDLER, exceptionHandler);
+
+        if (additionalProperties.containsKey(BEAN_QUALIFIERS) && library.equals(SPRING_BOOT)) {
+            this.setBeanQualifiers(convertPropertyToBoolean(BEAN_QUALIFIERS));
+        }
+        writePropertyBack(BEAN_QUALIFIERS, beanQualifiers);
 
         if (additionalProperties.containsKey(INTERFACE_ONLY)) {
             this.setInterfaceOnly(Boolean.parseBoolean(additionalProperties.get(INTERFACE_ONLY).toString()));

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -40,7 +40,7 @@ import kotlinx.coroutines.flow.Flow;
 import kotlin.collections.List
 import kotlin.collections.Map
 
-@RestController
+@RestController{{#beanQualifiers}}("{{package}}.{{classname}}Controller"){{/beanQualifiers}}
 {{#useBeanValidation}}
 @Validated
 {{/useBeanValidation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Optional;
 {{>generatedAnnotation}}
 
-@Controller
+@Controller{{#beanQualifiers}}("{{package}}.{{classname}}Controller"){{/beanQualifiers}}
 {{=<% %>=}}
 @RequestMapping("\${openapi.<%title%>.base-path:<%>defaultBasePath%>}")
 <%={{ }}=%>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -374,4 +374,25 @@ public class KotlinSpringServerCodegenTest {
                 "@org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME)"
         );
     }
+
+    @Test(description = "test bean qualifiers")
+    public void beanQualifiers() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        KotlinSpringServerCodegen codegen = new KotlinSpringServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(KotlinSpringServerCodegen.BEAN_QUALIFIERS, true);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/kotlin/bean-qualifiers.yaml"))
+                        .config(codegen))
+                .generate();
+
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/kotlin/org/openapitools/api/PingApiController.kt"),
+                "@RestController(\"org.openapitools.api.PingApiController\")"
+        );
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/bean-qualifiers.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/bean-qualifiers.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.1"
+info:
+  title: test
+  version: "1.0"
+
+paths:
+
+  /ping:
+    get:
+      operationId: ping
+      responses:
+        200:
+          description: OK


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  -  @jimschubert , @dr4ke616 , @karismann , @Zomzog , @andrewemery , @4brunu , @yutaka0m


P.S.: Yes, i do understand that indented behaviour can be archived using customized templates (and we are using them right now). But i feel that this setting is a solution to quite common problem and may be other Spring-based generators (including Java) shall have this option as well.