### PR TITLE
[ALL] Add imports for `anyOf` schemas when handling composed schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import io.swagger.v3.oas.models.media.Schema;
@@ -246,9 +247,13 @@ public interface IJsonSchemaValidationProperties {
         Set<String> imports = new HashSet<>();
         if (this.getComposedSchemas() != null) {
             CodegenComposedSchemas composed = (CodegenComposedSchemas) this.getComposedSchemas();
-            List<CodegenProperty> allOfs =  composed.getAllOf() == null ? Collections.emptyList() : composed.getAllOf();
-            List<CodegenProperty> oneOfs =  composed.getOneOf() == null ? Collections.emptyList() : composed.getOneOf();
-            Stream<CodegenProperty> innerTypes = Stream.concat(allOfs.stream(), oneOfs.stream());
+            Stream<CodegenProperty> allOfs =  composed.getAllOf() == null ? Stream.of() : composed.getAllOf().stream();
+            Stream<CodegenProperty> oneOfs =  composed.getOneOf() == null ? Stream.of() : composed.getOneOf().stream();
+            Stream<CodegenProperty> anyOfs =  composed.getAnyOf() == null ? Stream.of() : composed.getAnyOf().stream();
+            Stream<CodegenProperty> innerTypes = Stream.concat(
+              Stream.concat(allOfs, oneOfs),
+              anyOfs
+            );
             innerTypes.flatMap(cp -> cp.getImports(includeContainerTypes).stream()).forEach(s -> imports.add(s));
         } else if (includeContainerTypes || !(this.getIsArray() || this.getIsMap())) {
             // this is our base case, add imports for referenced schemas

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -57,6 +57,51 @@ public class TypeScriptClientCodegenTest {
     }
 
     @Test
+    public void testComposedAnyOfSchemaImports() {
+      final TypeScriptClientCodegen codegen = new TypeScriptClientCodegen();
+      final ComposedSchema composedAnyOfSchema = new ComposedSchema();
+      final Schema<Object> schema1 = new Schema<>();
+      schema1.set$ref("Foo");
+      final Schema<Object> schema2 = new Schema<>();
+      schema2.set$ref("Bar");
+      
+      composedAnyOfSchema.addAnyOfItem(schema1);
+      composedAnyOfSchema.addAnyOfItem(schema2);
+      
+      final Schema nestedAnyOfSchema = new ObjectSchema()
+              .addProperties("id", new StringSchema())
+              .addProperties("anyFooBar", composedAnyOfSchema)
+              .description("Any Foo or Bar");
+      OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("ComposedFooBar", nestedAnyOfSchema);
+      codegen.setOpenAPI(openAPI);
+      final CodegenModel codegenModel = codegen.fromModel("ComposedFooBar", nestedAnyOfSchema);
+      Assert.assertEquals(codegenModel.imports, Sets.newHashSet("Bar", "Foo"));
+    }
+
+    @Test
+    public void testComposedOneOfSchemaImports() {
+      final TypeScriptClientCodegen codegen = new TypeScriptClientCodegen();
+      final ComposedSchema composedOneOfSchema = new ComposedSchema();
+        
+      final Schema<Object> schema1 = new Schema<>();
+      schema1.set$ref("Foo");
+      final Schema<Object> schema2 = new Schema<>();
+      schema2.set$ref("Bar");
+      
+      composedOneOfSchema.addOneOfItem(schema1);
+      composedOneOfSchema.addOneOfItem(schema2);
+
+      final Schema nestedOneOfSchema = new ObjectSchema()
+              .addProperties("id", new StringSchema())
+              .addProperties("oneFooBar", composedOneOfSchema)
+              .description("One Of Foo or Bar");
+      OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("ComposedFooBar", nestedOneOfSchema);
+      codegen.setOpenAPI(openAPI);
+      final CodegenModel codegenModel = codegen.fromModel("ComposedFooBar", nestedOneOfSchema);
+      Assert.assertEquals(codegenModel.imports, Sets.newHashSet("Bar", "Foo"));
+    }
+
+    @Test
     public void testArrayWithUniqueItems() {
         final Schema uniqueArray = new ArraySchema()
             .items(new StringSchema())


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
https://github.com/OpenAPITools/openapi-generator/commit/6430aaf3b1b2a6bafc67d5342f9e3703ada1a671 introduced deeply nested imports. More specifically the method that recursively collects imports handles `allOf` and `oneOf` composed schemas but seems to ignore `anyOf` schemas.

This Pull Request is aimed at adding imports needed by `anyOf` properties.

This affects TypeScript directly, as is the language we are using to generate code, however, looking at where the fix is applied I would assume any other language is just as impacted.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
