### PR TITLE
Process additionalProperties: true as arbitrary type instead of object

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1203,12 +1203,11 @@ public class ModelUtils {
             */
         }
         if (addProps == null || (addProps instanceof Boolean && (Boolean) addProps)) {
-            // Return ObjectSchema to specify any object (map) value is allowed.
-            // Set nullable to specify the value of additional properties may be
-            // the null value.
-            // Free-form additionalProperties don't need to have an inner
-            // additional properties, the type is already free-form.
-            return new ObjectSchema().additionalProperties(Boolean.FALSE).nullable(Boolean.TRUE);
+            // Return an empty schema as the properties can take on any type per
+            // the spec. See
+            // https://github.com/OpenAPITools/openapi-generator/issues/9282 for
+            // more details.
+            return new Schema();
         }
         return null;
     }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -5,7 +5,7 @@
  */
 export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#additionalPropertiesType}}
-    [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
+    [key: string]: {{{additionalPropertiesType}}}{{^additionalPropertiesIsAnyType}}{{#hasVars}} | any{{/hasVars}}{{/additionalPropertiesIsAnyType}};
 
 {{/additionalPropertiesType}}
 {{#vars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -447,7 +447,7 @@ public class DefaultCodegenTest {
         // extended with any undeclared properties.
         Schema addProps = ModelUtils.getAdditionalProperties(openAPI, componentSchema);
         Assert.assertNotNull(addProps);
-        Assert.assertTrue(addProps instanceof ObjectSchema);
+        Assert.assertEquals(addProps, new Schema());
         CodegenModel cm = codegen.fromModel("AdditionalPropertiesClass", componentSchema);
         Assert.assertNotNull(cm.getAdditionalProperties());
 
@@ -492,7 +492,7 @@ public class DefaultCodegenTest {
         Assert.assertNull(map_with_undeclared_properties_anytype_1_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(openAPI, map_with_undeclared_properties_anytype_1_sc);
         Assert.assertNotNull(addProps);
-        Assert.assertTrue(addProps instanceof ObjectSchema);
+        Assert.assertEquals(addProps, new Schema());
         Assert.assertNotNull(map_with_undeclared_properties_anytype_1_cp.getAdditionalProperties());
 
         // map_with_undeclared_properties_anytype_2
@@ -502,7 +502,7 @@ public class DefaultCodegenTest {
         Assert.assertNull(map_with_undeclared_properties_anytype_2_sc.getAdditionalProperties());
         addProps = ModelUtils.getAdditionalProperties(openAPI, map_with_undeclared_properties_anytype_2_sc);
         Assert.assertNotNull(addProps);
-        Assert.assertTrue(addProps instanceof ObjectSchema);
+        Assert.assertEquals(addProps, new Schema());
         Assert.assertNotNull(map_with_undeclared_properties_anytype_2_cp.getAdditionalProperties());
 
         // map_with_undeclared_properties_anytype_3
@@ -515,7 +515,7 @@ public class DefaultCodegenTest {
         Assert.assertEquals(map_with_undeclared_properties_anytype_3_sc.getAdditionalProperties(), Boolean.TRUE);
         addProps = ModelUtils.getAdditionalProperties(openAPI, map_with_undeclared_properties_anytype_3_sc);
         Assert.assertNotNull(addProps);
-        Assert.assertTrue(addProps instanceof ObjectSchema);
+        Assert.assertEquals(addProps, new Schema());
         Assert.assertNotNull(map_with_undeclared_properties_anytype_3_cp.getAdditionalProperties());
 
         // empty_map
@@ -2768,6 +2768,26 @@ public class DefaultCodegenTest {
         if (isGenerateAliasAsModel) { // restore the setting
             GlobalSettings.setProperty("generateAliasAsModel", "true");
         }
+    }
+
+    @Test
+    public void testAdditionalPropertiesAnyType() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_9282.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        CodegenProperty anyTypeSchema = codegen.fromProperty("", new Schema());
+
+        Schema sc;
+        CodegenModel cm;
+
+        sc = openAPI.getComponents().getSchemas().get("AdditionalPropertiesTrue");
+        cm = codegen.fromModel("AdditionalPropertiesTrue", sc);
+        assertEquals(cm.getVars().get(0).additionalProperties, anyTypeSchema);
+
+        sc = openAPI.getComponents().getSchemas().get("AdditionalPropertiesAnyType");
+        cm = codegen.fromModel("AdditionalPropertiesAnyType", sc);
+        assertEquals(cm.getVars().get(0).additionalProperties, anyTypeSchema);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/AbstractGoCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/AbstractGoCodegenTest.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenType;
@@ -90,6 +91,13 @@ public class AbstractGoCodegenTest {
         ModelUtils.setGenerateAliasAsModel(true);
         defaultValue = codegen.getTypeDeclaration(schema);
         Assert.assertEquals(defaultValue, "map[string]NestedArray");
+
+        // Create object schema with additionalProperties set to true
+        schema = new ObjectSchema().additionalProperties(Boolean.TRUE);
+
+        ModelUtils.setGenerateAliasAsModel(false);
+        defaultValue = codegen.getTypeDeclaration(schema);
+        Assert.assertEquals(defaultValue, "map[string]interface{}");
     }
 
     private static class P_AbstractGoCodegen extends AbstractGoCodegen {

--- a/modules/openapi-generator/src/test/resources/3_0/issue_9282.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_9282.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+components:
+  schemas:
+    AdditionalPropertiesTrue:
+      description: additionalProperties set to true
+      type: object
+      properties:
+        child:
+          type: object
+          additionalProperties: true
+
+    AdditionalPropertiesAnyType:
+      description: additionalProperties set to any type explicitly
+      type: object
+      properties:
+        child:
+          type: object
+          additionalProperties: {}

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -59,10 +59,10 @@ export interface AdditionalPropertiesClass {
     'map_with_undeclared_properties_anytype_2'?: object;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: any; }}
      * @memberof AdditionalPropertiesClass
      */
-    'map_with_undeclared_properties_anytype_3'?: { [key: string]: object; };
+    'map_with_undeclared_properties_anytype_3'?: { [key: string]: any; };
     /**
      * an object with no declared properties and no undeclared properties, hence it\'s an empty map.
      * @type {object}
@@ -1706,7 +1706,7 @@ export interface Whale {
  * @interface Zebra
  */
 export interface Zebra {
-    [key: string]: object | any;
+    [key: string]: any;
 
     /**
      * 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -173,7 +173,7 @@ export interface ArrayTest {
  * @interface Banana
  */
 export interface Banana {
-    [key: string]: object | any;
+    [key: string]: any;
 
     /**
      * 


### PR DESCRIPTION
When a schema specifies `additionalProperties: true`, we need not restrict those properties to a particular type. This change sets the schemas for them to `AnyType` instead of `object`.

From a generation perspective, this only changes the output for generators that differentiate between `AnyType` and `object` in their type mappings; most do not. This fixes at least one bug in the Go and TypeScript generators.

* Fixes #9282
* Fixes #3277 (Go-specific)

New tests for the Go generator and `DefaultCodegen` demonstrate the intent of this change.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

For Go, @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d
For TypeScript, @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero

Thanks in advance for the review!