### PR TITLE
Spring Boot Dependency Upgrade

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -51,6 +51,11 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                {{#classifier}}
+                <configuration>
+                  <classifier>{{{classifier}}}</classifier>
+                </configuration>
+                {{/classifier}}
             </plugin>
             {{#apiFirst}}
             <plugin>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -13,20 +13,20 @@
         <springfox.version>2.9.2</springfox.version>
         {{/springFoxDocumentationProvider}}
         {{#springDocDocumentationProvider}}
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
         {{/springDocDocumentationProvider}}
         {{^springFoxDocumentationProvider}}
         {{^springDocDocumentationProvider}}
         {{#swagger1AnnotationLibrary}}
-        <swagger-annotations.version>1.6.4</swagger-annotations.version>
+        <swagger-annotations.version>1.6.5</swagger-annotations.version>
         {{/swagger1AnnotationLibrary}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.1.12</swagger-annotations.version>
+        <swagger-annotations.version>}2.1.13</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
         {{/springFoxDocumentationProvider}}
         {{#useSwaggerUI}}
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
         {{/useSwaggerUI}}
     </properties>
 {{#parentOverridden}}
@@ -40,7 +40,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>{{#springFoxDocumentationProvider}}2.5.8{{/springFoxDocumentationProvider}}{{^springFoxDocumentationProvider}}2.6.3{{/springFoxDocumentationProvider}}</version>
+        <version>{{#springFoxDocumentationProvider}}2.5.8{{/springFoxDocumentationProvider}}{{^springFoxDocumentationProvider}}2.6.4{{/springFoxDocumentationProvider}}</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
 {{/parentOverridden}}
     <build>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -40,7 +40,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>{{#springFoxDocumentationProvider}}2.5.10{{/springFoxDocumentationProvider}}{{^springFoxDocumentationProvider}}2.6.4{{/springFoxDocumentationProvider}}</version>
+        <version>{{#springFoxDocumentationProvider}}2.5.11{{/springFoxDocumentationProvider}}{{^springFoxDocumentationProvider}}2.6.5{{/springFoxDocumentationProvider}}</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 {{/parentOverridden}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -40,7 +40,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>{{#springFoxDocumentationProvider}}2.5.8{{/springFoxDocumentationProvider}}{{^springFoxDocumentationProvider}}2.6.4{{/springFoxDocumentationProvider}}</version>
+        <version>{{#springFoxDocumentationProvider}}2.5.10{{/springFoxDocumentationProvider}}{{^springFoxDocumentationProvider}}2.6.4{{/springFoxDocumentationProvider}}</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 {{/parentOverridden}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -37,7 +37,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 {{/parentOverridden}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -13,15 +13,15 @@
         <springfox.version>2.9.2</springfox.version>
         {{/springFoxDocumentationProvider}}
         {{#springDocDocumentationProvider}}
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
         {{/springDocDocumentationProvider}}
         {{^springFoxDocumentationProvider}}
         {{^springDocDocumentationProvider}}
         {{#swagger1AnnotationLibrary}}
-        <swagger-annotations.version>1.6.4</swagger-annotations.version>
+        <swagger-annotations.version>1.6.5</swagger-annotations.version>
         {{/swagger1AnnotationLibrary}}
         {{#swagger2AnnotationLibrary}}
-        <swagger-annotations.version>}2.1.12</swagger-annotations.version>
+        <swagger-annotations.version>}2.1.13</swagger-annotations.version>
         {{/swagger2AnnotationLibrary}}
         {{/springDocDocumentationProvider}}
         {{/springFoxDocumentationProvider}}
@@ -37,7 +37,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
 {{/parentOverridden}}
     <build>

--- a/samples/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/client/petstore/spring-cloud-async/pom.xml
@@ -14,7 +14,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/client/petstore/spring-cloud-async/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/client/petstore/spring-cloud-date-time/pom.xml
@@ -14,7 +14,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/client/petstore/spring-cloud-date-time/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -14,7 +14,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -14,7 +14,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/client/petstore/spring-stubs/pom.xml
+++ b/samples/client/petstore/spring-stubs/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/client/petstore/spring-stubs/pom.xml
+++ b/samples/client/petstore/spring-stubs/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
@@ -9,12 +9,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
@@ -9,12 +9,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
@@ -9,12 +9,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -9,12 +9,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/client/petstore/spring-cloud/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud/pom.xml
@@ -9,12 +9,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-cloud/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/client/petstore/spring-stubs/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/client/petstore/spring-stubs/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
@@ -9,12 +9,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
+        <springdoc.version>1.6.6</springdoc.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/springboot-delegate/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-delegate/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/springboot-delegate/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-delegate/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/springboot-reactive/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-reactive/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/springboot-reactive/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-reactive/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/springboot-source/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-source/pom.xml
@@ -9,12 +9,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/springboot-source/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-source/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-useoptional/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-useoptional/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/openapi3/server/petstore/springboot/pom.xml
+++ b/samples/openapi3/server/petstore/springboot/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/openapi3/server/petstore/springboot/pom.xml
+++ b/samples/openapi3/server/petstore/springboot/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/pom.xml
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/pom.xml
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/spring-boot-nullable-set/pom.xml
+++ b/samples/server/petstore/spring-boot-nullable-set/pom.xml
@@ -9,13 +9,14 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springdoc.version>1.6.4</springdoc.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <springdoc.version>1.6.6</springdoc.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/spring-boot-nullable-set/pom.xml
+++ b/samples/server/petstore/spring-boot-nullable-set/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -14,7 +14,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-delegate/pom.xml
+++ b/samples/server/petstore/springboot-delegate/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-delegate/pom.xml
+++ b/samples/server/petstore/springboot-delegate/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/server/petstore/springboot-implicitHeaders/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/server/petstore/springboot-implicitHeaders/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-spring-pageable/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-spring-pageable/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/server/petstore/springboot-useoptional/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/server/petstore/springboot-useoptional/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot-virtualan/pom.xml
+++ b/samples/server/petstore/springboot-virtualan/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot-virtualan/pom.xml
+++ b/samples/server/petstore/springboot-virtualan/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/springboot/pom.xml
+++ b/samples/server/petstore/springboot/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.10</version>
+        <version>2.5.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>

--- a/samples/server/petstore/springboot/pom.xml
+++ b/samples/server/petstore/springboot/pom.xml
@@ -10,12 +10,13 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
-        <swagger-ui.version>4.4.1-1</swagger-ui.version>
+        <swagger-ui.version>4.8.1</swagger-ui.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.5.10</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>


### PR DESCRIPTION
## Spring Boot Dependency Upgrade

Upgrade Spring Generator Dependencies

- Upgrade to Spring Boot 2.6.5 / 2.5.11
- Upgrade to Springdoc 1.6.6 
- Upgrade to Swagger Annotations 1.6.5 / 2.1.13
- Upgrade to Swagger Ui 4.8.1

Some minor cosmetic changes to the spring-boot pom in order to use the generated project as a dependency:

- Set relativePath in parent section
- Support a classifier in the spring-boot maven plugin configuration

### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
