### PR TITLE
Added space between @NotNull-annotation and Type

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/beanValidationQueryParams.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/beanValidationQueryParams.mustache
@@ -1,1 +1,1 @@
-{{#required}} @NotNull{{/required}}{{>beanValidationCore}}
+{{#required}} @NotNull {{/required}}{{>beanValidationCore}}

--- a/modules/openapi-generator/src/test/resources/3_0/issue-11340.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue-11340.yaml
@@ -1,0 +1,28 @@
+openapi: "3.0.3"
+info:
+  title: Issue 11340 - Bean Validation Breaks Generated Java Code
+  version: "1.0.2"
+  description: With Bean Validation @NotNull and type of parameter must be separated by space.
+paths:
+  /configuration:
+    put:
+      operationId: operation
+      description: Operation with required header and required request body
+      parameters:
+        - in: header
+          name: x-non-null-header-parameter
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              additionalProperties:
+                type: object
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Added space between @NotNull-annotation and Java type to produce code  that compiles. fix #11340
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)