### PR TITLE
[Ruby] Add support for faraday 2.x

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -12,6 +12,7 @@ require 'typhoeus'
 {{/isFaraday}}
 {{#isFaraday}}
 require 'faraday'
+require 'faraday/multipart' if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
 {{/isFaraday}}
 
 module {{moduleName}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -3,47 +3,24 @@
     # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
     #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
-      ssl_options = {
-        :ca_file => @config.ssl_ca_file,
-        :verify => @config.ssl_verify,
-        :verify_mode => @config.ssl_verify_mode,
-        :client_cert => @config.ssl_client_cert,
-        :client_key => @config.ssl_client_key
-      }
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
-        if config.username && config.password
-          if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
-            conn.request(:authorization, :basic, config.username, config.password)
-          else
-            conn.request(:basic_auth, config.username, config.password)
-          end
-        end
-        @config.configure_middleware(conn)
-        if opts[:header_params]["Content-Type"] == "multipart/form-data"
-          conn.request :multipart
-          conn.request :url_encoded
-        end
-        conn.adapter(Faraday.default_adapter)
-      end
-
       begin
-        response = connection.public_send(http_method.to_sym.downcase) do |req|
+        response = connection(opts).public_send(http_method.to_sym.downcase) do |req|
           build_request(http_method, path, req, opts)
         end
 
-        if @config.debugging
-          @config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
+        if config.debugging
+          config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
         end
 
         unless response.success?
           if response.status == 0
             # Errors from libcurl will be made visible here
-            fail ApiError.new(:code => 0,
-                              :message => response.return_message)
+            fail ApiError.new(code: 0,
+                              message: response.return_message)
           else
-            fail ApiError.new(:code => response.status,
-                              :response_headers => response.headers,
-                              :response_body => response.body),
+            fail ApiError.new(code: response.status,
+                              response_headers: response.headers,
+                              response_body: response.body),
                  response.reason_phrase
           end
         end
@@ -80,17 +57,17 @@
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
-        if @config.debugging
-          @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
+        if config.debugging
+          config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
       end
       request.headers = header_params
       request.body = req_body
 
       # Overload default options only if provided
-      request.options.params_encoder = @config.params_encoder if @config.params_encoder
-      request.options.timeout         = @config.timeout         if @config.timeout
-      request.options.verbose         = @config.debugging       if @config.debugging
+      request.options.params_encoder = config.params_encoder if config.params_encoder
+      request.options.timeout        = config.timeout        if config.timeout
+      request.options.verbose        = config.debugging      if config.debugging
 
       request.url url
       request.params = query_params
@@ -136,5 +113,49 @@
       # handle streaming Responses
       request.options.on_data = Proc.new do |chunk, overall_received_bytes|
         @stream << chunk
+      end
+    end
+
+    def connection(opts)
+      opts[:header_params]['Content-Type'] == 'multipart/form-data' ? connection_multipart : connection_regular
+    end
+
+    def connection_multipart
+      @connection_multipart ||= build_connection do |conn|
+        conn.request :multipart
+        conn.request :url_encoded
+      end
+    end
+
+    def connection_regular
+      @connection_regular ||= build_connection
+    end
+
+    def build_connection
+      Faraday.new(url: config.base_url, ssl: ssl_options) do |conn|
+        basic_auth(conn)
+        config.configure_middleware(conn)
+        yield(conn) if block_given?
+        conn.adapter(Faraday.default_adapter)
+      end
+    end
+
+    def ssl_options
+      {
+        ca_file: config.ssl_ca_file,
+        verify: config.ssl_verify,
+        verify_mode: config.ssl_verify_mode,
+        client_cert: config.ssl_client_cert,
+        client_key: config.ssl_client_key
+      }
+    end
+
+    def basic_auth(conn)
+      if config.username && config.password
+        if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
+          conn.request(:authorization, :basic, config.username, config.password)
+        else
+          conn.request(:basic_auth, config.username, config.password)
+        end
       end
     end

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -10,10 +10,7 @@
         :client_cert => @config.ssl_client_cert,
         :client_key => @config.ssl_client_key
       }
-      request_options = {
-        :params_encoder => @config.params_encoder
-      }
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options, :request => request_options) do |conn|
+      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
         if config.username && config.password
           if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
             conn.request(:authorization, :basic, config.username, config.password)

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -14,7 +14,13 @@
         :params_encoder => @config.params_encoder
       }
       connection = Faraday.new(:url => config.base_url, :ssl => ssl_options, :request => request_options) do |conn|
-        conn.request(:basic_auth, config.username, config.password)
+        if config.username && config.password
+          if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
+            conn.request(:authorization, :basic, config.username, config.password)
+          else
+            conn.request(:basic_auth, config.username, config.password)
+          end
+        end
         @config.configure_middleware(conn)
         if opts[:header_params]["Content-Type"] == "multipart/form-data"
           conn.request :multipart

