### PR TITLE
Fix list keyword

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.h.mustache
@@ -23,8 +23,8 @@ typedef struct list_t {
 
 #define list_ForEach(element, list) for(element = (list != NULL) ? (list)->firstEntry : NULL; element != NULL; element = element->nextListEntry)
 
-list_t* List();
-void list_freeListList(list_t* listToFree);
+list_t* list_createList();
+void list_freeList(list_t* listToFree);
 
 void list_addElement(list_t* list, void* dataToAddInList);
 listEntry_t* list_getElementAt(list_t *list, long indexOfElement);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix Wrong keyword to list_createList and list_freeList keyword. 

"before"
`list_t* List();

void list_freeListList(list_t* listToFree);`


"after"
`list_t* list_createList();

void list_freeList(list_t* listToFree);`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
