### PR TITLE
Update Spring dependencies to address CVE-2022-22965

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -104,7 +104,7 @@ ext {
     jackson_databind_nullable_version = "0.2.2"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
-    spring_web_version = "5.2.5.RELEASE"
+    spring_web_version = "5.3.18"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -301,7 +301,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
-        <spring-web-version>5.2.5.RELEASE</spring-web-version>
+        <spring-web-version>5.3.18</spring-web-version>
         <jackson-version>2.10.5</jackson-version>
         <jackson-databind-version>2.10.5.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -113,7 +113,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.3"
-    spring_web_version = "2.4.3"
+    spring_boot_version = "2.6.6"
     jackson_version = "2.11.4"
     jackson_databind_version = "2.11.4"
     {{#openApiNullable}}
@@ -130,7 +130,7 @@ dependencies {
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
-    implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_web_version"
+    implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor.netty:reactor-netty-http:$reactor_netty_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>${spring-web-version}</version>
+            <version>${spring-boot-version}</version>
         </dependency>
 
         <dependency>
@@ -147,7 +147,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.3</swagger-annotations-version>
-        <spring-web-version>2.4.3</spring-web-version>
+        <spring-boot-version>2.6.6</spring-boot-version>
         <jackson-version>2.11.3</jackson-version>
         <jackson-databind-version>2.11.4</jackson-databind-version>
         {{#openApiNullable}}

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -102,7 +102,7 @@ ext {
     jackson_databind_version = "2.10.5.1"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
-    spring_web_version = "5.2.5.RELEASE"
+    spring_web_version = "5.3.18"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }

--- a/samples/client/petstore/java/resttemplate-withXml/pom.xml
+++ b/samples/client/petstore/java/resttemplate-withXml/pom.xml
@@ -280,7 +280,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
-        <spring-web-version>5.2.5.RELEASE</spring-web-version>
+        <spring-web-version>5.3.18</spring-web-version>
         <jackson-version>2.10.5</jackson-version>
         <jackson-databind-version>2.10.5.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -102,7 +102,7 @@ ext {
     jackson_databind_version = "2.10.5.1"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
-    spring_web_version = "5.2.5.RELEASE"
+    spring_web_version = "5.3.18"
     jodatime_version = "2.9.9"
     junit_version = "4.13.2"
 }

--- a/samples/client/petstore/java/resttemplate/pom.xml
+++ b/samples/client/petstore/java/resttemplate/pom.xml
@@ -272,7 +272,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
-        <spring-web-version>5.2.5.RELEASE</spring-web-version>
+        <spring-web-version>5.3.18</spring-web-version>
         <jackson-version>2.10.5</jackson-version>
         <jackson-databind-version>2.10.5.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/webclient-nulable-arrays/build.gradle
+++ b/samples/client/petstore/java/webclient-nulable-arrays/build.gradle
@@ -113,7 +113,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.3"
-    spring_web_version = "2.4.3"
+    spring_boot_version = "2.6.6"
     jackson_version = "2.11.4"
     jackson_databind_version = "2.11.4"
     jackson_databind_nullable_version = "0.2.2"
@@ -128,7 +128,7 @@ dependencies {
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
-    implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_web_version"
+    implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor.netty:reactor-netty-http:$reactor_netty_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/samples/client/petstore/java/webclient-nulable-arrays/pom.xml
+++ b/samples/client/petstore/java/webclient-nulable-arrays/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>${spring-web-version}</version>
+            <version>${spring-boot-version}</version>
         </dependency>
 
         <dependency>
@@ -126,7 +126,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.3</swagger-annotations-version>
-        <spring-web-version>2.4.3</spring-web-version>
+        <spring-boot-version>2.6.6</spring-boot-version>
         <jackson-version>2.11.3</jackson-version>
         <jackson-databind-version>2.11.4</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -113,7 +113,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.3"
-    spring_web_version = "2.4.3"
+    spring_boot_version = "2.6.6"
     jackson_version = "2.11.4"
     jackson_databind_version = "2.11.4"
     jackson_databind_nullable_version = "0.2.2"
@@ -128,7 +128,7 @@ dependencies {
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
-    implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_web_version"
+    implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor.netty:reactor-netty-http:$reactor_netty_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/samples/client/petstore/java/webclient/pom.xml
+++ b/samples/client/petstore/java/webclient/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>${spring-web-version}</version>
+            <version>${spring-boot-version}</version>
         </dependency>
 
         <dependency>
@@ -126,7 +126,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.3</swagger-annotations-version>
-        <spring-web-version>2.4.3</spring-web-version>
+        <spring-boot-version>2.6.6</spring-boot-version>
         <jackson-version>2.11.3</jackson-version>
         <jackson-databind-version>2.11.4</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>


### PR DESCRIPTION
[CVE-2022-22965: Spring Framework RCE via Data Binding on JDK 9+](https://tanzu.vmware.com/security/cve-2022-22965)
[Spring Boot 2.6.6 available now](https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now)
[Spring Framework RCE, Early Announcement](https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
