### PR TITLE
#6008 fix typescript fetch error "Object is possibly 'undefined'." for body requestParameters array mapping

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -260,7 +260,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{#bodyParam}}
             {{#isContainer}}
             {{^withoutRuntimeChecks}}
-            body: requestParameters.{{paramName}}{{#isArray}}{{#items}}{{^isPrimitiveType}}.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isArray}},
+            body: requestParameters.{{paramName}}{{#isArray}}{{#items}}{{^isPrimitiveType}}?.map({{datatype}}ToJSON){{/isPrimitiveType}}{{/items}}{{/isArray}},
             {{/withoutRuntimeChecks}}
             {{#withoutRuntimeChecks}}
             body: requestParameters.{{paramName}},


### PR DESCRIPTION
Adding null conditional operator to body requestParameters mapping.  Fixes error: "Object is possibly 'undefined'."

Generating post api with a collection creates api interface with nullable collection but api method calls the nullable property without null conditional operator.

Example:

Original post api:
`        public async Task<IActionResult> OnPost([FromBody] List<CreateSampleViewModel> model) {
`
creates following code:
```
export interface VversionSamplePostRequest {
  createSampleViewModel?: Array<CreateSampleViewModel>
}
```
:
```
        body: requestParameters.createSampleViewModel.map(
          CreateSampleViewModelToJSON
        ),
```
-> Typescript complains about object being possibly undefined.

#6008 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
