### PR TITLE
add stale bot actions

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          stale-issue-message: This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+          stale-issue-label: "stale"
+          exempt-issue-labels: "Issue: Bug,Enhancement: Feature"
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          # do not close pull requests
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
**I would like to use this as a basis for discussion.**

This PR try to add [stale bot actions](https://github.com/actions/stale).

Motivations are described at https://github.com/OpenAPITools/openapi-generator/issues/10138.

**I think it's worth using this bot in, but how about it?**

note: I think we can still use [stalebot for github apps](https://github.com/marketplace/stale), but it seems that [github actions version stalebot has more options](https://github.com/actions/stale#all-options).

close: https://github.com/OpenAPITools/openapi-generator/issues/10138

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.