### PR TITLE
[typescript-fetch] Remove undefined headers

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -55,6 +55,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -66,6 +66,8 @@ export class BaseAPI {
         : JSON.stringify(context.body);
 
         const headers = Object.assign({}, this.configuration.headers, context.headers);
+        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
         const init = {
             method: context.method,
             headers: headers,


### PR DESCRIPTION
### Remove undefined values from headers

I have encountered this issues when I want to pass an api key in the request but the endpoint support multiple header api key. 
So I use a fonction to set the right api key and set the other api key to `undefined`.

With this code : 

```
function getFirstApiKey(keyName) {
    if (keyName === 'first-api-key') {
      return "my-key-value";
    }
    return undefined;
  };
```

The generated code for api key in the api endpoint : 

```
    if (this.configuration && this.configuration.apiKey) {
        headerParameters["first-api-key"] = this.configuration.apiKey("first-api-key"); // first-api-key authentication
    }

    if (this.configuration && this.configuration.apiKey) {
        headerParameters["second-api-key"] = this.configuration.apiKey("second-api-key"); // second-api-key authentication
    }
```

The generated `apiKey` function : 

```
    get apiKey(): ((name: string) => string) | undefined {
        const apiKey = this.configuration.apiKey;
        if (apiKey) {
            return typeof apiKey === 'function' ? apiKey : () => apiKey;
        }
        return undefined;
    }
```

Result headers : 

```
first-api-key: my-key-value
second-api-key: undefined
```

Expected headers : 
```
first-api-key: my-key-value
```

The headers was send with the two api key with one with the right value and the other with undefined as a string

To fix this issues, just remove any header who has undefined as value.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)

Thanks for the review