### PR TITLE
Add OneSignal as a Bronze Sponsor and User

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you find OpenAPI Generator useful for work, please consider asking your compa
 [<img src="https://openapi-generator.tech/img/companies/apideck.jpg" width="128" height="128">](https://www.apideck.com/?utm_source=openapi_generator&utm_medium=github_webpage&utm_campaign=sponsor)
 [<img src="https://openapi-generator.tech/img/companies/pexa.png" width="128" height="128">](https://www.pexa.com.au/?utm_source=openapi_generator&utm_medium=github_webpage&utm_campaign=sponsor)
 [<img src="https://openapi-generator.tech/img/companies/numary.png" width="128" height="128">](https://www.numary.com/?utm_source=openapi_generator&utm_medium=github_webpage&utm_campaign=sponsor)
+[<img src="https://openapi-generator.tech/img/companies/onesignal.png" width="128" height="128">](https://www.onesignal.com/?utm_source=openapi_generator&utm_medium=github_webpage&utm_campaign=sponsor)
 
 #### Thank you GoDaddy for sponsoring the domain names, Linode for sponsoring the VPS and Checkly for sponsoring the API monitoring
 
@@ -631,6 +632,7 @@ Here are some companies/projects (alphabetical order) using OpenAPI Generator in
 - [Neverfail](https://www.neverfail.com/)
 - [NeuerEnergy](https://neuerenergy.com)
 - [Nokia](https://www.nokia.com/)
+- [OneSignal](https://www.onesignal.com/)
 - [Options Clearing Corporation (OCC)](https://www.theocc.com/)
 - [Openet](https://www.openet.com/)
 - [openVALIDATION](https://openvalidation.io/)


### PR DESCRIPTION
This change adds OneSignal as a Bronze Sponsor and User of openapi-generator.  Please find attached to this PR a copy of our logo you can use for your website:

![onesignal](https://user-images.githubusercontent.com/435158/163065704-435e2c6a-faa4-4391-896f-f784d8d59cc3.png)