### PR TITLE
Fixed java/spring oneOf generator (Inline oneOf support) #11932 

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7122,6 +7122,7 @@ public class DefaultCodegen implements CodegenConfig {
     public void addOneOfNameExtension(ComposedSchema s, String name) {
         if (s.getOneOf() != null && s.getOneOf().size() > 0) {
             s.addExtension("x-one-of-name", name);
+            s.setType(name);
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -988,6 +988,19 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void oneOf_11932() throws Exception {
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.setUseOneOfInterfaces(true);
+
+        final Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/issue_11932-oneOf.yaml");
+
+        final File fruitBaseClass = files.get("Fruit.java");
+        final String line = "public Fruit putBodyItem(String key,  bodyItem)";
+
+        assertFileNotContains(fruitBaseClass.toPath(), line);
+    }
+
+    @Test
     public void testTypeMappings() {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.processOpts();

--- a/modules/openapi-generator/src/test/resources/3_0/issue_11932-oneOf.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_11932-oneOf.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.1
+info:
+   title: fruity
+   version: 0.0.1
+servers:
+   - url: /
+paths:
+   /:
+      get:
+         responses:
+            "200":
+               content:
+                  application/json:
+                     schema:
+                        $ref: '#/components/schemas/fruit'
+               description: desc
+         x-accepts: application/json
+components:
+   schemas:
+      fruit:
+         example:
+            fruitId: fruitId
+            body: "{}"
+         properties:
+            fruitId:
+               description: The unique ID of the fruit
+               type: string
+            body:
+               description: |
+                  The raw event payload that will be different based on the event.
+               oneOf:
+                  - $ref: '#/components/schemas/apple'
+                  - $ref: '#/components/schemas/banana'
+               type: object
+               x-one-of-name: FruitBodyOneOf
+         title: fruit
+      apple:
+         properties:
+            kind:
+               type: string
+         title: apple
+         type: object
+      banana:
+         properties:
+            count:
+               type: number
+         title: banana
+         type: object


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #11932 
> When generating a spring or java code with a spec that contains an attribute with an inline oneOf, the code generator creates a code with a bug. 

Currently, before the code generation, the **DefaultGenerator** validates the schema type, if the schema is an object, it calls the default _setTypeProperties_ method in the **IJsonSchemaValidationProperties** interface to validate the schema. If the schema is an object, the **CodegenModel** _isMap_ attribute is set to true, which incorrectly creates the code with an additional method for _Map_ structures.

This simple change modifies the Schema type from object to the OneOf interface created to support the provided sub-subschemas.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlevente