### PR TITLE
Fix jaxrs-spec to run with JDK 17

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pom.mustache
@@ -186,6 +186,11 @@
         <scope>provided</scope>
     </dependency>
 {{/useBeanValidation}}
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
 
   </dependencies>
   <repositories>

--- a/samples/server/petstore/jaxrs-datelib-j8/pom.xml
+++ b/samples/server/petstore/jaxrs-datelib-j8/pom.xml
@@ -175,6 +175,11 @@
         <version>${beanvalidation-version}</version>
         <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
 
   </dependencies>
   <repositories>

--- a/samples/server/petstore/jaxrs-jersey/pom.xml
+++ b/samples/server/petstore/jaxrs-jersey/pom.xml
@@ -175,6 +175,11 @@
         <version>${beanvalidation-version}</version>
         <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
 
   </dependencies>
   <repositories>

--- a/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
@@ -175,6 +175,11 @@
         <version>${beanvalidation-version}</version>
         <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
 
   </dependencies>
   <repositories>

--- a/samples/server/petstore/jaxrs/jersey2/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2/pom.xml
@@ -175,6 +175,11 @@
         <version>${beanvalidation-version}</version>
         <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
 
   </dependencies>
   <repositories>


### PR DESCRIPTION
JDK17 is missing class `javax.annotation.Generated`.

Add javax.annotation:javax.annotation-api 1.3.2

Fixes https://github.com/OpenAPITools/openapi-generator/issues/11795

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
