### PR TITLE
[typescript] Skip missing fields during deserialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -169,7 +169,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -141,7 +141,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -162,7 +162,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -158,7 +158,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -158,7 +158,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -158,7 +158,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -158,7 +158,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -158,7 +158,10 @@ export class ObjectSerializer {
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
-                instance[attributeType.name] = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                let value = ObjectSerializer.deserialize(data[attributeType.baseName], attributeType.type, attributeType.format);
+                if (value !== undefined) {
+                    instance[attributeType.name] = value;
+                }
             }
             return instance;
         }

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -20,7 +20,6 @@ describe("PetApi", () => {
         pet.photoUrls = []
         pet.status = 'available'
         pet.tags = [ tag ]
-        pet.category = undefined
 
         await petApi.addPet(pet);
     });

--- a/samples/openapi3/client/petstore/typescript/tests/deno/test/api/PetApi_test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/deno/test/api/PetApi_test.ts
@@ -19,7 +19,6 @@ pet.name = "PetName";
 pet.photoUrls = [];
 pet.status = "available";
 pet.tags = [tag];
-pet.category = undefined;
 
 Deno.test({
   name: "PetApi addPet getPetById",

--- a/samples/openapi3/client/petstore/typescript/tests/jquery/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/jquery/test/api/PetApi.test.ts
@@ -18,7 +18,6 @@ pet.name = "PetName"
 pet.photoUrls = []
 pet.status = 'available'
 pet.tags = [ tag ]
-pet.category = undefined
 
 QUnit.module("PetApi")
 

--- a/samples/openapi3/client/petstore/typescript/tests/object_params/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/object_params/test/api/PetApi.test.ts
@@ -17,7 +17,6 @@ pet.name = "PetName"
 pet.photoUrls = []
 pet.status = 'available'
 pet.tags = [ tag ]
-pet.category = undefined
 
 describe("PetApi", () =>{ 
     it("addPet", (done) => {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Currently the deserializer fills all fields which are missing in the payload with the value `undefined`. Usually the difference between a missing field and a field which is set to `undefined` is not important. In some cases the behaviour is different however. For example when using `Object.keys`, the `in` operator or a strict recursive comparison like lodash’s `isEqual`.

This PR changes the behaviour, so that the missing fields are skipped and the deserialized objects do not have them set to `undefined` anymore.
I feel this is the correct approach, because this is the most strict meaning for optional properties in typescript. (Even though [the flag](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) that checks strictly is not enabled by default, for backward compatibility.)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03)
