### PR TITLE
[java][native] add connection timeout

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -14,6 +14,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
@@ -54,6 +55,7 @@ public class ApiClient {
   private Consumer<HttpResponse<InputStream>> responseInterceptor;
   private Consumer<HttpResponse<String>> asyncResponseInterceptor;
   private Duration readTimeout;
+  private Duration connectTimeout;
 
   private static String valueToString(Object value) {
     if (value == null) {
@@ -158,6 +160,7 @@ public class ApiClient {
     updateBaseUri(getDefaultBaseUri());
     interceptor = null;
     readTimeout = null;
+    connectTimeout = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
   }
@@ -175,6 +178,7 @@ public class ApiClient {
     updateBaseUri(baseUri != null ? baseUri : getDefaultBaseUri());
     interceptor = null;
     readTimeout = null;
+    connectTimeout = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
   }
@@ -410,5 +414,36 @@ public class ApiClient {
    */
   public Duration getReadTimeout() {
     return readTimeout;
+  }
+  /**
+   * Sets the connect timeout (in milliseconds) for the http client.
+   *
+   * <p> In the case where a new connection needs to be established, if
+   * the connection cannot be established within the given {@code
+   * duration}, then {@link HttpClient#send(HttpRequest,BodyHandler)
+   * HttpClient::send} throws an {@link HttpConnectTimeoutException}, or
+   * {@link HttpClient#sendAsync(HttpRequest,BodyHandler)
+   * HttpClient::sendAsync} completes exceptionally with an
+   * {@code HttpConnectTimeoutException}. If a new connection does not
+   * need to be established, for example if a connection can be reused
+   * from a previous request, then this timeout duration has no effect.
+   *
+   * @param connectTimeout connection timeout in milliseconds
+   *
+   * @return This object.
+   */
+  public ApiClient setConnectTimeout(Duration connectTimeout) {
+    this.connectTimeout = connectTimeout;
+    this.builder.connectTimeout(connectTimeout);
+    return this;
+  }
+
+  /**
+   * Get connection timeout (in milliseconds).
+   *
+   * @return Timeout in milliseconds
+   */
+  public Duration getConnectTimeout() {
+    return connectTimeout;
   }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -63,7 +63,7 @@ artifacts {
 
 ext {
     swagger_annotations_version = "1.5.22"
-    jackson_version = "2.10.4"
+    jackson_version = "2.13.0"
     jakarta_annotation_version = "1.3.5"
     junit_version = "4.13.2"
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
@@ -221,7 +221,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <jackson-version>2.10.4</jackson-version>
+        <jackson-version>2.13.0</jackson-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>4.13.2</junit-version>

--- a/samples/client/petstore/java/native-async/build.gradle
+++ b/samples/client/petstore/java/native-async/build.gradle
@@ -63,7 +63,7 @@ artifacts {
 
 ext {
     swagger_annotations_version = "1.5.22"
-    jackson_version = "2.10.4"
+    jackson_version = "2.13.0"
     jakarta_annotation_version = "1.3.5"
     junit_version = "4.13.2"
 }

--- a/samples/client/petstore/java/native-async/pom.xml
+++ b/samples/client/petstore/java/native-async/pom.xml
@@ -214,7 +214,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <jackson-version>2.10.4</jackson-version>
+        <jackson-version>2.13.0</jackson-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>4.13.2</junit-version>

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
@@ -63,6 +64,7 @@ public class ApiClient {
   private Consumer<HttpResponse<InputStream>> responseInterceptor;
   private Consumer<HttpResponse<String>> asyncResponseInterceptor;
   private Duration readTimeout;
+  private Duration connectTimeout;
 
   private static String valueToString(Object value) {
     if (value == null) {
@@ -167,6 +169,7 @@ public class ApiClient {
     updateBaseUri(getDefaultBaseUri());
     interceptor = null;
     readTimeout = null;
+    connectTimeout = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
   }
@@ -184,6 +187,7 @@ public class ApiClient {
     updateBaseUri(baseUri != null ? baseUri : getDefaultBaseUri());
     interceptor = null;
     readTimeout = null;
+    connectTimeout = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
   }
@@ -417,5 +421,36 @@ public class ApiClient {
    */
   public Duration getReadTimeout() {
     return readTimeout;
+  }
+  /**
+   * Sets the connect timeout (in milliseconds) for the http client.
+   *
+   * <p> In the case where a new connection needs to be established, if
+   * the connection cannot be established within the given {@code
+   * duration}, then {@link HttpClient#send(HttpRequest,BodyHandler)
+   * HttpClient::send} throws an {@link HttpConnectTimeoutException}, or
+   * {@link HttpClient#sendAsync(HttpRequest,BodyHandler)
+   * HttpClient::sendAsync} completes exceptionally with an
+   * {@code HttpConnectTimeoutException}. If a new connection does not
+   * need to be established, for example if a connection can be reused
+   * from a previous request, then this timeout duration has no effect.
+   *
+   * @param connectTimeout connection timeout in milliseconds
+   *
+   * @return This object.
+   */
+  public ApiClient setConnectTimeout(Duration connectTimeout) {
+    this.connectTimeout = connectTimeout;
+    this.builder.connectTimeout(connectTimeout);
+    return this;
+  }
+
+  /**
+   * Get connection timeout (in milliseconds).
+   *
+   * @return Timeout in milliseconds
+   */
+  public Duration getConnectTimeout() {
+    return connectTimeout;
   }
 }

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -63,7 +63,7 @@ artifacts {
 
 ext {
     swagger_annotations_version = "1.5.22"
-    jackson_version = "2.10.4"
+    jackson_version = "2.13.0"
     jakarta_annotation_version = "1.3.5"
     junit_version = "4.13.2"
 }

--- a/samples/client/petstore/java/native/pom.xml
+++ b/samples/client/petstore/java/native/pom.xml
@@ -214,7 +214,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <jackson-version>2.10.4</jackson-version>
+        <jackson-version>2.13.0</jackson-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>4.13.2</junit-version>

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
@@ -63,6 +64,7 @@ public class ApiClient {
   private Consumer<HttpResponse<InputStream>> responseInterceptor;
   private Consumer<HttpResponse<String>> asyncResponseInterceptor;
   private Duration readTimeout;
+  private Duration connectTimeout;
 
   private static String valueToString(Object value) {
     if (value == null) {
@@ -167,6 +169,7 @@ public class ApiClient {
     updateBaseUri(getDefaultBaseUri());
     interceptor = null;
     readTimeout = null;
+    connectTimeout = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
   }
@@ -184,6 +187,7 @@ public class ApiClient {
     updateBaseUri(baseUri != null ? baseUri : getDefaultBaseUri());
     interceptor = null;
     readTimeout = null;
+    connectTimeout = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
   }
@@ -417,5 +421,36 @@ public class ApiClient {
    */
   public Duration getReadTimeout() {
     return readTimeout;
+  }
+  /**
+   * Sets the connect timeout (in milliseconds) for the http client.
+   *
+   * <p> In the case where a new connection needs to be established, if
+   * the connection cannot be established within the given {@code
+   * duration}, then {@link HttpClient#send(HttpRequest,BodyHandler)
+   * HttpClient::send} throws an {@link HttpConnectTimeoutException}, or
+   * {@link HttpClient#sendAsync(HttpRequest,BodyHandler)
+   * HttpClient::sendAsync} completes exceptionally with an
+   * {@code HttpConnectTimeoutException}. If a new connection does not
+   * need to be established, for example if a connection can be reused
+   * from a previous request, then this timeout duration has no effect.
+   *
+   * @param connectTimeout connection timeout in milliseconds
+   *
+   * @return This object.
+   */
+  public ApiClient setConnectTimeout(Duration connectTimeout) {
+    this.connectTimeout = connectTimeout;
+    this.builder.connectTimeout(connectTimeout);
+    return this;
+  }
+
+  /**
+   * Get connection timeout (in milliseconds).
+   *
+   * @return Timeout in milliseconds
+   */
+  public Duration getConnectTimeout() {
+    return connectTimeout;
   }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR includes the updates below:
- Add set/get for connection timeout
- bump jackson version to 2.13.0
- updated the samples via ./bin/generate-samples.sh;
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 @sebastien-rosset @cbornet @jeff9finger @bbdouglas @sreeshas @jfiala @lukoyanov @karismann @Zomzog @lwlee2608 @bkabrda @jfeltesse-mdsol @jcarres-mdsol