### PR TITLE
[java][jersey2] Update jackson databind to newer version (v2.13.2.2)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -100,13 +100,13 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.6.5"
     jackson_version = "2.13.2"
-    jackson_databind_version = "2.13.2"
+    jackson_databind_version = "2.13.2.2"
     {{#openApiNullable}}
     jackson_databind_nullable_version = "0.2.2"
     {{/openApiNullable}}
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
-    junit_version = "4.13.2"
+    junit_version = "5.8.2"
     {{#hasOAuthMethods}}
     scribejava_apis_version = "8.3.1"
     {{/hasOAuthMethods}}
@@ -140,7 +140,12 @@ dependencies {
     implementation "org.tomitribe:tomitribe-http-signatures:$tomitribe_http_signatures_version"
     {{/hasHttpSignatureMethods}}
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 javadoc {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
@@ -18,11 +18,11 @@ lazy val root = (project in file(".")).
       "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "2.35",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2" % "compile",
       {{#joda}}
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.13.0" % "compile",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.13.2" % "compile",
       {{/joda}}
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.0" % "compile",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.2" % "compile",
       {{#openApiNullable}}
       "org.openapitools" % "jackson-databind-nullable" % "0.2.2" % "compile",
       {{/openApiNullable}}
@@ -33,7 +33,6 @@ lazy val root = (project in file(".")).
       "org.tomitribe" % "tomitribe-http-signatures" % "1.7" % "compile",
       {{/hasHttpSignatureMethods}}
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
-      "junit" % "junit" % "4.13.2" % "test",
-      "com.novocode" % "junit-interface" % "0.10" % "test"
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )
   )

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -383,7 +383,7 @@
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
         <jersey-version>2.35</jersey-version>
         <jackson-version>2.13.2</jackson-version>
-        <jackson-databind-version>2.13.2</jackson-databind-version>
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         {{#useBeanValidation}}

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
@@ -100,11 +100,11 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.6.5"
     jackson_version = "2.13.2"
-    jackson_databind_version = "2.13.2"
+    jackson_databind_version = "2.13.2.2"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
-    junit_version = "4.13.2"
+    junit_version = "5.8.2"
     scribejava_apis_version = "8.3.1"
 }
 
@@ -123,7 +123,12 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 javadoc {

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/build.sbt
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/build.sbt
@@ -18,12 +18,11 @@ lazy val root = (project in file(".")).
       "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "2.35",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.0" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2" % "compile",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.2" % "compile",
       "org.openapitools" % "jackson-databind-nullable" % "0.2.2" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
-      "junit" % "junit" % "4.13.2" % "test",
-      "com.novocode" % "junit-interface" % "0.10" % "test"
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )
   )

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/pom.xml
@@ -341,7 +341,7 @@
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
         <jersey-version>2.35</jersey-version>
         <jackson-version>2.13.2</jackson-version>
-        <jackson-databind-version>2.13.2</jackson-databind-version>
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.8.2</junit-version>

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -100,11 +100,11 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.6.5"
     jackson_version = "2.13.2"
-    jackson_databind_version = "2.13.2"
+    jackson_databind_version = "2.13.2.2"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
-    junit_version = "4.13.2"
+    junit_version = "5.8.2"
     scribejava_apis_version = "8.3.1"
 }
 
@@ -123,7 +123,12 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 javadoc {

--- a/samples/client/petstore/java/jersey2-java8/build.sbt
+++ b/samples/client/petstore/java/jersey2-java8/build.sbt
@@ -18,12 +18,11 @@ lazy val root = (project in file(".")).
       "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "2.35",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.0" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2" % "compile",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.2" % "compile",
       "org.openapitools" % "jackson-databind-nullable" % "0.2.2" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
-      "junit" % "junit" % "4.13.2" % "test",
-      "com.novocode" % "junit-interface" % "0.10" % "test"
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )
   )

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -341,7 +341,7 @@
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
         <jersey-version>2.35</jersey-version>
         <jackson-version>2.13.2</jackson-version>
-        <jackson-databind-version>2.13.2</jackson-databind-version>
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.8.2</junit-version>

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
@@ -100,11 +100,11 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.6.5"
     jackson_version = "2.13.2"
-    jackson_databind_version = "2.13.2"
+    jackson_databind_version = "2.13.2.2"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
-    junit_version = "4.13.2"
+    junit_version = "5.8.2"
 }
 
 dependencies {
@@ -121,7 +121,12 @@ dependencies {
     implementation "org.openapitools:jackson-databind-nullable:$jackson_databind_nullable_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 javadoc {

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.sbt
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.sbt
@@ -18,11 +18,10 @@ lazy val root = (project in file(".")).
       "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "2.35",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.0" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2" % "compile",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.2" % "compile",
       "org.openapitools" % "jackson-databind-nullable" % "0.2.2" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
-      "junit" % "junit" % "4.13.2" % "test",
-      "com.novocode" % "junit-interface" % "0.10" % "test"
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )
   )

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/pom.xml
@@ -336,7 +336,7 @@
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
         <jersey-version>2.35</jersey-version>
         <jackson-version>2.13.2</jackson-version>
-        <jackson-databind-version>2.13.2</jackson-databind-version>
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.8.2</junit-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
@@ -100,11 +100,11 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.6.5"
     jackson_version = "2.13.2"
-    jackson_databind_version = "2.13.2"
+    jackson_databind_version = "2.13.2.2"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
-    junit_version = "4.13.2"
+    junit_version = "5.8.2"
 }
 
 dependencies {
@@ -121,7 +121,12 @@ dependencies {
     implementation "org.openapitools:jackson-databind-nullable:$jackson_databind_nullable_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 javadoc {

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.sbt
@@ -18,11 +18,10 @@ lazy val root = (project in file(".")).
       "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "2.35",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.0" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2" % "compile",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.2" % "compile",
       "org.openapitools" % "jackson-databind-nullable" % "0.2.2" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
-      "junit" % "junit" % "4.13.2" % "test",
-      "com.novocode" % "junit-interface" % "0.10" % "test"
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )
   )

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/pom.xml
@@ -336,7 +336,7 @@
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
         <jersey-version>2.35</jersey-version>
         <jackson-version>2.13.2</jackson-version>
-        <jackson-databind-version>2.13.2</jackson-databind-version>
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.8.2</junit-version>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
@@ -100,11 +100,11 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.6.5"
     jackson_version = "2.13.2"
-    jackson_databind_version = "2.13.2"
+    jackson_databind_version = "2.13.2.2"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "2.35"
-    junit_version = "4.13.2"
+    junit_version = "5.8.2"
     scribejava_apis_version = "8.3.1"
     tomitribe_http_signatures_version = "1.7"
 }
@@ -125,7 +125,12 @@ dependencies {
     implementation "com.github.scribejava:scribejava-apis:$scribejava_apis_version"
     implementation "org.tomitribe:tomitribe-http-signatures:$tomitribe_http_signatures_version"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+}
+
+test {
+    useJUnitPlatform()
 }
 
 javadoc {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.sbt
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.sbt
@@ -18,13 +18,12 @@ lazy val root = (project in file(".")).
       "org.glassfish.jersey.connectors" % "jersey-apache-connector" % "2.35",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.2" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2" % "compile",
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.0" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.2.2" % "compile",
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.13.2" % "compile",
       "org.openapitools" % "jackson-databind-nullable" % "0.2.2" % "compile",
       "com.github.scribejava" % "scribejava-apis" % "8.3.1" % "compile",
       "org.tomitribe" % "tomitribe-http-signatures" % "1.7" % "compile",
       "jakarta.annotation" % "jakarta.annotation-api" % "1.3.5" % "compile",
-      "junit" % "junit" % "4.13.2" % "test",
-      "com.novocode" % "junit-interface" % "0.10" % "test"
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.8.2" % "test"
     )
   )

--- a/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/pom.xml
@@ -346,7 +346,7 @@
         <swagger-annotations-version>1.6.5</swagger-annotations-version>
         <jersey-version>2.35</jersey-version>
         <jackson-version>2.13.2</jackson-version>
-        <jackson-databind-version>2.13.2</jackson-databind-version>
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <junit-version>5.8.2</junit-version>


### PR DESCRIPTION
Update jackson databind to newer version (v2.13.2.2) to address security concerns.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
