### PR TITLE
Return type for Azure funcs

### DIFF
--- a/docs/generators/csharp-netcore-functions.md
+++ b/docs/generators/csharp-netcore-functions.md
@@ -1,7 +1,9 @@
 ---
 title: Documentation for the csharp-netcore-functions Generator
 ---
+## DESCRIPTION
 
+Creates Azure function templates on top of the models/converters created by the C# codegens. This function is contained in a partial class. Default Get/Create/Patch/Post etc. methods are created with an underscore prefix. The assumption is that when the function is implemented, the partial class will be completed with another partial class. The implementing code should be located in a method of the same name, only without the underscore prefix. If no such method is found then the function will throw a Not Implemented exception. This setup allows the endpoints to be specified in the schema at build time, and separated from the implementing function.
 ## METADATA
 
 | Property | Value | Notes |

--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/function.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/function.mustache
@@ -17,13 +17,13 @@ namespace {{apiPackage}}
     public partial {{#classModifier}}{{classModifier}} {{/classModifier}}class {{classname}}
     { {{#operation}}
         [FunctionName("{{classname}}_{{operationId}}")]
-        public async Task<IActionResult> _{{operationId}}([HttpTrigger(AuthorizationLevel.Anonymous, "{{httpMethod}}", Route = "{{{apiBasePath}}}{{{path}}}")]HttpRequest req, ExecutionContext context{{#allParams}}{{#isPathParam}}, {{>pathParam}}{{/isPathParam}}{{/allParams}}){{^generateBody}};{{/generateBody}}
+        public async Task<{{{returnType}}}> _{{operationId}}([HttpTrigger(AuthorizationLevel.Anonymous, "{{httpMethod}}", Route = "{{{apiBasePath}}}{{{path}}}")]HttpRequest req, ExecutionContext context{{#allParams}}{{#isPathParam}}, {{>pathParam}}{{/isPathParam}}{{/allParams}}){{^generateBody}};{{/generateBody}}
         {{#generateBody}}
         {
             var method = this.GetType().GetMethod("{{operationId}}");
 
             return method != null 
-                ? (await ((Task<IActionResult>)method.Invoke(this, new object[] { req, context{{#allParams}}{{#isPathParam}}, {{>paramName}}{{/isPathParam}}{{/allParams}} })).ConfigureAwait(false))
+                ? (await ((Task<{{{returnType}}}>)method.Invoke(this, new object[] { req, context{{#allParams}}{{#isPathParam}}, {{>paramName}}{{/isPathParam}}{{/allParams}} })).ConfigureAwait(false))
                 : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
         {{/generateBody}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/function.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/function.mustache
@@ -11,20 +11,22 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
+using Org.OpenAPITools.Models;
 
 namespace {{apiPackage}}
 { {{#operations}}
     public partial {{#classModifier}}{{classModifier}} {{/classModifier}}class {{classname}}
     { {{#operation}}
         [FunctionName("{{classname}}_{{operationId}}")]
-        public async Task<{{{returnType}}}> _{{operationId}}([HttpTrigger(AuthorizationLevel.Anonymous, "{{httpMethod}}", Route = "{{{apiBasePath}}}{{{path}}}")]HttpRequest req, ExecutionContext context{{#allParams}}{{#isPathParam}}, {{>pathParam}}{{/isPathParam}}{{/allParams}}){{^generateBody}};{{/generateBody}}
+        public async Task<ActionResult<{{{returnType}}}>> _{{operationId}}([HttpTrigger(AuthorizationLevel.Anonymous, "{{httpMethod}}", Route = "{{{apiBasePath}}}{{{path}}}")]HttpRequest req, ExecutionContext context{{#allParams}}{{#isPathParam}}, {{>pathParam}}{{/isPathParam}}{{/allParams}}){{^generateBody}};{{/generateBody}}
         {{#generateBody}}
         {
             var method = this.GetType().GetMethod("{{operationId}}");
-
-            return method != null 
-                ? (await ((Task<{{{returnType}}}>)method.Invoke(this, new object[] { req, context{{#allParams}}{{#isPathParam}}, {{>paramName}}{{/isPathParam}}{{/allParams}} })).ConfigureAwait(false))
-                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
+            if(method == null)
+            {
+                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
+            }
+            return (await ((Task<{{{returnType}}}>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
         }
         {{/generateBody}}
         {{/operation}}


### PR DESCRIPTION
Change to Azure functions code gen which gives the functions an explicit return type instead of IActionResult.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
