### PR TITLE
[C#][netcore] Fix warning in cref for list

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -19,6 +19,8 @@ package org.openapitools.codegen.languages;
 
 import com.google.common.collect.ImmutableMap;
 import com.samskivert.mustache.Mustache.Lambda;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
 
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
@@ -36,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
@@ -399,6 +402,18 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
         // This either updates additionalProperties with the above fixes, or sets the default if the option was not specified.
         additionalProperties.put(CodegenConstants.INTERFACE_PREFIX, interfacePrefix);
+
+        // add lambda for mustache templates
+        additionalProperties.put("lambdaCref", new Mustache.Lambda() {
+            @Override
+            public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+                String content = fragment.execute();
+                content = content.trim().replace("<", "{");
+                content = content.replace(">", "}");
+                content = content.replace("{string}", "{String}");
+                writer.write(content);
+            }
+        });
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelAnyOf.mustache
@@ -19,7 +19,7 @@
         {{#anyOf}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class
-        /// with the <see cref="{{{.}}}" /> class
+        /// with the <see cref="{{#lambdaCref}}{{{.}}}{{/lambdaCref}}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of {{{.}}}.</param>
         public {{classname}}({{{.}}} actualInstance)

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
@@ -21,7 +21,7 @@
         {{^isNull}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class
-        /// with the <see cref="{{dataType}}" /> class
+        /// with the <see cref="{{#lambdaCref}}{{{dataType}}}{{/lambdaCref}}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of {{dataType}}.</param>
         public {{classname}}({{{dataType}}} actualInstance)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
-        /// with the <see cref="List&lt;string&gt;" /> class
+        /// with the <see cref="List{String}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of List&lt;string&gt;.</param>
         public PolymorphicProperty(List<string> actualInstance)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
-        /// with the <see cref="List&lt;string&gt;" /> class
+        /// with the <see cref="List{String}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of List&lt;string&gt;.</param>
         public PolymorphicProperty(List<string> actualInstance)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
-        /// with the <see cref="List&lt;string&gt;" /> class
+        /// with the <see cref="List{String}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of List&lt;string&gt;.</param>
         public PolymorphicProperty(List<string> actualInstance)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
-        /// with the <see cref="List&lt;string&gt;" /> class
+        /// with the <see cref="List{String}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of List&lt;string&gt;.</param>
         public PolymorphicProperty(List<string> actualInstance)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
-        /// with the <see cref="List&lt;string&gt;" /> class
+        /// with the <see cref="List{String}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of List&lt;string&gt;.</param>
         public PolymorphicProperty(List<string> actualInstance)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class
-        /// with the <see cref="List&lt;string&gt;" /> class
+        /// with the <see cref="List{String}" /> class
         /// </summary>
         /// <param name="actualInstance">An instance of List&lt;string&gt;.</param>
         public PolymorphicProperty(List<string> actualInstance)


### PR DESCRIPTION
Fix warning in cref for list

ref: https://stackoverflow.com/questions/532166/how-to-reference-generic-classes-and-methods-in-xml-documentation

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05)
