### PR TITLE
Configure apiNameSuffix via plugins

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -204,6 +204,11 @@ apply plugin: 'org.openapi.generator'
 |None
 |Suffix that will be appended to all model names.
 
+|apiNameSuffix
+|String
+|None
+|Suffix that will be appended to all api names.
+
 |instantiationTypes
 |Map(String,String)
 |None

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -106,6 +106,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     modelPackage.set(generate.modelPackage)
                     modelNamePrefix.set(generate.modelNamePrefix)
                     modelNameSuffix.set(generate.modelNameSuffix)
+                    apiNameSuffix.set(generate.apiNameSuffix)
                     instantiationTypes.set(generate.instantiationTypes)
                     typeMappings.set(generate.typeMappings)
                     additionalProperties.set(generate.additionalProperties)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -107,6 +107,11 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val modelNameSuffix = project.objects.property<String>()
 
     /**
+     * Suffix that will be appended to all api names. Default is the empty string.
+     */
+    val apiNameSuffix = project.objects.property<String>()
+
+    /**
      * Sets instantiation type mappings.
      */
     val instantiationTypes = project.objects.mapProperty<String, String>()
@@ -326,6 +331,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
         releaseNote.set("Minor update")
         modelNamePrefix.set("")
         modelNameSuffix.set("")
+        apiNameSuffix.set("")
         generateModelTests.set(true)
         generateModelDocumentation.set(true)
         generateApiTests.set(true)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -169,6 +169,13 @@ open class GenerateTask : DefaultTask() {
     val modelNameSuffix = project.objects.property<String>()
 
     /**
+     * Suffix that will be appended to all api names. Default is the empty string.
+     */
+    @Optional
+    @Input
+    val apiNameSuffix = project.objects.property<String>()
+
+    /**
      * Sets instantiation type mappings.
      */
     @Optional
@@ -571,6 +578,10 @@ open class GenerateTask : DefaultTask() {
 
             modelNameSuffix.ifNotEmpty { value ->
                 configurator.setModelNameSuffix(value)
+            }
+
+            apiNameSuffix.ifNotEmpty { value ->
+                configurator.setApiNameSuffix(value)
             }
 
             invokerPackage.ifNotEmpty { value ->

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -67,6 +67,7 @@ mvn clean compile
 | `library` |  `openapi.generator.maven.plugin.library` | library template (sub-template)
 | `modelNamePrefix` |  `openapi.generator.maven.plugin.modelNamePrefix` | Sets the prefix for model classes and enums
 | `modelNameSuffix` |  `openapi.generator.maven.plugin.modelNameSuffix` | Sets the suffix for model classes and enums
+| `apiNameSuffix` |  `openapi.generator.maven.plugin.apiNameSuffix` | Sets the suffix for api classes
 | `ignoreFileOverride` |  `openapi.generator.maven.plugin.ignoreFileOverride` | specifies the full path to a `.openapi-generator-ignore` used for pattern based overrides of generated outputs
 | `httpUserAgent` | `openapi.generator.maven.plugin.httpUserAgent` | Sets custom User-Agent header value
 | `removeOperationIdPrefix` |  `openapi.generator.maven.plugin.removeOperationIdPrefix` | remove operationId prefix (e.g. user_getName => getName)

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -221,6 +221,12 @@ public class CodeGenMojo extends AbstractMojo {
     private String modelNameSuffix;
 
     /**
+     * Sets the suffix for api classes
+     */
+    @Parameter(name = "apiNameSuffix", property = "openapi.generator.maven.plugin.apiNameSuffix")
+    private String apiNameSuffix;
+
+    /**
      * Sets an optional ignoreFileOverride path
      */
     @Parameter(name = "ignoreFileOverride", property = "openapi.generator.maven.plugin.ignoreFileOverride")
@@ -594,6 +600,10 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (isNotEmpty(modelNameSuffix)) {
                 configurator.setModelNameSuffix(modelNameSuffix);
+            }
+
+            if (isNotEmpty(apiNameSuffix)) {
+                configurator.setApiNameSuffix(apiNameSuffix);
             }
 
             if (null != templateDirectory) {

--- a/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
+++ b/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
@@ -46,6 +46,7 @@ public class CodeGenMojoTest extends BaseTestCase {
         mojo.execute();
         assertEquals("java", getVariableValueFromObject(mojo, "generatorName"));
         assertEquals("jersey2", getVariableValueFromObject(mojo, "library"));
+        assertEquals("Suffix", getVariableValueFromObject(mojo, "apiNameSuffix"));
         assertEquals("remote.org.openapitools.client.api", getVariableValueFromObject(mojo, "apiPackage"));
         assertEquals("remote.org.openapitools.client.model", getVariableValueFromObject(mojo, "modelPackage"));
         assertEquals("remote.org.openapitools.client", getVariableValueFromObject(mojo, "invokerPackage"));

--- a/modules/openapi-generator-maven-plugin/src/test/resources/default/pom.xml
+++ b/modules/openapi-generator-maven-plugin/src/test/resources/default/pom.xml
@@ -34,6 +34,7 @@
                     <configOptions>
                         <dateLibrary>joda</dateLibrary>
                     </configOptions>
+                    <apiNameSuffix>Suffix</apiNameSuffix>
                     <library>jersey2</library>
                     <output>${basedir}/target/generated-sources/common-maven/remote-openapi</output>
                     <apiPackage>remote.org.openapitools.client.api</apiPackage>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Add `apiNameSuffix` parameter to maven & gradle plugins. Fix for https://github.com/OpenAPITools/openapi-generator/issues/12055
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
