### PR TITLE
[Ruby] Add x-group-parameters support to Ruby client

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -19,12 +19,30 @@ module {{moduleName}}
     {{#notes}}
     # {{{.}}}
     {{/notes}}
-{{#allParams}}{{#required}}    # @param {{paramName}} [{{{dataType}}}] {{description}}
-{{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
-{{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
-{{/required}}{{/allParams}}    # @return [{{{returnType}}}{{^returnType}}nil{{/returnType}}]
-    def {{operationId}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
-      {{#returnType}}data, _status_code, _headers = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts)
+{{#vendorExtensions.x-group-parameters}}
+    # @param [Hash] opts the parameters
+{{#allParams}}
+{{#required}}
+    # @option opts [{{{dataType}}}] :{{paramName}} {{description}} (required)
+{{/required}}
+{{/allParams}}
+{{/vendorExtensions.x-group-parameters}}
+{{^vendorExtensions.x-group-parameters}}
+{{#allParams}}
+{{#required}}
+    # @param {{paramName}} [{{{dataType}}}] {{description}}
+{{/required}}
+{{/allParams}}
+    # @param [Hash] opts the optional parameters
+{{/vendorExtensions.x-group-parameters}}
+{{#allParams}}
+{{^required}}
+    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+{{/required}}
+{{/allParams}}
+    # @return [{{{returnType}}}{{^returnType}}nil{{/returnType}}]
+    def {{operationId}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}opts = {})
+      {{#returnType}}data, _status_code, _headers = {{/returnType}}{{operationId}}_with_http_info({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}opts)
       {{#returnType}}data{{/returnType}}{{^returnType}}nil{{/returnType}}
     end
 
@@ -34,14 +52,42 @@ module {{moduleName}}
     {{#notes}}
     # {{.}}
     {{/notes}}
-{{#allParams}}{{#required}}    # @param {{paramName}} [{{{dataType}}}] {{description}}
-{{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
-{{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
-{{/required}}{{/allParams}}    # @return [Array<({{{returnType}}}{{^returnType}}nil{{/returnType}}, Integer, Hash)>] {{#returnType}}{{{.}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
-    def {{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
+{{#vendorExtensions.x-group-parameters}}
+    # @param [Hash] opts the parameters
+{{#allParams}}
+{{#required}}
+    # @option opts [{{{dataType}}}] :{{paramName}} {{description}} (required)
+{{/required}}
+{{/allParams}}
+{{/vendorExtensions.x-group-parameters}}
+{{^vendorExtensions.x-group-parameters}}
+{{#allParams}}
+{{#required}}
+    # @param {{paramName}} [{{{dataType}}}] {{description}}
+{{/required}}
+{{/allParams}}
+    # @param [Hash] opts the optional parameters
+{{/vendorExtensions.x-group-parameters}}
+{{#allParams}}
+{{^required}}
+    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+{{/required}}
+{{/allParams}}
+    # @return [Array<({{{returnType}}}{{^returnType}}nil{{/returnType}}, Integer, Hash)>] {{#returnType}}{{{.}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
+    def {{operationId}}_with_http_info({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: {{classname}}.{{operationId}} ...'
       end
+      {{#vendorExtensions.x-group-parameters}}
+      # unbox the parameters from the hash
+      {{#allParams}}
+      {{^isNullable}}
+      {{#required}}
+      {{{paramName}}} = opts[:'{{{paramName}}}']
+      {{/required}}
+      {{/isNullable}}
+      {{/allParams}}
+      {{/vendorExtensions.x-group-parameters}}
       {{#allParams}}
       {{^isNullable}}
       {{#required}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
@@ -17,7 +17,7 @@ All URIs are relative to *{{basePath}}*
 
 ## {{operationId}}
 
-> {{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}} {{/returnType}}{{operationId}}{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+> {{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}} {{/returnType}}{{operationId}}{{#hasParams}}({{^vendorExtensions.x-group-parameters}}{{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}opts{{/vendorExtensions.x-group-parameters}}){{/hasParams}}
 
 {{{summary}}}{{#notes}}
 
@@ -46,6 +46,7 @@ require '{{{gemName}}}'
 {{/hasAuthMethods}}
 
 api_instance = {{{moduleName}}}::{{{classname}}}.new
+{{^vendorExtensions.x-group-parameters}}
 {{#requiredParams}}
 {{{paramName}}} = {{{vendorExtensions.x-ruby-example}}} # {{{dataType}}} | {{{description}}}
 {{/requiredParams}}
@@ -58,10 +59,23 @@ opts = {
 }
 {{/-last}}
 {{/optionalParams}}
+{{/vendorExtensions.x-group-parameters}}
+{{#vendorExtensions.x-group-parameters}}
+{{#hasParams}}
+opts = {
+{{#requiredParams}}
+    {{{paramName}}}: {{{vendorExtensions.x-ruby-example}}}, # {{{dataType}}} | {{{description}}} (required)
+{{/requiredParams}}
+{{#optionalParams}}
+    {{{paramName}}}: {{{vendorExtensions.x-ruby-example}}}, # {{{dataType}}} | {{{description}}}
+{{/optionalParams}}
+}
+{{/hasParams}}
+{{/vendorExtensions.x-group-parameters}}
 
 begin
   {{#summary}}# {{{.}}}{{/summary}}
-  {{#returnType}}result = {{/returnType}}api_instance.{{{operationId}}}{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+  {{#returnType}}result = {{/returnType}}api_instance.{{{operationId}}}{{#hasParams}}({{^vendorExtensions.x-group-parameters}}{{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}opts{{/vendorExtensions.x-group-parameters}}){{/hasParams}}
   {{#returnType}}
   p result
   {{/returnType}}
@@ -74,12 +88,12 @@ end
 
 This returns an Array which contains the response data{{^returnType}} (`nil` in this case){{/returnType}}, status code and headers.
 
-> <Array({{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Integer, Hash)> {{operationId}}_with_http_info{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+> <Array({{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Integer, Hash)> {{operationId}}_with_http_info{{#hasParams}}({{^vendorExtensions.x-group-parameters}}{{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}opts{{/vendorExtensions.x-group-parameters}}){{/hasParams}}
 
 ```ruby
 begin
   {{#summary}}# {{{.}}}{{/summary}}
-  data, status_code, headers = api_instance.{{{operationId}}}_with_http_info{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+  data, status_code, headers = api_instance.{{{operationId}}}_with_http_info{{#hasParams}}({{^vendorExtensions.x-group-parameters}}{{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}opts{{/vendorExtensions.x-group-parameters}}){{/hasParams}}
   p status_code # => 2xx
   p headers # => { ... }
   p data # => {{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}nil{{/returnType}}

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -911,7 +911,7 @@ No authorization required
 
 ## test_group_parameters
 
-> test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts)
+> test_group_parameters(opts)
 
 Fake endpoint to test group parameters (optional)
 
@@ -929,18 +929,18 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-required_string_group = 56 # Integer | Required String in group parameters
-required_boolean_group = true # Boolean | Required Boolean in group parameters
-required_int64_group = 789 # Integer | Required Integer in group parameters
 opts = {
-  string_group: 56, # Integer | String in group parameters
-  boolean_group: true, # Boolean | Boolean in group parameters
-  int64_group: 789 # Integer | Integer in group parameters
+    required_string_group: 56, # Integer | Required String in group parameters (required)
+    required_boolean_group: true, # Boolean | Required Boolean in group parameters (required)
+    required_int64_group: 789, # Integer | Required Integer in group parameters (required)
+    string_group: 56, # Integer | String in group parameters
+    boolean_group: true, # Boolean | Boolean in group parameters
+    int64_group: 789, # Integer | Integer in group parameters
 }
 
 begin
   # Fake endpoint to test group parameters (optional)
-  api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts)
+  api_instance.test_group_parameters(opts)
 rescue Petstore::ApiError => e
   puts "Error when calling FakeApi->test_group_parameters: #{e}"
 end
@@ -950,12 +950,12 @@ end
 
 This returns an Array which contains the response data (`nil` in this case), status code and headers.
 
-> <Array(nil, Integer, Hash)> test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+> <Array(nil, Integer, Hash)> test_group_parameters_with_http_info(opts)
 
 ```ruby
 begin
   # Fake endpoint to test group parameters (optional)
-  data, status_code, headers = api_instance.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+  data, status_code, headers = api_instance.test_group_parameters_with_http_info(opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => nil

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -912,13 +912,13 @@ module Petstore
     # To test enum parameters
     # @param [Hash] opts the optional parameters
     # @option opts [Array<String>] :enum_header_string_array Header parameter enum test (string array)
-    # @option opts [String] :enum_header_string Header parameter enum test (string)
+    # @option opts [String] :enum_header_string Header parameter enum test (string) (default to '-efg')
     # @option opts [Array<String>] :enum_query_string_array Query parameter enum test (string array)
-    # @option opts [String] :enum_query_string Query parameter enum test (string)
+    # @option opts [String] :enum_query_string Query parameter enum test (string) (default to '-efg')
     # @option opts [Integer] :enum_query_integer Query parameter enum test (double)
     # @option opts [Float] :enum_query_double Query parameter enum test (double)
-    # @option opts [Array<String>] :enum_form_string_array Form parameter enum test (string array)
-    # @option opts [String] :enum_form_string Form parameter enum test (string)
+    # @option opts [Array<String>] :enum_form_string_array Form parameter enum test (string array) (default to '$')
+    # @option opts [String] :enum_form_string Form parameter enum test (string) (default to '-efg')
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_enum_parameters_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -1009,33 +1009,37 @@ module Petstore
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group [Integer] Required String in group parameters
-    # @param required_boolean_group [Boolean] Required Boolean in group parameters
-    # @param required_int64_group [Integer] Required Integer in group parameters
-    # @param [Hash] opts the optional parameters
+    # @param [Hash] opts the parameters
+    # @option opts [Integer] :required_string_group Required String in group parameters (required)
+    # @option opts [Boolean] :required_boolean_group Required Boolean in group parameters (required)
+    # @option opts [Integer] :required_int64_group Required Integer in group parameters (required)
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [Boolean] :boolean_group Boolean in group parameters
     # @option opts [Integer] :int64_group Integer in group parameters
     # @return [nil]
-    def test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts = {})
-      test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+    def test_group_parameters(opts = {})
+      test_group_parameters_with_http_info(opts)
       nil
     end
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group [Integer] Required String in group parameters
-    # @param required_boolean_group [Boolean] Required Boolean in group parameters
-    # @param required_int64_group [Integer] Required Integer in group parameters
-    # @param [Hash] opts the optional parameters
+    # @param [Hash] opts the parameters
+    # @option opts [Integer] :required_string_group Required String in group parameters (required)
+    # @option opts [Boolean] :required_boolean_group Required Boolean in group parameters (required)
+    # @option opts [Integer] :required_int64_group Required Integer in group parameters (required)
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [Boolean] :boolean_group Boolean in group parameters
     # @option opts [Integer] :int64_group Integer in group parameters
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts = {})
+    def test_group_parameters_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_group_parameters ...'
       end
+      # unbox the parameters from the hash
+      required_string_group = opts[:'required_string_group']
+      required_boolean_group = opts[:'required_boolean_group']
+      required_int64_group = opts[:'required_int64_group']
       # verify the required parameter 'required_string_group' is set
       if @api_client.config.client_side_validation && required_string_group.nil?
         fail ArgumentError, "Missing the required parameter 'required_string_group' when calling FakeApi.test_group_parameters"

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -911,7 +911,7 @@ No authorization required
 
 ## test_group_parameters
 
-> test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts)
+> test_group_parameters(opts)
 
 Fake endpoint to test group parameters (optional)
 
@@ -929,18 +929,18 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-required_string_group = 56 # Integer | Required String in group parameters
-required_boolean_group = true # Boolean | Required Boolean in group parameters
-required_int64_group = 789 # Integer | Required Integer in group parameters
 opts = {
-  string_group: 56, # Integer | String in group parameters
-  boolean_group: true, # Boolean | Boolean in group parameters
-  int64_group: 789 # Integer | Integer in group parameters
+    required_string_group: 56, # Integer | Required String in group parameters (required)
+    required_boolean_group: true, # Boolean | Required Boolean in group parameters (required)
+    required_int64_group: 789, # Integer | Required Integer in group parameters (required)
+    string_group: 56, # Integer | String in group parameters
+    boolean_group: true, # Boolean | Boolean in group parameters
+    int64_group: 789, # Integer | Integer in group parameters
 }
 
 begin
   # Fake endpoint to test group parameters (optional)
-  api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts)
+  api_instance.test_group_parameters(opts)
 rescue Petstore::ApiError => e
   puts "Error when calling FakeApi->test_group_parameters: #{e}"
 end
@@ -950,12 +950,12 @@ end
 
 This returns an Array which contains the response data (`nil` in this case), status code and headers.
 
-> <Array(nil, Integer, Hash)> test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+> <Array(nil, Integer, Hash)> test_group_parameters_with_http_info(opts)
 
 ```ruby
 begin
   # Fake endpoint to test group parameters (optional)
-  data, status_code, headers = api_instance.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+  data, status_code, headers = api_instance.test_group_parameters_with_http_info(opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => nil

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -912,13 +912,13 @@ module Petstore
     # To test enum parameters
     # @param [Hash] opts the optional parameters
     # @option opts [Array<String>] :enum_header_string_array Header parameter enum test (string array)
-    # @option opts [String] :enum_header_string Header parameter enum test (string)
+    # @option opts [String] :enum_header_string Header parameter enum test (string) (default to '-efg')
     # @option opts [Array<String>] :enum_query_string_array Query parameter enum test (string array)
-    # @option opts [String] :enum_query_string Query parameter enum test (string)
+    # @option opts [String] :enum_query_string Query parameter enum test (string) (default to '-efg')
     # @option opts [Integer] :enum_query_integer Query parameter enum test (double)
     # @option opts [Float] :enum_query_double Query parameter enum test (double)
-    # @option opts [Array<String>] :enum_form_string_array Form parameter enum test (string array)
-    # @option opts [String] :enum_form_string Form parameter enum test (string)
+    # @option opts [Array<String>] :enum_form_string_array Form parameter enum test (string array) (default to '$')
+    # @option opts [String] :enum_form_string Form parameter enum test (string) (default to '-efg')
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_enum_parameters_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -1009,33 +1009,37 @@ module Petstore
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group [Integer] Required String in group parameters
-    # @param required_boolean_group [Boolean] Required Boolean in group parameters
-    # @param required_int64_group [Integer] Required Integer in group parameters
-    # @param [Hash] opts the optional parameters
+    # @param [Hash] opts the parameters
+    # @option opts [Integer] :required_string_group Required String in group parameters (required)
+    # @option opts [Boolean] :required_boolean_group Required Boolean in group parameters (required)
+    # @option opts [Integer] :required_int64_group Required Integer in group parameters (required)
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [Boolean] :boolean_group Boolean in group parameters
     # @option opts [Integer] :int64_group Integer in group parameters
     # @return [nil]
-    def test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts = {})
-      test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+    def test_group_parameters(opts = {})
+      test_group_parameters_with_http_info(opts)
       nil
     end
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group [Integer] Required String in group parameters
-    # @param required_boolean_group [Boolean] Required Boolean in group parameters
-    # @param required_int64_group [Integer] Required Integer in group parameters
-    # @param [Hash] opts the optional parameters
+    # @param [Hash] opts the parameters
+    # @option opts [Integer] :required_string_group Required String in group parameters (required)
+    # @option opts [Boolean] :required_boolean_group Required Boolean in group parameters (required)
+    # @option opts [Integer] :required_int64_group Required Integer in group parameters (required)
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [Boolean] :boolean_group Boolean in group parameters
     # @option opts [Integer] :int64_group Integer in group parameters
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts = {})
+    def test_group_parameters_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_group_parameters ...'
       end
+      # unbox the parameters from the hash
+      required_string_group = opts[:'required_string_group']
+      required_boolean_group = opts[:'required_boolean_group']
+      required_int64_group = opts[:'required_int64_group']
       # verify the required parameter 'required_string_group' is set
       if @api_client.config.client_side_validation && required_string_group.nil?
         fail ArgumentError, "Missing the required parameter 'required_string_group' when calling FakeApi.test_group_parameters"


### PR DESCRIPTION
This PR introduces support for `x-group-parameters` in the `ruby-client` templates, similar to how it has been added to PHP (#1337) and others in the past.

This helps prevent breakage if the order of parameter documentation changes, and at Fastly helped us in writing data-driven tests. (Other use cases #641 #5451)

Support for grouped parameters already exists in the Codegen, so these changes are completely self-contained in template files only. Unfortunately it seems tests for the API files in the Ruby client file have not existed, and for now I didn't have the time to draft them from scratch.

I'm branching from 6.0.x as I believe this can be considered breaking. The existence of `x-group-parameters` is automatically picked up from input files, and the updated generated client will break user code using those operations.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cliffano @zlx @autopp
