### PR TITLE
[Python] Update APIException Output

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/exceptions.mustache
+++ b/modules/openapi-generator/src/main/resources/python/exceptions.mustache
@@ -104,7 +104,7 @@ class ApiException(OpenApiException):
 
     def __str__(self):
         """Custom error messages for exception"""
-        error_message = "({0})\n"\
+        error_message = "Status Code: {0}\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.headers:
             error_message += "HTTP response headers: {0}\n".format(

--- a/samples/client/petstore/python/petstore_api/exceptions.py
+++ b/samples/client/petstore/python/petstore_api/exceptions.py
@@ -112,7 +112,7 @@ class ApiException(OpenApiException):
 
     def __str__(self):
         """Custom error messages for exception"""
-        error_message = "({0})\n"\
+        error_message = "Status Code: {0}\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.headers:
             error_message += "HTTP response headers: {0}\n".format(

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/exceptions.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/exceptions.py
@@ -112,7 +112,7 @@ class ApiException(OpenApiException):
 
     def __str__(self):
         """Custom error messages for exception"""
-        error_message = "({0})\n"\
+        error_message = "Status Code: {0}\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.headers:
             error_message += "HTTP response headers: {0}\n".format(

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/exceptions.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/exceptions.py
@@ -112,7 +112,7 @@ class ApiException(OpenApiException):
 
     def __str__(self):
         """Custom error messages for exception"""
-        error_message = "({0})\n"\
+        error_message = "Status Code: {0}\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.headers:
             error_message += "HTTP response headers: {0}\n".format(

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/exceptions.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/exceptions.py
@@ -112,7 +112,7 @@ class ApiException(OpenApiException):
 
     def __str__(self):
         """Custom error messages for exception"""
-        error_message = "({0})\n"\
+        error_message = "Status Code: {0}\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.headers:
             error_message += "HTTP response headers: {0}\n".format(

--- a/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
@@ -112,7 +112,7 @@ class ApiException(OpenApiException):
 
     def __str__(self):
         """Custom error messages for exception"""
-        error_message = "({0})\n"\
+        error_message = "Status Code: {0}\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.headers:
             error_message += "HTTP response headers: {0}\n".format(


### PR DESCRIPTION
This PR changes the \_\_str\_\_ function for the APIException class to print `Status Code: ` before printing the status code. This is just to remain consistent with the other output in the custom error message.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11)