### PR TITLE
Fix oneOf discriminator mapping leak when used directly inside allOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
@@ -151,6 +151,15 @@ public class CodegenDiscriminator {
         public int hashCode() {
             return Objects.hash(mappingName, modelName);
         }
+
+        @Override
+        public String toString() {
+            final StringBuffer sb = new StringBuffer("CodegenDiscriminator.MappedModel{");
+            sb.append("mappingName='").append(mappingName).append('\'');
+            sb.append(", modelName='").append(modelName).append('\'');
+            sb.append('}');
+            return sb.toString();
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1521,6 +1521,36 @@ public class DefaultCodegenTest {
         assertEquals(discriminator, test);
     }
 
+    @Test
+    public void testAllOfCompositionWithClosedOneOf() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf_composition_oneOf_closed.yaml");
+        verifyAllOfCompositionWithOneOf(openAPI);
+    }
+
+    @Test
+    public void testAllOfCompositionWithOpenOneOf() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf_composition_oneOf_open.yaml");
+        verifyAllOfCompositionWithOneOf(openAPI);
+    }
+
+    private void verifyAllOfCompositionWithOneOf(OpenAPI openAPI) {
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setLegacyDiscriminatorBehavior(false);
+        codegen.setOpenAPI(openAPI);
+
+        Schema s = openAPI.getComponents().getSchemas().get("AdoptableAnimal");
+        CodegenModel m = codegen.fromModel("AdoptableAnimal", s);
+
+        CodegenDiscriminator expected = new CodegenDiscriminator();
+        expected.setPropertyName("petType");
+        expected.setPropertyBaseName("petType");
+        expected.setMappedModels(new HashSet<CodegenDiscriminator.MappedModel>(){{
+            add(new CodegenDiscriminator.MappedModel("Cat", "Cat"));
+            add(new CodegenDiscriminator.MappedModel("Dog", "Dog"));
+        }});
+        assertEquals(m.discriminator, expected);
+    }
+
     public CodegenModel getModel(List<ModelMap> allModels, String modelName) {
         for (ModelMap obj : allModels) {
             CodegenModel cm = obj.getModel();

--- a/modules/openapi-generator/src/test/resources/3_0/allOf_composition_oneOf_closed.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf_composition_oneOf_closed.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.2
+info:
+  title: OAI Specification example for Polymorphism
+  version: 1.0.0
+paths:
+  /pet:
+    get:
+      responses:
+        '200':
+          description: desc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    CanBeNamed:
+      type: object
+      properties:
+        name:
+          type: string
+    Animal:
+      type: object
+      properties:
+        petType:
+          type: string
+      required:
+      - petType
+    Cat:
+      allOf:
+      - $ref: '#/components/schemas/Animal'
+      - type: object
+        properties:
+          furry:
+            type: boolean
+    Dog:
+      allOf:
+      - $ref: '#/components/schemas/Animal'
+      - type: object
+        properties:
+          barky:
+            type: boolean
+    AdoptableAnimal:
+      oneOf:
+      - $ref: '#/components/schemas/Cat'
+      - $ref: '#/components/schemas/Dog'
+      discriminator:
+        propertyName: petType
+    Pet:
+      allOf:
+      - $ref: '#/components/schemas/CanBeNamed'
+      - $ref: '#/components/schemas/AdoptableAnimal'

--- a/modules/openapi-generator/src/test/resources/3_0/allOf_composition_oneOf_open.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf_composition_oneOf_open.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.2
+info:
+  title: OAI Specification example for Polymorphism
+  version: 1.0.0
+paths:
+  /pet:
+    get:
+      responses:
+        '200':
+          description: desc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    CanBeNamed:
+      type: object
+      properties:
+        name:
+          type: string
+    Animal:
+      type: object
+      properties:
+        petType:
+          type: string
+      required:
+      - petType
+      discriminator:
+        propertyName: petType
+    Cat:
+      allOf:
+      - $ref: '#/components/schemas/Animal'
+      - type: object
+        properties:
+          furry:
+            type: boolean
+    Dog:
+      allOf:
+      - $ref: '#/components/schemas/Animal'
+      - type: object
+        properties:
+          barky:
+            type: boolean
+    AdoptableAnimal:
+      oneOf:
+      - $ref: '#/components/schemas/Cat'
+      - $ref: '#/components/schemas/Dog'
+    Pet:
+      allOf:
+      - $ref: '#/components/schemas/CanBeNamed'
+      - $ref: '#/components/schemas/AdoptableAnimal'


### PR DESCRIPTION
There are two ways that discriminators can be used: with `oneOf` or `anyOf`, explicitly, alongside the definition of their respective schemas; or with `allOf`, in which case a discriminator defined in a parent schema may be implicitly inherited by any other schema that includes it.

The code generator correctly handles both of those cases, except when an explicit ("closed") `oneOf` is used directly inside an unrelated `allOf` composite schema. In this situation, the `allOf` leaks into the discriminator mappings for the `oneOf` schema.

This change checks whether a schema for which a discriminator is being created is a `oneOf`/`anyOf` and skips the "open" `allOf` check that follows if so.

Without this change, in the included test cases, the discriminator mapping would also include `Pet`.

This is particularly important for generators that support `useOneOfDiscriminatorLookup`, as they will try to assign to fields of the `oneOf` schema type that don't exist.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
