### PR TITLE
[Micronaut] Add support for OffsetDateTime for Micronaut generators

### DIFF
--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -30,6 +30,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |booleanGetterPrefix|Set booleanGetterPrefix| |get|
 |build|Specify for which build tool to generate files|<dl><dt>**gradle**</dt><dd>Gradle configuration is generated for the project</dd><dt>**all**</dt><dd>Both Gradle and Maven configurations are generated</dd><dt>**maven**</dt><dd>Maven configuration is generated for the project</dd></dl>|all|
 |configureAuth|Configure all the authorization methods as specified in the file| |false|
+|dateFormat|Specify the format pattern of date as a string| |null|
+|dateLibrary|Option. Date library to use|<dl><dt>**java8-localdatetime**</dt><dd>Java 8 using LocalDateTime (for legacy app only)</dd><dt>**java8**</dt><dd>Java 8 native JSR310 (preferred for jdk 1.8+)</dd></dl>|java8|
+|datetimeFormat|Specify the format pattern of date-time as a string| |null|
 |developerEmail|developer email in generated pom.xml| |team@openapitools.org|
 |developerName|developer name in generated pom.xml| |OpenAPI-Generator Contributors|
 |developerOrganization|developer organization in generated pom.xml| |OpenAPITools.org|

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -29,6 +29,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |booleanGetterPrefix|Set booleanGetterPrefix| |get|
 |build|Specify for which build tool to generate files|<dl><dt>**gradle**</dt><dd>Gradle configuration is generated for the project</dd><dt>**all**</dt><dd>Both Gradle and Maven configurations are generated</dd><dt>**maven**</dt><dd>Maven configuration is generated for the project</dd></dl>|all|
 |controllerPackage|The package in which controllers will be generated| |org.openapitools.api|
+|dateFormat|Specify the format pattern of date as a string| |null|
+|dateLibrary|Option. Date library to use|<dl><dt>**java8-localdatetime**</dt><dd>Java 8 using LocalDateTime (for legacy app only)</dd><dt>**java8**</dt><dd>Java 8 native JSR310 (preferred for jdk 1.8+)</dd></dl>|java8|
+|datetimeFormat|Specify the format pattern of date-time as a string| |null|
 |developerEmail|developer email in generated pom.xml| |team@openapitools.org|
 |developerName|developer name in generated pom.xml| |OpenAPI-Generator Contributors|
 |developerOrganization|developer organization in generated pom.xml| |OpenAPITools.org|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautServerCodegen.java
