### PR TITLE
[typescript*] drop support typescript below 4.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-aurelia/package.json.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-aurelia/package.json.mustache
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "tslint": "^3.15.1",
-    "typescript": "^2.4 || ^3.0"
+    "typescript": "^4.0"
   }
 }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
@@ -18,11 +18,11 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^0.26.1"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",
-    "typescript": "^3.6.4"
+    "typescript": "^4.0"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
   "publishConfig": {

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/package.mustache
@@ -15,7 +15,7 @@
     },
     "devDependencies": {
         "@types/jquery": "^3.1",
-        "typescript": "^2.4"
+        "typescript": "^4.0"
     }{{#npmRepository}},
     "publishConfig": {
         "registry": "{{npmRepository}}"

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/package.mustache
@@ -46,7 +46,7 @@
     "ts-node": "8.3.0",
     "tsconfig-paths": "3.8.0",
     "tslint": "5.18.0",
-    "typescript": "3.5.3",
+    "typescript": "^4.0",
     "wait-on": "^3.2.0"
   },
   "jest": {

--- a/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
@@ -15,13 +15,13 @@
     "dependencies": {
         "bluebird": "^3.5.0",
         "request": "^2.81.0",
-        "@types/bluebird": "3.5.33",
-        "@types/request": "*",
         "rewire": "^3.0.2"
     },
     "devDependencies": {
-        "typescript": "^2.4.2",
-        "@types/node": "8.10.34"
+        "@types/bluebird": "^3.5.33",
+        "@types/node": "^12",
+        "@types/request": "^2.48.8",
+        "typescript": "^4.0"
     }{{#npmRepository}},
     "publishConfig": {
         "registry": "{{npmRepository}}"

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/package.mustache
@@ -13,7 +13,7 @@
     "redux-query": "^3.2.0"
   },
   "devDependencies": {
-    "typescript": "^3.0"
+    "typescript": "^4.0"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
   "publishConfig": {

--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -61,7 +61,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/package.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/package.json
@@ -32,7 +32,7 @@
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "^0.6.17",
-    "typescript": "^2.0.0",
+    "typescript": "^4.0",
     "typings": "^1.3.2"
   }
 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/package.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/package.json
@@ -32,7 +32,7 @@
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "^0.6.17",
-    "typescript": "^2.0.0",
+    "typescript": "^4.0",
     "typings": "^1.3.2"
   }
 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/node-es5-expected/package.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/node-es5-expected/package.json
@@ -17,7 +17,7 @@
         "request": "^2.72.0"
     },
     "devDependencies": {
-        "typescript": "^1.8.10",
+        "typescript": "^4.0",
         "typings": "^0.8.1"
     }
 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/objectsWithEnums-expected/package.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/objectsWithEnums-expected/package.json
@@ -20,7 +20,7 @@
         "rewire": "^3.0.2"
     },
     "devDependencies": {
-        "typescript": "^2.4.2",
+        "typescript": "^4.0",
         "@types/node": "8.10.34"
     }
 }

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/package.json
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/package.json
@@ -32,7 +32,7 @@
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "^0.6.17",
-    "typescript": "^2.0.0",
+    "typescript": "^4.0",
     "typings": "^1.3.2"
   }
 }

--- a/samples/client/others/typescript/builds/with-unique-items/package.json
+++ b/samples/client/others/typescript/builds/with-unique-items/package.json
@@ -26,7 +26,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/client/petstore/typescript-aurelia/default/package.json
+++ b/samples/client/petstore/typescript-aurelia/default/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "tslint": "^3.15.1",
-    "typescript": "^2.4 || ^3.0"
+    "typescript": "^4.0"
   }
 }

--- a/samples/client/petstore/typescript-axios/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/package.json
@@ -18,11 +18,11 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^0.26.1"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",
-    "typescript": "^3.6.4"
+    "typescript": "^4.0"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
@@ -18,11 +18,11 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^0.26.1"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",
-    "typescript": "^3.6.4"
+    "typescript": "^4.0"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/package-lock.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "Unlicense",
       "dependencies": {
-        "axios": "^0.21.4"
+        "axios": "^0.26.1"
       },
       "devDependencies": {
         "@types/node": "^12.11.5",
-        "typescript": "^3.6.4"
+        "typescript": "^4.0"
       }
     },
     "node_modules/@types/node": {
@@ -23,17 +23,17 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -71,22 +71,22 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.8"
       }
     },
     "follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     }
   }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
