### PR TITLE
List/Map emptiness checking and stream variation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -68,11 +68,11 @@ public class CodegenOperation {
      * @return true if parameter exists, false otherwise
      */
     private static boolean nonEmpty(List<?> params) {
-        return params != null && params.size() > 0;
+        return params != null && !params.isEmpty();
     }
 
     private static boolean nonEmpty(Map<?, ?> params) {
-        return params != null && params.size() > 0;
+        return params != null && !params.isEmpty();
     }
 
     /**
@@ -189,7 +189,7 @@ public class CodegenOperation {
      * @return true if responses contain a default response, false otherwise
      */
     public boolean getHasDefaultResponse() {
-        return responses.stream().filter(response -> response.isDefault).findFirst().isPresent();
+        return responses.stream().anyMatch(response -> response.isDefault);
     }
 
     /**


### PR DESCRIPTION
I have changed the way of checking empty maps and lists, instead of checking if the size is greater than 0, It is more understandable and efficient using !x.isEmpty() method. 
Also, instead of using stream().filter().findFirst().isPresent(), it is recomendable using its equivalent stream().anyMatch() which as well, makes it easier to understand and efficient.

These are fixes for code smells provided from SonarCloud.
