### PR TITLE
Flatten inline schemas in requestBody components

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
@@ -455,6 +455,29 @@ public class InlineModelResolverTest {
     }
 
     @Test
+    public void testResolveInlineRequestBodyRef() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
+        new InlineModelResolver().flatten(openAPI);
+
+        RequestBody requestBodyReference = openAPI
+                .getPaths()
+                .get("/resolve_inline_request_body_ref")
+                .getPost()
+                .getRequestBody();
+        assertNotNull(requestBodyReference.get$ref());
+
+        RequestBody requestBody = ModelUtils.getReferencedRequestBody(openAPI, requestBodyReference);
+        assertTrue(requestBody.getRequired());
+        MediaType mediaType = requestBody.getContent().get("application/json");
+        assertNotNull(mediaType.getSchema().get$ref());
+        assertEquals("#/components/schemas/ResolveInlineRequestBodyRefRequest", mediaType.getSchema().get$ref());
+
+        Schema schema = ModelUtils.getReferencedSchema(openAPI, mediaType.getSchema());
+        assertTrue(schema instanceof ObjectSchema);
+        assertTrue(schema.getProperties().get("name") instanceof StringSchema);
+    }
+
+    @Test
     public void resolveInlineArrayResponse() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
         new InlineModelResolver().flatten(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1365,4 +1365,18 @@ public class SpringCodegenTest {
                 .assertParameterAnnotations()
                 .containsWithNameAndAttributes("RequestParam", ImmutableMap.of("defaultValue", "\"\""));
     }
+
+    @Test
+    public void testInlineRequestBody() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_10435.yaml");
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Schema target = openAPI.getComponents().getSchemas().get("setupReq");
+        Assert.assertNotNull(target);
+        CodegenModel cm = codegen.fromModel("setupReq", target);
+
+        Assert.assertEquals(cm.dataType, "Object");
+        Assert.assertEquals(cm.vars.get(0).name, "property");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
@@ -166,6 +166,23 @@ public class AbstractPhpCodegenTest {
         Assert.assertEquals(cp1.getDefaultValue(), "'VALUE'");
     }
 
+    @Test(description = "Issue #9123")
+    public void TestNamedInlineRequestBody() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_9123.yaml");
+        final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Schema target = openAPI.getComponents().getSchemas().get("ListOfDefinitions");
+        Assert.assertNotNull(target);
+        CodegenModel cm = codegen.fromModel("ListOfDefinitions", target);
+
+        Assert.assertEquals(cm.getDataType(), "object");
+        Assert.assertEquals(codegen.getTypeDeclaration("ListOfDefinitions"), "\\php\\Model\\ListOfDefinitions");
+
+        CodegenProperty label = cm.vars.get(0);
+        Assert.assertEquals(label.getName(), "label");
+    }
+
     private static class P_AbstractPhpCodegen extends AbstractPhpCodegen {
         @Override
         public CodegenType getTag() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -386,4 +386,18 @@ public class TypeScriptFetchModelTest {
 
         Assert.assertEquals(codegen.getTypeDeclaration(model), "{ [key: string]: string; }");
     }
+
+    @Test(description = "Inline request bodies create models")
+    public void testInlineRequestBody() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_11811.yaml");
+        final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Schema target = openAPI.getComponents().getSchemas().get("UserPost");
+        Assert.assertNotNull(target);
+        CodegenModel cm = codegen.fromModel("UserPost", target);
+
+        Assert.assertEquals(cm.dataType, "object");
+        Assert.assertEquals(cm.vars.get(0).name, "firstName");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
@@ -115,7 +115,6 @@ parameters:
     in: body
     required: true
     schema:
-      # Erroneously ends up as `Option<models::InlineObject>`
       properties:
         id:
           type: string

--- a/modules/openapi-generator/src/test/resources/3_0/inline_model_resolver.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/inline_model_resolver.yaml
@@ -105,6 +105,14 @@ paths:
       responses:
         '200':
           description: OK
+  /resolve_inline_request_body_ref:
+    post:
+      operationId: resolveInlineRequestBodyRef
+      requestBody:
+        $ref: '#/components/requestBodies/ResolveInlineRequestBodyRefRequest'
+      responses:
+        '200':
+          description: OK
   /resolve_inline_array_response:
     get:
       operationId: resolveInlineArrayResponse
@@ -328,6 +336,16 @@ paths:
                         data:
                           type: string
 components:
+  requestBodies:
+    ResolveInlineRequestBodyRefRequest:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+      required: true
   schemas:
     Users:
       type: array

--- a/modules/openapi-generator/src/test/resources/3_0/issue_10435.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_10435.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.1
+info:
+  title: Example API
+  version: '1.0'
+paths:
+  /test:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/setupReq'
+      responses:
+        '201':
+          description: ok
+components:
+  requestBodies:
+    setupReq:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              property:
+                type: string

--- a/modules/openapi-generator/src/test/resources/3_0/issue_11811.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_11811.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+paths:
+  /user:
+    post:
+      summary: Create New User
+      operationId: post-user
+      requestBody:
+        $ref: '#/components/requestBodies/UserPost'
+      responses:
+        '200':
+          description: OK
+components:
+  requestBodies:
+    UserPost:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              firstName:
+                type: string
+              lastName:
+                type: string

--- a/modules/openapi-generator/src/test/resources/3_0/issue_8605.json
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_8605.json
@@ -1,0 +1,106 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "example",
+    "description": "example",
+    "version": "1.2.3",
+    "contact": {}
+  },
+  "servers": [
+    {
+      "url": "/api/example/v1",
+      "description": "relative path"
+    }
+  ],
+  "tags": [
+    {
+      "name": "example",
+      "description": "example"
+    }
+  ],
+  "paths": {
+    "/example/{id}/run": {
+      "post": {
+        "tags": [
+          "example"
+        ],
+        "summary": "Execute example",
+        "description": "Execute example",
+        "operationId": "runExample",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ExampleId"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExampleRunsInput"
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecuteExample"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "ExampleId": {
+        "in": "path",
+        "name": "remediation",
+        "description": "example identifier (uuid)",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ExampleId"
+        }
+      }
+    },
+    "requestBodies": {
+      "ExampleRunsInput": {
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "exclude": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "ExampleId": {
+        "type": "string",
+        "format": "uuid",
+        "example": "9197ba55-0abc-4028-9bbe-269e530f8bd5"
+      },
+      "ExecuteExample": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ExampleId"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/issue_9123.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_9123.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.1
+info:
+  title: test
+  description: test
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /definitions:
+    put:
+      summary: test
+      operationId: putTest
+      requestBody:
+        description: test
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                label:
+                  type: string
+                  description: label
+        required: true
+      responses:
+        204:
+          description: successful operation
+          content: {}
+      x-codegen-request-body-name: ListOfDefinitions

--- a/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
@@ -8,7 +8,7 @@ docs/AdditionalPropertiesObject.md
 docs/AllOfObject.md
 docs/BaseAllOf.md
 docs/GetYamlResponse.md
-docs/InlineObject.md
+docs/NestedResponse.md
 docs/ObjectOfObjects.md
 docs/ObjectOfObjectsInner.md
 docs/default_api.md

--- a/samples/server/petstore/rust-server/output/rust-server-test/README.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/README.md
@@ -119,7 +119,7 @@ Method | HTTP request | Description
  - [AllOfObject](docs/AllOfObject.md)
  - [BaseAllOf](docs/BaseAllOf.md)
  - [GetYamlResponse](docs/GetYamlResponse.md)
- - [InlineObject](docs/InlineObject.md)
+ - [NestedResponse](docs/NestedResponse.md)
  - [ObjectOfObjects](docs/ObjectOfObjects.md)
  - [ObjectOfObjectsInner](docs/ObjectOfObjectsInner.md)
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
@@ -17,7 +17,7 @@ paths:
     put:
       operationId: dummyPut
       requestBody:
-        $ref: '#/components/requestBodies/inline_object'
+        $ref: '#/components/requestBodies/nested_response'
         content:
           '*/*':
             schema:
@@ -135,20 +135,7 @@ components:
       content:
         '*/*':
           schema:
-            properties:
-              id:
-                type: string
-              password:
-                type: string
-            required:
-            - id
-            type: object
-      required: true
-    inline_object:
-      content:
-        '*/*':
-          schema:
-            $ref: '#/components/schemas/inline_object'
+            $ref: '#/components/schemas/nested_response'
       required: true
   schemas:
     additionalPropertiesObject:
@@ -194,7 +181,7 @@ components:
           description: Inner string
           type: string
       type: object
-    inline_object:
+    nested_response:
       properties:
         id:
           type: string

--- a/samples/server/petstore/rust-server/output/rust-server-test/docs/NestedResponse.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/docs/NestedResponse.md
@@ -1,4 +1,4 @@
-# InlineObject
+# NestedResponse
 
 ## Properties
 Name | Type | Description | Notes

--- a/samples/server/petstore/rust-server/output/rust-server-test/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/docs/default_api.md
@@ -69,7 +69,7 @@ No authorization required
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-  **nested_response** | [**InlineObject**](InlineObject.md)|  | 
+  **nested_response** | [**NestedResponse**](NestedResponse.md)|  | 
 
 ### Return type
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/server/server.rs
@@ -131,7 +131,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
 
     async fn dummy_put(
         &self,
-        nested_response: models::InlineObject,
+        nested_response: models::NestedResponse,
         context: &C) -> Result<DummyPutResponse, ApiError>
     {
         let context = context.clone();

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -536,7 +536,7 @@ impl<S, C> Api<C> for Client<S, C> where
 
     async fn dummy_put(
         &self,
-        param_nested_response: models::InlineObject,
+        param_nested_response: models::NestedResponse,
         context: &C) -> Result<DummyPutResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -89,7 +89,7 @@ pub trait Api<C: Send + Sync> {
 
     async fn dummy_put(
         &self,
-        nested_response: models::InlineObject,
+        nested_response: models::NestedResponse,
         context: &C) -> Result<DummyPutResponse, ApiError>;
 
     /// Get a file
@@ -144,7 +144,7 @@ pub trait ApiNoContext<C: Send + Sync> {
 
     async fn dummy_put(
         &self,
-        nested_response: models::InlineObject,
+        nested_response: models::NestedResponse,
         ) -> Result<DummyPutResponse, ApiError>;
 
     /// Get a file
@@ -222,7 +222,7 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
 
     async fn dummy_put(
         &self,
-        nested_response: models::InlineObject,
+        nested_response: models::NestedResponse,
         ) -> Result<DummyPutResponse, ApiError>
     {
         let context = self.context().clone();

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -546,7 +546,7 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct InlineObject {
+pub struct NestedResponse {
     #[serde(rename = "id")]
     pub id: String,
 
@@ -556,19 +556,19 @@ pub struct InlineObject {
 
 }
 
-impl InlineObject {
-    pub fn new(id: String, ) -> InlineObject {
-        InlineObject {
+impl NestedResponse {
+    pub fn new(id: String, ) -> NestedResponse {
+        NestedResponse {
             id: id,
             password: None,
         }
     }
 }
 
-/// Converts the InlineObject value to the Query Parameters representation (style=form, explode=false)
+/// Converts the NestedResponse value to the Query Parameters representation (style=form, explode=false)
 /// specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde serializer
-impl std::string::ToString for InlineObject {
+impl std::string::ToString for NestedResponse {
     fn to_string(&self) -> String {
         let mut params: Vec<String> = vec![];
 
@@ -585,10 +585,10 @@ impl std::string::ToString for InlineObject {
     }
 }
 
-/// Converts Query Parameters representation (style=form, explode=false) to a InlineObject value
+/// Converts Query Parameters representation (style=form, explode=false) to a NestedResponse value
 /// as specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde deserializer
-impl std::str::FromStr for InlineObject {
+impl std::str::FromStr for NestedResponse {
     type Err = String;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -608,14 +608,14 @@ impl std::str::FromStr for InlineObject {
         while key_result.is_some() {
             let val = match string_iter.next() {
                 Some(x) => x,
-                None => return std::result::Result::Err("Missing value while parsing InlineObject".to_string())
+                None => return std::result::Result::Err("Missing value while parsing NestedResponse".to_string())
             };
 
             if let Some(key) = key_result {
                 match key {
                     "id" => intermediate_rep.id.push(<String as std::str::FromStr>::from_str(val).map_err(|x| format!("{}", x))?),
                     "password" => intermediate_rep.password.push(<String as std::str::FromStr>::from_str(val).map_err(|x| format!("{}", x))?),
-                    _ => return std::result::Result::Err("Unexpected key while parsing InlineObject".to_string())
+                    _ => return std::result::Result::Err("Unexpected key while parsing NestedResponse".to_string())
                 }
             }
 
@@ -624,41 +624,41 @@ impl std::str::FromStr for InlineObject {
         }
 
         // Use the intermediate representation to return the struct
-        std::result::Result::Ok(InlineObject {
-            id: intermediate_rep.id.into_iter().next().ok_or("id missing in InlineObject".to_string())?,
+        std::result::Result::Ok(NestedResponse {
+            id: intermediate_rep.id.into_iter().next().ok_or("id missing in NestedResponse".to_string())?,
             password: intermediate_rep.password.into_iter().next(),
         })
     }
 }
 
-// Methods for converting between header::IntoHeaderValue<InlineObject> and hyper::header::HeaderValue
+// Methods for converting between header::IntoHeaderValue<NestedResponse> and hyper::header::HeaderValue
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl std::convert::TryFrom<header::IntoHeaderValue<InlineObject>> for hyper::header::HeaderValue {
+impl std::convert::TryFrom<header::IntoHeaderValue<NestedResponse>> for hyper::header::HeaderValue {
     type Error = String;
 
-    fn try_from(hdr_value: header::IntoHeaderValue<InlineObject>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(hdr_value: header::IntoHeaderValue<NestedResponse>) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match hyper::header::HeaderValue::from_str(&hdr_value) {
              std::result::Result::Ok(value) => std::result::Result::Ok(value),
              std::result::Result::Err(e) => std::result::Result::Err(
-                 format!("Invalid header value for InlineObject - value: {} is invalid {}",
+                 format!("Invalid header value for NestedResponse - value: {} is invalid {}",
                      hdr_value, e))
         }
     }
 }
 
 #[cfg(any(feature = "client", feature = "server"))]
-impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<InlineObject> {
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NestedResponse> {
     type Error = String;
 
     fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
              std::result::Result::Ok(value) => {
-                    match <InlineObject as std::str::FromStr>::from_str(value) {
+                    match <NestedResponse as std::str::FromStr>::from_str(value) {
                         std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
                         std::result::Result::Err(err) => std::result::Result::Err(
-                            format!("Unable to convert header value '{}' into InlineObject - {}",
+                            format!("Unable to convert header value '{}' into NestedResponse - {}",
                                 value, err))
                     }
              },

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -235,7 +235,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                 match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
-                                let param_nested_response: Option<models::InlineObject> = if !body.is_empty() {
+                                let param_nested_response: Option<models::NestedResponse> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&*body);
                                     match serde_ignored::deserialize(deserializer, |path| {
                                             warn!("Ignoring unknown field in body: {}", path);


### PR DESCRIPTION
For request bodies that are completely inlined into a path's operations, the inline model resolver correctly generates both a schema component and a requestBody component and adds $refs.

However, when an operation already contains an $ref to a requestBody that itself contains an inline schema, that schema was not being flattened to a separate component. This change adds a separate method to do such flattening and add an $ref if needed.

This fixes the dreaded error about a model having an unknown base type (with typically invalid code generated) in this situation.

I have included several tests to verify the corrected behavior, including one test each for the issues this fixes (I suspect there are more duplicates, but this is what I could find from an initial search). I know the issue-specific tests are a little redundant, but I wanted to make sure each was actually solved, as everyone's specs varied slightly.

Fixes #8605
Fixes #9123
Fixes #10435
Fixes #11811

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
