### PR TITLE
[Java] Update jackson databind to newer version

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -114,8 +114,8 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.3"
-    jackson_version = "2.12.5"
-    jackson_databind_version = "2.10.5.1"
+    jackson_version = "2.12.6"
+    jackson_databind_version = "2.12.6.1"
     {{#openApiNullable}}
     jackson_databind_nullable_version = "0.2.2"
     {{/openApiNullable}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
@@ -114,8 +114,8 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.5.22"
-    jackson_version = "2.12.1"
-    jackson_databind_version = "2.10.5.1"
+    jackson_version = "2.12.6"
+    jackson_databind_version = "2.12.6.1"
     {{#openApiNullable}}
     jackson_databind_nullable_version = "0.2.2"
     {{/openApiNullable}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-version}</version>
+            <version>${jackson-databind-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -327,7 +327,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.5.21</swagger-annotations-version>
         <httpclient-version>4.5.13</httpclient-version>
-        <jackson-version>2.12.1</jackson-version>
+        <jackson-version>2.12.6</jackson-version>
+        <jackson-databind-version>2.12.6.1</jackson-databind-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
 {{#useBeanValidation}}
         <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-version}</version>
+            <version>${jackson-databind-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -327,7 +327,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.3</swagger-annotations-version>
         <jersey-version>1.19.4</jersey-version>
-        <jackson-version>2.12.5</jackson-version>
+        <jackson-version>2.12.6</jackson-version>
+        <jackson-databind-version>2.12.6.1</jackson-databind-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
 {{#useBeanValidation}}
         <beanvalidation-version>2.0.2</beanvalidation-version>

--- a/samples/client/petstore/java/apache-httpclient/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient/build.gradle
@@ -114,8 +114,8 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.5.22"
-    jackson_version = "2.12.1"
-    jackson_databind_version = "2.10.5.1"
+    jackson_version = "2.12.6"
+    jackson_databind_version = "2.12.6.1"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     httpclient_version = "4.5.13"

--- a/samples/client/petstore/java/apache-httpclient/pom.xml
+++ b/samples/client/petstore/java/apache-httpclient/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-version}</version>
+            <version>${jackson-databind-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -277,7 +277,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.5.21</swagger-annotations-version>
         <httpclient-version>4.5.13</httpclient-version>
-        <jackson-version>2.12.1</jackson-version>
+        <jackson-version>2.12.6</jackson-version>
+        <jackson-databind-version>2.12.6.1</jackson-databind-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.2</junit-version>

--- a/samples/client/petstore/java/jersey1/build.gradle
+++ b/samples/client/petstore/java/jersey1/build.gradle
@@ -114,8 +114,8 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.3"
-    jackson_version = "2.12.5"
-    jackson_databind_version = "2.10.5.1"
+    jackson_version = "2.12.6"
+    jackson_databind_version = "2.12.6.1"
     jackson_databind_nullable_version = "0.2.2"
     jakarta_annotation_version = "1.3.5"
     jersey_version = "1.19.4"

--- a/samples/client/petstore/java/jersey1/pom.xml
+++ b/samples/client/petstore/java/jersey1/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-version}</version>
+            <version>${jackson-databind-version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -277,7 +277,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.3</swagger-annotations-version>
         <jersey-version>1.19.4</jersey-version>
-        <jackson-version>2.12.5</jackson-version>
+        <jackson-version>2.12.6</jackson-version>
+        <jackson-databind-version>2.12.6.1</jackson-databind-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.2</junit-version>


### PR DESCRIPTION
Update jackson databind to newer version for jersey1 and apache-httpclient

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
