### PR TITLE
[kotlin][client] fix encoding of individual parts of a multipart request

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -705,6 +705,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     private void commonJvmMultiplatformSupportingFiles(String infrastructureFolder) {
         supportingFiles.add(new SupportingFile("infrastructure/ApiClient.kt.mustache", infrastructureFolder, "ApiClient.kt"));
         supportingFiles.add(new SupportingFile("infrastructure/ApiAbstractions.kt.mustache", infrastructureFolder, "ApiAbstractions.kt"));
+        supportingFiles.add(new SupportingFile("infrastructure/PartConfig.kt.mustache", infrastructureFolder, "PartConfig.kt"));
         supportingFiles.add(new SupportingFile("infrastructure/RequestConfig.kt.mustache", infrastructureFolder, "RequestConfig.kt"));
         supportingFiles.add(new SupportingFile("infrastructure/RequestMethod.kt.mustache", infrastructureFolder, "RequestMethod.kt"));
     }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/PartConfig.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/PartConfig.kt.mustache
@@ -1,0 +1,11 @@
+package {{packageName}}.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+{{#nonPublicApi}}internal {{/nonPublicApi}}data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -38,6 +38,7 @@ import {{packageName}}.infrastructure.ClientError
 import {{packageName}}.infrastructure.ServerException
 import {{packageName}}.infrastructure.ServerError
 import {{packageName}}.infrastructure.MultiValueMap
+import {{packageName}}.infrastructure.PartConfig
 import {{packageName}}.infrastructure.RequestConfig
 import {{packageName}}.infrastructure.RequestMethod
 import {{packageName}}.infrastructure.ResponseType
@@ -169,7 +170,7 @@ import {{packageName}}.infrastructure.toMultiValue
         {{/isDeprecated}}
         val localVariableConfig = {{operationId}}RequestConfig({{#allParams}}{{{paramName}}} = {{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
 
-        return{{^doNotUseRxAndCoroutines}}{{#useCoroutines}}@withContext{{/useCoroutines}}{{/doNotUseRxAndCoroutines}} request<{{#hasBodyParam}}{{#bodyParams}}{{{dataType}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}Unit{{/hasFormParams}}{{#hasFormParams}}Map<String, Any?>{{/hasFormParams}}{{/hasBodyParam}}, {{{returnType}}}{{^returnType}}Unit{{/returnType}}>(
+        return{{^doNotUseRxAndCoroutines}}{{#useCoroutines}}@withContext{{/useCoroutines}}{{/doNotUseRxAndCoroutines}} request<{{#hasBodyParam}}{{#bodyParams}}{{{dataType}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}Unit{{/hasFormParams}}{{#hasFormParams}}Map<String, PartConfig<*>>{{/hasFormParams}}{{/hasBodyParam}}, {{{returnType}}}{{^returnType}}Unit{{/returnType}}>(
             localVariableConfig
         )
     }
@@ -183,8 +184,14 @@ import {{packageName}}.infrastructure.toMultiValue
     {{#isDeprecated}}
     @Deprecated(message = "This operation is deprecated.")
     {{/isDeprecated}}
-    fun {{operationId}}RequestConfig({{#allParams}}{{{paramName}}}: {{#isEnum}}{{#isContainer}}kotlin.collections.List<{{enumName}}_{{operationId}}>{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : RequestConfig<{{#hasBodyParam}}{{#bodyParams}}{{{dataType}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}Unit{{/hasFormParams}}{{#hasFormParams}}Map<String, Any?>{{/hasFormParams}}{{/hasBodyParam}}> {
-        val localVariableBody = {{#hasBodyParam}}{{#bodyParams}}{{{paramName}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}null{{/hasFormParams}}{{#hasFormParams}}mapOf({{#formParams}}"{{{baseName}}}" to {{{paramName}}}{{^-last}}, {{/-last}}{{/formParams}}){{/hasFormParams}}{{/hasBodyParam}}
+    fun {{operationId}}RequestConfig({{#allParams}}{{{paramName}}}: {{#isEnum}}{{#isContainer}}kotlin.collections.List<{{enumName}}_{{operationId}}>{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : RequestConfig<{{#hasBodyParam}}{{#bodyParams}}{{{dataType}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}Unit{{/hasFormParams}}{{#hasFormParams}}Map<String, PartConfig<*>>{{/hasFormParams}}{{/hasBodyParam}}> {
+        val localVariableBody = {{#hasBodyParam}}{{!
+          }}{{#bodyParams}}{{{paramName}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{!
+          }}{{^hasFormParams}}null{{/hasFormParams}}{{!
+          }}{{#hasFormParams}}mapOf({{#formParams}}
+            "{{{baseName}}}" to PartConfig(body = {{{paramName}}}, headers = mutableMapOf({{#contentType}}"Content-Type" to "{{contentType}}"{{/contentType}})),{{!
+            }}{{/formParams}}){{/hasFormParams}}{{!
+        }}{{/hasBodyParam}}
         val localVariableQuery: MultiValueMap = {{^hasQueryParams}}mutableMapOf()
 {{/hasQueryParams}}{{#hasQueryParams}}mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
             .apply {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -25,6 +25,9 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 {{/jvm-okhttp4}}
 import okhttp3.Request
 import okhttp3.Headers
+{{#jvm-okhttp4}}
+import okhttp3.Headers.Companion.toHeaders
+{{/jvm-okhttp4}}
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -111,78 +114,62 @@ import com.squareup.moshi.adapter
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            {{#jvm-okhttp3}}
-            content is File -> RequestBody.create(MediaType.parse(mediaType), content)
-            {{/jvm-okhttp3}}
-            {{#jvm-okhttp4}}
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            {{/jvm-okhttp4}}
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.{{#jvm-okhttp3}}of{{/jvm-okhttp3}}{{#jvm-okhttp4}}headersOf{{/jvm-okhttp4}}(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                {{#jvm-okhttp3}}
-                                val fileMediaType = MediaType.parse(guessContentTypeFromFile(value))
-                                addPart(partHeaders, RequestBody.create(fileMediaType, value))
-                                {{/jvm-okhttp3}}
-                                {{#jvm-okhttp4}}
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                                {{/jvm-okhttp4}}
-                            } else {
-                                val partHeaders = Headers.{{#jvm-okhttp3}}of{{/jvm-okhttp3}}{{#jvm-okhttp4}}headersOf{{/jvm-okhttp4}}(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    {{#jvm-okhttp3}}
-                                    RequestBody.create(null, parameterToString(value))
-                                    {{/jvm-okhttp3}}
-                                    {{#jvm-okhttp4}}
-                                    parameterToString(value).toRequestBody(null)
-                                    {{/jvm-okhttp4}}
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart({{#jvm-okhttp3}}Headers.of(headers){{/jvm-okhttp3}}{{#jvm-okhttp4}}headers.toHeaders(){{/jvm-okhttp4}},
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            {{#jvm-okhttp3}}
+            content is File -> RequestBody.create(MediaType.parse(mediaType ?: guessContentTypeFromFile(content)), content)
+            {{/jvm-okhttp3}}
+            {{#jvm-okhttp4}}
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
+            {{/jvm-okhttp4}}
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
             {{#jvm-okhttp3}}
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     RequestBody.create(
                         {{#moshi}}
-                        MediaType.parse(mediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
+                        MediaType.parse(mediaType ?: JsonMediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
                         {{/moshi}}
                         {{#gson}}
-                        MediaType.parse(mediaType), Serializer.gson.toJson(content, T::class.java)
+                        MediaType.parse(mediaType ?: JsonMediaType), Serializer.gson.toJson(content, T::class.java)
                         {{/gson}}
                         {{#jackson}}
-                        MediaType.parse(mediaType), Serializer.jacksonObjectMapper.writeValueAsString(content)
+                        MediaType.parse(mediaType ?: JsonMediaType), Serializer.jacksonObjectMapper.writeValueAsString(content)
                         {{/jackson}}
                         {{#kotlinx_serialization}}
-                        MediaType.parse(mediaType), Serializer.jvmJson.encodeToString(content)
+                        MediaType.parse(mediaType ?: JsonMediaType), Serializer.jvmJson.encodeToString(content)
                         {{/kotlinx_serialization}}
                     )
                 }
@@ -203,9 +190,7 @@ import com.squareup.moshi.adapter
                     {{#kotlinx_serialization}}
                     Serializer.jvmJson.encodeToString(content)
                     {{/kotlinx_serialization}}
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             {{/jvm-okhttp4}}
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -205,10 +205,6 @@ import com.squareup.moshi.adapter
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             {{^supportAndroidApiLevel25AndBelow}}
@@ -224,14 +220,19 @@ import com.squareup.moshi.adapter
             }
             {{/supportAndroidApiLevel25AndBelow}}
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
-                {{#moshi}}Serializer.moshi.adapter<T>().fromJson(bodyContent){{/moshi}}{{#gson}}Serializer.gson.fromJson(bodyContent, (object: TypeToken<T>(){}).getType()){{/gson}}{{#jackson}}Serializer.jacksonObjectMapper.readValue(bodyContent, object: TypeReference<T>() {}){{/jackson}}{{#kotlinx_serialization}}Serializer.jvmJson.decodeFromString<T>(bodyContent){{/kotlinx_serialization}}
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+                {{#moshi}}Serializer.moshi.adapter<T>().fromJson(bodyContent){{/moshi}}{{!
+                }}{{#gson}}Serializer.gson.fromJson(bodyContent, (object: TypeToken<T>(){}).getType()){{/gson}}{{!
+                }}{{#jackson}}Serializer.jacksonObjectMapper.readValue(bodyContent, object: TypeReference<T>() {}){{/jackson}}{{!
+                }}{{#kotlinx_serialization}}Serializer.jvmJson.decodeFromString<T>(bodyContent){{/kotlinx_serialization}}
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -460,7 +460,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 26);
+            Assert.assertEquals(files.size(), 27);
 
             // Generator should report a library templated file as a generated file
             TestUtils.ensureContainsFile(files, output, "src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt");
@@ -502,7 +502,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 26);
+            Assert.assertEquals(files.size(), 27);
 
             // Generator should report README.md as a generated file
             TestUtils.ensureContainsFile(files, output, "README.md");
@@ -567,7 +567,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 26);
+            Assert.assertEquals(files.size(), 27);
 
             // Generator should report a library templated file as a generated file
             TestUtils.ensureContainsFile(files, output, "src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt");
@@ -621,7 +621,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 26);
+            Assert.assertEquals(files.size(), 27);
 
             // Generator should report README.md as a generated file
             TestUtils.ensureContainsFile(files, output, "README.md");

--- a/samples/client/petstore/kotlin-array-simple-string/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-array-simple-string/.openapi-generator/FILES
@@ -17,6 +17,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-array-simple-string/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-array-simple-string/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -32,6 +32,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-array-simple-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-array-simple-string/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-array-simple-string/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-enum-default-value/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-enum-default-value/.openapi-generator/FILES
@@ -18,6 +18,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-gson/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-gson/.openapi-generator/FILES
@@ -25,6 +25,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.gson.toJson(content, T::class.java)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -122,22 +116,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.gson.fromJson(bodyContent, (object: TypeToken<T>(){}).getType())
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-jackson/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-jackson/.openapi-generator/FILES
@@ -22,6 +22,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.jacksonObjectMapper.writeValueAsString(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -122,22 +116,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.jacksonObjectMapper.readValue(bodyContent, object: TypeReference<T>() {})
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-json-request-string/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-json-request-string/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -524,7 +525,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -537,8 +538,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -599,7 +602,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -612,8 +615,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -11,6 +11,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -66,53 +67,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -124,10 +118,6 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             val f = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -137,13 +127,15 @@ open class ApiClient(val baseUrl: String) {
                 createTempFile("tmp.net.medicineone.teleconsultationandroid.openapi.openapicommon", null)
             }
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/.openapi-generator/FILES
@@ -25,6 +25,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -36,6 +36,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -534,7 +535,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> = withContext(Dispatchers.IO) {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return@withContext request<Map<String, Any?>, Unit>(
+        return@withContext request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -547,8 +548,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -609,7 +612,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> = withContext(Dispatchers.IO) {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return@withContext request<Map<String, Any?>, ModelApiResponse>(
+        return@withContext request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -622,8 +625,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -35,6 +35,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -35,6 +35,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -68,53 +69,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.gson.toJson(content, T::class.java)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -125,22 +119,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.gson.fromJson(bodyContent, (object: TypeToken<T>(){}).getType())
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-modelMutable/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-modelMutable/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-moshi-codegen/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-moshi-codegen/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-multiplatform/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-multiplatform/.openapi-generator/FILES
@@ -24,6 +24,7 @@ src/commonMain/kotlin/org/openapitools/client/infrastructure/Base64ByteArray.kt
 src/commonMain/kotlin/org/openapitools/client/infrastructure/Bytes.kt
 src/commonMain/kotlin/org/openapitools/client/infrastructure/HttpResponse.kt
 src/commonMain/kotlin/org/openapitools/client/infrastructure/OctetByteArray.kt
+src/commonMain/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/commonMain/kotlin/org/openapitools/client/models/Category.kt

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-nonpublic/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-nonpublic/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ internal open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ internal open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+internal data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-nullable/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-nullable/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-okhttp3/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-okhttp3/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -63,51 +63,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> RequestBody.create(MediaType.parse(mediaType), content)
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.of(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = MediaType.parse(guessContentTypeFromFile(value))
-                                addPart(partHeaders, RequestBody.create(fileMediaType, value))
-                            } else {
-                                val partHeaders = Headers.of(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    RequestBody.create(null, parameterToString(value))
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(Headers.of(headers),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> RequestBody.create(MediaType.parse(mediaType ?: guessContentTypeFromFile(content)), content)
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     RequestBody.create(
-                        MediaType.parse(mediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
+                        MediaType.parse(mediaType ?: JsonMediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
                     )
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
@@ -120,22 +115,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-string/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-string/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-threetenbp/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-threetenbp/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin-uppercase-enum/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-uppercase-enum/.openapi-generator/FILES
@@ -18,6 +18,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/apis/EnumApi.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/apis/EnumApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)

--- a/samples/client/petstore/kotlin/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin/.openapi-generator/FILES
@@ -27,6 +27,7 @@ src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateTimeAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/OffsetDateTimeAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
 src/main/kotlin/org/openapitools/client/infrastructure/RequestMethod.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -34,6 +34,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType
@@ -532,7 +533,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithFormWithHttpInfo(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : ApiResponse<Unit?> {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        return request<Map<String, Any?>, Unit>(
+        return request<Map<String, PartConfig<*>>, Unit>(
             localVariableConfig
         )
     }
@@ -545,8 +546,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "name" to PartConfig(body = name, headers = mutableMapOf()),
+            "status" to PartConfig(body = status, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
@@ -607,7 +610,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFileWithHttpInfo(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse<ModelApiResponse?> {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        return request<Map<String, Any?>, ModelApiResponse>(
+        return request<Map<String, PartConfig<*>>, ModelApiResponse>(
             localVariableConfig
         )
     }
@@ -620,8 +623,10 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
-        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, PartConfig<*>>> {
+        val localVariableBody = mapOf(
+            "additionalMetadata" to PartConfig(body = additionalMetadata, headers = mutableMapOf()),
+            "file" to PartConfig(body = file, headers = mutableMapOf()),)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -33,6 +33,7 @@ import org.openapitools.client.infrastructure.ClientError
 import org.openapitools.client.infrastructure.ServerException
 import org.openapitools.client.infrastructure.ServerError
 import org.openapitools.client.infrastructure.MultiValueMap
+import org.openapitools.client.infrastructure.PartConfig
 import org.openapitools.client.infrastructure.RequestConfig
 import org.openapitools.client.infrastructure.RequestMethod
 import org.openapitools.client.infrastructure.ResponseType

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,6 +10,7 @@ import okhttp3.ResponseBody
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MultipartBody
 import okhttp3.Call
 import okhttp3.Callback
@@ -65,53 +66,46 @@ open class ApiClient(val baseUrl: String) {
         return contentType ?: "application/octet-stream"
     }
 
-    protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
+    protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
-            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
-            mediaType == FormDataMediaType -> {
+            mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .apply {
-                        // content's type *must* be Map<String, Any?>
+                        // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
-                        (content as Map<String, Any?>).forEach { (key, value) ->
-                            if (value is File) {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\"; filename=\"${value.name}\""
-                                )
-                                val fileMediaType = guessContentTypeFromFile(value).toMediaTypeOrNull()
-                                addPart(partHeaders, value.asRequestBody(fileMediaType))
-                            } else {
-                                val partHeaders = Headers.headersOf(
-                                    "Content-Disposition",
-                                    "form-data; name=\"$key\""
-                                )
-                                addPart(
-                                    partHeaders,
-                                    parameterToString(value).toRequestBody(null)
-                                )
+                        (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                            val contentType = part.headers.remove("Content-Type")
+                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
+                            bodies.forEach { body ->
+                                val headers = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
+                                addPart(headers.toHeaders(),
+                                    requestSingleBody(body, contentType))
                             }
                         }
                     }.build()
-            }
+            else -> requestSingleBody(content, mediaType)
+        }
+
+    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
+        when {
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
-                    // content's type *must* be Map<String, Any?>
+                    // content's type *must* be Map<String, PartConfig<*>>
                     @Suppress("UNCHECKED_CAST")
-                    (content as Map<String, Any?>).forEach { (key, value) ->
-                        add(key, parameterToString(value))
+                    (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
+                        add(name, parameterToString(part.body))
                     }
                 }.build()
             }
-            mediaType.startsWith("application/") && mediaType.endsWith("json") ->
+            mediaType == null || mediaType.startsWith("application/") && mediaType.endsWith("json") ->
                 if (content == null) {
                     EMPTY_REQUEST
                 } else {
                     Serializer.moshi.adapter(T::class.java).toJson(content)
-                        .toRequestBody(
-                            mediaType.toMediaTypeOrNull()
-                        )
+                        .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
             mediaType == XmlMediaType -> throw UnsupportedOperationException("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -123,22 +117,20 @@ open class ApiClient(val baseUrl: String) {
         if(body == null) {
             return null
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
-            return null
-        }
         if (T::class.java == File::class.java) {
             // return tempfile
             // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val f = java.nio.file.Files.createTempFile("tmp.org.openapitools.client", null).toFile()
             f.deleteOnExit()
-            val out = BufferedWriter(FileWriter(f))
-            out.write(bodyContent)
-            out.close()
+            body.byteStream().use { java.nio.file.Files.copy(it, f.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING) }
             return f as T
         }
+        val bodyContent = body.string()
+        if (bodyContent.isEmpty()) {
+            return null
+        }
         return when {
-        mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
+            mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 Serializer.moshi.adapter<T>().fromJson(bodyContent)
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/PartConfig.kt
@@ -1,0 +1,11 @@
+package org.openapitools.client.infrastructure
+
+/**
+ * Defines a config object for a given part of a multi-part request.
+ * NOTE: Headers is a Map<String,String> because rfc2616 defines
+ *       multi-valued headers as csv-only.
+ */
+data class PartConfig<T>(
+    val headers: MutableMap<String, String> = mutableMapOf(),
+    val body: T? = null
+)


### PR DESCRIPTION
Fixes #11910

This propagates param.contentType field from individual API endpoint definitions to the actual ApiClient and uses it to create RequestBody for each individual part with correct Content-Type header as well as correct serialization of the individual part's body. If not specified, the default Content-Type is "application/octet-stream" for files and "application/json" for models - see https://swagger.io/docs/specification/describing-request-body/multipart-requests/. The actual serialization of individual part's body is now reusing code for serialization of the non-multipart body, so it now properly handles many cases.

^ This part was also verified on our own internal project using ok-http4 library only.

Potential questions/risks:
- I'm not 100% sure about how this works for part bodies that are neither files, nor models. But since it reuses code that is handling non-multipart body, so it is consistent with that at least.
- Some samples still contain old code, even though other samples were updated by the specified script? How does this work?
- Should this go to `master` instead? I will rebase as necessary.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert, @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m 
