### PR TITLE
[Java Play Framework Generator] Fix NPE when passing null in a formData that is not required.

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/newApiController.mustache
@@ -163,10 +163,10 @@ public class {{classname}}Controller extends Controller {
         }
         {{/collectionFormat}}
         {{^collectionFormat}}
-        String value{{paramName}} = (request.body().asMultipartFormData().asFormUrlEncoded().get("{{baseName}}"))[0];
+        String[] value{{paramName}} = request.body().asMultipartFormData().asFormUrlEncoded().get("{{baseName}}");
         {{{dataType}}} {{paramName}};
         if (value{{paramName}} != null) {
-            {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};
+            {{paramName}} = {{>conversionBegin}}value{{paramName}}[0]{{>conversionEnd}};
         } else {
             {{#required}}
             throw new IllegalArgumentException("'{{baseName}}' parameter is required");

--- a/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-api-package-override/app/com/puppies/store/apis/PetApiController.java
@@ -121,17 +121,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -140,10 +140,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-async/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-async/app/controllers/PetApiController.java
@@ -124,17 +124,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public CompletionStage<Result> updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -143,10 +143,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public CompletionStage<Result> uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-controller-only/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-controller-only/app/controllers/PetApiController.java
@@ -119,17 +119,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -138,10 +138,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
@@ -174,96 +174,96 @@ public class FakeApiController extends Controller {
 
     @ApiAction
     public Result testEndpointParameters(Http.Request request) throws Exception {
-        String valueinteger = (request.body().asMultipartFormData().asFormUrlEncoded().get("integer"))[0];
+        String[] valueinteger = request.body().asMultipartFormData().asFormUrlEncoded().get("integer");
         Integer integer;
         if (valueinteger != null) {
-            integer = Integer.parseInt(valueinteger);
+            integer = Integer.parseInt(valueinteger[0]);
         } else {
             integer = null;
         }
-        String valueint32 = (request.body().asMultipartFormData().asFormUrlEncoded().get("int32"))[0];
+        String[] valueint32 = request.body().asMultipartFormData().asFormUrlEncoded().get("int32");
         Integer int32;
         if (valueint32 != null) {
-            int32 = Integer.parseInt(valueint32);
+            int32 = Integer.parseInt(valueint32[0]);
         } else {
             int32 = null;
         }
-        String valueint64 = (request.body().asMultipartFormData().asFormUrlEncoded().get("int64"))[0];
+        String[] valueint64 = request.body().asMultipartFormData().asFormUrlEncoded().get("int64");
         Long int64;
         if (valueint64 != null) {
-            int64 = Long.parseLong(valueint64);
+            int64 = Long.parseLong(valueint64[0]);
         } else {
             int64 = null;
         }
-        String valuenumber = (request.body().asMultipartFormData().asFormUrlEncoded().get("number"))[0];
+        String[] valuenumber = request.body().asMultipartFormData().asFormUrlEncoded().get("number");
         BigDecimal number;
         if (valuenumber != null) {
-            number = new BigDecimal(valuenumber);
+            number = new BigDecimal(valuenumber[0]);
         } else {
             throw new IllegalArgumentException("'number' parameter is required");
         }
-        String value_float = (request.body().asMultipartFormData().asFormUrlEncoded().get("float"))[0];
+        String[] value_float = request.body().asMultipartFormData().asFormUrlEncoded().get("float");
         Float _float;
         if (value_float != null) {
-            _float = Float.parseFloat(value_float);
+            _float = Float.parseFloat(value_float[0]);
         } else {
             _float = null;
         }
-        String value_double = (request.body().asMultipartFormData().asFormUrlEncoded().get("double"))[0];
+        String[] value_double = request.body().asMultipartFormData().asFormUrlEncoded().get("double");
         Double _double;
         if (value_double != null) {
-            _double = Double.parseDouble(value_double);
+            _double = Double.parseDouble(value_double[0]);
         } else {
             throw new IllegalArgumentException("'double' parameter is required");
         }
-        String valuestring = (request.body().asMultipartFormData().asFormUrlEncoded().get("string"))[0];
+        String[] valuestring = request.body().asMultipartFormData().asFormUrlEncoded().get("string");
         String string;
         if (valuestring != null) {
-            string = valuestring;
+            string = valuestring[0];
         } else {
             string = null;
         }
-        String valuepatternWithoutDelimiter = (request.body().asMultipartFormData().asFormUrlEncoded().get("pattern_without_delimiter"))[0];
+        String[] valuepatternWithoutDelimiter = request.body().asMultipartFormData().asFormUrlEncoded().get("pattern_without_delimiter");
         String patternWithoutDelimiter;
         if (valuepatternWithoutDelimiter != null) {
-            patternWithoutDelimiter = valuepatternWithoutDelimiter;
+            patternWithoutDelimiter = valuepatternWithoutDelimiter[0];
         } else {
             throw new IllegalArgumentException("'pattern_without_delimiter' parameter is required");
         }
-        String value_byte = (request.body().asMultipartFormData().asFormUrlEncoded().get("byte"))[0];
+        String[] value_byte = request.body().asMultipartFormData().asFormUrlEncoded().get("byte");
         byte[] _byte;
         if (value_byte != null) {
-            _byte = value_byte.getBytes();
+            _byte = value_byte[0].getBytes();
         } else {
             throw new IllegalArgumentException("'byte' parameter is required");
         }
         Http.MultipartFormData<TemporaryFile> bodybinary = request.body().asMultipartFormData();
         Http.MultipartFormData.FilePart<TemporaryFile> binary = bodybinary.getFile("binary");
-        String valuedate = (request.body().asMultipartFormData().asFormUrlEncoded().get("date"))[0];
+        String[] valuedate = request.body().asMultipartFormData().asFormUrlEncoded().get("date");
         LocalDate date;
         if (valuedate != null) {
-            date = LocalDate.parse(valuedate);
+            date = LocalDate.parse(valuedate[0]);
         } else {
             date = null;
         }
-        String valuedateTime = (request.body().asMultipartFormData().asFormUrlEncoded().get("dateTime"))[0];
+        String[] valuedateTime = request.body().asMultipartFormData().asFormUrlEncoded().get("dateTime");
         OffsetDateTime dateTime;
         if (valuedateTime != null) {
-            dateTime = OffsetDateTime.parse(valuedateTime);
+            dateTime = OffsetDateTime.parse(valuedateTime[0]);
         } else {
             dateTime = null;
         }
-        String valuepassword = (request.body().asMultipartFormData().asFormUrlEncoded().get("password"))[0];
+        String[] valuepassword = request.body().asMultipartFormData().asFormUrlEncoded().get("password");
         String password;
         if (valuepassword != null) {
-            password = valuepassword;
+            password = valuepassword[0];
         } else {
             password = null;
         }
-        String valueparamCallback = (request.body().asMultipartFormData().asFormUrlEncoded().get("callback"))[0];
+        String[] valueparamCallback = request.body().asMultipartFormData().asFormUrlEncoded().get("callback");
         String paramCallback;
         if (valueparamCallback != null) {
-            paramCallback = valueparamCallback;
+            paramCallback = valueparamCallback[0];
         } else {
             paramCallback = null;
         }
@@ -311,10 +311,10 @@ public class FakeApiController extends Controller {
                 enumFormStringArray.add(curParam);
             }
         }
-        String valueenumFormString = (request.body().asMultipartFormData().asFormUrlEncoded().get("enum_form_string"))[0];
+        String[] valueenumFormString = request.body().asMultipartFormData().asFormUrlEncoded().get("enum_form_string");
         String enumFormString;
         if (valueenumFormString != null) {
-            enumFormString = valueenumFormString;
+            enumFormString = valueenumFormString[0];
         } else {
             enumFormString = "-efg";
         }
@@ -403,17 +403,17 @@ public class FakeApiController extends Controller {
 
     @ApiAction
     public Result testJsonFormData(Http.Request request) throws Exception {
-        String valueparam = (request.body().asMultipartFormData().asFormUrlEncoded().get("param"))[0];
+        String[] valueparam = request.body().asMultipartFormData().asFormUrlEncoded().get("param");
         String param;
         if (valueparam != null) {
-            param = valueparam;
+            param = valueparam[0];
         } else {
             throw new IllegalArgumentException("'param' parameter is required");
         }
-        String valueparam2 = (request.body().asMultipartFormData().asFormUrlEncoded().get("param2"))[0];
+        String[] valueparam2 = request.body().asMultipartFormData().asFormUrlEncoded().get("param2");
         String param2;
         if (valueparam2 != null) {
-            param2 = valueparam2;
+            param2 = valueparam2[0];
         } else {
             throw new IllegalArgumentException("'param2' parameter is required");
         }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/PetApiController.java
@@ -122,17 +122,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -141,10 +141,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }
@@ -155,10 +155,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFileWithRequiredFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/PetApiController.java
@@ -111,17 +111,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -130,10 +130,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/PetApiController.java
@@ -122,17 +122,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId)  {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -141,10 +141,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId)  {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-interface/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/controllers/PetApiController.java
@@ -181,17 +181,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -206,10 +206,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-nullable/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-nullable/app/controllers/PetApiController.java
@@ -121,17 +121,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -140,10 +140,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/PetApiController.java
@@ -121,17 +121,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -140,10 +140,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/PetApiController.java
@@ -120,17 +120,17 @@ public class PetApiController extends Controller {
 
     
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -139,10 +139,10 @@ public class PetApiController extends Controller {
 
     
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/PetApiController.java
@@ -121,17 +121,17 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result updatePetWithForm(Http.Request request, Long petId) throws Exception {
-        String valuename = (request.body().asMultipartFormData().asFormUrlEncoded().get("name"))[0];
+        String[] valuename = request.body().asMultipartFormData().asFormUrlEncoded().get("name");
         String name;
         if (valuename != null) {
-            name = valuename;
+            name = valuename[0];
         } else {
             name = null;
         }
-        String valuestatus = (request.body().asMultipartFormData().asFormUrlEncoded().get("status"))[0];
+        String[] valuestatus = request.body().asMultipartFormData().asFormUrlEncoded().get("status");
         String status;
         if (valuestatus != null) {
-            status = valuestatus;
+            status = valuestatus[0];
         } else {
             status = null;
         }
@@ -140,10 +140,10 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result uploadFile(Http.Request request, Long petId) throws Exception {
-        String valueadditionalMetadata = (request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata"))[0];
+        String[] valueadditionalMetadata = request.body().asMultipartFormData().asFormUrlEncoded().get("additionalMetadata");
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
-            additionalMetadata = valueadditionalMetadata;
+            additionalMetadata = valueadditionalMetadata[0];
         } else {
             additionalMetadata = null;
         }


### PR DESCRIPTION
This change is to prevent a NPE when the field in a formData is "not required" and that we pass null.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
