### PR TITLE
[ruby] Allow boolean for discriminator value in oneOf handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
@@ -44,11 +44,11 @@
       def build(data)
       {{#discriminator}}
         discriminator_value = data[openapi_discriminator_name]
-        return nil unless discriminator_value
+        return nil if discriminator_value.nil?
       {{#mappedModels}}
       {{#-first}}
 
-        klass = openapi_discriminator_mapping[discriminator_value.to_sym]
+        klass = openapi_discriminator_mapping[discriminator_value.to_s.to_sym]
         return nil unless klass
 
         {{moduleName}}.const_get(klass).build_from_hash(data)


### PR DESCRIPTION
This must be a very rare case but we are using a boolean property as discriminator:
```yaml
    CarOrCustomCar:
      oneOf:
        - $ref: '#/components/schemas/Car'
        - $ref: '#/components/schemas/CustomCar'
      discriminator:
        propertyName: custom_flag
        mapping:
          true: '#/components/schemas/CustomCar'
          false: '#/components/schemas/Car'

    CustomCar:
      properties:
         :
        custom_flag:
          type: boolean

    Car:
      properties:
         :
        custom_flag:
          type: boolean
```

The [OpenAPI specification](https://swagger.io/specification/#discriminator-object) says:
> Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.

So I think we can modify to handle boolean values property for discriminator.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
