### PR TITLE
[GoClient] Fixed StringIndexOutOfBoundsException when multiple properties has the same required $ref oneOf objects

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -568,7 +568,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
                 // We can't easily generate a pointer inline, so just use nil in that case
                 return prefix + "{nil}";
             }
-            return prefix + "{" + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap, depth) + "}";
+            return prefix + "{" + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap, depth+1) + "}";
         } else if (codegenProperty.isMap) { // map
             String prefix = codegenProperty.dataType;
             String dataType = StringUtils.removeStart(codegenProperty.dataType, "map[string][]");
@@ -578,7 +578,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
             if (codegenProperty.items == null) {
                 return prefix + "{ ... }";
             }
-            return prefix + "{\"key\": " + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap, depth) + "}";
+            return prefix + "{\"key\": " + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap, depth+1) + "}";
         } else if (codegenProperty.isPrimitiveType) { // primitive type
             if (codegenProperty.isString) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -460,7 +460,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         objs = super.postProcessOperationsWithModels(objs, allModels);
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         HashMap<String, CodegenModel> modelMaps = new HashMap<String, CodegenModel>();
-        HashMap<String, Integer> processedModelMaps = new HashMap<String, Integer>();
+        HashMap<String, ArrayList<Integer>> processedModelMaps = new HashMap<>();
 
         for (ModelMap modelMap : allModels) {
             CodegenModel m = modelMap.getModel();
@@ -488,14 +488,14 @@ public class GoClientCodegen extends AbstractGoCodegen {
         return objs;
     }
 
-    private String constructExampleCode(CodegenParameter codegenParameter, HashMap<String, CodegenModel> modelMaps, HashMap<String, Integer> processedModelMap) {
+    private String constructExampleCode(CodegenParameter codegenParameter, HashMap<String, CodegenModel> modelMaps, HashMap<String, ArrayList<Integer>> processedModelMap) {
         if (codegenParameter.isArray) { // array
             String prefix = codegenParameter.dataType;
             String dataType = StringUtils.removeStart(codegenParameter.dataType, "[]");
             if (modelMaps.containsKey(dataType)) {
                 prefix = "[]" + goImportAlias + "." + dataType;
             }
-            return prefix + "{" + constructExampleCode(codegenParameter.items, modelMaps, processedModelMap) + "}";
+            return prefix + "{" + constructExampleCode(codegenParameter.items, modelMaps, processedModelMap, 0) + "}";
         } else if (codegenParameter.isMap) {
             String prefix = codegenParameter.dataType;
             String dataType = StringUtils.removeStart(codegenParameter.dataType, "map[string][]");
@@ -505,7 +505,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
             if (codegenParameter.items == null) {
                 return prefix + "{ ... }";
             }
-            return prefix + "{\"key\": " + constructExampleCode(codegenParameter.items, modelMaps, processedModelMap) + "}";
+            return prefix + "{\"key\": " + constructExampleCode(codegenParameter.items, modelMaps, processedModelMap, 0) + "}";
         } else if (codegenParameter.isPrimitiveType) { // primitive type
             if (codegenParameter.isString) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
@@ -522,7 +522,9 @@ public class GoClientCodegen extends AbstractGoCodegen {
             } else if (codegenParameter.isUri) { // URL
                 return "\"https://example.com\"";
             } else if (codegenParameter.isDateTime || codegenParameter.isDate) { // datetime or date
-                processedModelMap.put("time.Time", 1);
+                ArrayList<Integer> v = new ArrayList<>();
+                v.add(1);
+                processedModelMap.put("time.Time", v);
                 return "time.Now()";
             } else if (codegenParameter.isFile) {
                 return "os.NewFile(1234, \"some_file\")";
@@ -536,7 +538,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         } else { // model
             // look up the model
             if (modelMaps.containsKey(codegenParameter.dataType)) {
-                return constructExampleCode(modelMaps.get(codegenParameter.dataType), modelMaps, processedModelMap);
+                return constructExampleCode(modelMaps.get(codegenParameter.dataType), modelMaps, processedModelMap, 0);
             } else if (codegenParameter.isEmail) { // email
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
                     return "\"" + codegenParameter.example + "\"";
@@ -544,7 +546,9 @@ public class GoClientCodegen extends AbstractGoCodegen {
                     return "\"" + codegenParameter.paramName + "@example.com\"";
                 }
             } else if (codegenParameter.isDateTime || codegenParameter.isDate) { // datetime or date
-                processedModelMap.put("time.Time", 1);
+                ArrayList<Integer> v = new ArrayList<>();
+                v.add(1);
+                processedModelMap.put("time.Time", v);
                 return "time.Now()";
             } else {
                 //LOGGER.error("Error in constructing examples. Failed to look up the model " + codegenParameter.dataType);
@@ -553,7 +557,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         }
     }
 
-    private String constructExampleCode(CodegenProperty codegenProperty, HashMap<String, CodegenModel> modelMaps, HashMap<String, Integer> processedModelMap) {
+    private String constructExampleCode(CodegenProperty codegenProperty, HashMap<String, CodegenModel> modelMaps, HashMap<String, ArrayList<Integer>> processedModelMap, int depth) {
         if (codegenProperty.isArray) { // array
             String prefix = codegenProperty.dataType;
             String dataType = StringUtils.removeStart(codegenProperty.dataType, "[]");
@@ -564,7 +568,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
                 // We can't easily generate a pointer inline, so just use nil in that case
                 return prefix + "{nil}";
             }
-            return prefix + "{" + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap) + "}";
+            return prefix + "{" + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap, depth) + "}";
         } else if (codegenProperty.isMap) { // map
             String prefix = codegenProperty.dataType;
             String dataType = StringUtils.removeStart(codegenProperty.dataType, "map[string][]");
@@ -574,7 +578,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
             if (codegenProperty.items == null) {
                 return prefix + "{ ... }";
             }
-            return prefix + "{\"key\": " + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap) + "}";
+            return prefix + "{\"key\": " + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap, depth) + "}";
         } else if (codegenProperty.isPrimitiveType) { // primitive type
             if (codegenProperty.isString) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
@@ -591,7 +595,9 @@ public class GoClientCodegen extends AbstractGoCodegen {
             } else if (codegenProperty.isUri) { // URL
                 return "\"https://example.com\"";
             } else if (codegenProperty.isDateTime || codegenProperty.isDate) { // datetime or date
-                processedModelMap.put("time.Time", 1);
+                ArrayList<Integer> v = new ArrayList<>();
+                v.add(1);
+                processedModelMap.put("time.Time", v);
                 return "time.Now()";
             } else { // numeric
                 String example;
@@ -606,7 +612,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         } else {
             // look up the model
             if (modelMaps.containsKey(codegenProperty.dataType)) {
-                return constructExampleCode(modelMaps.get(codegenProperty.dataType), modelMaps, processedModelMap);
+                return constructExampleCode(modelMaps.get(codegenProperty.dataType), modelMaps, processedModelMap, depth+1);
             } else if (codegenProperty.isEmail) { // email
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
                     return "\"" + codegenProperty.example + "\"";
@@ -614,7 +620,9 @@ public class GoClientCodegen extends AbstractGoCodegen {
                     return "\"" + codegenProperty.name + "@example.com\"";
                 }
             } else if (codegenProperty.isDateTime || codegenProperty.isDate) { // datetime or date
-                processedModelMap.put("time.Time", 1);
+                ArrayList<Integer> v = new ArrayList<>();
+                v.add(1);
+                processedModelMap.put("time.Time", v);
                 return "time.Now()";
             } else {
                 //LOGGER.error("Error in constructing examples. Failed to look up the model " + codegenProperty.dataType);
@@ -623,17 +631,20 @@ public class GoClientCodegen extends AbstractGoCodegen {
         }
     }
 
-    private String constructExampleCode(CodegenModel codegenModel, HashMap<String, CodegenModel> modelMaps, HashMap<String, Integer> processedModelMap) {
+    private String constructExampleCode(CodegenModel codegenModel, HashMap<String, CodegenModel> modelMaps, HashMap<String, ArrayList<Integer>> processedModelMap, int depth) {
         // break infinite recursion. Return, in case a model is already processed in the current context.
         String model = codegenModel.name;
         if (processedModelMap.containsKey(model)) {
-            int count = processedModelMap.get(model);
-            if (count == 1) {
-                processedModelMap.put(model, 2);
-            } else if (count == 2) {
+            ArrayList<Integer> depthList = processedModelMap.get(model);
+            if (depthList.size() == 1) {
+                if (depthList.get(0) != depth) {
+                    depthList.add(depth);
+                    processedModelMap.put(model, depthList);
+                }
+            } else if (depthList.size() == 2) {
                 return "";
             } else {
-                throw new RuntimeException("Invalid count when constructing example: " + count);
+                throw new RuntimeException("Invalid count when constructing example: " + depthList.size());
             }
         } else if (codegenModel.isEnum) {
             Map<String, Object> allowableValues = codegenModel.allowableValues;
@@ -645,15 +656,17 @@ public class GoClientCodegen extends AbstractGoCodegen {
             return goImportAlias + "." + model + "(" + example + ")";
         } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
             String subModel = (String) codegenModel.oneOf.toArray()[0];
-            String oneOf = constructExampleCode(modelMaps.get(subModel), modelMaps, processedModelMap).substring(1);
+            String oneOf = constructExampleCode(modelMaps.get(subModel), modelMaps, processedModelMap, depth+1).substring(1);
             return goImportAlias + "." + model + "{" + subModel + ": " + oneOf + "}";
         } else {
-            processedModelMap.put(model, 1);
+            ArrayList<Integer> v = new ArrayList<>();
+            v.add(depth);
+            processedModelMap.put(model, v);
         }
 
         List<String> propertyExamples = new ArrayList<>();
         for (CodegenProperty codegenProperty : codegenModel.requiredVars) {
-            propertyExamples.add(constructExampleCode(codegenProperty, modelMaps, processedModelMap));
+            propertyExamples.add(constructExampleCode(codegenProperty, modelMaps, processedModelMap, depth+1));
         }
         return "*" + goImportAlias + ".New" + toModelName(model) + "(" + StringUtils.join(propertyExamples, ", ") + ")";
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -158,4 +158,23 @@ public class GoClientCodegenTest {
 
         TestUtils.assertFileContains(Paths.get(output + "/model_example.go"), "Child NullableChild");
     }
+
+    @Test
+    public void testMultipleRequiredPropertiesHasSameOneOfObject() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setInputSpec("src/test/resources/3_0/petstore-multiple-required-properties-has-same-oneOf-object.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        System.out.println(files);
+        files.forEach(File::deleteOnExit);
+
+        Path docFile = Paths.get(output + "/docs/PetApi.md");
+        TestUtils.assertFileContains(docFile, "openapiclient.pet{Cat: openapiclient.NewCat(\"Attr_example\")}, openapiclient.pet{Cat: openapiclient.NewCat(\"Attr_example\")}, openapiclient.pet{Cat: openapiclient.NewCat(\"Attr_example\")}");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-multiple-required-properties-has-same-oneOf-object.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-multiple-required-properties-has-same-oneOf-object.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.1
+info:
+  title: My title
+  description: API under test
+  version: 1.0.7
+servers:
+  - url: https://localhost:9999/root
+paths:
+  /pet_preference:
+    post:
+      operationId: postPreference
+      tags:
+        - pet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/petPreference'
+      responses:
+        201:
+          description: OK
+components:
+  schemas:
+    dog:
+      type: object
+      required:
+        - attr
+      properties:
+        attr:
+          type: string
+          enum:
+            - DOG
+    cat:
+      type: object
+      required:
+        - attr
+      properties:
+        attr:
+          type: string
+          enum:
+            - CAT
+
+    pet:
+      oneOf:
+        - $ref: '#/components/schemas/dog'
+        - $ref: '#/components/schemas/cat'
+      discriminator:
+        propertyName: attr
+        mapping:
+          DOG: '#/components/schemas/dog'
+          CAT: '#/components/schemas/cat'
+
+    petPreference:
+      type: object
+      required:
+        - pet1
+        - pet2
+        - pet3
+      properties:
+        pet1:
+          $ref: '#/components/schemas/pet'
+        pet2:
+          $ref: '#/components/schemas/pet'
+        pet3:
+          $ref: '#/components/schemas/pet'


### PR DESCRIPTION
Go client generator will hit  StringIndexOutOfBoundsException when the object (petPreference) has multiple (2+) required fields (pet1, pet2, pet3) that pointing to the same object (pet).

The code triggering the error coming from the `processedMap` that checks if the same model is in an infinite loop, and returns an empty string when more than two stimes cause this error.

The fix introduces the depth of the recursion to the function and the `processedMap`, so the processedMap tracks the depth of the model wherever it processes

Example
```
    pet:
      oneOf:
        - $ref: '#/components/schemas/dog'
        - $ref: '#/components/schemas/cat'
      discriminator:
        propertyName: attr
        mapping:
          DOG: '#/components/schemas/dog'
          CAT: '#/components/schemas/cat'

    petPreference:
      type: object
      required:
        - pet1
        - pet2
        - pet3
      properties:
        pet1:
          $ref: '#/components/schemas/pet'
        pet2:
          $ref: '#/components/schemas/pet'
        pet3:
          $ref: '#/components/schemas/pet'
```

Stacktrace:
```
[main] INFO  o.o.codegen.TemplateManager - writing file /local/gen/docs/PetPreference.md                                                                                                                 
Exception in thread "main" java.lang.RuntimeException: Could not generate api file for 'Pet'                                                                                                             
        at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:665)                                                                                                             
        at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:891)                                                                                                                 
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:441)                         
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)                                                                                                     
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)                                                                                                                      
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1                                                                                                                      
        at java.base/java.lang.String.substring(Unknown Source)                                                                                                                                          
        at org.openapitools.codegen.languages.GoClientCodegen.constructExampleCode(GoClientCodegen.java:632)                                                                                             
        at org.openapitools.codegen.languages.GoClientCodegen.constructExampleCode(GoClientCodegen.java:593)                                                                                             
        at org.openapitools.codegen.languages.GoClientCodegen.constructExampleCode(GoClientCodegen.java:640)                                                                                             
        at org.openapitools.codegen.languages.GoClientCodegen.constructExampleCode(GoClientCodegen.java:523)                                                                                             
        at org.openapitools.codegen.languages.GoClientCodegen.postProcessOperationsWithModels(GoClientCodegen.java:460)                                                                                  
        at org.openapitools.codegen.DefaultGenerator.processOperations(DefaultGenerator.java:1212)  
        at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:568)        
        ... 4 more  
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ph4r5h4d