--- a/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 2.4{{/gemRequiredRubyVersion}}"
 
   {{#isFaraday}}
-  s.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'
+  s.add_runtime_dependency 'faraday-multipart'
   {{/isFaraday}}
   {{^isFaraday}}
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -55,10 +55,7 @@ module Petstore
         :client_cert => @config.ssl_client_cert,
         :client_key => @config.ssl_client_key
       }
-      request_options = {
-        :params_encoder => @config.params_encoder
-      }
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options, :request => request_options) do |conn|
+      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
         if config.username && config.password
           if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
             conn.request(:authorization, :basic, config.username, config.password)

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -48,47 +48,24 @@ module Petstore
     # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
     #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
-      ssl_options = {
-        :ca_file => @config.ssl_ca_file,
-        :verify => @config.ssl_verify,
-        :verify_mode => @config.ssl_verify_mode,
-        :client_cert => @config.ssl_client_cert,
-        :client_key => @config.ssl_client_key
-      }
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
-        if config.username && config.password
-          if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
-            conn.request(:authorization, :basic, config.username, config.password)
-          else
-            conn.request(:basic_auth, config.username, config.password)
-          end
-        end
-        @config.configure_middleware(conn)
-        if opts[:header_params]["Content-Type"] == "multipart/form-data"
-          conn.request :multipart
-          conn.request :url_encoded
-        end
-        conn.adapter(Faraday.default_adapter)
-      end
-
       begin
-        response = connection.public_send(http_method.to_sym.downcase) do |req|
+        response = connection(opts).public_send(http_method.to_sym.downcase) do |req|
           build_request(http_method, path, req, opts)
         end
 
-        if @config.debugging
-          @config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
+        if config.debugging
+          config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
         end
 
         unless response.success?
           if response.status == 0
             # Errors from libcurl will be made visible here
-            fail ApiError.new(:code => 0,
-                              :message => response.return_message)
+            fail ApiError.new(code: 0,
+                              message: response.return_message)
           else
-            fail ApiError.new(:code => response.status,
-                              :response_headers => response.headers,
-                              :response_body => response.body),
+            fail ApiError.new(code: response.status,
+                              response_headers: response.headers,
+                              response_body: response.body),
                  response.reason_phrase
           end
         end
@@ -125,17 +102,17 @@ module Petstore
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
-        if @config.debugging
-          @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
+        if config.debugging
+          config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
       end
       request.headers = header_params
       request.body = req_body
 
       # Overload default options only if provided
-      request.options.params_encoder = @config.params_encoder if @config.params_encoder
-      request.options.timeout         = @config.timeout         if @config.timeout
-      request.options.verbose         = @config.debugging       if @config.debugging
+      request.options.params_encoder = config.params_encoder if config.params_encoder
+      request.options.timeout        = config.timeout        if config.timeout
+      request.options.verbose        = config.debugging      if config.debugging
 
       request.url url
       request.params = query_params
@@ -181,6 +158,50 @@ module Petstore
       # handle streaming Responses
       request.options.on_data = Proc.new do |chunk, overall_received_bytes|
         @stream << chunk
+      end
+    end
+
+    def connection(opts)
+      opts[:header_params]['Content-Type'] == 'multipart/form-data' ? connection_multipart : connection_regular
+    end
+
+    def connection_multipart
+      @connection_multipart ||= build_connection do |conn|
+        conn.request :multipart
+        conn.request :url_encoded
+      end
+    end
+
+    def connection_regular
+      @connection_regular ||= build_connection
+    end
+
+    def build_connection
+      Faraday.new(url: config.base_url, ssl: ssl_options) do |conn|
+        basic_auth(conn)
+        config.configure_middleware(conn)
+        yield(conn) if block_given?
+        conn.adapter(Faraday.default_adapter)
+      end
+    end
+
+    def ssl_options
+      {
+        ca_file: config.ssl_ca_file,
+        verify: config.ssl_verify,
+        verify_mode: config.ssl_verify_mode,
+        client_cert: config.ssl_client_cert,
+        client_key: config.ssl_client_key
+      }
+    end
+
+    def basic_auth(conn)
+      if config.username && config.password
+        if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new('2.0')
+          conn.request(:authorization, :basic, config.username, config.password)
+        else
+          conn.request(:basic_auth, config.username, config.password)
+        end
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/petstore.gemspec
+++ b/samples/client/petstore/ruby-faraday/petstore.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.4"
 
-  s.add_runtime_dependency 'faraday', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'
+  s.add_runtime_dependency 'faraday-multipart'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 


### PR DESCRIPTION
Closes #12074

To support Faraday 2.x, we only need the changes in dfa16a68fb7417259d38c11d05a2a2147764ec22
I also did a little refactoring mainly to memoize Faraday connections in 1594f4eb5e346e6002982f66dc6c882d2719bdf9.
If it doesn't look good, I can take it out so let me know.

Additionally, since the `params_encoder` option seems to be configured twice, modified in f8d4cff2a3c94a4f580fa7fd38d2ca6caf7f245d to remove redundancy.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 @cliffano @zlx @autopp