### PR TITLE
Conditionally import the java validation API in the resource interface definition

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
@@ -16,6 +16,11 @@ import javax.ws.rs.core.MediaType;
 import org.apache.cxf.jaxrs.ext.multipart.*;
 {{/disableMultipart}}
 
+{{#useBeanValidation}}
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+{{/useBeanValidation}}
+
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 


### PR DESCRIPTION
In case 'useBeanValidation' is enabled the relevant annotation classes should be imported on the API as well.
In the current version (5.4.0) the resource methods parameters are annotated with @Valid but without importing them.