### PR TITLE
Conditionally install phpenv based on cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,9 @@ before_install:
   - sudo apt-get install libonig-dev libzip-dev
   - git clone https://github.com/php-build/php-build $(phpenv root)/plugins/php-build
   - git clone https://github.com/ngyuki/phpenv-composer.git $(phpenv root)/plugins/phpenv-composer
-  #- phpenv install 8.1.4
+  - if [ $(ls -A "$HOME/.phpenv/versions/8.1.4" | wc -l) -eq 0 ]; then
+      phpenv install 8.1.4;
+    fi;
   - phpenv rehash
   - phpenv versions
   #- phpenv global 7.2.15
@@ -104,10 +106,10 @@ before_install:
   # - Rely on `kerl` for [pre-compiled versions available](https://docs.travis-ci.com/user/languages/erlang#Choosing-OTP-releases-to-test-against). Rely on installation path chosen by [`travis-erlang-builder`](https://github.com/travis-ci/travis-erlang-builder/blob/e6d016b1a91ca7ecac5a5a46395bde917ea13d36/bin/compile#L18).
   # - . ~/otp/18.2.1/activate && erl -version
   #- curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
-  # install C++ tools 
-  - sudo apt install -y --no-install-recommends valgrind cmake build-essential 
+  # install C++ tools
+  - sudo apt install -y --no-install-recommends valgrind cmake build-essential
   # install Qt5
-  - sudo apt install -y --no-install-recommends qt5-default 
+  - sudo apt install -y --no-install-recommends qt5-default
   - cmake --version
   # -- skip perl test to shorten build time
   # perl dep


### PR DESCRIPTION
Conditionally install `phpenv` based on whether the cache is currently empty.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
