### PR TITLE
[Go] fix oneOf naming

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -18,6 +18,8 @@
 package org.openapitools.codegen.languages;
 
 import com.google.common.collect.Iterables;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -244,6 +248,19 @@ public class GoClientCodegen extends AbstractGoCodegen {
             this.setDisallowAdditionalPropertiesIfNotPresent(Boolean.parseBoolean(additionalProperties
                     .get(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT).toString()));
         }
+
+        // add lambda for mustache templates to handle oneOf/anyOf naming
+        // e.g. 
+        additionalProperties.put("lambda.type-to-name", new Mustache.Lambda() {
+            @Override
+            public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+                String content = fragment.execute();
+                content = content.trim().replaceAll("[]", "array_of");
+                content = content.trim().replaceAll("map[", "map_of");
+                content = content.trim().replaceAll("]", "");
+                writer.write(content);
+            }
+        });
 
         supportingFiles.add(new SupportingFile("openapi.mustache", "api", "openapi.yaml"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -250,15 +250,15 @@ public class GoClientCodegen extends AbstractGoCodegen {
         }
 
         // add lambda for mustache templates to handle oneOf/anyOf naming
-        // e.g. 
+        // e.g. []string => ArrayOfString
         additionalProperties.put("lambda.type-to-name", new Mustache.Lambda() {
             @Override
             public void execute(Template.Fragment fragment, Writer writer) throws IOException {
                 String content = fragment.execute();
-                content = content.trim().replaceAll("[]", "array_of");
-                content = content.trim().replaceAll("map[", "map_of");
-                content = content.trim().replaceAll("]", "");
-                writer.write(content);
+                content = content.trim().replace("[]", "array_of_");
+                content = content.trim().replace("[", "map_of_");
+                content = content.trim().replace("]", "");
+                writer.write(camelize(content));
             }
         });
 

--- a/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
@@ -1,15 +1,15 @@
 // {{classname}} - {{{description}}}{{^description}}struct for {{{classname}}}{{/description}}
 type {{classname}} struct {
 	{{#oneOf}}
-	{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} *{{{.}}}
+	{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} *{{{.}}}
 	{{/oneOf}}
 }
 
 {{#oneOf}}
 // {{{.}}}As{{classname}} is a convenience function that returns {{{.}}} wrapped in {{classname}}
-func {{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}As{{classname}}(v *{{{.}}}) {{classname}} {
+func {{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}As{{classname}}(v *{{{.}}}) {{classname}} {
 	return {{classname}}{
-		{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}: v,
+		{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}: v,
 	}
 }
 
@@ -55,24 +55,24 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{^discriminator}}
         match := 0
         {{#oneOf}}
-        // try to unmarshal data into {{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}
-        err = json.Unmarshal(data, &dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}})
+        // try to unmarshal data into {{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}
+        err = json.Unmarshal(data, &dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
         if err == nil {
-                json{{{.}}}, _ := json.Marshal(dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}})
+                json{{{.}}}, _ := json.Marshal(dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
                 if string(json{{{.}}}) == "{}" { // empty struct
-                        dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
+                        dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
                 } else {
                         match++
                 }
         } else {
-                dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
+                dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
         }
 
         {{/oneOf}}
         if match > 1 { // more than 1 match
                 // reset to nil
                 {{#oneOf}}
-                dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
+                dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
                 {{/oneOf}}
 
                 return fmt.Errorf("Data matches more than one schema in oneOf({{classname}})")
@@ -86,24 +86,24 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{^useOneOfDiscriminatorLookup}}
 	match := 0
 	{{#oneOf}}
-	// try to unmarshal data into {{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}
-	err = newStrictDecoder(data).Decode(&dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}})
+	// try to unmarshal data into {{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}
+	err = newStrictDecoder(data).Decode(&dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
 	if err == nil {
-		json{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}, _ := json.Marshal(dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}})
-		if string(json{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}) == "{}" { // empty struct
-			dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
+		json{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}, _ := json.Marshal(dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
+		if string(json{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}) == "{}" { // empty struct
+			dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
 		} else {
 			match++
 		}
 	} else {
-		dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
+		dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
 	}
 
 	{{/oneOf}}
 	if match > 1 { // more than 1 match
 		// reset to nil
 		{{#oneOf}}
-		dst.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} = nil
+		dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
 		{{/oneOf}}
 
 		return fmt.Errorf("Data matches more than one schema in oneOf({{classname}})")
@@ -118,8 +118,8 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src {{classname}}) MarshalJSON() ([]byte, error) {
 {{#oneOf}}
-	if src.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} != nil {
-		return json.Marshal(&src.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}})
+	if src.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} != nil {
+		return json.Marshal(&src.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
 	}
 
 {{/oneOf}}
@@ -132,8 +132,8 @@ func (obj *{{classname}}) GetActualInstance() (interface{}) {
 		return nil
 	}
 {{#oneOf}}
-	if obj.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}} != nil {
-		return obj.{{#lambda.titlecase}}{{{.}}}{{/lambda.titlecase}}
+	if obj.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} != nil {
+		return obj.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}
 	}
 
 {{/oneOf}}

--- a/modules/openapi-generator/src/test/resources/3_0/go/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -1976,13 +1976,13 @@ components:
       - $ref: '#/components/schemas/OneOfPrimitiveTypeChild'
       - type: integer
         format: int32
-      #- $ref: '#/components/schemas/OneOfArrayOfString'
+      - $ref: '#/components/schemas/OneOfArrayOfString'
     OneOfPrimitiveTypeChild:
       type: object
       properties:
         name:
           type: string
-    #OneOfArrayOfString: 
-    #  type: array
-    #  items:
-    #    type: string
+    OneOfArrayOfString: 
+      type: array
+      items:
+        type: string

--- a/samples/openapi3/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/go/go-petstore/api/openapi.yaml
@@ -2104,11 +2104,16 @@ components:
       - $ref: '#/components/schemas/OneOfPrimitiveTypeChild'
       - format: int32
         type: integer
+      - $ref: '#/components/schemas/OneOfArrayOfString'
     OneOfPrimitiveTypeChild:
       properties:
         name:
           type: string
       type: object
+    OneOfArrayOfString:
+      items:
+        type: string
+      type: array
     inline_response_default:
       example:
         string:

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
@@ -18,6 +18,7 @@ import (
 // OneOfPrimitiveType - struct for OneOfPrimitiveType
 type OneOfPrimitiveType struct {
 	OneOfPrimitiveTypeChild *OneOfPrimitiveTypeChild
+	[]string *[]string
 	Int32 *int32
 }
 
@@ -25,6 +26,13 @@ type OneOfPrimitiveType struct {
 func OneOfPrimitiveTypeChildAsOneOfPrimitiveType(v *OneOfPrimitiveTypeChild) OneOfPrimitiveType {
 	return OneOfPrimitiveType{
 		OneOfPrimitiveTypeChild: v,
+	}
+}
+
+// []stringAsOneOfPrimitiveType is a convenience function that returns []string wrapped in OneOfPrimitiveType
+func []stringAsOneOfPrimitiveType(v *[]string) OneOfPrimitiveType {
+	return OneOfPrimitiveType{
+		[]string: v,
 	}
 }
 
@@ -53,6 +61,19 @@ func (dst *OneOfPrimitiveType) UnmarshalJSON(data []byte) error {
 		dst.OneOfPrimitiveTypeChild = nil
 	}
 
+	// try to unmarshal data into []string
+	err = newStrictDecoder(data).Decode(&dst.[]string)
+	if err == nil {
+		json[]string, _ := json.Marshal(dst.[]string)
+		if string(json[]string) == "{}" { // empty struct
+			dst.[]string = nil
+		} else {
+			match++
+		}
+	} else {
+		dst.[]string = nil
+	}
+
 	// try to unmarshal data into Int32
 	err = newStrictDecoder(data).Decode(&dst.Int32)
 	if err == nil {
@@ -69,6 +90,7 @@ func (dst *OneOfPrimitiveType) UnmarshalJSON(data []byte) error {
 	if match > 1 { // more than 1 match
 		// reset to nil
 		dst.OneOfPrimitiveTypeChild = nil
+		dst.[]string = nil
 		dst.Int32 = nil
 
 		return fmt.Errorf("Data matches more than one schema in oneOf(OneOfPrimitiveType)")
@@ -85,6 +107,10 @@ func (src OneOfPrimitiveType) MarshalJSON() ([]byte, error) {
 		return json.Marshal(&src.OneOfPrimitiveTypeChild)
 	}
 
+	if src.[]string != nil {
+		return json.Marshal(&src.[]string)
+	}
+
 	if src.Int32 != nil {
 		return json.Marshal(&src.Int32)
 	}
@@ -99,6 +125,10 @@ func (obj *OneOfPrimitiveType) GetActualInstance() (interface{}) {
 	}
 	if obj.OneOfPrimitiveTypeChild != nil {
 		return obj.OneOfPrimitiveTypeChild
+	}
+
+	if obj.[]string != nil {
+		return obj.[]string
 	}
 
 	if obj.Int32 != nil {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
@@ -18,7 +18,7 @@ import (
 // OneOfPrimitiveType - struct for OneOfPrimitiveType
 type OneOfPrimitiveType struct {
 	OneOfPrimitiveTypeChild *OneOfPrimitiveTypeChild
-	[]string *[]string
+	ArrayOfString *[]string
 	Int32 *int32
 }
 
@@ -30,9 +30,9 @@ func OneOfPrimitiveTypeChildAsOneOfPrimitiveType(v *OneOfPrimitiveTypeChild) One
 }
 
 // []stringAsOneOfPrimitiveType is a convenience function that returns []string wrapped in OneOfPrimitiveType
-func []stringAsOneOfPrimitiveType(v *[]string) OneOfPrimitiveType {
+func ArrayOfStringAsOneOfPrimitiveType(v *[]string) OneOfPrimitiveType {
 	return OneOfPrimitiveType{
-		[]string: v,
+		ArrayOfString: v,
 	}
 }
 
@@ -61,17 +61,17 @@ func (dst *OneOfPrimitiveType) UnmarshalJSON(data []byte) error {
 		dst.OneOfPrimitiveTypeChild = nil
 	}
 
-	// try to unmarshal data into []string
-	err = newStrictDecoder(data).Decode(&dst.[]string)
+	// try to unmarshal data into ArrayOfString
+	err = newStrictDecoder(data).Decode(&dst.ArrayOfString)
 	if err == nil {
-		json[]string, _ := json.Marshal(dst.[]string)
-		if string(json[]string) == "{}" { // empty struct
-			dst.[]string = nil
+		jsonArrayOfString, _ := json.Marshal(dst.ArrayOfString)
+		if string(jsonArrayOfString) == "{}" { // empty struct
+			dst.ArrayOfString = nil
 		} else {
 			match++
 		}
 	} else {
-		dst.[]string = nil
+		dst.ArrayOfString = nil
 	}
 
 	// try to unmarshal data into Int32
@@ -90,7 +90,7 @@ func (dst *OneOfPrimitiveType) UnmarshalJSON(data []byte) error {
 	if match > 1 { // more than 1 match
 		// reset to nil
 		dst.OneOfPrimitiveTypeChild = nil
-		dst.[]string = nil
+		dst.ArrayOfString = nil
 		dst.Int32 = nil
 
 		return fmt.Errorf("Data matches more than one schema in oneOf(OneOfPrimitiveType)")
@@ -107,8 +107,8 @@ func (src OneOfPrimitiveType) MarshalJSON() ([]byte, error) {
 		return json.Marshal(&src.OneOfPrimitiveTypeChild)
 	}
 
-	if src.[]string != nil {
-		return json.Marshal(&src.[]string)
+	if src.ArrayOfString != nil {
+		return json.Marshal(&src.ArrayOfString)
 	}
 
 	if src.Int32 != nil {
@@ -127,8 +127,8 @@ func (obj *OneOfPrimitiveType) GetActualInstance() (interface{}) {
 		return obj.OneOfPrimitiveTypeChild
 	}
 
-	if obj.[]string != nil {
-		return obj.[]string
+	if obj.ArrayOfString != nil {
+		return obj.ArrayOfString
 	}
 
 	if obj.Int32 != nil {


### PR DESCRIPTION
- fix oneOf naming by using a lambda in the template to handle more cases (e.g.  array of string: []string)
- add tests

To fix https://github.com/OpenAPITools/openapi-generator/issues/11842


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d