### PR TITLE
[typescript-fetch] Removed functions that are unused when withoutRuntime is true.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -211,10 +211,12 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
+{{^withoutRuntimeChecks}}
 export function exists(json: any, key: string) {
     const value = json[key];
     return value !== null && value !== undefined;
 }
+{{/withoutRuntimeChecks}}
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
@@ -238,12 +240,14 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
         .join('&');
 }
 
+{{^withoutRuntimeChecks}}
 export function mapValues(data: any, fn: (item: any) => any) {
   return Object.keys(data).reduce(
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
 }
+{{/withoutRuntimeChecks}}
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -222,10 +222,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string) {
-    const value = json[key];
-    return value !== null && value !== undefined;
-}
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
@@ -249,12 +245,6 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
         .join('&');
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-  return Object.keys(data).reduce(
-    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
-    {}
-  );
-}
 
 export function canConsumeForm(consumes: Consume[]): boolean {
     for (const consume of consumes) {


### PR DESCRIPTION
Changed to remove the `exist` and `mapValue` functions from runtime.ts when withoutRuntimeChecks is true.

This is because these functions are not used when this option is true.
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03)