### PR TITLE
Upgrade maven-core dependency version

### DIFF
--- a/modules/openapi-generator-maven-plugin/pom.xml
+++ b/modules/openapi-generator-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.3.1</version>
+			<version>3.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION

Hello, this PR is related to issue 11869 about security dependency. 
After passing my professional application to the XRAY scan, it appears that your application has multiple dependencies which open up major flaws:

The version of org.sonatype.plexus:plexus-build-api:jar (0.0.7) which is very old (from 2011) and contains org.codehaus.plexus:plexus-utils:jar:1.5.8:compile reassembled by xray. In addition, your jar also contains a version of maven-core which is obsolete and also contains a major security flaw. 

I just upgraded maven core to last version but i cant for plaxus build api because there is no new version since 2007 => why do you use it ? Could you use another lib instead ? If you wants use plexus utils you can take last versions like https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils 

Thanks you 
