### PR TITLE
[doc] Fix urls to sbt-openapi-generator in doc and script

### DIFF
--- a/bin/utils/release_checkout.rb
+++ b/bin/utils/release_checkout.rb
@@ -9,7 +9,7 @@ require 'net/http'
 def check_sbt_openapi_generator
   print "Checking sbt-openapi-generator... "
 
-  url = "https://raw.githubusercontent.com/upstart-commerce/sbt-openapi-generator/master/build.sbt"
+  url = "https://raw.githubusercontent.com/OpenAPITools/sbt-openapi-generator/master/build.sbt"
   open(url) do |f|
     content = f.read
     if !content.nil? && content.include?($version)

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -21,7 +21,7 @@ See the [openapi-generator-maven-plugin README](https://github.com/OpenAPITools/
 
 ### sbt Integration
 
-Please refer to https://github.com/upstart-commerce/sbt-openapi-generator
+Please refer to https://github.com/OpenAPITools/sbt-openapi-generator
 
 ### Bazel Integration
 


### PR DESCRIPTION
It fixes two references to outdated repo outside OpenAPITool organization - https://github.com/upstart-commerce/sbt-openapi-generator. 
Now URLs are pointing to the project mentioned in https://github.com/OpenAPITools/openapi-generator/issues/3650#issuecomment-632902919 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