@@ -18,11 +18,11 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^0.26.1"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",
-    "typescript": "^3.6.4"
+    "typescript": "^4.0"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-axios/tests/default/package-lock.json
+++ b/samples/client/petstore/typescript-axios/tests/default/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "typescript-fetch-test",
+  "name": "typescript-axios-test",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "typescript-fetch-test",
+      "name": "typescript-axios-test",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "ISC",
@@ -28,11 +28,11 @@
       "version": "1.0.0",
       "license": "Unlicense",
       "dependencies": {
-        "axios": "^0.21.4"
+        "axios": "^0.26.1"
       },
       "devDependencies": {
         "@types/node": "^12.11.5",
-        "typescript": "^3.6.4"
+        "typescript": "^4.0"
       }
     },
     "../../builds/with-npm-version/node_modules/@types/node": {
@@ -1533,7 +1533,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2744,8 +2743,8 @@
       "version": "file:../../builds/with-npm-version",
       "requires": {
         "@types/node": "^12.11.5",
-        "axios": "^0.21.4",
-        "typescript": "^3.6.4"
+        "axios": "^0.26.1",
+        "typescript": "^4.0"
       },
       "dependencies": {
         "@types/node": {

--- a/samples/client/petstore/typescript-axios/tests/default/package.json
+++ b/samples/client/petstore/typescript-axios/tests/default/package.json
@@ -19,7 +19,7 @@
     "mocha": "^8.2.1",
     "typescript": "^4.1.2"
   },
-  "name": "typescript-fetch-test",
+  "name": "typescript-axios-test",
   "version": "1.0.0",
   "directories": {
     "test": "test"

--- a/samples/client/petstore/typescript-jquery/npm/package.json
+++ b/samples/client/petstore/typescript-jquery/npm/package.json
@@ -15,7 +15,7 @@
     },
     "devDependencies": {
         "@types/jquery": "^3.1",
-        "typescript": "^2.4"
+        "typescript": "^4.0"
     },
     "publishConfig": {
         "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/package.json
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/package.json
@@ -46,7 +46,7 @@
     "ts-node": "8.3.0",
     "tsconfig-paths": "3.8.0",
     "tslint": "5.18.0",
-    "typescript": "3.5.3",
+    "typescript": "^4.0",
     "wait-on": "^3.2.0"
   },
   "jest": {

--- a/samples/client/petstore/typescript-node/npm/package.json
+++ b/samples/client/petstore/typescript-node/npm/package.json
@@ -15,13 +15,13 @@
     "dependencies": {
         "bluebird": "^3.5.0",
         "request": "^2.81.0",
-        "@types/bluebird": "3.5.33",
-        "@types/request": "*",
         "rewire": "^3.0.2"
     },
     "devDependencies": {
-        "typescript": "^2.4.2",
-        "@types/node": "8.10.34"
+        "@types/bluebird": "^3.5.33",
+        "@types/node": "^12",
+        "@types/request": "^2.48.8",
+        "typescript": "^4.0"
     },
     "publishConfig": {
         "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-redux-query/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-redux-query/builds/with-npm-version/package.json
@@ -13,7 +13,7 @@
     "redux-query": "^3.2.0"
   },
   "devDependencies": {
-    "typescript": "^3.0"
+    "typescript": "^4.0"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/openapi3/client/petstore/typescript/builds/browser/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/package.json
@@ -27,7 +27,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/package.json
@@ -26,7 +26,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/default/package.json
@@ -30,7 +30,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
@@ -31,7 +31,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
@@ -27,7 +27,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
@@ -30,7 +30,7 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "typescript": "^3.9.3",
+    "typescript": "^4.0",
     "@types/url-parse": "1.4.4"
   }
 }


### PR DESCRIPTION
Changed the lower limit of typescript version generated by the typescirpt-related generator to 4.0 as well as https://github.com/OpenAPITools/openapi-generator/pull/12102

See https://github.com/OpenAPITools/openapi-generator/pull/12102 for motivation and benefits.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) and @wing328