### PR TITLE
[C][Client] Free list or map memory when json parsing fails

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -555,21 +555,14 @@ fail:
     {{#vars}}
     {{#isContainer}}
     {{#isArray}}
-    {{#isPrimitiveType}}
     // define the local list for {{{classname}}}->{{{name}}}
     list_t *{{{name}}}List = NULL;
 
-    {{/isPrimitiveType}}
-    {{^isPrimitiveType}}
-    // define the local list for {{{classname}}}->{{{name}}}
-    list_t *{{{name}}}List = NULL;
-
-    {{/isPrimitiveType}}
     {{/isArray}}
     {{#isMap}}
-    // define the local list for {{{classname}}}->{{{name}}}
+    // define the local map for {{{classname}}}->{{{name}}}
     list_t *{{{name}}}List = NULL;
-    
+
     {{/isMap}}
     {{/isContainer}}
     {{^isContainer}}
@@ -774,6 +767,7 @@ fail:
     {{/isArray}}
     {{#isMap}}
     {{^required}}if ({{{name}}}) { {{/required}}
+    {{#isPrimitiveType}}
     cJSON *{{{name}}}_local_map = NULL;
     if(!cJSON_IsObject({{{name}}})) {
         goto end;//primitive map container
@@ -815,6 +809,12 @@ fail:
 		{{/items}}
         list_addElement({{{name}}}List , localMapKeyPair);
     }
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+
+    // The data type of the elements in {{{classname}}}->{{{name}}} is currently not supported.
+
+    {{/isPrimitiveType}}
     {{/isMap}}
     {{/isContainer}}
     {{^required}}
@@ -957,6 +957,7 @@ end:
     {{/isPrimitiveType}}
     {{/isArray}}
     {{#isMap}}
+    {{#isPrimitiveType}}
     if ({{{name}}}List) {
         listEntry_t *listEntry = NULL;
         list_ForEach(listEntry, {{{name}}}List) {
@@ -979,6 +980,12 @@ end:
         list_freeList({{{name}}}List);
         {{{name}}}List = NULL;
     }
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+
+    // The data type of the elements in {{{classname}}}->{{{name}}} is currently not supported.
+
+    {{/isPrimitiveType}}
     {{/isMap}}
     {{/isContainer}}
     {{/vars}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -553,6 +553,25 @@ fail:
     {{classname}}_t *{{classname}}_local_var = NULL;
 
     {{#vars}}
+    {{#isContainer}}
+    {{#isArray}}
+    {{#isPrimitiveType}}
+    // define the local list for {{{classname}}}->{{{name}}}
+    list_t *{{{name}}}List = NULL;
+
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+    // define the local list for {{{classname}}}->{{{name}}}
+    list_t *{{{name}}}List = NULL;
+
+    {{/isPrimitiveType}}
+    {{/isArray}}
+    {{#isMap}}
+    // define the local list for {{{classname}}}->{{{name}}}
+    list_t *{{{name}}}List = NULL;
+    
+    {{/isMap}}
+    {{/isContainer}}
     {{^isContainer}}
     {{^isPrimitiveType}}
     {{#isModel}}
@@ -693,9 +712,8 @@ fail:
     {{#isContainer}}
     {{#isArray}}
     {{#isPrimitiveType}}
-    list_t *{{{name}}}List;
     {{^required}}if ({{{name}}}) { {{/required}}
-    cJSON *{{{name}}}_local;
+    cJSON *{{{name}}}_local = NULL;
     if(!cJSON_IsArray({{{name}}})) {
         goto end;//primitive container
     }
@@ -735,9 +753,8 @@ fail:
     }
     {{/isPrimitiveType}}
     {{^isPrimitiveType}}
-    list_t *{{{name}}}List;
     {{^required}}if ({{{name}}}) { {{/required}}
-    cJSON *{{{name}}}_local_nonprimitive;
+    cJSON *{{{name}}}_local_nonprimitive = NULL;
     if(!cJSON_IsArray({{{name}}})){
         goto end; //nonprimitive container
     }
@@ -756,9 +773,8 @@ fail:
     {{/isPrimitiveType}}
     {{/isArray}}
     {{#isMap}}
-    list_t *{{{name}}}List;
     {{^required}}if ({{{name}}}) { {{/required}}
-    cJSON *{{{name}}}_local_map;
+    cJSON *{{{name}}}_local_map = NULL;
     if(!cJSON_IsObject({{{name}}})) {
         goto end;//primitive map container
     }
@@ -903,6 +919,67 @@ end:
     {{/isFreeFormObject}}
     {{/isModel}}
     {{/isPrimitiveType}}
+    {{/isContainer}}
+    {{#isContainer}}
+    {{#isArray}}
+    {{#isPrimitiveType}}
+    if ({{{name}}}List) {
+        {{#items}}
+        {{#isString}}
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, {{{name}}}List) {
+            free(listEntry->data);
+            listEntry->data = NULL;
+        }
+        {{/isString}}
+        {{#isNumeric}}
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, {{{name}}}List) {
+            free(listEntry->data);
+            listEntry->data = NULL;
+        }
+        {{/isNumeric}}
+        {{/items}}
+        list_freeList({{{name}}}List);
+        {{{name}}}List = NULL;
+    }
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+    if ({{{name}}}List) {
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, {{{name}}}List) {
+            {{complexType}}_free(listEntry->data);
+            listEntry->data = NULL;
+        }
+        list_freeList({{{name}}}List);
+        {{{name}}}List = NULL;
+    }
+    {{/isPrimitiveType}}
+    {{/isArray}}
+    {{#isMap}}
+    if ({{{name}}}List) {
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, {{{name}}}List) {
+            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            free(localKeyValue->key);
+            localKeyValue->key = NULL;
+            {{#items}}
+            {{#isString}}
+            free(localKeyValue->value);
+            localKeyValue->value = NULL;
+            {{/isString}}
+            {{#isByteArray}}
+            free(localKeyValue->value);
+            localKeyValue->value = NULL;
+            {{/isByteArray}}
+            {{/items}}
+            keyValuePair_free(localKeyValue);
+            localKeyValue = NULL;
+        }
+        list_freeList({{{name}}}List);
+        {{{name}}}List = NULL;
+    }
+    {{/isMap}}
     {{/isContainer}}
     {{/vars}}
     return NULL;

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -171,6 +171,12 @@ pet_t *pet_parseFromJSON(cJSON *petJSON){
     // define the local variable for pet->category
     category_t *category_local_nonprim = NULL;
 
+    // define the local list for pet->photo_urls
+    list_t *photo_urlsList = NULL;
+
+    // define the local list for pet->tags
+    list_t *tagsList = NULL;
+
     // pet->id
     cJSON *id = cJSON_GetObjectItemCaseSensitive(petJSON, "id");
     if (id) { 
@@ -204,9 +210,8 @@ pet_t *pet_parseFromJSON(cJSON *petJSON){
         goto end;
     }
 
-    list_t *photo_urlsList;
     
-    cJSON *photo_urls_local;
+    cJSON *photo_urls_local = NULL;
     if(!cJSON_IsArray(photo_urls)) {
         goto end;//primitive container
     }
@@ -223,9 +228,8 @@ pet_t *pet_parseFromJSON(cJSON *petJSON){
 
     // pet->tags
     cJSON *tags = cJSON_GetObjectItemCaseSensitive(petJSON, "tags");
-    list_t *tagsList;
     if (tags) { 
-    cJSON *tags_local_nonprimitive;
+    cJSON *tags_local_nonprimitive = NULL;
     if(!cJSON_IsArray(tags)){
         goto end; //nonprimitive container
     }
@@ -269,6 +273,24 @@ end:
     if (category_local_nonprim) {
         category_free(category_local_nonprim);
         category_local_nonprim = NULL;
+    }
+    if (photo_urlsList) {
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, photo_urlsList) {
+            free(listEntry->data);
+            listEntry->data = NULL;
+        }
+        list_freeList(photo_urlsList);
+        photo_urlsList = NULL;
+    }
+    if (tagsList) {
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, tagsList) {
+            tag_free(listEntry->data);
+            listEntry->data = NULL;
+        }
+        list_freeList(tagsList);
+        tagsList = NULL;
     }
     return NULL;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When a list or map JSON cannot to be parsed successfully,  the original code will goto the end of function `*_parseFromJSON` without freeing the memory of the list or map.

This PR fixes this memory leak.

@wing328 @zhemant @michelealbano

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
