### PR TITLE
Add auto-generated doc to scala-akka client

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
@@ -43,6 +43,7 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
     protected String artifactId = "openapi-client";
     protected String artifactVersion = "1.0.0";
     protected String resourcesFolder = "src/main/resources";
+    protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
     protected String configKey = "apiRequest";
     protected int defaultTimeoutInMs = 5000;
@@ -86,6 +87,7 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
         outputFolder = "generated-code/scala-akka";
         modelTemplateFiles.put("model.mustache", ".scala");
         apiTemplateFiles.put("api.mustache", ".scala");
+        apiDocTemplateFiles.put("api_doc.mustache", ".md");
         modelDocTemplateFiles.put("model_doc.mustache", ".md");
         embeddedTemplateDir = templateDir = "scala-akka-client";
         apiPackage = mainPackage + ".api";
@@ -166,6 +168,8 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
             }
         }
         additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
+        // make api and model doc path available in mustache template
+        additionalProperties.put("apiDocPath", apiDocPath);
         additionalProperties.put("modelDocPath", modelDocPath);
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
@@ -362,6 +366,11 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
 
     public void setMainPackage(String mainPackage) {
         this.configKeyPath = this.mainPackage = mainPackage;
+    }
+
+    @Override
+    public String apiDocFileFolder() {
+        return (outputFolder + File.separator + apiDocPath).replace('/', File.separatorChar);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/README.mustache
@@ -65,13 +65,70 @@ libraryDependencies += "{{{groupId}}}" % "{{{artifactId}}}" % "{{{artifactVersio
 
 ## Getting Started
 
+Please follow the [installation](#installation) instruction and execute the following Java code:
+
+```scala
+{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}
+import {{invokerPackage}}._
+import {{modelPackage}}._
+import {{{package}}}.{{{classname}}}
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object {{{classname}}}Example extends App {
+
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher{{#hasAuthMethods}}
+    {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+    // Configure HTTP basic authorization: {{{name}}}
+    implicit val {{{name}}}: BasicCredentials = BasicCredentials("YOUR USERNAME", "YOUR PASSWORD"){{/isBasicBasic}}{{#isBasicBearer}}
+    // Configure HTTP bearer authorization: {{{name}}}
+    implicit val {{{name}}}: BearerToken = BearerToken("BEARER TOKEN"){{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+    // Configure API key authorization: {{{name}}}
+    implicit val {{{name}}}: ApiKeyValue = ApiKeyValue("YOUR API KEY"){{/isApiKey}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+
+    // Create invoker to execute requests
+    val apiInvoker = ApiInvoker()
+    val apiInstance = {{{classname}}}("{{{basePath}}}"){{#allParams}}
+    val {{{paramName}}}: {{{dataType}}} = {{{example}}} // {{{dataType}}} | {{{description}}}
+    {{/allParams}}
+
+    val request = apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(org.openapitools.client.core.ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}"){{#returnType}}
+            System.out.println(s"Response body: $content"){{/returnType}}
+
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) =>
+            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}")
+            exception.printStackTrace();
+    }
+
+}
+{{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
+```
+
 ## Documentation for API Endpoints
 
 All URIs are relative to *{{basePath}}*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | **{{operationId}}** | **{{httpMethod}}** {{path}} | {{summary}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{summary}}
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
 ## Documentation for Models

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/api_doc.mustache
@@ -1,0 +1,114 @@
+# {{classname}}{{#description}}
+
+{{.}}{{/description}}
+
+All URIs are relative to *{{basePath}}*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+{{#operations}}{{#operation}}[**{{operationId}}**]({{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{summary}}
+[**{{operationId}}WithHttpInfo**]({{classname}}.md#{{operationId}}WithHttpInfo) | **{{httpMethod}}** {{path}} | {{summary}}
+{{/operation}}{{/operations}}
+
+{{#operations}}
+{{#operation}}
+
+## {{operationId}}
+
+> {{operationId}}({{#hasParams}}{{operationId}}Request{{/hasParams}}): ApiRequest[{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}}]
+
+{{summary}}{{#notes}}
+
+{{.}}{{/notes}}
+
+### Example
+
+```scala
+// Import classes:
+{{#imports}}
+import {{import}}
+{{/imports}}
+import {{invokerPackage}}._
+import {{invokerPackage}}.CollectionFormats._
+import {{invokerPackage}}.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    {{#hasAuthMethods}}
+    {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+    // Configure HTTP basic authorization: {{{name}}}
+    implicit val {{{name}}}: BasicCredentials = BasicCredentials("YOUR USERNAME", "YOUR PASSWORD"){{/isBasicBasic}}{{#isBasicBearer}}
+    // Configure HTTP bearer authorization: {{{name}}}
+    implicit val {{{name}}}: BearerToken = BearerToken("BEARER TOKEN"){{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+    // Configure API key authorization: {{{name}}}
+    implicit val {{{name}}}: ApiKeyValue = ApiKeyValue("YOUR API KEY"){{/isApiKey}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = {{{classname}}}("{{{basePath}}}"){{#allParams}}
+    val {{{paramName}}}: {{{dataType}}} = {{{example}}} // {{{dataType}}} | {{{description}}}
+    {{/allParams}}
+    
+    val request = apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}"){{#returnType}}
+            System.out.println(s"Response body: $content"){{/returnType}}
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
+{{#allParams}} **{{paramName}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{#isFile}}**{{dataType}}**{{/isFile}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{^isContainer}}{{#defaultValue}} [default to {{.}}]{{/defaultValue}}{{/isContainer}}{{#allowableValues}} [enum: {{#values}}{{{.}}}{{^-last}}, {{/-last}}{{/values}}]{{/allowableValues}}
+{{/allParams}}
+
+### Return type
+
+{{#returnType}}ApiRequest[{{#returnTypeIsPrimitive}}**{{returnType}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{returnType}}**]({{returnBaseType}}.md){{/returnTypeIsPrimitive}}]{{/returnType}}
+{{^returnType}}ApiRequest[Unit] (empty response body){{/returnType}}
+
+### Authorization
+
+{{^authMethods}}No authorization required{{/authMethods}}{{#authMethods}}[{{name}}](../README.md#{{name}}){{^-last}}, {{/-last}}{{/authMethods}}
+
+### HTTP request headers
+
+- **Content-Type**: {{#consumes}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
+- **Accept**: {{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}{{^produces}}Not defined{{/produces}}
+
+{{#responses.0}}
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+{{#responses}}
+| **{{code}}** | {{message}} | {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} |
+{{/responses}}
+{{/responses.0}}
+
+{{/operation}}
+{{/operations}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -467,6 +467,7 @@ public class ScalaAkkaClientCodegenTest {
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.API_DOCS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "true");
 
         Generator gen = generator.opts(clientOptInput);
@@ -504,6 +505,7 @@ public class ScalaAkkaClientCodegenTest {
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.API_DOCS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "true");
 
         Generator gen = generator.opts(clientOptInput);

--- a/samples/client/petstore/scala-akka/.openapi-generator/FILES
+++ b/samples/client/petstore/scala-akka/.openapi-generator/FILES
@@ -4,8 +4,11 @@ docs/ApiResponse.md
 docs/Category.md
 docs/Order.md
 docs/Pet.md
+docs/PetApi.md
+docs/StoreApi.md
 docs/Tag.md
 docs/User.md
+docs/UserApi.md
 project/build.properties
 src/main/resources/reference.conf
 src/main/scala/org/openapitools/client/api/EnumsSerializers.scala

--- a/samples/client/petstore/scala-akka/README.md
+++ b/samples/client/petstore/scala-akka/README.md
@@ -59,32 +59,79 @@ libraryDependencies += "org.openapitools" % "scala-akka-petstore-client" % "1.0.
 
 ## Getting Started
 
+Please follow the [installation](#installation) instruction and execute the following Java code:
+
+```scala
+
+import org.openapitools.client.core._
+import org.openapitools.client.model._
+import org.openapitools.client.api.PetApi
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object PetApiExample extends App {
+
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Create invoker to execute requests
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val pet: Pet =  // Pet | Pet object that needs to be added to the store
+
+    val request = apiInstance.addPet(pet)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(org.openapitools.client.core.ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#addPet")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) =>
+            System.err.println("Exception when calling PetApi#addPet")
+            exception.printStackTrace();
+    }
+
+}
+
+```
+
 ## Documentation for API Endpoints
 
 All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PetApi* | **addPet** | **POST** /pet | Add a new pet to the store
-*PetApi* | **deletePet** | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | **findPetsByStatus** | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | **findPetsByTags** | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | **getPetById** | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | **updatePet** | **PUT** /pet | Update an existing pet
-*PetApi* | **updatePetWithForm** | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | **uploadFile** | **POST** /pet/{petId}/uploadImage | uploads an image
-*StoreApi* | **deleteOrder** | **DELETE** /store/order/{orderId} | Delete purchase order by ID
-*StoreApi* | **getInventory** | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | **getOrderById** | **GET** /store/order/{orderId} | Find purchase order by ID
-*StoreApi* | **placeOrder** | **POST** /store/order | Place an order for a pet
-*UserApi* | **createUser** | **POST** /user | Create user
-*UserApi* | **createUsersWithArrayInput** | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | **createUsersWithListInput** | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | **deleteUser** | **DELETE** /user/{username} | Delete user
-*UserApi* | **getUserByName** | **GET** /user/{username} | Get user by user name
-*UserApi* | **loginUser** | **GET** /user/login | Logs user into the system
-*UserApi* | **logoutUser** | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | **updateUser** | **PUT** /user/{username} | Updated user
+*PetApi* | [**addPet**](docs/PetApi.md#addPet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](docs/PetApi.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](docs/PetApi.md#findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](docs/PetApi.md#findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](docs/PetApi.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](docs/PetApi.md#updatePet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](docs/PetApi.md#updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](docs/PetApi.md#uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*StoreApi* | [**deleteOrder**](docs/StoreApi.md#deleteOrder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](docs/StoreApi.md#getInventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](docs/StoreApi.md#getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](docs/StoreApi.md#placeOrder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](docs/UserApi.md#createUser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](docs/UserApi.md#createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](docs/UserApi.md#createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](docs/UserApi.md#deleteUser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](docs/UserApi.md#getUserByName) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](docs/UserApi.md#loginUser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](docs/UserApi.md#logoutUser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](docs/UserApi.md#updateUser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation for Models

--- a/samples/client/petstore/scala-akka/docs/PetApi.md
+++ b/samples/client/petstore/scala-akka/docs/PetApi.md
@@ -1,0 +1,688 @@
+# PetApi
+
+All URIs are relative to *http://petstore.swagger.io/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**addPet**](PetApi.md#addPet) | **POST** /pet | Add a new pet to the store
+[**addPetWithHttpInfo**](PetApi.md#addPetWithHttpInfo) | **POST** /pet | Add a new pet to the store
+[**deletePet**](PetApi.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
+[**deletePetWithHttpInfo**](PetApi.md#deletePetWithHttpInfo) | **DELETE** /pet/{petId} | Deletes a pet
+[**findPetsByStatus**](PetApi.md#findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
+[**findPetsByStatusWithHttpInfo**](PetApi.md#findPetsByStatusWithHttpInfo) | **GET** /pet/findByStatus | Finds Pets by status
+[**findPetsByTags**](PetApi.md#findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
+[**findPetsByTagsWithHttpInfo**](PetApi.md#findPetsByTagsWithHttpInfo) | **GET** /pet/findByTags | Finds Pets by tags
+[**getPetById**](PetApi.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
+[**getPetByIdWithHttpInfo**](PetApi.md#getPetByIdWithHttpInfo) | **GET** /pet/{petId} | Find pet by ID
+[**updatePet**](PetApi.md#updatePet) | **PUT** /pet | Update an existing pet
+[**updatePetWithHttpInfo**](PetApi.md#updatePetWithHttpInfo) | **PUT** /pet | Update an existing pet
+[**updatePetWithForm**](PetApi.md#updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
+[**updatePetWithFormWithHttpInfo**](PetApi.md#updatePetWithFormWithHttpInfo) | **POST** /pet/{petId} | Updates a pet in the store with form data
+[**uploadFile**](PetApi.md#uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
+[**uploadFileWithHttpInfo**](PetApi.md#uploadFileWithHttpInfo) | **POST** /pet/{petId}/uploadImage | uploads an image
+
+
+
+## addPet
+
+> addPet(addPetRequest): ApiRequest[Pet]
+
+Add a new pet to the store
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val pet: Pet =  // Pet | Pet object that needs to be added to the store
+    
+    val request = apiInstance.addPet(pet)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#addPet")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#addPet")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store |
+
+### Return type
+
+ApiRequest[[**Pet**](Pet.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/xml
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
+
+## deletePet
+
+> deletePet(deletePetRequest): ApiRequest[Unit]
+
+Deletes a pet
+
+
+
+### Example
+
+```scala
+// Import classes:
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val petId: Long = 789 // Long | Pet id to delete
+
+    val apiKey: String = apiKey_example // String | 
+    
+    val request = apiInstance.deletePet(petId, apiKey)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#deletePet")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#deletePet")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **petId** | **Long**| Pet id to delete |
+ **apiKey** | **String**|  | [optional]
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid pet value |  -  |
+
+
+## findPetsByStatus
+
+> findPetsByStatus(findPetsByStatusRequest): ApiRequest[Seq[Pet]]
+
+Finds Pets by status
+
+Multiple status values can be provided with comma separated strings
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val status: Seq[String] =  // Seq[String] | Status values that need to be considered for filter
+    
+    val request = apiInstance.findPetsByStatus(status)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#findPetsByStatus")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#findPetsByStatus")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **status** | [**Seq[String]**](String.md)| Status values that need to be considered for filter | [enum: available, pending, sold]
+
+### Return type
+
+ApiRequest[[**Seq[Pet]**](Pet.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
+
+## findPetsByTags
+
+> findPetsByTags(findPetsByTagsRequest): ApiRequest[Seq[Pet]]
+
+Finds Pets by tags
+
+Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val tags: Seq[String] =  // Seq[String] | Tags to filter by
+    
+    val request = apiInstance.findPetsByTags(tags)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#findPetsByTags")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#findPetsByTags")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **tags** | [**Seq[String]**](String.md)| Tags to filter by |
+
+### Return type
+
+ApiRequest[[**Seq[Pet]**](Pet.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
+
+## getPetById
+
+> getPetById(getPetByIdRequest): ApiRequest[Pet]
+
+Find pet by ID
+
+Returns a single pet
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: api_key
+    implicit val api_key: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val petId: Long = 789 // Long | ID of pet to return
+    
+    val request = apiInstance.getPetById(petId)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#getPetById")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#getPetById")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **petId** | **Long**| ID of pet to return |
+
+### Return type
+
+ApiRequest[[**Pet**](Pet.md)]
+
+
+### Authorization
+
+[api_key](../README.md#api_key)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
+
+## updatePet
+
+> updatePet(updatePetRequest): ApiRequest[Pet]
+
+Update an existing pet
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val pet: Pet =  // Pet | Pet object that needs to be added to the store
+    
+    val request = apiInstance.updatePet(pet)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#updatePet")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#updatePet")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store |
+
+### Return type
+
+ApiRequest[[**Pet**](Pet.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/xml
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
+
+## updatePetWithForm
+
+> updatePetWithForm(updatePetWithFormRequest): ApiRequest[Unit]
+
+Updates a pet in the store with form data
+
+
+
+### Example
+
+```scala
+// Import classes:
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val petId: Long = 789 // Long | ID of pet that needs to be updated
+
+    val name: String = name_example // String | Updated name of the pet
+
+    val status: String = status_example // String | Updated status of the pet
+    
+    val request = apiInstance.updatePetWithForm(petId, name, status)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#updatePetWithForm")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#updatePetWithForm")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **petId** | **Long**| ID of pet that needs to be updated |
+ **name** | **String**| Updated name of the pet | [optional]
+ **status** | **String**| Updated status of the pet | [optional]
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
+
+## uploadFile
+
+> uploadFile(uploadFileRequest): ApiRequest[ApiResponse]
+
+uploads an image
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    val apiInvoker = ApiInvoker()
+    val apiInstance = PetApi("http://petstore.swagger.io/v2")
+    val petId: Long = 789 // Long | ID of pet to update
+
+    val additionalMetadata: String = additionalMetadata_example // String | Additional data to pass to server
+
+    val file: File = BINARY_DATA_HERE // File | file to upload
+    
+    val request = apiInstance.uploadFile(petId, additionalMetadata, file)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling PetApi#uploadFile")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling PetApi#uploadFile")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **petId** | **Long**| ID of pet to update |
+ **additionalMetadata** | **String**| Additional data to pass to server | [optional]
+ **file** | **File**| file to upload | [optional]
+
+### Return type
+
+ApiRequest[[**ApiResponse**](ApiResponse.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: multipart/form-data
+- **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+

--- a/samples/client/petstore/scala-akka/docs/StoreApi.md
+++ b/samples/client/petstore/scala-akka/docs/StoreApi.md
@@ -1,0 +1,335 @@
+# StoreApi
+
+All URIs are relative to *http://petstore.swagger.io/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**deleteOrder**](StoreApi.md#deleteOrder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+[**deleteOrderWithHttpInfo**](StoreApi.md#deleteOrderWithHttpInfo) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+[**getInventory**](StoreApi.md#getInventory) | **GET** /store/inventory | Returns pet inventories by status
+[**getInventoryWithHttpInfo**](StoreApi.md#getInventoryWithHttpInfo) | **GET** /store/inventory | Returns pet inventories by status
+[**getOrderById**](StoreApi.md#getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
+[**getOrderByIdWithHttpInfo**](StoreApi.md#getOrderByIdWithHttpInfo) | **GET** /store/order/{orderId} | Find purchase order by ID
+[**placeOrder**](StoreApi.md#placeOrder) | **POST** /store/order | Place an order for a pet
+[**placeOrderWithHttpInfo**](StoreApi.md#placeOrderWithHttpInfo) | **POST** /store/order | Place an order for a pet
+
+
+
+## deleteOrder
+
+> deleteOrder(deleteOrderRequest): ApiRequest[Unit]
+
+Delete purchase order by ID
+
+For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+
+### Example
+
+```scala
+// Import classes:
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = StoreApi("http://petstore.swagger.io/v2")
+    val orderId: String = orderId_example // String | ID of the order that needs to be deleted
+    
+    val request = apiInstance.deleteOrder(orderId)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling StoreApi#deleteOrder")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling StoreApi#deleteOrder")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **orderId** | **String**| ID of the order that needs to be deleted |
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
+
+## getInventory
+
+> getInventory(): ApiRequest[Map[String, Int]]
+
+Returns pet inventories by status
+
+Returns a map of status codes to quantities
+
+### Example
+
+```scala
+// Import classes:
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: api_key
+    implicit val api_key: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = StoreApi("http://petstore.swagger.io/v2")    
+    val request = apiInstance.getInventory()
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling StoreApi#getInventory")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling StoreApi#getInventory")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+This endpoint does not need any parameter.
+
+### Return type
+
+ApiRequest[**Map[String, Int]**]
+
+
+### Authorization
+
+[api_key](../README.md#api_key)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
+
+## getOrderById
+
+> getOrderById(getOrderByIdRequest): ApiRequest[Order]
+
+Find purchase order by ID
+
+For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = StoreApi("http://petstore.swagger.io/v2")
+    val orderId: Long = 789 // Long | ID of pet that needs to be fetched
+    
+    val request = apiInstance.getOrderById(orderId)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling StoreApi#getOrderById")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling StoreApi#getOrderById")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **orderId** | **Long**| ID of pet that needs to be fetched |
+
+### Return type
+
+ApiRequest[[**Order**](Order.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
+
+## placeOrder
+
+> placeOrder(placeOrderRequest): ApiRequest[Order]
+
+Place an order for a pet
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = StoreApi("http://petstore.swagger.io/v2")
+    val order: Order =  // Order | order placed for purchasing the pet
+    
+    val request = apiInstance.placeOrder(order)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling StoreApi#placeOrder")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling StoreApi#placeOrder")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **order** | [**Order**](Order.md)| order placed for purchasing the pet |
+
+### Return type
+
+ApiRequest[[**Order**](Order.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
+

--- a/samples/client/petstore/scala-akka/docs/UserApi.md
+++ b/samples/client/petstore/scala-akka/docs/UserApi.md
@@ -1,0 +1,680 @@
+# UserApi
+
+All URIs are relative to *http://petstore.swagger.io/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**createUser**](UserApi.md#createUser) | **POST** /user | Create user
+[**createUserWithHttpInfo**](UserApi.md#createUserWithHttpInfo) | **POST** /user | Create user
+[**createUsersWithArrayInput**](UserApi.md#createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
+[**createUsersWithArrayInputWithHttpInfo**](UserApi.md#createUsersWithArrayInputWithHttpInfo) | **POST** /user/createWithArray | Creates list of users with given input array
+[**createUsersWithListInput**](UserApi.md#createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
+[**createUsersWithListInputWithHttpInfo**](UserApi.md#createUsersWithListInputWithHttpInfo) | **POST** /user/createWithList | Creates list of users with given input array
+[**deleteUser**](UserApi.md#deleteUser) | **DELETE** /user/{username} | Delete user
+[**deleteUserWithHttpInfo**](UserApi.md#deleteUserWithHttpInfo) | **DELETE** /user/{username} | Delete user
+[**getUserByName**](UserApi.md#getUserByName) | **GET** /user/{username} | Get user by user name
+[**getUserByNameWithHttpInfo**](UserApi.md#getUserByNameWithHttpInfo) | **GET** /user/{username} | Get user by user name
+[**loginUser**](UserApi.md#loginUser) | **GET** /user/login | Logs user into the system
+[**loginUserWithHttpInfo**](UserApi.md#loginUserWithHttpInfo) | **GET** /user/login | Logs user into the system
+[**logoutUser**](UserApi.md#logoutUser) | **GET** /user/logout | Logs out current logged in user session
+[**logoutUserWithHttpInfo**](UserApi.md#logoutUserWithHttpInfo) | **GET** /user/logout | Logs out current logged in user session
+[**updateUser**](UserApi.md#updateUser) | **PUT** /user/{username} | Updated user
+[**updateUserWithHttpInfo**](UserApi.md#updateUserWithHttpInfo) | **PUT** /user/{username} | Updated user
+
+
+
+## createUser
+
+> createUser(createUserRequest): ApiRequest[Unit]
+
+Create user
+
+This can only be done by the logged in user.
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: auth_cookie
+    implicit val auth_cookie: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")
+    val user: User =  // User | Created user object
+    
+    val request = apiInstance.createUser(user)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#createUser")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#createUser")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **user** | [**User**](User.md)| Created user object |
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+[auth_cookie](../README.md#auth_cookie)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
+
+## createUsersWithArrayInput
+
+> createUsersWithArrayInput(createUsersWithArrayInputRequest): ApiRequest[Unit]
+
+Creates list of users with given input array
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: auth_cookie
+    implicit val auth_cookie: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")
+    val user: Seq[User] =  // Seq[User] | List of user object
+    
+    val request = apiInstance.createUsersWithArrayInput(user)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **user** | [**Seq[User]**](User.md)| List of user object |
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+[auth_cookie](../README.md#auth_cookie)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
+
+## createUsersWithListInput
+
+> createUsersWithListInput(createUsersWithListInputRequest): ApiRequest[Unit]
+
+Creates list of users with given input array
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: auth_cookie
+    implicit val auth_cookie: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")
+    val user: Seq[User] =  // Seq[User] | List of user object
+    
+    val request = apiInstance.createUsersWithListInput(user)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#createUsersWithListInput")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#createUsersWithListInput")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **user** | [**Seq[User]**](User.md)| List of user object |
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+[auth_cookie](../README.md#auth_cookie)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
+
+## deleteUser
+
+> deleteUser(deleteUserRequest): ApiRequest[Unit]
+
+Delete user
+
+This can only be done by the logged in user.
+
+### Example
+
+```scala
+// Import classes:
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: auth_cookie
+    implicit val auth_cookie: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")
+    val username: String = username_example // String | The name that needs to be deleted
+    
+    val request = apiInstance.deleteUser(username)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#deleteUser")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#deleteUser")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **username** | **String**| The name that needs to be deleted |
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+[auth_cookie](../README.md#auth_cookie)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
+
+## getUserByName
+
+> getUserByName(getUserByNameRequest): ApiRequest[User]
+
+Get user by user name
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")
+    val username: String = username_example // String | The name that needs to be fetched. Use user1 for testing.
+    
+    val request = apiInstance.getUserByName(username)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#getUserByName")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#getUserByName")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **username** | **String**| The name that needs to be fetched. Use user1 for testing. |
+
+### Return type
+
+ApiRequest[[**User**](User.md)]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
+
+## loginUser
+
+> loginUser(loginUserRequest): ApiRequest[String]
+
+Logs user into the system
+
+
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")
+    val username: String = username_example // String | The user name for login
+
+    val password: String = password_example // String | The password for login in clear text
+    
+    val request = apiInstance.loginUser(username, password)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+            System.out.println(s"Response body: $content")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#loginUser")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#loginUser")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **username** | **String**| The user name for login |
+ **password** | **String**| The password for login in clear text |
+
+### Return type
+
+ApiRequest[**String**]
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * Set-Cookie - Cookie authentication key for use with the &#x60;auth_cookie&#x60; apiKey authentication. <br>  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
+
+## logoutUser
+
+> logoutUser(): ApiRequest[Unit]
+
+Logs out current logged in user session
+
+
+
+### Example
+
+```scala
+// Import classes:
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: auth_cookie
+    implicit val auth_cookie: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")    
+    val request = apiInstance.logoutUser()
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#logoutUser")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#logoutUser")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+This endpoint does not need any parameter.
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+[auth_cookie](../README.md#auth_cookie)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
+
+## updateUser
+
+> updateUser(updateUserRequest): ApiRequest[Unit]
+
+Updated user
+
+This can only be done by the logged in user.
+
+### Example
+
+```scala
+// Import classes:
+import 
+import org.openapitools.client.core._
+import org.openapitools.client.core.CollectionFormats._
+import org.openapitools.client.core.ApiKeyLocations._
+
+import akka.actor.ActorSystem
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object Example extends App {
+    
+    implicit val system: ActorSystem = ActorSystem()
+    import system.dispatcher
+    
+    // Configure API key authorization: auth_cookie
+    implicit val auth_cookie: ApiKeyValue = ApiKeyValue("YOUR API KEY")
+
+    val apiInvoker = ApiInvoker()
+    val apiInstance = UserApi("http://petstore.swagger.io/v2")
+    val username: String = username_example // String | name that need to be deleted
+
+    val user: User =  // User | Updated user object
+    
+    val request = apiInstance.updateUser(username, user)
+    val response = apiInvoker.execute(request)
+
+    response.onComplete {
+        case Success(ApiResponse(code, content, headers)) =>
+            System.out.println(s"Status code: $code}")
+            System.out.println(s"Response headers: ${headers.mkString(", ")}")
+        
+        case Failure(error @ ApiError(code, message, responseContent, cause, headers)) =>
+            System.err.println("Exception when calling UserApi#updateUser")
+            System.err.println(s"Status code: $code}")
+            System.err.println(s"Reason: $responseContent")
+            System.err.println(s"Response headers: ${headers.mkString(", ")}")
+            error.printStackTrace();
+
+        case Failure(exception) => 
+            System.err.println("Exception when calling UserApi#updateUser")
+            exception.printStackTrace();
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **username** | **String**| name that need to be deleted |
+ **user** | [**User**](User.md)| Updated user object |
+
+### Return type
+
+
+ApiRequest[Unit] (empty response body)
+
+### Authorization
+
+[auth_cookie](../README.md#auth_cookie)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
+


### PR DESCRIPTION
Adds API Docs to the scala-akka client, as requested in #5795

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
