### PR TITLE
[scala][sttp]convert header parameter to string

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp/paramCreation.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/paramCreation.mustache
@@ -1,1 +1,1 @@
-"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}
+"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}.toString

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -56,7 +56,7 @@ class PetApi(baseUrl: String) {
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
-      .header("api_key", apiKey)
+      .header("api_key", apiKey.toString)
       .response(asJson[Unit])
 
   /**


### PR DESCRIPTION
This PR fixes the issue [#11942](https://github.com/OpenAPITools/openapi-generator/issues/11942)

Here is the openapi spec for reproduce the issue and verify the fix.
```ymal
openapi: 3.0.0
info:
  title: Request Header
  version: "1.0.0"
paths:
  /test:
    get:
      summary: Empty Route
      parameters:
      - description: Gets user info.
        explode: false
        in: header
        name: user_uuid
        required: true
        schema:
          format: uuid
          type: string
        style: simple
      responses:
        "200":
          description: Good Request.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ReturnValue'
        "400":
          description: Bad Request.
components:
  schemas:
    ReturnValue:
      properties:
        name:
          type: string
``` 
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@chameleon82 @clasnake @jimschubert @shijinkui @ramzimaalej @Bouillie @wing328