### PR TITLE
[Micronaut] remove duplicate JsonTypeName

### DIFF
--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/typeInfoAnnotation.mustache
@@ -14,7 +14,4 @@
 })
 {{/-last}}
 {{/discriminator.mappedModels}}
-{{#isClassnameSanitized}}
-@JsonTypeName("{{name}}")
-{{/isClassnameSanitized}}
 {{/jackson}}


### PR DESCRIPTION
In some cases, where the openapi file uses a discriminator, `@JsonTypeName` will appear twice - causing an error. This PR removes it from `typeInfoAnnotation.mustache` since it will always be included in `pojo.mustache`

<!-- Please check the completed items below -->
### PR checklist


- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
Java technical committee (not sure if required):
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608