### PR TITLE
[C++][Pistache] Fixes for struct model

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/helpers-source.mustache
@@ -37,15 +37,21 @@ namespace
 bool validateRfc3339_date(const std::string& str) {
     std::smatch match;
     const bool found = std::regex_search(str, match, regexRfc3339_date);
-    return found && validateDateValues(std::stoi(match[1]), std::stoi(match[2]), std::stoi(match[3]));
+    return found && validateDateValues(static_cast<uint16_t>(std::stoi(match[1])),
+                                       static_cast<uint16_t>(std::stoi(match[2])),
+                                       static_cast<uint16_t>(std::stoi(match[3])));
 }
 
 bool validateRfc3339_date_time(const std::string& str) {
     std::smatch match;
     const bool found = std::regex_search(str, match, regexRfc3339_date_time);
     return found
-        && validateDateValues(std::stoi(match[1]), std::stoi(match[2]), std::stoi(match[3]))
-        && validateTimeValues(std::stoi(match[4]), std::stoi(match[5]), std::stoi(match[6]));
+        && validateDateValues(static_cast<uint16_t>(std::stoi(match[1])),
+                              static_cast<uint16_t>(std::stoi(match[2])),
+                              static_cast<uint16_t>(std::stoi(match[3])))
+        && validateTimeValues(static_cast<uint16_t>(std::stoi(match[4])),
+                              static_cast<uint16_t>(std::stoi(match[5])),
+                              static_cast<uint16_t>(std::stoi(match[6])));
 }
 
 std::string toStringValue(const std::string &value){

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-header.mustache
@@ -26,6 +26,23 @@ struct {{classname}}
     bool operator==(const {{classname}}& other) const;
     bool operator!=(const {{classname}}& other) const;
 
+    /// <summary>
+    /// Validate the current data in the model. Throws a ValidationException on failure.
+    /// </summary>
+    void validate() const;
+
+    /// <summary>
+    /// Validate the current data in the model. Returns false on error and writes an error
+    /// message into the given stringstream.
+    /// </summary>
+    bool validate(std::stringstream& msg) const;
+
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     nlohmann::json to_json() const;
     static {{classname}} from_json(const nlohmann::json& j);
 };

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -33,8 +33,8 @@ bool {{classname}}::operator!=(const {{classname}}& other) const
 void to_json(nlohmann::json& j, const {{classname}}& o)
 {
     {{#vars}}
-    {{^required}}if (!o.{{name}}.isEmpty()){{/required}}
-        j["{{baseName}}"] = o.{{name}}{{^required}}.get(){{/required}};
+    {{^required}}if (o.{{name}}.has_value()){{/required}}
+        j["{{baseName}}"] = o.{{name}}{{^required}}.value(){{/required}};
     {{/vars}}
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -2,6 +2,7 @@
 {{#models}}{{#model}}
 
 #include "{{classname}}.h"
+#include "{{prefix}}Helpers.h"
 
 namespace {{modelNamespace}}
 {
@@ -18,6 +19,56 @@ nlohmann::json {{classname}}::to_json() const
     {{classname}} o{};
     {{#modelNamespaceDeclarations}}::{{this}}{{/modelNamespaceDeclarations}}::from_json(j, o);
     return o;
+}
+
+void {{classname}}::validate() const
+{
+    std::stringstream msg;
+    if (!validate(msg))
+    {
+        throw {{helpersNamespace}}::ValidationException(msg.str());
+    }
+}
+
+bool {{classname}}::validate(std::stringstream& msg) const
+{
+    return validate(msg, "");
+}
+
+bool {{classname}}::validate(std::stringstream& msg, const std::string& pathPrefix) const
+{
+    bool success = true;
+    const std::string _pathPrefix = pathPrefix.empty() ? "{{classname}}" : pathPrefix;
+
+    {{#isEnum}}{{! Special case for enum types }}
+    if (m_value == {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED)
+    {
+        success = false;
+        msg << _pathPrefix << ": has no value;";
+    }
+    {{/isEnum}}
+    {{^isEnum}}
+    {{#vars}}
+    {{#isArray}} {{! Always generate validation body for array types }}
+    {{^required}}if ({{name}}.has_value()){{/required}}
+    {{#required}}/* {{name}} */ {{/required}}{
+        const {{{dataType}}}& value = {{name}}{{^required}}.value(){{/required}};
+        const std::string currentValuePath = _pathPrefix + ".{{nameInCamelCase}}";
+        {{> model-validation-body }}
+    }
+    {{/isArray}}{{^isArray}}{{#hasValidation}} {{! Only generate validation if necessary }}
+    {{^required}}if ({{name}}.has_value()){{/required}}
+    {{#required}}/* {{name}} */ {{/required}}{
+        const {{{dataType}}}& value = {{name}}{{^required}}.value(){{/required}};
+        const std::string currentValuePath = _pathPrefix + ".{{nameInCamelCase}}";
+        {{> model-validation-body }}
+    }
+    {{/hasValidation}}{{/isArray}}{{/vars}}{{/isEnum}}{{#vendorExtensions.x-is-string-enum-container}}{{#anyOf}}{{#-first}}
+    if (!m_value.validate(msg))
+    {
+        success = false;
+    }{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
+    return success;
 }
 
 bool {{classname}}::operator==(const {{classname}}& other) const

--- a/samples/server/petstore/cpp-pistache/model/Helpers.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Helpers.cpp
@@ -47,15 +47,21 @@ namespace
 bool validateRfc3339_date(const std::string& str) {
     std::smatch match;
     const bool found = std::regex_search(str, match, regexRfc3339_date);
-    return found && validateDateValues(std::stoi(match[1]), std::stoi(match[2]), std::stoi(match[3]));
+    return found && validateDateValues(static_cast<uint16_t>(std::stoi(match[1])),
+                                       static_cast<uint16_t>(std::stoi(match[2])),
+                                       static_cast<uint16_t>(std::stoi(match[3])));
 }
 
 bool validateRfc3339_date_time(const std::string& str) {
     std::smatch match;
     const bool found = std::regex_search(str, match, regexRfc3339_date_time);
     return found
-        && validateDateValues(std::stoi(match[1]), std::stoi(match[2]), std::stoi(match[3]))
-        && validateTimeValues(std::stoi(match[4]), std::stoi(match[5]), std::stoi(match[6]));
+        && validateDateValues(static_cast<uint16_t>(std::stoi(match[1])),
+                              static_cast<uint16_t>(std::stoi(match[2])),
+                              static_cast<uint16_t>(std::stoi(match[3])))
+        && validateTimeValues(static_cast<uint16_t>(std::stoi(match[4])),
+                              static_cast<uint16_t>(std::stoi(match[5])),
+                              static_cast<uint16_t>(std::stoi(match[6])));
 }
 
 std::string toStringValue(const std::string &value){


### PR DESCRIPTION
Hi, I have tried to use struct models with newest Pistache version but it does not compile:
- bunch of conversion warnings (truncating from 32-bit int to 16-bit uint)
- Pistache::Optional was used but it got removed from Pistache some time ago
- validation was missing, I have ported the validation to struct model, I think it looks okay - I have generated samples with `useStructModel: "true"` and the part related to validation did not change in PetStore sample

I have run `bin/generate-samples.sh` and it modified a bunch of files in .NET Core generator, but I didn't commit these files, apart from that everything else is committed.

```
$ git status
On branch pistache-fix-struct-model
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/.openapi-generator/FILES
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/.openapi-generator/FILES
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/.openapi-generator/FILES
```

@ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @martindelille (2018/03) @muttleyxd (2019/08)

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
