### PR TITLE
[dart-dio] Adds support for enumUnknownDefaultCase to BuiltValue enums

### DIFF
--- a/bin/configs/dart-dio-next-petstore-client-lib-fake.yaml
+++ b/bin/configs/dart-dio-next-petstore-client-lib-fake.yaml
@@ -8,3 +8,4 @@ typeMappings:
   EnumClass: "ModelEnumClass"
 additionalProperties:
   hideGenerationTimestamp: "true"
+  enumUnknownDefaultCase: "true"

--- a/bin/configs/dart-dio-petstore-client-lib.yaml
+++ b/bin/configs/dart-dio-petstore-client-lib.yaml
@@ -4,3 +4,4 @@ inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/dart-dio
 additionalProperties:
   hideGenerationTimestamp: "true"
+  enumUnknownDefaultCase: "true"

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
@@ -11,7 +11,7 @@ class {{classname}} extends EnumClass {
       {{#description}}
   /// {{{.}}}
       {{/description}}
-  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}})
+  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{classname}} {{name}} = _${{name}};
     {{/enumVars}}
   {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
@@ -5,7 +5,7 @@ class {{{enumName}}} extends EnumClass {
       {{#description}}
   /// {{{.}}}
       {{/description}}
-  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}})
+  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{{enumName}}} {{name}} = _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}_{{name}};
     {{/enumVars}}
   {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum.mustache
@@ -11,7 +11,7 @@ class {{classname}} extends EnumClass {
       {{#description}}
   /// {{{.}}}
       {{/description}}
-  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}})
+  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{classname}} {{name}} = _${{name}};
     {{/enumVars}}
   {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/enum_inline.mustache
@@ -5,7 +5,7 @@ class {{{enumName}}} extends EnumClass {
       {{#description}}
   /// {{{.}}}
       {{/description}}
-  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}})
+  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{#isLong}}wireNumber: {{{value}}}{{/isLong}}{{^isInteger}}{{^isLong}}wireName: r{{{value}}}{{/isLong}}{{/isInteger}}{{#enumUnknownDefaultCase}}{{#-last}}, fallback: true{{/-last}}{{/enumUnknownDefaultCase}})
   static const {{{enumName}}} {{name}} = _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}_{{name}};
     {{/enumVars}}
   {{/allowableValues}}

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/enum_arrays.dart
@@ -93,6 +93,8 @@ class EnumArraysJustSymbolEnum extends EnumClass {
   static const EnumArraysJustSymbolEnum greaterThanEqual = _$enumArraysJustSymbolEnum_greaterThanEqual;
   @BuiltValueEnumConst(wireName: r'$')
   static const EnumArraysJustSymbolEnum dollar = _$enumArraysJustSymbolEnum_dollar;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const EnumArraysJustSymbolEnum unknownDefaultOpenApi = _$enumArraysJustSymbolEnum_unknownDefaultOpenApi;
 
   static Serializer<EnumArraysJustSymbolEnum> get serializer => _$enumArraysJustSymbolEnumSerializer;
 
@@ -108,6 +110,8 @@ class EnumArraysArrayEnumEnum extends EnumClass {
   static const EnumArraysArrayEnumEnum fish = _$enumArraysArrayEnumEnum_fish;
   @BuiltValueEnumConst(wireName: r'crab')
   static const EnumArraysArrayEnumEnum crab = _$enumArraysArrayEnumEnum_crab;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const EnumArraysArrayEnumEnum unknownDefaultOpenApi = _$enumArraysArrayEnumEnum_unknownDefaultOpenApi;
 
   static Serializer<EnumArraysArrayEnumEnum> get serializer => _$enumArraysArrayEnumEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/enum_test.dart
@@ -194,6 +194,8 @@ class EnumTestEnumStringEnum extends EnumClass {
   static const EnumTestEnumStringEnum lower = _$enumTestEnumStringEnum_lower;
   @BuiltValueEnumConst(wireName: r'')
   static const EnumTestEnumStringEnum empty = _$enumTestEnumStringEnum_empty;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const EnumTestEnumStringEnum unknownDefaultOpenApi = _$enumTestEnumStringEnum_unknownDefaultOpenApi;
 
   static Serializer<EnumTestEnumStringEnum> get serializer => _$enumTestEnumStringEnumSerializer;
 
@@ -211,6 +213,8 @@ class EnumTestEnumStringRequiredEnum extends EnumClass {
   static const EnumTestEnumStringRequiredEnum lower = _$enumTestEnumStringRequiredEnum_lower;
   @BuiltValueEnumConst(wireName: r'')
   static const EnumTestEnumStringRequiredEnum empty = _$enumTestEnumStringRequiredEnum_empty;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const EnumTestEnumStringRequiredEnum unknownDefaultOpenApi = _$enumTestEnumStringRequiredEnum_unknownDefaultOpenApi;
 
   static Serializer<EnumTestEnumStringRequiredEnum> get serializer => _$enumTestEnumStringRequiredEnumSerializer;
 
@@ -226,6 +230,8 @@ class EnumTestEnumIntegerEnum extends EnumClass {
   static const EnumTestEnumIntegerEnum number1 = _$enumTestEnumIntegerEnum_number1;
   @BuiltValueEnumConst(wireNumber: -1)
   static const EnumTestEnumIntegerEnum numberNegative1 = _$enumTestEnumIntegerEnum_numberNegative1;
+  @BuiltValueEnumConst(wireNumber: 11184809, fallback: true)
+  static const EnumTestEnumIntegerEnum unknownDefaultOpenApi = _$enumTestEnumIntegerEnum_unknownDefaultOpenApi;
 
   static Serializer<EnumTestEnumIntegerEnum> get serializer => _$enumTestEnumIntegerEnumSerializer;
 
@@ -241,6 +247,8 @@ class EnumTestEnumNumberEnum extends EnumClass {
   static const EnumTestEnumNumberEnum number1Period1 = _$enumTestEnumNumberEnum_number1Period1;
   @BuiltValueEnumConst(wireName: r'-1.2')
   static const EnumTestEnumNumberEnum numberNegative1Period2 = _$enumTestEnumNumberEnum_numberNegative1Period2;
+  @BuiltValueEnumConst(wireName: r'11184809', fallback: true)
+  static const EnumTestEnumNumberEnum unknownDefaultOpenApi = _$enumTestEnumNumberEnum_unknownDefaultOpenApi;
 
   static Serializer<EnumTestEnumNumberEnum> get serializer => _$enumTestEnumNumberEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/map_test.dart
@@ -122,6 +122,8 @@ class MapTestMapOfEnumStringEnum extends EnumClass {
   static const MapTestMapOfEnumStringEnum UPPER = _$mapTestMapOfEnumStringEnum_UPPER;
   @BuiltValueEnumConst(wireName: r'lower')
   static const MapTestMapOfEnumStringEnum lower = _$mapTestMapOfEnumStringEnum_lower;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const MapTestMapOfEnumStringEnum unknownDefaultOpenApi = _$mapTestMapOfEnumStringEnum_unknownDefaultOpenApi;
 
   static Serializer<MapTestMapOfEnumStringEnum> get serializer => _$mapTestMapOfEnumStringEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/model_enum_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/model_enum_class.dart
@@ -16,6 +16,8 @@ class ModelEnumClass extends EnumClass {
   static const ModelEnumClass efg = _$efg;
   @BuiltValueEnumConst(wireName: r'(xyz)')
   static const ModelEnumClass leftParenthesisXyzRightParenthesis = _$leftParenthesisXyzRightParenthesis;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const ModelEnumClass unknownDefaultOpenApi = _$unknownDefaultOpenApi;
 
   static Serializer<ModelEnumClass> get serializer => _$modelEnumClassSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/order.dart
@@ -159,6 +159,9 @@ class OrderStatusEnum extends EnumClass {
   /// Order Status
   @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
+  /// Order Status
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const OrderStatusEnum unknownDefaultOpenApi = _$orderStatusEnum_unknownDefaultOpenApi;
 
   static Serializer<OrderStatusEnum> get serializer => _$orderStatusEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum.dart
@@ -16,6 +16,8 @@ class OuterEnum extends EnumClass {
   static const OuterEnum approved = _$approved;
   @BuiltValueEnumConst(wireName: r'delivered')
   static const OuterEnum delivered = _$delivered;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const OuterEnum unknownDefaultOpenApi = _$unknownDefaultOpenApi;
 
   static Serializer<OuterEnum> get serializer => _$outerEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum_default_value.dart
@@ -16,6 +16,8 @@ class OuterEnumDefaultValue extends EnumClass {
   static const OuterEnumDefaultValue approved = _$approved;
   @BuiltValueEnumConst(wireName: r'delivered')
   static const OuterEnumDefaultValue delivered = _$delivered;
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const OuterEnumDefaultValue unknownDefaultOpenApi = _$unknownDefaultOpenApi;
 
   static Serializer<OuterEnumDefaultValue> get serializer => _$outerEnumDefaultValueSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum_integer.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum_integer.dart
@@ -16,6 +16,8 @@ class OuterEnumInteger extends EnumClass {
   static const OuterEnumInteger number1 = _$number1;
   @BuiltValueEnumConst(wireNumber: 2)
   static const OuterEnumInteger number2 = _$number2;
+  @BuiltValueEnumConst(wireNumber: 11184809, fallback: true)
+  static const OuterEnumInteger unknownDefaultOpenApi = _$unknownDefaultOpenApi;
 
   static Serializer<OuterEnumInteger> get serializer => _$outerEnumIntegerSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum_integer_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/outer_enum_integer_default_value.dart
@@ -16,6 +16,8 @@ class OuterEnumIntegerDefaultValue extends EnumClass {
   static const OuterEnumIntegerDefaultValue number1 = _$number1;
   @BuiltValueEnumConst(wireNumber: 2)
   static const OuterEnumIntegerDefaultValue number2 = _$number2;
+  @BuiltValueEnumConst(wireNumber: 11184809, fallback: true)
+  static const OuterEnumIntegerDefaultValue unknownDefaultOpenApi = _$unknownDefaultOpenApi;
 
   static Serializer<OuterEnumIntegerDefaultValue> get serializer => _$outerEnumIntegerDefaultValueSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/model/pet.dart
@@ -156,6 +156,9 @@ class PetStatusEnum extends EnumClass {
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'sold')
   static const PetStatusEnum sold = _$petStatusEnum_sold;
+  /// pet status in the store
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const PetStatusEnum unknownDefaultOpenApi = _$petStatusEnum_unknownDefaultOpenApi;
 
   static Serializer<PetStatusEnum> get serializer => _$petStatusEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -151,6 +151,9 @@ class OrderStatusEnum extends EnumClass {
   /// Order Status
   @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
+  /// Order Status
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const OrderStatusEnum unknownDefaultOpenApi = _$orderStatusEnum_unknownDefaultOpenApi;
 
   static Serializer<OrderStatusEnum> get serializer => _$orderStatusEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -147,6 +147,9 @@ class PetStatusEnum extends EnumClass {
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'sold')
   static const PetStatusEnum sold = _$petStatusEnum_sold;
+  /// pet status in the store
+  @BuiltValueEnumConst(wireName: r'unknown_default_open_api', fallback: true)
+  static const PetStatusEnum unknownDefaultOpenApi = _$petStatusEnum_unknownDefaultOpenApi;
 
   static Serializer<PetStatusEnum> get serializer => _$petStatusEnumSerializer;
 


### PR DESCRIPTION
Adds support to dart-dio and built value for the new enumUnknownDefaultCase flag. When this flag is enabled, a default enum value is created.

With this change, that value is now set as the fallback value when deserializing unknown enums. This prevents runtime errors when the deserializer encounters an unknown enum.

### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)