### PR TITLE
fix: respect configured generator URL in swagger config

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
@@ -92,7 +92,7 @@ public class OpenAPIDocumentationConfig {
                 }
                 String authority = hostURI.getAuthority();
                 if (authority != null) {
-                    // In Swagger host refers to host _and_ port, a.k.a. the URI authority
+                    // In OpenAPI `host` refers to host _and_ port, a.k.a. the URI authority
                     docket.host(authority);
                 }
                 docket.pathMapping(hostURI.getPath());

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
@@ -28,15 +28,22 @@ import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Properties;
+import java.util.Set;
 
 
 @Configuration
 @EnableSwagger2
 public class OpenAPIDocumentationConfig {
+    private final Logger LOGGER = LoggerFactory.getLogger(OpenAPIDocumentationConfig.class);
 
     ApiInfo apiInfo() {
         final Properties properties = new Properties();
@@ -63,7 +70,7 @@ public class OpenAPIDocumentationConfig {
 
     @Bean
     public Docket customImplementation(){
-        return new Docket(DocumentationType.SWAGGER_2)
+        Docket docket = new Docket(DocumentationType.SWAGGER_2)
                 .select()
                     .apis(RequestHandlerSelectors.basePackage("org.openapitools.codegen.online.api"))
                     .build()
@@ -74,6 +81,27 @@ public class OpenAPIDocumentationConfig {
                 .ignoredParameterTypes(Resource.class)
                 .ignoredParameterTypes(InputStream.class)
                 .apiInfo(apiInfo());
+
+        String hostString = System.getenv("GENERATOR_HOST");
+        if (!StringUtils.isBlank(hostString)) {
+            try {
+                URI hostURI = new URI(hostString);
+                String scheme = hostURI.getScheme();
+                if (scheme != null) {
+                    docket.protocols(Set.of(new String[] { scheme }));
+                }
+                String authority = hostURI.getAuthority();
+                if (authority != null) {
+                    // In Swagger host refers to host _and_ port, a.k.a. the URI authority
+                    docket.host(authority);
+                }
+                docket.pathMapping(hostURI.getPath());
+            } catch(URISyntaxException e) {
+                LOGGER.warn("Could not parse configured GENERATOR_HOST '" + hostString + "': " + e.getMessage());
+            }
+        }
+
+        return docket;
     }
 
 }

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
@@ -88,7 +88,9 @@ public class OpenAPIDocumentationConfig {
                 URI hostURI = new URI(hostString);
                 String scheme = hostURI.getScheme();
                 if (scheme != null) {
-                    docket.protocols(Set.of(new String[] { scheme }));
+                    Set<String> protocols = new HashSet<String>();
+                    protocols.add(scheme);
+                    docket.protocols(protocols);
                 }
                 String authority = hostURI.getAuthority();
                 if (authority != null) {

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
@@ -38,6 +38,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
 import java.util.Set;
+import java.util.HashSet;
 
 
 @Configuration


### PR DESCRIPTION
The generated OpenAPI spec does not reflect the GENERATOR_HOST which causes wrong generated code and non-functional snippets in the UI.

This PR improves that by adding the relevant parts to the spec.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

🛠 with ❤ at [Siemens](https://opensource.siemens.com/)