### PR TITLE
[php-slim4] Add Mock Server

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
@@ -115,6 +115,22 @@ Switch your app environment to development in `public/.htaccess` file:
 </IfModule>
 ```
 
+## Mock Server
+Since this feature should be used for development only, change environment to `development` and send additional HTTP header `X-{{invokerPackage}}-Mock: ping` with any request to get mocked response.
+CURL example:
+```console
+curl --request GET \
+    --url 'http://localhost:8888/v2/pet/findByStatus?status=available' \
+    --header 'accept: application/json' \
+    --header 'X-{{invokerPackage}}-Mock: ping'
+[{"id":-8738629417578509312,"category":{"id":-4162503862215270400,"name":"Lorem ipsum dol"},"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem i","photoUrls":["Lor"],"tags":[{"id":-3506202845849391104,"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectet"}],"status":"pending"}]
+```
+
+Used packages:
+* [Openapi Data Mocker](https://github.com/ybelenko/openapi-data-mocker) - first implementation of OAS3 fake data generator.
+* [Openapi Data Mocker Server Middleware](https://github.com/ybelenko/openapi-data-mocker-server-middleware) - PSR-15 HTTP server middleware.
+* [Openapi Data Mocker Interfaces](https://github.com/ybelenko/openapi-data-mocker-interfaces) - package with mocking interfaces.
+
 {{#generateApiDocs}}
 ## API Endpoints
 

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
@@ -27,7 +27,7 @@
     "slim/psr7": "^1.1.0",
     {{/isSlimPsr7}}
     "ybelenko/openapi-data-mocker": "^1.0",
-    "ybelenko/openapi-data-mocker-server-middleware": "^1.0"
+    "ybelenko/openapi-data-mocker-server-middleware": "^1.2"
   },
   "require-dev": {
     "overtrue/phplint": "^2.0.2",

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/config_dev_default.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/config_dev_default.mustache
@@ -62,4 +62,37 @@ return [
     'pdo.options' => [
         \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
     ],
+
+    // mocker
+    // OBVIOUSLY MUST NOT BE USED for production
+    // @see https://github.com/ybelenko/openapi-data-mocker-server-middleware
+    'mocker.getMockStatusCodeCallback' => function () {
+        return function (\Psr\Http\Message\ServerRequestInterface $request, array $responses) {
+            // check if client clearly asks for mocked response
+            $pingHeader = 'X-{{invokerPackage}}-Mock';
+            $pingHeaderCode = 'X-{{invokerPackage}}-Mock-Code';
+            if (
+                $request->hasHeader($pingHeader)
+                && $request->getHeader($pingHeader)[0] === 'ping'
+            ) {
+                $responses = (array) $responses;
+                $requestedResponseCode = ($request->hasHeader($pingHeaderCode)) ? $request->getHeader($pingHeaderCode)[0] : 'default';
+                if (array_key_exists($requestedResponseCode, $responses)) {
+                    return $requestedResponseCode;
+                }
+
+                // return first response key
+                reset($responses);
+                return key($responses);
+            }
+
+            return false;
+        };
+    },
+    'mocker.afterCallback' => function () {
+        return function (\Psr\Http\Message\ServerRequestInterface $request, \Psr\Http\Message\ResponseInterface $response) {
+            // mark mocked response to distinguish real and fake responses
+            return $response->withHeader('X-{{invokerPackage}}-Mock', 'pong');
+        };
+    },
 ];

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/register_dependencies.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/register_dependencies.mustache
@@ -59,6 +59,15 @@ final class RegisterDependencies
                     \DI\get('pdo.password'),
                     \DI\get('pdo.options', null)
                 ),
+
+            // DataMocker
+            // @see https://github.com/ybelenko/openapi-data-mocker-server-middleware
+            \OpenAPIServer\Mock\OpenApiDataMockerInterface::class => \DI\create(\OpenAPIServer\Mock\OpenApiDataMocker::class)
+                ->method('setModelsNamespace', '{{modelPackage}}\\'),
+
+            \OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory::class => \DI\autowire()
+                ->constructorParameter('getMockStatusCodeCallback', \DI\get('mocker.getMockStatusCodeCallback'))
+                ->constructorParameter('afterCallback', \DI\get('mocker.afterCallback')),
         ]);
     }
 }

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
@@ -116,6 +116,16 @@ class RegisterRoutes
             return $response;
         });
 
+        // create mock middleware factory
+        /** @var \Psr\Container\ContainerInterface */
+        $container = $app->getContainer();
+        /** @var \OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory|null */
+        $mockMiddlewareFactory = null;
+        if ($container->has(\OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory::class)) {
+            // I know, anti-pattern. Don't retrieve dependency directly from container
+            $mockMiddlewareFactory = $container->get(\OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory::class);
+        }
+
         foreach ($this->operations as $operation) {
             $callback = function (ServerRequestInterface $request) use ($operation) {
                 $message = "How about extending {$operation['classname']} by {$operation['apiPackage']}\\{$operation['userClassname']} class implementing {$operation['operationId']} as a {$operation['httpMethod']} method?";
@@ -127,6 +137,13 @@ class RegisterRoutes
                 // Notice how we register the controller using the class name?
                 // PHP-DI will instantiate the class for us only when it's actually necessary
                 $callback = ["\\{$operation['apiPackage']}\\{$operation['userClassname']}", $operation['operationId']];
+            }
+
+            if ($mockMiddlewareFactory) {
+                $mockSchemaResponses = array_map(function ($item) {
+                    return json_decode($item['jsonSchema'], true);
+                }, $operation['responses']);
+                $middlewares[] = $mockMiddlewareFactory->create($mockSchemaResponses);
             }
 
             $route = $app->map(

--- a/samples/server/petstore/php-slim4/README.md
+++ b/samples/server/petstore/php-slim4/README.md
@@ -98,6 +98,22 @@ Switch your app environment to development in `public/.htaccess` file:
 </IfModule>
 ```
 
