### PR TITLE
[C][Client] Do not put the invalid value of the enum to a JSON structure

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -336,8 +336,20 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
         goto fail;
     }
     {{/isEnum}}
+    {{#isEnum}}
+    if ({{projectName}}_{{classVarName}}_{{enumName}}_NULL == {{{classname}}}->{{{name}}}) {
+        goto fail;
+    }
+    {{/isEnum}}
     {{/required}}
-    {{^required}}{{^isEnum}}if({{{classname}}}->{{{name}}}) { {{/isEnum}}{{/required}}
+    {{^required}}
+    {{^isEnum}}
+    if({{{classname}}}->{{{name}}}) {
+    {{/isEnum}}
+    {{#isEnum}}
+    if({{{classname}}}->{{{name}}} != {{projectName}}_{{classVarName}}_{{enumName}}_NULL) {
+    {{/isEnum}}
+    {{/required}}
     {{^isContainer}}
     {{#isPrimitiveType}}
     {{#isNumeric}}
@@ -536,7 +548,7 @@ cJSON *{{classname}}_convertToJSON({{classname}}_t *{{classname}}) {
     {{/isMap}}
     {{/isContainer}}
     {{^required}}
-    {{^isEnum}} } {{/isEnum}}
+    }
     {{/required}}
 
     {{/vars}}

--- a/samples/client/petstore/c/model/api_response.c
+++ b/samples/client/petstore/c/model/api_response.c
@@ -42,27 +42,27 @@ cJSON *api_response_convertToJSON(api_response_t *api_response) {
     cJSON *item = cJSON_CreateObject();
 
     // api_response->code
-    if(api_response->code) { 
+    if(api_response->code) {
     if(cJSON_AddNumberToObject(item, "code", api_response->code) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // api_response->type
-    if(api_response->type) { 
+    if(api_response->type) {
     if(cJSON_AddStringToObject(item, "type", api_response->type) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
 
     // api_response->message
-    if(api_response->message) { 
+    if(api_response->message) {
     if(cJSON_AddStringToObject(item, "message", api_response->message) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
     return item;
 fail:

--- a/samples/client/petstore/c/model/category.c
+++ b/samples/client/petstore/c/model/category.c
@@ -36,19 +36,19 @@ cJSON *category_convertToJSON(category_t *category) {
     cJSON *item = cJSON_CreateObject();
 
     // category->id
-    if(category->id) { 
+    if(category->id) {
     if(cJSON_AddNumberToObject(item, "id", category->id) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // category->name
-    if(category->name) { 
+    if(category->name) {
     if(cJSON_AddStringToObject(item, "name", category->name) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
     return item;
 fail:

--- a/samples/client/petstore/c/model/order.c
+++ b/samples/client/petstore/c/model/order.c
@@ -61,52 +61,52 @@ cJSON *order_convertToJSON(order_t *order) {
     cJSON *item = cJSON_CreateObject();
 
     // order->id
-    if(order->id) { 
+    if(order->id) {
     if(cJSON_AddNumberToObject(item, "id", order->id) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // order->pet_id
-    if(order->pet_id) { 
+    if(order->pet_id) {
     if(cJSON_AddNumberToObject(item, "petId", order->pet_id) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // order->quantity
-    if(order->quantity) { 
+    if(order->quantity) {
     if(cJSON_AddNumberToObject(item, "quantity", order->quantity) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // order->ship_date
-    if(order->ship_date) { 
+    if(order->ship_date) {
     if(cJSON_AddStringToObject(item, "shipDate", order->ship_date) == NULL) {
     goto fail; //Date-Time
     }
-     } 
+    }
 
 
     // order->status
-    
+    if(order->status != openapi_petstore_order_STATUS_NULL) {
     if(cJSON_AddStringToObject(item, "status", statusorder_ToString(order->status)) == NULL)
     {
     goto fail; //Enum
     }
-    
+    }
 
 
     // order->complete
-    if(order->complete) { 
+    if(order->complete) {
     if(cJSON_AddBoolToObject(item, "complete", order->complete) == NULL) {
     goto fail; //Bool
     }
-     } 
+    }
 
     return item;
 fail:

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -79,15 +79,15 @@ cJSON *pet_convertToJSON(pet_t *pet) {
     cJSON *item = cJSON_CreateObject();
 
     // pet->id
-    if(pet->id) { 
+    if(pet->id) {
     if(cJSON_AddNumberToObject(item, "id", pet->id) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // pet->category
-    if(pet->category) { 
+    if(pet->category) {
     cJSON *category_local_JSON = category_convertToJSON(pet->category);
     if(category_local_JSON == NULL) {
     goto fail; //model
@@ -96,14 +96,13 @@ cJSON *pet_convertToJSON(pet_t *pet) {
     if(item->child == NULL) {
     goto fail;
     }
-     } 
+    }
 
 
     // pet->name
     if (!pet->name) {
         goto fail;
     }
-    
     if(cJSON_AddStringToObject(item, "name", pet->name) == NULL) {
     goto fail; //String
     }
@@ -113,7 +112,6 @@ cJSON *pet_convertToJSON(pet_t *pet) {
     if (!pet->photo_urls) {
         goto fail;
     }
-    
     cJSON *photo_urls = cJSON_AddArrayToObject(item, "photoUrls");
     if(photo_urls == NULL) {
         goto fail; //primitive container
@@ -129,7 +127,7 @@ cJSON *pet_convertToJSON(pet_t *pet) {
 
 
     // pet->tags
-    if(pet->tags) { 
+    if(pet->tags) {
     cJSON *tags = cJSON_AddArrayToObject(item, "tags");
     if(tags == NULL) {
     goto fail; //nonprimitive container
@@ -145,16 +143,16 @@ cJSON *pet_convertToJSON(pet_t *pet) {
     cJSON_AddItemToArray(tags, itemLocal);
     }
     }
-     } 
+    }
 
 
     // pet->status
-    
+    if(pet->status != openapi_petstore_pet_STATUS_NULL) {
     if(cJSON_AddStringToObject(item, "status", statuspet_ToString(pet->status)) == NULL)
     {
     goto fail; //Enum
     }
-    
+    }
 
     return item;
 fail:

--- a/samples/client/petstore/c/model/tag.c
+++ b/samples/client/petstore/c/model/tag.c
@@ -36,19 +36,19 @@ cJSON *tag_convertToJSON(tag_t *tag) {
     cJSON *item = cJSON_CreateObject();
 
     // tag->id
-    if(tag->id) { 
+    if(tag->id) {
     if(cJSON_AddNumberToObject(item, "id", tag->id) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // tag->name
-    if(tag->name) { 
+    if(tag->name) {
     if(cJSON_AddStringToObject(item, "name", tag->name) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
     return item;
 fail:

--- a/samples/client/petstore/c/model/user.c
+++ b/samples/client/petstore/c/model/user.c
@@ -68,67 +68,67 @@ cJSON *user_convertToJSON(user_t *user) {
     cJSON *item = cJSON_CreateObject();
 
     // user->id
-    if(user->id) { 
+    if(user->id) {
     if(cJSON_AddNumberToObject(item, "id", user->id) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
 
     // user->username
-    if(user->username) { 
+    if(user->username) {
     if(cJSON_AddStringToObject(item, "username", user->username) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
 
     // user->first_name
-    if(user->first_name) { 
+    if(user->first_name) {
     if(cJSON_AddStringToObject(item, "firstName", user->first_name) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
 
     // user->last_name
-    if(user->last_name) { 
+    if(user->last_name) {
     if(cJSON_AddStringToObject(item, "lastName", user->last_name) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
 
     // user->email
-    if(user->email) { 
+    if(user->email) {
     if(cJSON_AddStringToObject(item, "email", user->email) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
 
     // user->password
-    if(user->password) { 
+    if(user->password) {
     if(cJSON_AddStringToObject(item, "password", user->password) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
 
     // user->phone
-    if(user->phone) { 
+    if(user->phone) {
     if(cJSON_AddStringToObject(item, "phone", user->phone) == NULL) {
     goto fail; //String
     }
-     } 
+    }
 
 
     // user->user_status
-    if(user->user_status) { 
+    if(user->user_status) {
     if(cJSON_AddNumberToObject(item, "userStatus", user->user_status) == NULL) {
     goto fail; //Numeric
     }
-     } 
+    }
 
     return item;
 fail:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The PR https://github.com/OpenAPITools/openapi-generator/pull/5477 supports the data type `enum` e.g.

```c
typedef enum  { 
    kubernetes_v1_container_IMAGEPULLPOLICY_NULL = 0, 
    kubernetes_v1_container_IMAGEPULLPOLICY_Always, 
    kubernetes_v1_container_IMAGEPULLPOLICY_IfNotPresent, 
    kubernetes_v1_container_IMAGEPULLPOLICY_Never 
} kubernetes_v1_container_IMAGEPULLPOLICY_e;
```

And the default value is `kubernetes_v1_container_IMAGEPULLPOLICY_NULL` if the enum data does not appear in json string at all. 

Actually `kubernetes_v1_container_IMAGEPULLPOLICY_NULL` is invalid to API server because it is not defined in OpenAPI Spec. So it should not be passed to API server.

But in the function `*_convertToJSON`, the current code puts the value to the JSON structure (which will be passed to the API server) whether or not the value is valid.
 
This PR will fix this issue. When the value of enum is `kubernetes_v1_container_IMAGEPULLPOLICY_NULL`, it will be ignored by `*_convertToJSON`

@wing328 @zhemant @michelealbano

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
