### PR TITLE
C-libcurl: remove stray printf

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -325,11 +325,6 @@ end:
                     localVarBodyParameters,
                     "{{{httpMethod}}}");
 
-    {{#responses}}
-    if (apiClient->response_code == {{code}}) {
-        printf("%s\n","{{message}}");
-    }
-    {{/responses}}
     {{#returnType}}
     {{#returnTypeIsPrimitive}}
     {{#returnSimpleType}}

--- a/samples/client/petstore/c/api/PetAPI.c
+++ b/samples/client/petstore/c/api/PetAPI.c
@@ -95,9 +95,6 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t * body )
                     localVarBodyParameters,
                     "POST");
 
-    if (apiClient->response_code == 405) {
-        printf("%s\n","Invalid input");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -174,9 +171,6 @@ PetAPI_deletePet(apiClient_t *apiClient, long petId , char * api_key )
                     localVarBodyParameters,
                     "DELETE");
 
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid pet value");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -242,12 +236,6 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t * status )
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid status value");
-    }
     cJSON *PetAPIlocalVarJSON = cJSON_Parse(apiClient->dataReceived);
     if(!cJSON_IsArray(PetAPIlocalVarJSON)) {
         return 0;//nonprimitive container
@@ -324,12 +312,6 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t * tags )
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid tag value");
-    }
     cJSON *PetAPIlocalVarJSON = cJSON_Parse(apiClient->dataReceived);
     if(!cJSON_IsArray(PetAPIlocalVarJSON)) {
         return 0;//nonprimitive container
@@ -414,15 +396,6 @@ PetAPI_getPetById(apiClient_t *apiClient, long petId )
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid ID supplied");
-    }
-    if (apiClient->response_code == 404) {
-        printf("%s\n","Pet not found");
-    }
     //nonprimitive not container
     cJSON *PetAPIlocalVarJSON = cJSON_Parse(apiClient->dataReceived);
     pet_t *elementToReturn = pet_parseFromJSON(PetAPIlocalVarJSON);
@@ -491,15 +464,6 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t * body )
                     localVarBodyParameters,
                     "PUT");
 
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid ID supplied");
-    }
-    if (apiClient->response_code == 404) {
-        printf("%s\n","Pet not found");
-    }
-    if (apiClient->response_code == 405) {
-        printf("%s\n","Validation exception");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -589,9 +553,6 @@ PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId , char * name , char
                     localVarBodyParameters,
                     "POST");
 
-    if (apiClient->response_code == 405) {
-        printf("%s\n","Invalid input");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -696,9 +657,6 @@ PetAPI_uploadFile(apiClient_t *apiClient, long petId , char * additionalMetadata
                     localVarBodyParameters,
                     "POST");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
     //nonprimitive not container
     cJSON *PetAPIlocalVarJSON = cJSON_Parse(apiClient->dataReceived);
     api_response_t *elementToReturn = api_response_parseFromJSON(PetAPIlocalVarJSON);

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -53,12 +53,6 @@ StoreAPI_deleteOrder(apiClient_t *apiClient, char * orderId )
                     localVarBodyParameters,
                     "DELETE");
 
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid ID supplied");
-    }
-    if (apiClient->response_code == 404) {
-        printf("%s\n","Order not found");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -108,9 +102,6 @@ StoreAPI_getInventory(apiClient_t *apiClient)
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
     //primitive return type not simple
     cJSON *localVarJSON = cJSON_Parse(apiClient->dataReceived);
     cJSON *VarJSON;
@@ -186,15 +177,6 @@ StoreAPI_getOrderById(apiClient_t *apiClient, long orderId )
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid ID supplied");
-    }
-    if (apiClient->response_code == 404) {
-        printf("%s\n","Order not found");
-    }
     //nonprimitive not container
     cJSON *StoreAPIlocalVarJSON = cJSON_Parse(apiClient->dataReceived);
     order_t *elementToReturn = order_parseFromJSON(StoreAPIlocalVarJSON);
@@ -263,12 +245,6 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t * body )
                     localVarBodyParameters,
                     "POST");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid Order");
-    }
     //nonprimitive not container
     cJSON *StoreAPIlocalVarJSON = cJSON_Parse(apiClient->dataReceived);
     order_t *elementToReturn = order_parseFromJSON(StoreAPIlocalVarJSON);

--- a/samples/client/petstore/c/api/UserAPI.c
+++ b/samples/client/petstore/c/api/UserAPI.c
@@ -52,9 +52,6 @@ UserAPI_createUser(apiClient_t *apiClient, user_t * body )
                     localVarBodyParameters,
                     "POST");
 
-    if (apiClient->response_code == 0) {
-        printf("%s\n","successful operation");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -134,9 +131,6 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t * body )
                     localVarBodyParameters,
                     "POST");
 
-    if (apiClient->response_code == 0) {
-        printf("%s\n","successful operation");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -224,9 +218,6 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t * body )
                     localVarBodyParameters,
                     "POST");
 
-    if (apiClient->response_code == 0) {
-        printf("%s\n","successful operation");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -297,12 +288,6 @@ UserAPI_deleteUser(apiClient_t *apiClient, char * username )
                     localVarBodyParameters,
                     "DELETE");
 
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid username supplied");
-    }
-    if (apiClient->response_code == 404) {
-        printf("%s\n","User not found");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -361,15 +346,6 @@ UserAPI_getUserByName(apiClient_t *apiClient, char * username )
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid username supplied");
-    }
-    if (apiClient->response_code == 404) {
-        printf("%s\n","User not found");
-    }
     //nonprimitive not container
     cJSON *UserAPIlocalVarJSON = cJSON_Parse(apiClient->dataReceived);
     user_t *elementToReturn = user_parseFromJSON(UserAPIlocalVarJSON);
@@ -453,12 +429,6 @@ UserAPI_loginUser(apiClient_t *apiClient, char * username , char * password )
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 200) {
-        printf("%s\n","successful operation");
-    }
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid username/password supplied");
-    }
     //primitive return type simple
     char* elementToReturn =  strdup((char*)apiClient->dataReceived);
 
@@ -533,9 +503,6 @@ UserAPI_logoutUser(apiClient_t *apiClient)
                     localVarBodyParameters,
                     "GET");
 
-    if (apiClient->response_code == 0) {
-        printf("%s\n","successful operation");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {
@@ -602,12 +569,6 @@ UserAPI_updateUser(apiClient_t *apiClient, char * username , user_t * body )
                     localVarBodyParameters,
                     "PUT");
 
-    if (apiClient->response_code == 400) {
-        printf("%s\n","Invalid user supplied");
-    }
-    if (apiClient->response_code == 404) {
-        printf("%s\n","User not found");
-    }
     //No return type
 end:
     if (apiClient->dataReceived) {


### PR DESCRIPTION
printing in library code is bad practice, and the user of the library
should be able to control what is printed by their program.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
