### PR TITLE
[csharp-netcore] Fix incorrect FileParameter deserialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
@@ -97,6 +97,10 @@ namespace {{packageName}}.Client
             {
                 return await response.Content.ReadAsByteArrayAsync();
             }
+            else if (type == typeof(FileParameter))
+            {
+                return new FileParameter(await response.Content.ReadAsStreamAsync());
+            }
 
             // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
             if (type == typeof(Stream))

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -97,6 +97,10 @@ namespace {{packageName}}.Client
             {
                 return await response.Content.ReadAsByteArrayAsync();
             }
+            else if (type == typeof(FileParameter))
+            {
+                return new FileParameter(await response.Content.ReadAsStreamAsync());
+            }
 
             // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
             if (type == typeof(Stream))

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -100,6 +100,10 @@ namespace Org.OpenAPITools.Client
             {
                 return await response.Content.ReadAsByteArrayAsync();
             }
+            else if (type == typeof(FileParameter))
+            {
+                return new FileParameter(await response.Content.ReadAsStreamAsync());
+            }
 
             // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
             if (type == typeof(Stream))


### PR DESCRIPTION
Fixes #10588.

OpenAPI responses with binary content have a method generated that returns a `FileParameter` with the csharp-netcore generator, but this type can't actually be deserialized properly when the call is made, resulting in an error. The type is simply a wrapper for a stream, so reading the stream and creating the `FileParameter` is sufficient to fix the problem.

Testing done is that we've tried this fix proposed in #10588 successfully and are using it in production with an OpenAPI that has the following 200 response definition for a GET request that downloads a file:

```json
{
    "description": "The call was successful.",
    "content": {
        "image/png": {
            "schema": { "type": "string", "format": "binary" }
        }
    }
}
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @mandrean, @frankyjuang, @shibayan, @Blackclaws, @lucamazzanti