### PR TITLE
[java][okhttp-gson] Improve errorObjectType to avoid regression

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -327,14 +327,20 @@ public class {{classname}} {
     public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-streaming}} InputStream {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
         okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}null);
         {{#returnType}}
+        {{#errorObjectType}}
         try {
             Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
             return localVarApiClient.executeStream(localVarCall, localVarReturnType);
         } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}{{^errorObjectType}}{{{returnType}}}{{/errorObjectType}}>(){}.getType()));
-            e.setErrorObjectType(new GenericType<{{{errorObjectType}}}{{^errorObjectType}}{{{returnType}}}{{/errorObjectType}}>(){});
+            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}>(){}.getType()));
+            e.setErrorObjectType(new GenericType<{{{errorObjectType}}}>(){});
             throw e;
         }
+        {{/errorObjectType}}
+        {{^errorObjectType}}
+        Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+        return localVarApiClient.executeStream(localVarCall, localVarReturnType);
+        {{/errorObjectType}}
         {{/returnType}}
     }
     {{/vendorExtensions.x-streaming}}{{^vendorExtensions.x-streaming}} ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
@@ -343,14 +349,20 @@ public class {{classname}} {
         return localVarApiClient.execute(localVarCall);
         {{/returnType}}
         {{#returnType}}
+        {{#errorObjectType}}
         try {
             Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
             return localVarApiClient.execute(localVarCall, localVarReturnType);
         } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}{{^errorObjectType}}{{{returnType}}}{{/errorObjectType}}>(){}.getType()));
-            e.setErrorObjectType(new GenericType<{{{errorObjectType}}}{{^errorObjectType}}{{{returnType}}}{{/errorObjectType}}>(){});
+            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}>(){}.getType()));
+            e.setErrorObjectType(new GenericType<{{{errorObjectType}}}>(){});
             throw e;
         }