+## Mock Server
+Since this feature should be used for development only, change environment to `development` and send additional HTTP header `X-OpenAPIServer-Mock: ping` with any request to get mocked response.
+CURL example:
+```console
+curl --request GET \
+    --url 'http://localhost:8888/v2/pet/findByStatus?status=available' \
+    --header 'accept: application/json' \
+    --header 'X-OpenAPIServer-Mock: ping'
+[{"id":-8738629417578509312,"category":{"id":-4162503862215270400,"name":"Lorem ipsum dol"},"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem i","photoUrls":["Lor"],"tags":[{"id":-3506202845849391104,"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectet"}],"status":"pending"}]
+```
+
+Used packages:
+* [Openapi Data Mocker](https://github.com/ybelenko/openapi-data-mocker) - first implementation of OAS3 fake data generator.
+* [Openapi Data Mocker Server Middleware](https://github.com/ybelenko/openapi-data-mocker-server-middleware) - PSR-15 HTTP server middleware.
+* [Openapi Data Mocker Interfaces](https://github.com/ybelenko/openapi-data-mocker-interfaces) - package with mocking interfaces.
+
 ## API Endpoints
 
 All URIs are relative to *http://petstore.swagger.io/v2*

--- a/samples/server/petstore/php-slim4/composer.json
+++ b/samples/server/petstore/php-slim4/composer.json
@@ -14,7 +14,7 @@
     "php-di/slim-bridge": "^3.2",
     "slim/psr7": "^1.1.0",
     "ybelenko/openapi-data-mocker": "^1.0",
-    "ybelenko/openapi-data-mocker-server-middleware": "^1.0"
+    "ybelenko/openapi-data-mocker-server-middleware": "^1.2"
   },
   "require-dev": {
     "overtrue/phplint": "^2.0.2",

--- a/samples/server/petstore/php-slim4/lib/App/RegisterDependencies.php
+++ b/samples/server/petstore/php-slim4/lib/App/RegisterDependencies.php
@@ -72,6 +72,15 @@ final class RegisterDependencies
                     \DI\get('pdo.password'),
                     \DI\get('pdo.options', null)
                 ),
+
+            // DataMocker
+            // @see https://github.com/ybelenko/openapi-data-mocker-server-middleware
+            \OpenAPIServer\Mock\OpenApiDataMockerInterface::class => \DI\create(\OpenAPIServer\Mock\OpenApiDataMocker::class)
+                ->method('setModelsNamespace', 'OpenAPIServer\Model\\'),
+
+            \OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory::class => \DI\autowire()
+                ->constructorParameter('getMockStatusCodeCallback', \DI\get('mocker.getMockStatusCodeCallback'))
+                ->constructorParameter('afterCallback', \DI\get('mocker.afterCallback')),
         ]);
     }
 }

