### PR TITLE
issue 11921 - encode all template values

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -637,8 +637,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
                         queryBuilder.append(encodedName);
                         if (value != null) {
                             String templatizedKey = encodedName + valueItemCounter++;
-                            final String encodedValue = URLEncoder.encode(value.toString(), "UTF-8");
-                            uriParams.put(templatizedKey, encodedValue);
+                            uriParams.put(templatizedKey, value.toString());
                             queryBuilder.append('=').append("{").append(templatizedKey).append("}");
                         }
                     }
@@ -785,7 +784,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         // disable default URL encoding
         DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory();
-        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
         restTemplate.setUriTemplateHandler(uriBuilderFactory);
         return restTemplate;
     }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -597,8 +597,7 @@ public class ApiClient extends JavaTimeFormatter {
                         queryBuilder.append(encodedName);
                         if (value != null) {
                             String templatizedKey = encodedName + valueItemCounter++;
-                            final String encodedValue = URLEncoder.encode(value.toString(), "UTF-8");
-                            uriParams.put(templatizedKey, encodedValue);
+                            uriParams.put(templatizedKey, value.toString());
                             queryBuilder.append('=').append("{").append(templatizedKey).append("}");
                         }
                     }
@@ -743,7 +742,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         // disable default URL encoding
         DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory();
-        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
         restTemplate.setUriTemplateHandler(uriBuilderFactory);
         return restTemplate;
     }

--- a/samples/client/petstore/java/resttemplate-withXml/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -28,4 +28,12 @@ public class ApiClientTest {
 
         assertEquals("/key=val%2Ccomma", apiClient.expandPath("/key={key0}", uriParams));
     }
+
+    @Test
+    public void testPathParamEncoding() {
+        Map<String,Object> uriParams = new HashMap<>();
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+        uriParams.put("username", "user_name,comma&amp space");
+        assertEquals("user/user_name%2Ccomma%26amp%20space", apiClient.expandPath("user/{username}", uriParams));
+    }
 }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -592,8 +592,7 @@ public class ApiClient extends JavaTimeFormatter {
                         queryBuilder.append(encodedName);
                         if (value != null) {
                             String templatizedKey = encodedName + valueItemCounter++;
-                            final String encodedValue = URLEncoder.encode(value.toString(), "UTF-8");
-                            uriParams.put(templatizedKey, encodedValue);
+                            uriParams.put(templatizedKey, value.toString());
                             queryBuilder.append('=').append("{").append(templatizedKey).append("}");
                         }
                     }
@@ -730,7 +729,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         // disable default URL encoding
         DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory();
-        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
         restTemplate.setUriTemplateHandler(uriBuilderFactory);
         return restTemplate;
     }

--- a/samples/client/petstore/java/resttemplate/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/resttemplate/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -1,12 +1,13 @@
 package org.openapitools.client;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-import java.util.*;
-import org.junit.*;
-import org.springframework.util.MultiValueMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 public class ApiClientTest {
     ApiClient apiClient;
@@ -23,9 +24,15 @@ public class ApiClientTest {
     public void testUriEncoderWithComma() {
         Map<String,Object> uriParams = new HashMap<>();
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
-        queryParams.add("key", "val,comma");
-        apiClient.generateQueryUri(queryParams, uriParams);
+        queryParams.add("ke,&y", "val,?&comma");
+        String queryTemplate = apiClient.generateQueryUri(queryParams, uriParams);
+        assertEquals("ke%2C%26y=val%2C%3F%26comma", apiClient.expandPath(queryTemplate, uriParams));
+    }
 
-        assertEquals("/key=val%2Ccomma", apiClient.expandPath("/key={key0}", uriParams));
+    @Test
+    public void testPathParamEncoding() {
+        Map<String,Object> uriParams = new HashMap<>();
+        uriParams.put("username", "user_name,comma&amp space");
+        assertEquals("user/user_name%2Ccomma%26amp%20space", apiClient.expandPath("user/{username}", uriParams));
     }
 }


### PR DESCRIPTION
using uriBuilderFactory to encode all template values, and remove explicit query param value encoding.
