### PR TITLE
[DefaultCodegen] GetReferenceHeader for both calls of headerToCodegenParameter

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6696,6 +6696,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (header == null) {
             return null;
         }
+        header = ModelUtils.getReferencedHeader(this.openAPI, header);
         Parameter headerParam = new Parameter();
         headerParam.setName(headerName);
         headerParam.setIn("header");
@@ -6735,7 +6736,7 @@ public class DefaultCodegen implements CodegenConfig {
                         Map<String, Header> encHeaders = enc.getHeaders();
                         for (Entry<String, Header> headerEntry : encHeaders.entrySet()) {
                             String headerName = headerEntry.getKey();
-                            Header header = ModelUtils.getReferencedHeader(this.openAPI, headerEntry.getValue());
+                            Header header = headerEntry.getValue();
                             CodegenParameter param = headerToCodegenParameter(header, headerName, imports, mediaTypeSchemaSuffix);
                             headers.add(param);
                         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4001,7 +4001,7 @@ public class DefaultCodegen implements CodegenConfig {
                     List<CodegenParameter> responseHeaders = new ArrayList<>();
                     for (Entry<String, Header> entry : headers.entrySet()) {
                         String headerName = entry.getKey();
-                        Header header = entry.getValue();
+                        Header header = ModelUtils.getReferencedHeader(this.openAPI, entry.getValue());
                         CodegenParameter responseHeader = headerToCodegenParameter(header, headerName, imports, String.format(Locale.ROOT, "%sResponseParameter", r.code));
                         responseHeaders.add(responseHeader);
                     }
@@ -6696,7 +6696,6 @@ public class DefaultCodegen implements CodegenConfig {
         if (header == null) {
             return null;
         }
-        header = ModelUtils.getReferencedHeader(this.openAPI, header);
         Parameter headerParam = new Parameter();
         headerParam.setName(headerName);
         headerParam.setIn("header");
@@ -6736,7 +6735,7 @@ public class DefaultCodegen implements CodegenConfig {
                         Map<String, Header> encHeaders = enc.getHeaders();
                         for (Entry<String, Header> headerEntry : encHeaders.entrySet()) {
                             String headerName = headerEntry.getKey();
-                            Header header = headerEntry.getValue();
+                            Header header = ModelUtils.getReferencedHeader(this.openAPI, headerEntry.getValue());
                             CodegenParameter param = headerToCodegenParameter(header, headerName, imports, mediaTypeSchemaSuffix);
                             headers.add(param);
                         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4053,11 +4053,16 @@ public class DefaultCodegenTest {
 
         CodegenResponse cr = co.responses.get(0);
         List<CodegenParameter> responseHeaders = cr.getResponseHeaders();
-        assertEquals(1, responseHeaders.size());
-        CodegenParameter header = responseHeaders.get(0);
-        assertEquals("X-Rate-Limit", header.baseName);
-        assertTrue(header.isUnboundedInteger);
-        assertEquals(header.getSchema().baseName, "X-Rate-Limit");
+        assertEquals(2, responseHeaders.size());
+        CodegenParameter header1 = responseHeaders.get(0);
+        assertEquals("X-Rate-Limit", header1.baseName);
+        assertTrue(header1.isUnboundedInteger);
+        assertEquals(header1.getSchema().baseName, "X-Rate-Limit");
+
+        CodegenParameter header2 = responseHeaders.get(1);
+        assertEquals("X-Rate-Limit-Ref", header2.baseName);
+        assertTrue(header2.isUnboundedInteger);
+        assertEquals(header2.getSchema().baseName, "X-Rate-Limit-Ref");
 
         content = cr.getContent();
         assertEquals(content.keySet(), new HashSet<>(Arrays.asList("application/json", "text/plain")));

--- a/modules/openapi-generator/src/test/resources/3_0/content-data.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/content-data.yaml
@@ -38,6 +38,8 @@ paths:
               description: "The number of allowed requests in the current period"
               schema:
                 type: integer
+            X-Rate-Limit-Ref:
+              $ref: '#/components/headers/X-Rate-Limit'
           content:
             application/json:
               schema:
@@ -97,6 +99,11 @@ paths:
         200:
           description: OK
 components:
+  headers:
+    X-Rate-Limit:
+      description: "The number of allowed requests in the current period"
+      schema:
+        type: integer
   schemas:
     stringWithMinLength:
       type: string


### PR DESCRIPTION
In #11046 a bug was introduced regarding the fetching of reference headers.
As ModelUtils.getReferencedHeader wasn't called in all cases before headerToCodegenParameter was.
So now it's called inside headerToCodegenParameter as the first thing after null checking the header.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Possibly solves #11058
Also might relate to #11061 