### PR TITLE
Support binary return format only  in Ruby faraday client

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -89,13 +89,13 @@ module {{moduleName}}
                             "explicitly with `tempfile.delete`"
         return @tempfile
       end
-      {{/isFaraday}}
 
       # return byte stream for Binary return type
       if return_type == 'Binary'
         encoding = body.encoding
         return @stream.join.force_encoding(encoding)
       end
+      {{/isFaraday}}
 
       return nil if body.nil? || body.empty?
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -71,7 +71,11 @@ module {{moduleName}}
       {{/isFaraday}}
       {{#isFaraday}}
       if return_type == 'File'
-        if @config.return_binary_data == false
+        if @config.return_binary_data == true
+          # return byte stream
+          encoding = body.encoding
+          return @stream.join.force_encoding(encoding)
+        else
           # return file instead of binary data
           content_disposition = response.headers['Content-Disposition']
           if content_disposition && content_disposition =~ /filename=/i
@@ -90,10 +94,6 @@ module {{moduleName}}
                               "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                               "explicitly with `tempfile.delete`"
           return @tempfile
-        else
-          # return byte stream
-          encoding = body.encoding
-          return @stream.join.force_encoding(encoding)
         end
       end
       {{/isFaraday}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -71,29 +71,30 @@ module {{moduleName}}
       {{/isFaraday}}
       {{#isFaraday}}
       if return_type == 'File'
-        content_disposition = response.headers['Content-Disposition']
-        if content_disposition && content_disposition =~ /filename=/i
-          filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-          prefix = sanitize_filename(filename)
+        if @config.return_binary_data == false
+          # return file instead of binary data
+          content_disposition = response.headers['Content-Disposition']
+          if content_disposition && content_disposition =~ /filename=/i
+            filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
+            prefix = sanitize_filename(filename)
+          else
+            prefix = 'download-'
+          end
+          prefix = prefix + '-' unless prefix.end_with?('-')
+          encoding = body.encoding
+          @tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
+          @tempfile.write(@stream.join.force_encoding(encoding))
+          @tempfile.close
+          @config.logger.info "Temp file written to #{@tempfile.path}, please copy the file to a proper folder "\
+                              "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
+                              "will be deleted automatically with GC. It's also recommended to delete the temp file "\
+                              "explicitly with `tempfile.delete`"
+          return @tempfile
         else
-          prefix = 'download-'
+          # return byte stream
+          encoding = body.encoding
+          return @stream.join.force_encoding(encoding)
         end
-        prefix = prefix + '-' unless prefix.end_with?('-')
-        encoding = body.encoding
-        @tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
-        @tempfile.write(@stream.join.force_encoding(encoding))
-        @tempfile.close
-        @config.logger.info "Temp file written to #{@tempfile.path}, please copy the file to a proper folder "\
-                            "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
-                            "will be deleted automatically with GC. It's also recommended to delete the temp file "\
-                            "explicitly with `tempfile.delete`"
-        return @tempfile
-      end
-
-      # return byte stream for Binary return type
-      if return_type == 'Binary'
-        encoding = body.encoding
-        return @stream.join.force_encoding(encoding)
       end
       {{/isFaraday}}
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -121,6 +121,8 @@ module {{moduleName}}
       @request_middlewares = []
       @response_middlewares = []
       @timeout = 60
+      # return data as binary instead of file
+      @return_binary_data = false
       {{/isFaraday}}
       {{^isFaraday}}
       @verify_ssl = true

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -201,29 +201,30 @@ module Petstore
       # handle file downloading - return the File instance processed in request callbacks
       # note that response body is empty when the file is written in chunks in request on_body callback
       if return_type == 'File'
-        content_disposition = response.headers['Content-Disposition']
-        if content_disposition && content_disposition =~ /filename=/i
-          filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-          prefix = sanitize_filename(filename)
+        if @config.return_binary_data == false
+          # return file instead of binary data
+          content_disposition = response.headers['Content-Disposition']
+          if content_disposition && content_disposition =~ /filename=/i
+            filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
+            prefix = sanitize_filename(filename)
+          else
+            prefix = 'download-'
+          end
+          prefix = prefix + '-' unless prefix.end_with?('-')
+          encoding = body.encoding
+          @tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
+          @tempfile.write(@stream.join.force_encoding(encoding))
+          @tempfile.close
+          @config.logger.info "Temp file written to #{@tempfile.path}, please copy the file to a proper folder "\
+                              "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
+                              "will be deleted automatically with GC. It's also recommended to delete the temp file "\
+                              "explicitly with `tempfile.delete`"
+          return @tempfile
         else
-          prefix = 'download-'
+          # return byte stream
+          encoding = body.encoding
+          return @stream.join.force_encoding(encoding)
         end
-        prefix = prefix + '-' unless prefix.end_with?('-')
-        encoding = body.encoding
-        @tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
-        @tempfile.write(@stream.join.force_encoding(encoding))
-        @tempfile.close
-        @config.logger.info "Temp file written to #{@tempfile.path}, please copy the file to a proper folder "\
-                            "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
-                            "will be deleted automatically with GC. It's also recommended to delete the temp file "\
-                            "explicitly with `tempfile.delete`"
-        return @tempfile
-      end
-
-      # return byte stream for Binary return type
-      if return_type == 'Binary'
-        encoding = body.encoding
-        return @stream.join.force_encoding(encoding)
       end
 
       return nil if body.nil? || body.empty?

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -201,7 +201,11 @@ module Petstore
       # handle file downloading - return the File instance processed in request callbacks
       # note that response body is empty when the file is written in chunks in request on_body callback
       if return_type == 'File'
-        if @config.return_binary_data == false
+        if @config.return_binary_data == true
+          # return byte stream
+          encoding = body.encoding
+          return @stream.join.force_encoding(encoding)
+        else
           # return file instead of binary data
           content_disposition = response.headers['Content-Disposition']
           if content_disposition && content_disposition =~ /filename=/i
@@ -220,10 +224,6 @@ module Petstore
                               "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                               "explicitly with `tempfile.delete`"
           return @tempfile
-        else
-          # return byte stream
-          encoding = body.encoding
-          return @stream.join.force_encoding(encoding)
         end
       end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -156,6 +156,8 @@ module Petstore
       @request_middlewares = []
       @response_middlewares = []
       @timeout = 60
+      # return data as binary instead of file
+      @return_binary_data = false
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -217,12 +217,6 @@ module Petstore
       # note that response body is empty when the file is written in chunks in request on_body callback
       return @tempfile if return_type == 'File'
 
-      # return byte stream for Binary return type
-      if return_type == 'Binary'
-        encoding = body.encoding
-        return @stream.join.force_encoding(encoding)
-      end
-
       return nil if body.nil? || body.empty?
 
       # return response body directly for String return type

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
@@ -217,12 +217,6 @@ module XAuthIDAlias
       # note that response body is empty when the file is written in chunks in request on_body callback
       return @tempfile if return_type == 'File'
 
-      # return byte stream for Binary return type
-      if return_type == 'Binary'
-        encoding = body.encoding
-        return @stream.join.force_encoding(encoding)
-      end
-
       return nil if body.nil? || body.empty?
 
       # return response body directly for String return type

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
@@ -216,12 +216,6 @@ module DynamicServers
       # note that response body is empty when the file is written in chunks in request on_body callback
       return @tempfile if return_type == 'File'
 
-      # return byte stream for Binary return type
-      if return_type == 'Binary'
-        encoding = body.encoding
-        return @stream.join.force_encoding(encoding)
-      end
-
       return nil if body.nil? || body.empty?
 
       # return response body directly for String return type

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
@@ -216,12 +216,6 @@ module Petstore
       # note that response body is empty when the file is written in chunks in request on_body callback
       return @tempfile if return_type == 'File'
 
-      # return byte stream for Binary return type
-      if return_type == 'Binary'
-        encoding = body.encoding
-        return @stream.join.force_encoding(encoding)
-      end
-
       return nil if body.nil? || body.empty?
 
       # return response body directly for String return type


### PR DESCRIPTION
Support binary return format only  in Ruby faraday client via the config option `return_binary_data`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
