### PR TITLE
[Go] Fix template for oneOfs with primitive types

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
@@ -55,24 +55,24 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{^discriminator}}
         match := 0
         {{#oneOf}}
-        // try to unmarshal data into {{{.}}}
-        err = json.Unmarshal(data, &dst.{{{.}}})
+        // try to unmarshal data into {{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}
+        err = json.Unmarshal(data, &dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}})
         if err == nil {
-                json{{{.}}}, _ := json.Marshal(dst.{{{.}}})
+                json{{{.}}}, _ := json.Marshal(dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}})
                 if string(json{{{.}}}) == "{}" { // empty struct
-                        dst.{{{.}}} = nil
+                        dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
                 } else {
                         match++
                 }
         } else {
-                dst.{{{.}}} = nil
+                dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
         }
 
         {{/oneOf}}
         if match > 1 { // more than 1 match
                 // reset to nil
                 {{#oneOf}}
-                dst.{{{.}}} = nil
+                dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
                 {{/oneOf}}
 
                 return fmt.Errorf("Data matches more than one schema in oneOf({{classname}})")

--- a/modules/openapi-generator/src/test/resources/3_0/oneOf_primitive.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneOf_primitive.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /example:
+    get:
+      operationId: list
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Example"
+components:
+  schemas:
+    Child:
+      type: object
+      properties:
+        name:
+          type: string
+    Example:
+      oneOf:
+      - $ref: '#/components/schemas/Child'
+      - type: integer
+        format: int32


### PR DESCRIPTION
A recent enhancement to the template made these primitive types usable as property names, but a small section of the template wasn't updated, leading to compilation problems.

See the added test case for an example.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

For Go, @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d