### PR TITLE
[Python] Fix incorrectly capitalized mustache identifier in apis template

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-experimental/__init__apis.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/__init__apis.handlebars
@@ -10,7 +10,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from {{packagename}}.{{apiPackage}}.{{classFilename}} import {{classname}}
+#   from {{packageName}}.{{apiPackage}}.{{classFilename}} import {{classname}}
 #
 # or import this package, but before doing it, use:
 #

--- a/modules/openapi-generator/src/main/resources/python/__init__apis.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__apis.mustache
@@ -9,7 +9,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from {{packagename}}.api.{{classFilename}} import {{classname}}
+#   from {{packageName}}.api.{{classFilename}} import {{classname}}
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/client/petstore/python/petstore_api/apis/__init__.py
+++ b/samples/client/petstore/python/petstore_api/apis/__init__.py
@@ -6,7 +6,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.another_fake_api import AnotherFakeApi
+#   from petstore_api.api.another_fake_api import AnotherFakeApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/apis/__init__.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/apis/__init__.py
@@ -6,7 +6,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.another_fake_api import AnotherFakeApi
+#   from petstore_api.api.another_fake_api import AnotherFakeApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/apis/__init__.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/apis/__init__.py
@@ -6,7 +6,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.usage_api import UsageApi
+#   from x_auth_id_alias.api.usage_api import UsageApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/apis/__init__.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/apis/__init__.py
@@ -6,7 +6,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.usage_api import UsageApi
+#   from dynamic_servers.api.usage_api import UsageApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/apis/__init__.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/apis/__init__.py
@@ -7,7 +7,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.another_fake_api import AnotherFakeApi
+#   from petstore_api.api.another_fake_api import AnotherFakeApi
 #
 # or import this package, but before doing it, use:
 #

--- a/samples/openapi3/client/petstore/python/petstore_api/apis/__init__.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/apis/__init__.py
@@ -6,7 +6,7 @@
 # raise a `RecursionError`.
 # In order to avoid this, import only the API that you directly need like:
 #
-#   from .api.another_fake_api import AnotherFakeApi
+#   from petstore_api.api.another_fake_api import AnotherFakeApi
 #
 # or import this package, but before doing it, use:
 #


### PR DESCRIPTION
This tiny PR fixes the spelling of an identifier that was incorrectly cased in a mustache template. The fix only affects a comment in the output, so it will make no runtime difference when consuming a generated client.

In the Ruby generator, the package name is available as `{{packageName}}`, but in `src/main/resources/python/__init__apis.mustache`, it was being referenced as `{{packagename}}`.
This produced incorrect output such as:

```ruby
# In order to avoid this, import only the API that you directly need like:
#
#   from .api.my_api import MyApi
```
(note the missing package name)

The corrected output:
```ruby
# In order to avoid this, import only the API that you directly need like:
#
#   from my_package.api.my_api import MyApi
```

cc @cliffano @zlx @autopp

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