--- a/samples/server/petstore/php-slim4/lib/App/RegisterRoutes.php
+++ b/samples/server/petstore/php-slim4/lib/App/RegisterRoutes.php
@@ -845,6 +845,16 @@ class RegisterRoutes
             return $response;
         });
 
+        // create mock middleware factory
+        /** @var \Psr\Container\ContainerInterface */
+        $container = $app->getContainer();
+        /** @var \OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory|null */
+        $mockMiddlewareFactory = null;
+        if ($container->has(\OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory::class)) {
+            // I know, anti-pattern. Don't retrieve dependency directly from container
+            $mockMiddlewareFactory = $container->get(\OpenAPIServer\Mock\OpenApiDataMockerRouteMiddlewareFactory::class);
+        }
+
         foreach ($this->operations as $operation) {
             $callback = function (ServerRequestInterface $request) use ($operation) {
                 $message = "How about extending {$operation['classname']} by {$operation['apiPackage']}\\{$operation['userClassname']} class implementing {$operation['operationId']} as a {$operation['httpMethod']} method?";
@@ -856,6 +866,13 @@ class RegisterRoutes
                 // Notice how we register the controller using the class name?
                 // PHP-DI will instantiate the class for us only when it's actually necessary
                 $callback = ["\\{$operation['apiPackage']}\\{$operation['userClassname']}", $operation['operationId']];
+            }
+
+            if ($mockMiddlewareFactory) {
+                $mockSchemaResponses = array_map(function ($item) {
+                    return json_decode($item['jsonSchema'], true);
+                }, $operation['responses']);
+                $middlewares[] = $mockMiddlewareFactory->create($mockSchemaResponses);
             }
 
             $route = $app->map(


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Added Mock Server as fully pre-configured dev only feature.

UPD: how it looks like from the CURL
with `production` env:
```console
$ curl --request GET \
>   --url 'http://phpslim4.test/v2/pet/findByStatus?status=available' \
>   --header 'accept: application/json' \
>   --header 'x-openapiserver-mock: ping'
{
    "message": "501 Not Implemented"
}
```

with `development` env:
```console
$  curl --request GET \
>   --url 'http://phpslim4.test/v2/pet/findByStatus?status=available' \
>   --header 'accept: application/json' \
>   --header 'x-openapiserver-mock: ping'
[{"id":-8738629417578509312,"category":{"id":-4162503862215270400,"name":"Lorem ipsum dol"},"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem i","photoUrls":["Lor"],"tags":[{"id":-3506202845849391104,"name":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectet"}],"status":"pending"}]
```

with `development` env, but without required HTTP mock header:
```console
$  curl --request GET \
>   --url 'http://phpslim4.test/v2/pet/findByStatus?status=available' \
>   --header 'accept: application/json'
{
    "message": "501 Not Implemented",
    "exception": [
        {
            "type": "Slim\\Exception\\HttpNotImplementedException",
            "code": 501,
            "message": "How about extending AbstractPetApi by OpenAPIServer\\Api\\PetApi class implementing findPetsByStatus as a GET method?",
            "file": "/Users/ybelenko/Sites/openapi-generator/samples/server/petstore/php-slim4/lib/App/RegisterRoutes.php",
            "line": 861
        }
    ]
}
```

cc @jebentier @dkarlovi @mandrean @jfastnacht @renepardon

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