+        {{/errorObjectType}}
+        {{^errorObjectType}}
+        Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+        {{/errorObjectType}}
         {{/returnType}}
     }
     {{/vendorExtensions.x-streaming}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -20,8 +20,10 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
-    private {{{errorObjectType}}}{{^errorObjectType}}Object{{/errorObjectType}} errorObject = null;
+    {{#errorObjectType}}
+    private {{{errorObjectType}}} errorObject = null;
     private GenericType errorObjectType = null;
+    {{/errorObjectType}}
  
     /**
      * <p>Constructor for ApiException.</p>
@@ -160,6 +162,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     public String getResponseBody() {
         return responseBody;
     }
+    {{#errorObjectType}}
 
     /**
      * Get the error object type.
@@ -184,7 +187,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
      *
      * @return Error object
      */
-    public {{{errorObjectType}}}{{^errorObjectType}}Object{{/errorObjectType}} getErrorObject() {
+    public {{{errorObjectType}}} getErrorObject() {
         return errorObject;
     }
 
@@ -193,7 +196,8 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
      *
      * @param errorObject Error object
      */
-    public void setErrorObject({{{errorObjectType}}}{{^errorObjectType}}Object{{/errorObjectType}} errorObject) {
+    public void setErrorObject({{{errorObjectType}}} errorObject) {
         this.errorObject = errorObject;
     }
+    {{/errorObjectType}}
 }

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
@@ -27,8 +27,6 @@ public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
-    private Object errorObject = null;
-    private GenericType errorObjectType = null;
  
     /**
      * <p>Constructor for ApiException.</p>
@@ -154,41 +152,5 @@ public class ApiException extends Exception {
      */
     public String getResponseBody() {
         return responseBody;
-    }
-
-    /**
-     * Get the error object type.
-     *
-     * @return Error object type
-     */
-    public GenericType getErrorObjectType() {
-        return errorObjectType;
-    }
-
-    /**
-     * Set the error object type.
-     *
-     * @param errorObjectType object type
-     */
-    public void setErrorObjectType(GenericType errorObjectType) {
-        this.errorObjectType = errorObjectType;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @return Error object
-     */
-    public Object getErrorObject() {
-        return errorObject;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @param errorObject Error object
-     */
-    public void setErrorObject(Object errorObject) {
-        this.errorObject = errorObject;
     }
 }

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/api/PingApi.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/api/PingApi.java
@@ -171,14 +171,8 @@ public class PingApi {
      */
     public InputStream postPingWithHttpInfo(SomeObj someObj) throws ApiException {
         okhttp3.Call localVarCall = postPingValidateBeforeCall(someObj, null);
-        try {
-            Type localVarReturnType = new TypeToken<SomeObj>(){}.getType();
-            return localVarApiClient.executeStream(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<SomeObj>(){}.getType()));
-            e.setErrorObjectType(new GenericType<SomeObj>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<SomeObj>(){}.getType();
+        return localVarApiClient.executeStream(localVarCall, localVarReturnType);
     }
     
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
@@ -27,8 +27,6 @@ public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
-    private Object errorObject = null;
-    private GenericType errorObjectType = null;
  
     /**
      * <p>Constructor for ApiException.</p>
@@ -154,41 +152,5 @@ public class ApiException extends Exception {
      */
     public String getResponseBody() {
         return responseBody;
-    }
-
-    /**
-     * Get the error object type.
-     *
-     * @return Error object type
-     */
-    public GenericType getErrorObjectType() {
-        return errorObjectType;
-    }
-
-    /**
-     * Set the error object type.
-     *
-     * @param errorObjectType object type
-     */
-    public void setErrorObjectType(GenericType errorObjectType) {
-        this.errorObjectType = errorObjectType;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @return Error object
-     */
-    public Object getErrorObject() {
-        return errorObject;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @param errorObject Error object
-     */
-    public void setErrorObject(Object errorObject) {
-        this.errorObject = errorObject;
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -186,14 +186,8 @@ public class AnotherFakeApi {
      */
     public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
         okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -319,14 +319,8 @@ public class FakeApi {
      */
     public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Boolean>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Boolean>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -454,14 +448,8 @@ public class FakeApi {
      */
     public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<OuterComposite>(){}.getType()));
-            e.setErrorObjectType(new GenericType<OuterComposite>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -589,14 +577,8 @@ public class FakeApi {
      */
     public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<BigDecimal>(){}.getType()));
-            e.setErrorObjectType(new GenericType<BigDecimal>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -724,14 +706,8 @@ public class FakeApi {
      */
     public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<String>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<String>(){}.getType()));
-            e.setErrorObjectType(new GenericType<String>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1134,14 +1110,8 @@ public class FakeApi {
      */
     public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
         okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -186,14 +186,8 @@ public class FakeClassnameTags123Api {
      */
     public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
         okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/PetApi.java
@@ -467,14 +467,8 @@ public class PetApi {
      */
     public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
         okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null);
-        try {
-            Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<List<Pet>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<List<Pet>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -619,14 +613,8 @@ public class PetApi {
     @Deprecated
     public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
         okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null);
-        try {
-            Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Set<Pet>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Set<Pet>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -769,14 +757,8 @@ public class PetApi {
      */
     public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
         okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null);
-        try {
-            Type localVarReturnType = new TypeToken<Pet>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Pet>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Pet>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Pet>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1215,14 +1197,8 @@ public class PetApi {
      */
     public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
         okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, _file, null);
-        try {
-            Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<ModelApiResponse>(){}.getType()));
-            e.setErrorObjectType(new GenericType<ModelApiResponse>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1377,14 +1353,8 @@ public class PetApi {
      */
     public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
         okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null);
-        try {
-            Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<ModelApiResponse>(){}.getType()));
-            e.setErrorObjectType(new GenericType<ModelApiResponse>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -313,14 +313,8 @@ public class StoreApi {
      */
     public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
         okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null);
-        try {
-            Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Map<String, Integer>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Map<String, Integer>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -459,14 +453,8 @@ public class StoreApi {
      */
     public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
         okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null);
-        try {
-            Type localVarReturnType = new TypeToken<Order>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Order>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Order>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Order>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -604,14 +592,8 @@ public class StoreApi {
      */
     public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
         okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Order>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Order>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Order>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Order>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
@@ -719,14 +719,8 @@ public class UserApi {
      */
     public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
         okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null);
-        try {
-            Type localVarReturnType = new TypeToken<User>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<User>(){}.getType()));
-            e.setErrorObjectType(new GenericType<User>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<User>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -874,14 +868,8 @@ public class UserApi {
      */
     public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
         okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null);
-        try {
-            Type localVarReturnType = new TypeToken<String>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<String>(){}.getType()));
-            e.setErrorObjectType(new GenericType<String>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
@@ -27,8 +27,6 @@ public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
-    private Object errorObject = null;
-    private GenericType errorObjectType = null;
  
     /**
      * <p>Constructor for ApiException.</p>
@@ -154,41 +152,5 @@ public class ApiException extends Exception {
      */
     public String getResponseBody() {
         return responseBody;
-    }
-
-    /**
-     * Get the error object type.
-     *
-     * @return Error object type
-     */
-    public GenericType getErrorObjectType() {
-        return errorObjectType;
-    }
-
-    /**
-     * Set the error object type.
-     *
-     * @param errorObjectType object type
-     */
-    public void setErrorObjectType(GenericType errorObjectType) {
-        this.errorObjectType = errorObjectType;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @return Error object
-     */
-    public Object getErrorObject() {
-        return errorObject;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @param errorObject Error object
-     */
-    public void setErrorObject(Object errorObject) {
-        this.errorObject = errorObject;
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -175,14 +175,8 @@ public class AnotherFakeApi {
      */
     public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
         okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -300,14 +300,8 @@ public class FakeApi {
      */
     public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Boolean>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Boolean>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -427,14 +421,8 @@ public class FakeApi {
      */
     public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<OuterComposite>(){}.getType()));
-            e.setErrorObjectType(new GenericType<OuterComposite>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -554,14 +542,8 @@ public class FakeApi {
      */
     public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<BigDecimal>(){}.getType()));
-            e.setErrorObjectType(new GenericType<BigDecimal>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -681,14 +663,8 @@ public class FakeApi {
      */
     public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<String>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<String>(){}.getType()));
-            e.setErrorObjectType(new GenericType<String>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1070,14 +1046,8 @@ public class FakeApi {
      */
     public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
         okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -175,14 +175,8 @@ public class FakeClassnameTags123Api {
      */
     public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
         okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/PetApi.java
@@ -446,14 +446,8 @@ public class PetApi {
      */
     public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
         okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null);
-        try {
-            Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<List<Pet>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<List<Pet>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -593,14 +587,8 @@ public class PetApi {
     @Deprecated
     public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
         okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null);
-        try {
-            Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Set<Pet>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Set<Pet>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -735,14 +723,8 @@ public class PetApi {
      */
     public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
         okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null);
-        try {
-            Type localVarReturnType = new TypeToken<Pet>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Pet>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Pet>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Pet>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1157,14 +1139,8 @@ public class PetApi {
      */
     public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
         okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, _file, null);
-        try {
-            Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<ModelApiResponse>(){}.getType()));
-            e.setErrorObjectType(new GenericType<ModelApiResponse>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1311,14 +1287,8 @@ public class PetApi {
      */
     public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
         okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null);
-        try {
-            Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<ModelApiResponse>(){}.getType()));
-            e.setErrorObjectType(new GenericType<ModelApiResponse>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -294,14 +294,8 @@ public class StoreApi {
      */
     public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
         okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null);
-        try {
-            Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Map<String, Integer>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Map<String, Integer>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -432,14 +426,8 @@ public class StoreApi {
      */
     public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
         okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null);
-        try {
-            Type localVarReturnType = new TypeToken<Order>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Order>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Order>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Order>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -569,14 +557,8 @@ public class StoreApi {
      */
     public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
         okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Order>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Order>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Order>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Order>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
@@ -676,14 +676,8 @@ public class UserApi {
      */
     public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
         okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null);
-        try {
-            Type localVarReturnType = new TypeToken<User>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<User>(){}.getType()));
-            e.setErrorObjectType(new GenericType<User>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<User>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -829,14 +823,8 @@ public class UserApi {
      */
     public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
         okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null);
-        try {
-            Type localVarReturnType = new TypeToken<String>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<String>(){}.getType()));
-            e.setErrorObjectType(new GenericType<String>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
@@ -27,8 +27,6 @@ public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;
-    private Object errorObject = null;
-    private GenericType errorObjectType = null;
  
     /**
      * <p>Constructor for ApiException.</p>
@@ -154,41 +152,5 @@ public class ApiException extends Exception {
      */
     public String getResponseBody() {
         return responseBody;
-    }
-
-    /**
-     * Get the error object type.
-     *
-     * @return Error object type
-     */
-    public GenericType getErrorObjectType() {
-        return errorObjectType;
-    }
-
-    /**
-     * Set the error object type.
-     *
-     * @param errorObjectType object type
-     */
-    public void setErrorObjectType(GenericType errorObjectType) {
-        this.errorObjectType = errorObjectType;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @return Error object
-     */
-    public Object getErrorObject() {
-        return errorObject;
-    }
-
-    /**
-     * Get the error object.
-     *
-     * @param errorObject Error object
-     */
-    public void setErrorObject(Object errorObject) {
-        this.errorObject = errorObject;
     }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -175,14 +175,8 @@ public class AnotherFakeApi {
      */
     public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client client) throws ApiException {
         okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(client, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -167,14 +167,8 @@ public class DefaultApi {
      */
     public ApiResponse<InlineResponseDefault> fooGetWithHttpInfo() throws ApiException {
         okhttp3.Call localVarCall = fooGetValidateBeforeCall(null);
-        try {
-            Type localVarReturnType = new TypeToken<InlineResponseDefault>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<InlineResponseDefault>(){}.getType()));
-            e.setErrorObjectType(new GenericType<InlineResponseDefault>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<InlineResponseDefault>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -176,14 +176,8 @@ public class FakeApi {
      */
     public ApiResponse<HealthCheckResult> fakeHealthGetWithHttpInfo() throws ApiException {
         okhttp3.Call localVarCall = fakeHealthGetValidateBeforeCall(null);
-        try {
-            Type localVarReturnType = new TypeToken<HealthCheckResult>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<HealthCheckResult>(){}.getType()));
-            e.setErrorObjectType(new GenericType<HealthCheckResult>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<HealthCheckResult>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -302,14 +296,8 @@ public class FakeApi {
      */
     public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Boolean>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Boolean>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -429,14 +417,8 @@ public class FakeApi {
      */
     public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(outerComposite, null);
-        try {
-            Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<OuterComposite>(){}.getType()));
-            e.setErrorObjectType(new GenericType<OuterComposite>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -556,14 +538,8 @@ public class FakeApi {
      */
     public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<BigDecimal>(){}.getType()));
-            e.setErrorObjectType(new GenericType<BigDecimal>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -683,14 +659,8 @@ public class FakeApi {
      */
     public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
         okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null);
-        try {
-            Type localVarReturnType = new TypeToken<String>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<String>(){}.getType()));
-            e.setErrorObjectType(new GenericType<String>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -807,14 +777,8 @@ public class FakeApi {
      */
     public ApiResponse<List<OuterEnum>> getArrayOfEnumsWithHttpInfo() throws ApiException {
         okhttp3.Call localVarCall = getArrayOfEnumsValidateBeforeCall(null);
-        try {
-            Type localVarReturnType = new TypeToken<List<OuterEnum>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<List<OuterEnum>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<List<OuterEnum>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<List<OuterEnum>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1195,14 +1159,8 @@ public class FakeApi {
      */
     public ApiResponse<Client> testClientModelWithHttpInfo(Client client) throws ApiException {
         okhttp3.Call localVarCall = testClientModelValidateBeforeCall(client, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -175,14 +175,8 @@ public class FakeClassnameTags123Api {
      */
     public ApiResponse<Client> testClassnameWithHttpInfo(Client client) throws ApiException {
         okhttp3.Call localVarCall = testClassnameValidateBeforeCall(client, null);
-        try {
-            Type localVarReturnType = new TypeToken<Client>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Client>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Client>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Client>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/PetApi.java
@@ -437,14 +437,8 @@ public class PetApi {
      */
     public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
         okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null);
-        try {
-            Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<List<Pet>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<List<Pet>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -584,14 +578,8 @@ public class PetApi {
     @Deprecated
     public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
         okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null);
-        try {
-            Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<List<Pet>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<List<Pet>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -726,14 +714,8 @@ public class PetApi {
      */
     public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
         okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null);
-        try {
-            Type localVarReturnType = new TypeToken<Pet>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Pet>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Pet>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Pet>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1144,14 +1126,8 @@ public class PetApi {
      */
     public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws ApiException {
         okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, _file, null);
-        try {
-            Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<ModelApiResponse>(){}.getType()));
-            e.setErrorObjectType(new GenericType<ModelApiResponse>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -1298,14 +1274,8 @@ public class PetApi {
      */
     public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
         okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null);
-        try {
-            Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<ModelApiResponse>(){}.getType()));
-            e.setErrorObjectType(new GenericType<ModelApiResponse>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -294,14 +294,8 @@ public class StoreApi {
      */
     public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
         okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null);
-        try {
-            Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Map<String, Integer>>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Map<String, Integer>>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -432,14 +426,8 @@ public class StoreApi {
      */
     public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
         okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null);
-        try {
-            Type localVarReturnType = new TypeToken<Order>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Order>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Order>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Order>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -569,14 +557,8 @@ public class StoreApi {
      */
     public ApiResponse<Order> placeOrderWithHttpInfo(Order order) throws ApiException {
         okhttp3.Call localVarCall = placeOrderValidateBeforeCall(order, null);
-        try {
-            Type localVarReturnType = new TypeToken<Order>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<Order>(){}.getType()));
-            e.setErrorObjectType(new GenericType<Order>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<Order>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
@@ -676,14 +676,8 @@ public class UserApi {
      */
     public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
         okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null);
-        try {
-            Type localVarReturnType = new TypeToken<User>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<User>(){}.getType()));
-            e.setErrorObjectType(new GenericType<User>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<User>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
@@ -829,14 +823,8 @@ public class UserApi {
      */
     public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
         okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null);
-        try {
-            Type localVarReturnType = new TypeToken<String>(){}.getType();
-            return localVarApiClient.execute(localVarCall, localVarReturnType);
-        } catch (ApiException e) {
-            e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<String>(){}.getType()));
-            e.setErrorObjectType(new GenericType<String>(){});
-            throw e;
-        }
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**


### PR DESCRIPTION
Improve errorObjectType to avoid regression

To fix https://github.com/OpenAPITools/openapi-generator/pull/11538#issuecomment-1090226625

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
