### PR TITLE
[typescript-fetch] add default config feature

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -4,6 +4,77 @@
 
 export const BASE_PATH = "{{{basePath}}}".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -13,7 +84,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -118,71 +189,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = {{#typescriptThreePlus}}WindowOrWorkerGlobalScope{{/typescriptThreePlus}}{{^typescriptThreePlus}}GlobalFetch{{/typescriptThreePlus}}['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -20,7 +20,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -73,7 +73,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -84,7 +84,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io:80/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://localhost:3000".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://localhost:3000".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -31,7 +31,7 @@ export interface ConfigurationParameters {
 export class Configuration {
     constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set defaultConfig(configuration: Configuration) {
+    set config(configuration: Configuration) {
         this.configuration = configuration;
     }
 
@@ -84,7 +84,7 @@ export class Configuration {
     }
 }
 
-export const GlobalConfig = new Configuration();
+export const DefaultConfig = new Configuration();
 
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
@@ -95,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = GlobalConfig) {
+    constructor(protected configuration = DefaultConfig) {
         this.middleware = configuration.middleware;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -15,6 +15,77 @@
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 
+export interface ConfigurationParameters {
+    basePath?: string; // override base path
+    fetchApi?: FetchAPI; // override for fetch implementation
+    middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    username?: string; // parameter for basic security
+    password?: string; // parameter for basic security
+    apiKey?: string | ((name: string) => string); // parameter for apiKey security
+    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+}
+
+export class Configuration {
+    constructor(private configuration: ConfigurationParameters = {}) {}
+
+    set defaultConfig(configuration: Configuration) {
+        this.configuration = configuration;
+    }
+
+    get basePath(): string {
+        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+    }
+
+    get fetchApi(): FetchAPI | undefined {
+        return this.configuration.fetchApi;
+    }
+
+    get middleware(): Middleware[] {
+        return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
+    }
+
+    get username(): string | undefined {
+        return this.configuration.username;
+    }
+
+    get password(): string | undefined {
+        return this.configuration.password;
+    }
+
+    get apiKey(): ((name: string) => string) | undefined {
+        const apiKey = this.configuration.apiKey;
+        if (apiKey) {
+            return typeof apiKey === 'function' ? apiKey : () => apiKey;
+        }
+        return undefined;
+    }
+
+    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+        const accessToken = this.configuration.accessToken;
+        if (accessToken) {
+            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
+        }
+        return undefined;
+    }
+
+    get headers(): HTTPHeaders | undefined {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials | undefined {
+        return this.configuration.credentials;
+    }
+}
+
+export const GlobalConfig = new Configuration();
+
 const isBlob = (value: any) => typeof Blob !== 'undefined' && value instanceof Blob;
 
 /**
@@ -24,7 +95,7 @@ export class BaseAPI {
 
     private middleware: Middleware[];
 
-    constructor(protected configuration = new Configuration()) {
+    constructor(protected configuration = GlobalConfig) {
         this.middleware = configuration.middleware;
     }
 
@@ -129,71 +200,6 @@ export const COLLECTION_FORMATS = {
 };
 
 export type FetchAPI = GlobalFetch['fetch'];
-
-export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
-
-export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
-
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
-
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
-
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
-
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
-
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
-
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
-
-    get apiKey(): ((name: string) => string) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
-    }
-
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
-    }
-
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
-
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
-}
 
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';


### PR DESCRIPTION
This PR allows we to write global settings for api clients.

Prior to this, we had to write the following for each api client (tag), which is a bit verbose.

```ts
import {
  Configuration,
  ClientAApi,
  ClientBApi,
  ClientCApi,
} from "./generated";

// custom config
const config = new Configuration({
  credentials: "include",
});

export const clientA = new ClientAApi(config);
export const clientB = new ClientBApi(config);
export const clientC = new ClientCApi(config);
```

After this change, it can be written simply as follows.

```ts
import {
  Configuration,
  ClientAApi,
  ClientBApi,
  ClientCApi,
  DefaultConfig,
} from "./generated";

// custom config
DefaultConfig.config = new Configuration({
  credentials: "include",
});

export const clientA = new ClientAApi();
export const clientB = new ClientBApi();
export const clientC = new ClientCApi();
```

Also, custom configuration for specific client still configurable.

I think this is not breaking change, so I didn't add any new options to this change.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03)