@@ -29,6 +29,7 @@ public class JavaMicronautServerCodegen extends JavaMicronautAbstractCodegen {
     protected String controllerSuffix = "Controller";
     protected String apiPrefix = "Abstract";
     protected String apiSuffix = "Controller";
+    private String testOutputDir;
 
     public JavaMicronautServerCodegen() {
         super();
@@ -141,17 +142,26 @@ public class JavaMicronautServerCodegen extends JavaMicronautAbstractCodegen {
     }
 
     @Override
+    public String apiTestFileFolder() {
+        return super.getOutputDir();
+    }
+
+    @Override
     public String apiTestFilename(String templateName, String tag) {
+        // For controller implementation
         if (generateControllerAsAbstract && templateName.contains("controllerImplementation")) {
-            return (
-                    outputFolder + File.separator +
+            String implementationFolder = outputFolder + File.separator +
                     sourceFolder + File.separator +
-                    controllerPackage.replace('.', File.separatorChar) + File.separator +
+                    controllerPackage.replace('.', File.separatorChar);
+            testOutputDir = implementationFolder;
+            return (implementationFolder + File.separator +
                     StringUtils.camelize(controllerPrefix + "_" + tag + "_" + controllerSuffix) + ".java"
             ).replace('/', File.separatorChar);
         }
 
-        return super.apiTestFilename(templateName, tag);
+        // For api tests
+        String suffix = apiTestTemplateFiles().get(templateName);
+        return super.apiTestFileFolder() + File.separator + toApiTestFilename(tag) + suffix;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/params/type.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/params/type.mustache
@@ -1,1 +1,7 @@
-{{!normal type}}{{^isDate}}{{^isDateTime}}{{{dataType}}}{{/isDateTime}}{{/isDate}}{{!date-time}}{{#isDateTime}}@Format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXX") {{{dataType}}}{{/isDateTime}}{{!date}}{{#isDate}}@Format("yyyy-MM-dd") {{{dataType}}}{{/isDate}}
+{{!
+default type
+}}{{^isDate}}{{^isDateTime}}{{{dataType}}}{{/isDateTime}}{{/isDate}}{{!
+date-time
+}}{{#isDateTime}}@Format("{{{datetimeFormat}}}") {{{dataType}}}{{/isDateTime}}{{!
+date
+}}{{#isDate}}@Format("{{{dateFormat}}}") {{{dataType}}}{{/isDate}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/jackson_annotations.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/jackson_annotations.mustache
@@ -19,8 +19,8 @@
         {{/isContainer}}
     {{/withXml}}
     {{#isDateTime}}
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "{{{datetimeFormat}}}")
     {{/isDateTime}}
     {{#isDate}}
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "{{{dateFormat}}}")
     {{/isDate}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/server/params/type.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/server/params/type.mustache
@@ -2,6 +2,6 @@
 default type
 }}{{^isDate}}{{^isDateTime}}{{{dataType}}}{{/isDateTime}}{{/isDate}}{{!
 date-time
-}}{{#isDateTime}}@Format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXX") {{{dataType}}}{{/isDateTime}}{{!
+}}{{#isDateTime}}@Format("{{{datetimeFormat}}}") {{{dataType}}}{{/isDateTime}}{{!
 date
-}}{{#isDate}}@Format("yyyy-MM-dd") {{{dataType}}}{{/isDate}}
+}}{{#isDate}}@Format("{{{dateFormat}}}") {{{dataType}}}{{/isDate}}

--- a/samples/client/petstore/java-micronaut-client/docs/apis/FakeApi.md
+++ b/samples/client/petstore/java-micronaut-client/docs/apis/FakeApi.md
@@ -268,7 +268,7 @@ Name | Type | Description  | Notes
  **string** | `String`| None | [optional parameter]
  **binary** | `File`| None | [optional parameter]
  **date** | `LocalDate`| None | [optional parameter]
- **dateTime** | `LocalDateTime`| None | [optional parameter]
+ **dateTime** | `OffsetDateTime`| None | [optional parameter]
  **password** | `String`| None | [optional parameter]
  **paramCallback** | `String`| None | [optional parameter]
 

--- a/samples/client/petstore/java-micronaut-client/docs/models/FormatTest.md
+++ b/samples/client/petstore/java-micronaut-client/docs/models/FormatTest.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **_byte** | `byte[]` |  | 
 **binary** | `File` |  |  [optional property]
 **date** | `LocalDate` |  | 
-**dateTime** | `LocalDateTime` |  |  [optional property]
+**dateTime** | `OffsetDateTime` |  |  [optional property]
 **uuid** | `UUID` |  |  [optional property]
 **password** | `String` |  | 
 **bigDecimal** | `BigDecimal` |  |  [optional property]

--- a/samples/client/petstore/java-micronaut-client/docs/models/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java-micronaut-client/docs/models/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -9,7 +9,7 @@ The class is defined in **[MixedPropertiesAndAdditionalPropertiesClass.java](../
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **uuid** | `UUID` |  |  [optional property]
-**dateTime** | `LocalDateTime` |  |  [optional property]
+**dateTime** | `OffsetDateTime` |  |  [optional property]
 **map** | [`Map&lt;String, Animal&gt;`](Animal.md) |  |  [optional property]
 
 

--- a/samples/client/petstore/java-micronaut-client/docs/models/Order.md
+++ b/samples/client/petstore/java-micronaut-client/docs/models/Order.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **id** | `Long` |  |  [optional property]
 **petId** | `Long` |  |  [optional property]
 **quantity** | `Integer` |  |  [optional property]
-**shipDate** | `LocalDateTime` |  |  [optional property]
+**shipDate** | `OffsetDateTime` |  |  [optional property]
 **status** | [**StatusEnum**](#StatusEnum) | Order Status |  [optional property]
 **complete** | `Boolean` |  |  [optional property]
 

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/api/FakeApi.java
@@ -21,8 +21,8 @@ import java.math.BigDecimal;
 import java.io.File;
 import org.openapitools.model.FileSchemaTestClass;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import org.openapitools.model.ModelClient;
+import java.time.OffsetDateTime;
 import org.openapitools.model.OuterComposite;
 import org.openapitools.model.User;
 import org.openapitools.model.XmlItem;
@@ -169,7 +169,7 @@ public interface FakeApi {
         @Nullable @Pattern(regexp="/[a-z]/i") String string, 
         @Nullable File binary, 
         @Nullable @Format("yyyy-MM-dd") LocalDate date, 
-        @Nullable @Format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXX") LocalDateTime dateTime, 
+        @Nullable @Format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXX") OffsetDateTime dateTime, 
         @Nullable @Size(min=10, max=64) String password, 
         @Nullable String paramCallback
   );

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/api/UserApi.java
@@ -17,7 +17,7 @@ import io.micronaut.core.annotation.*;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.core.convert.format.Format;
 import reactor.core.publisher.Mono;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import javax.annotation.Generated;
 import java.util.ArrayList;

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/FormatTest.java
@@ -20,7 +20,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.File;
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import com.fasterxml.jackson.annotation.*;
 
@@ -83,7 +83,7 @@ public class FormatTest {
     private LocalDate date;
 
     public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-    private LocalDateTime dateTime;
+    private OffsetDateTime dateTime;
 
     public static final String JSON_PROPERTY_UUID = "uuid";
     private UUID uuid;
@@ -349,7 +349,7 @@ public class FormatTest {
         this.date = date;
     }
 
-    public FormatTest dateTime(LocalDateTime dateTime) {
+    public FormatTest dateTime(OffsetDateTime dateTime) {
         this.dateTime = dateTime;
         return this;
     }
@@ -363,14 +363,14 @@ public class FormatTest {
     @JsonProperty(JSON_PROPERTY_DATE_TIME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public LocalDateTime getDateTime() {
+       public OffsetDateTime getDateTime() {
         return dateTime;
     }
 
     @JsonProperty(JSON_PROPERTY_DATE_TIME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public void setDateTime(LocalDateTime dateTime) {
+       public void setDateTime(OffsetDateTime dateTime) {
         this.dateTime = dateTime;
     }
 

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.Arrays;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     private UUID uuid;
 
     public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-    private LocalDateTime dateTime;
+    private OffsetDateTime dateTime;
 
     public static final String JSON_PROPERTY_MAP = "map";
     private Map<String, Animal> map = null;
@@ -75,7 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
         this.uuid = uuid;
     }
 
-    public MixedPropertiesAndAdditionalPropertiesClass dateTime(LocalDateTime dateTime) {
+    public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
         this.dateTime = dateTime;
         return this;
     }
@@ -89,14 +89,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     @JsonProperty(JSON_PROPERTY_DATE_TIME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public LocalDateTime getDateTime() {
+       public OffsetDateTime getDateTime() {
         return dateTime;
     }
 
     @JsonProperty(JSON_PROPERTY_DATE_TIME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public void setDateTime(LocalDateTime dateTime) {
+       public void setDateTime(OffsetDateTime dateTime) {
         this.dateTime = dateTime;
     }
 

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Order.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.Arrays;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.constraints.*;
@@ -49,7 +49,7 @@ public class Order {
     private Integer quantity;
 
     public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-    private LocalDateTime shipDate;
+    private OffsetDateTime shipDate;
 
     /**
      * Order Status
@@ -162,7 +162,7 @@ public class Order {
         this.quantity = quantity;
     }
 
-    public Order shipDate(LocalDateTime shipDate) {
+    public Order shipDate(OffsetDateTime shipDate) {
         this.shipDate = shipDate;
         return this;
     }
@@ -176,14 +176,14 @@ public class Order {
     @JsonProperty(JSON_PROPERTY_SHIP_DATE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public LocalDateTime getShipDate() {
+       public OffsetDateTime getShipDate() {
         return shipDate;
     }
 
     @JsonProperty(JSON_PROPERTY_SHIP_DATE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public void setShipDate(LocalDateTime shipDate) {
+       public void setShipDate(OffsetDateTime shipDate) {
         this.shipDate = shipDate;
     }
 

--- a/samples/server/petstore/java-micronaut-server/docs/models/Order.md
+++ b/samples/server/petstore/java-micronaut-server/docs/models/Order.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **id** | `Long` |  |  [optional property]
 **petId** | `Long` |  |  [optional property]
 **quantity** | `Integer` |  |  [optional property]
-**shipDate** | `LocalDateTime` |  |  [optional property]
+**shipDate** | `OffsetDateTime` |  |  [optional property]
 **status** | [**StatusEnum**](#StatusEnum) | Order Status |  [optional property]
 **complete** | `Boolean` |  |  [optional property]
 

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/UserController.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/UserController.java
@@ -16,7 +16,7 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.Format;
 import reactor.core.publisher.Mono;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import javax.annotation.Generated;
 import java.util.ArrayList;

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/model/Order.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.Arrays;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.constraints.*;
@@ -50,7 +50,7 @@ public class Order {
     private Integer quantity;
 
     public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-    private LocalDateTime shipDate;
+    private OffsetDateTime shipDate;
 
     /**
      * Order Status
@@ -164,7 +164,7 @@ public class Order {
         this.quantity = quantity;
     }
 
-    public Order shipDate(LocalDateTime shipDate) {
+    public Order shipDate(OffsetDateTime shipDate) {
         this.shipDate = shipDate;
         return this;
     }
@@ -178,14 +178,14 @@ public class Order {
     @JsonProperty(JSON_PROPERTY_SHIP_DATE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public LocalDateTime getShipDate() {
+       public OffsetDateTime getShipDate() {
         return shipDate;
     }
 
     @JsonProperty(JSON_PROPERTY_SHIP_DATE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXX")
-       public void setShipDate(LocalDateTime shipDate) {
+       public void setShipDate(OffsetDateTime shipDate) {
         this.shipDate = shipDate;
     }
 


### PR DESCRIPTION
(Rebased version of the https://github.com/OpenAPITools/openapi-generator/pull/11778 to exclude lots of previous commits)

This change is made based on this issue: https://github.com/OpenAPITools/openapi-generator/issues/11694
Additional fix for error of target files generated outside output directory in the maven plugin.

I ran the following to build and test the project:

```
./mvnw clean package
./bin/generate-samples.sh
./bin/utils/export_docs_generators.sh
./bin/meta-codegen.sh

./mvnw integration-test -P java-micronaut-client -P java-micronaut-server
```

@wing328 @pfyod

Java technical committee (not sure if required):
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608