### PR TITLE
[Java] Fix reactor-netty dependency

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -121,7 +121,7 @@ ext {
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     reactor_version = "3.4.3"
-    reactor_netty_version = "0.7.15.RELEASE"
+    reactor_netty_version = "1.0.4"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }
@@ -131,7 +131,7 @@ dependencies {
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_web_version"
-    implementation "io.projectreactor.ipc:reactor-netty:$reactor_netty_version"
+    implementation "io.projectreactor.netty:reactor-netty-http:$reactor_netty_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -93,8 +93,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.projectreactor.ipc</groupId>
-            <artifactId>reactor-netty</artifactId>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
             <version>${reactor-netty-version}</version>
         </dependency>
 
@@ -156,7 +156,7 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>4.13.2</junit-version>
         <reactor-version>3.4.3</reactor-version>
-        <reactor-netty-version>0.7.15.RELEASE</reactor-netty-version>
+        <reactor-netty-version>1.0.4</reactor-netty-version>
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}

--- a/samples/client/petstore/java/webclient-nulable-arrays/build.gradle
+++ b/samples/client/petstore/java/webclient-nulable-arrays/build.gradle
@@ -119,7 +119,7 @@ ext {
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     reactor_version = "3.4.3"
-    reactor_netty_version = "0.7.15.RELEASE"
+    reactor_netty_version = "1.0.4"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }
@@ -129,7 +129,7 @@ dependencies {
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_web_version"
-    implementation "io.projectreactor.ipc:reactor-netty:$reactor_netty_version"
+    implementation "io.projectreactor.netty:reactor-netty-http:$reactor_netty_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version"

--- a/samples/client/petstore/java/webclient-nulable-arrays/pom.xml
+++ b/samples/client/petstore/java/webclient-nulable-arrays/pom.xml
@@ -86,8 +86,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.projectreactor.ipc</groupId>
-            <artifactId>reactor-netty</artifactId>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
             <version>${reactor-netty-version}</version>
         </dependency>
 
@@ -133,6 +133,6 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>4.13.2</junit-version>
         <reactor-version>3.4.3</reactor-version>
-        <reactor-netty-version>0.7.15.RELEASE</reactor-netty-version>
+        <reactor-netty-version>1.0.4</reactor-netty-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -119,7 +119,7 @@ ext {
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     reactor_version = "3.4.3"
-    reactor_netty_version = "0.7.15.RELEASE"
+    reactor_netty_version = "1.0.4"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }
@@ -129,7 +129,7 @@ dependencies {
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_web_version"
-    implementation "io.projectreactor.ipc:reactor-netty:$reactor_netty_version"
+    implementation "io.projectreactor.netty:reactor-netty-http:$reactor_netty_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_databind_version"

--- a/samples/client/petstore/java/webclient/pom.xml
+++ b/samples/client/petstore/java/webclient/pom.xml
@@ -86,8 +86,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.projectreactor.ipc</groupId>
-            <artifactId>reactor-netty</artifactId>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
             <version>${reactor-netty-version}</version>
         </dependency>
 
@@ -133,6 +133,6 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>4.13.2</junit-version>
         <reactor-version>3.4.3</reactor-version>
-        <reactor-netty-version>0.7.15.RELEASE</reactor-netty-version>
+        <reactor-netty-version>1.0.4</reactor-netty-version>
     </properties>
 </project>


### PR DESCRIPTION
The spring-boot-starter-webflux uses
io.projectreactor.netty:reactor-netty-http
dependency so the io.projectreactor.ipc:reactor-netty
is actually not used at all

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)