### PR TITLE
[Dart] fix toJson() incorrectly shadowing fields named 'json'

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -52,7 +52,7 @@ class {{{classname}}} {
   String toString() => '{{{classname}}}[{{#vars}}{{{name}}}=${{{name}}}{{^-last}}, {{/-last}}{{/vars}}]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
   {{#vars}}
     {{#isNullable}}
     if ({{{name}}} != null) {
@@ -66,27 +66,27 @@ class {{{classname}}} {
     {{/isNullable}}
     {{#isDateTime}}
       {{#pattern}}
-      json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
+      _json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
         ? {{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
         : {{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
       {{/pattern}}
       {{^pattern}}
-      json[r'{{{baseName}}}'] = {{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
+      _json[r'{{{baseName}}}'] = {{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
       {{/pattern}}
     {{/isDateTime}}
     {{#isDate}}
       {{#pattern}}
-      json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
+      _json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
         ? {{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
         : _dateFormatter.format({{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
       {{/pattern}}
       {{^pattern}}
-      json[r'{{{baseName}}}'] = _dateFormatter.format({{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
+      _json[r'{{{baseName}}}'] = _dateFormatter.format({{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
       {{/pattern}}
     {{/isDate}}
     {{^isDateTime}}
       {{^isDate}}
-      json[r'{{{baseName}}}'] = {{{name}}};
+      _json[r'{{{baseName}}}'] = {{{name}}};
       {{/isDate}}
     {{/isDateTime}}
     {{#isNullable}}
@@ -100,7 +100,7 @@ class {{{classname}}} {
       {{/required}}
     {{/isNullable}}
   {{/vars}}
-    return json;
+    return _json;
   }
 
   /// Returns a new [{{{classname}}}] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -59,17 +59,17 @@ class ApiResponse {
   String toString() => 'ApiResponse[code=$code, type=$type, message=$message]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (code != null) {
-      json[r'code'] = code;
+      _json[r'code'] = code;
     }
     if (type != null) {
-      json[r'type'] = type;
+      _json[r'type'] = type;
     }
     if (message != null) {
-      json[r'message'] = message;
+      _json[r'message'] = message;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ApiResponse] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -48,14 +48,14 @@ class Category {
   String toString() => 'Category[id=$id, name=$name]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (name != null) {
-      json[r'name'] = name;
+      _json[r'name'] = name;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Category] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -81,24 +81,24 @@ class Order {
   String toString() => 'Order[id=$id, petId=$petId, quantity=$quantity, shipDate=$shipDate, status=$status, complete=$complete]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (petId != null) {
-      json[r'petId'] = petId;
+      _json[r'petId'] = petId;
     }
     if (quantity != null) {
-      json[r'quantity'] = quantity;
+      _json[r'quantity'] = quantity;
     }
     if (shipDate != null) {
-      json[r'shipDate'] = shipDate!.toUtc().toIso8601String();
+      _json[r'shipDate'] = shipDate!.toUtc().toIso8601String();
     }
     if (status != null) {
-      json[r'status'] = status;
+      _json[r'status'] = status;
     }
-      json[r'complete'] = complete;
-    return json;
+      _json[r'complete'] = complete;
+    return _json;
   }
 
   /// Returns a new [Order] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -69,20 +69,20 @@ class Pet {
   String toString() => 'Pet[id=$id, category=$category, name=$name, photoUrls=$photoUrls, tags=$tags, status=$status]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (category != null) {
-      json[r'category'] = category;
+      _json[r'category'] = category;
     }
-      json[r'name'] = name;
-      json[r'photoUrls'] = photoUrls;
-      json[r'tags'] = tags;
+      _json[r'name'] = name;
+      _json[r'photoUrls'] = photoUrls;
+      _json[r'tags'] = tags;
     if (status != null) {
-      json[r'status'] = status;
+      _json[r'status'] = status;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Pet] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -48,14 +48,14 @@ class Tag {
   String toString() => 'Tag[id=$id, name=$name]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (name != null) {
-      json[r'name'] = name;
+      _json[r'name'] = name;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Tag] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -115,32 +115,32 @@ class User {
   String toString() => 'User[id=$id, username=$username, firstName=$firstName, lastName=$lastName, email=$email, password=$password, phone=$phone, userStatus=$userStatus]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (username != null) {
-      json[r'username'] = username;
+      _json[r'username'] = username;
     }
     if (firstName != null) {
-      json[r'firstName'] = firstName;
+      _json[r'firstName'] = firstName;
     }
     if (lastName != null) {
-      json[r'lastName'] = lastName;
+      _json[r'lastName'] = lastName;
     }
     if (email != null) {
-      json[r'email'] = email;
+      _json[r'email'] = email;
     }
     if (password != null) {
-      json[r'password'] = password;
+      _json[r'password'] = password;
     }
     if (phone != null) {
-      json[r'phone'] = phone;
+      _json[r'phone'] = phone;
     }
     if (userStatus != null) {
-      json[r'userStatus'] = userStatus;
+      _json[r'userStatus'] = userStatus;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [User] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -36,10 +36,10 @@ class AdditionalPropertiesClass {
   String toString() => 'AdditionalPropertiesClass[mapProperty=$mapProperty, mapOfMapProperty=$mapOfMapProperty]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'map_property'] = mapProperty;
-      json[r'map_of_map_property'] = mapOfMapProperty;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'map_property'] = mapProperty;
+      _json[r'map_of_map_property'] = mapOfMapProperty;
+    return _json;
   }
 
   /// Returns a new [AdditionalPropertiesClass] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
@@ -36,10 +36,10 @@ class Animal {
   String toString() => 'Animal[className=$className, color=$color]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'className'] = className;
-      json[r'color'] = color;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'className'] = className;
+      _json[r'color'] = color;
+    return _json;
   }
 
   /// Returns a new [Animal] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
@@ -59,17 +59,17 @@ class ApiResponse {
   String toString() => 'ApiResponse[code=$code, type=$type, message=$message]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (code != null) {
-      json[r'code'] = code;
+      _json[r'code'] = code;
     }
     if (type != null) {
-      json[r'type'] = type;
+      _json[r'type'] = type;
     }
     if (message != null) {
-      json[r'message'] = message;
+      _json[r'message'] = message;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ApiResponse] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -31,9 +31,9 @@ class ArrayOfArrayOfNumberOnly {
   String toString() => 'ArrayOfArrayOfNumberOnly[arrayArrayNumber=$arrayArrayNumber]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'ArrayArrayNumber'] = arrayArrayNumber;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'ArrayArrayNumber'] = arrayArrayNumber;
+    return _json;
   }
 
   /// Returns a new [ArrayOfArrayOfNumberOnly] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -31,9 +31,9 @@ class ArrayOfNumberOnly {
   String toString() => 'ArrayOfNumberOnly[arrayNumber=$arrayNumber]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'ArrayNumber'] = arrayNumber;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'ArrayNumber'] = arrayNumber;
+    return _json;
   }
 
   /// Returns a new [ArrayOfNumberOnly] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -41,11 +41,11 @@ class ArrayTest {
   String toString() => 'ArrayTest[arrayOfString=$arrayOfString, arrayArrayOfInteger=$arrayArrayOfInteger, arrayArrayOfModel=$arrayArrayOfModel]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'array_of_string'] = arrayOfString;
-      json[r'array_array_of_integer'] = arrayArrayOfInteger;
-      json[r'array_array_of_model'] = arrayArrayOfModel;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'array_of_string'] = arrayOfString;
+      _json[r'array_array_of_integer'] = arrayArrayOfInteger;
+      _json[r'array_array_of_model'] = arrayArrayOfModel;
+    return _json;
   }
 
   /// Returns a new [ArrayTest] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -93,26 +93,26 @@ class Capitalization {
   String toString() => 'Capitalization[smallCamel=$smallCamel, capitalCamel=$capitalCamel, smallSnake=$smallSnake, capitalSnake=$capitalSnake, sCAETHFlowPoints=$sCAETHFlowPoints, ATT_NAME=$ATT_NAME]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (smallCamel != null) {
-      json[r'smallCamel'] = smallCamel;
+      _json[r'smallCamel'] = smallCamel;
     }
     if (capitalCamel != null) {
-      json[r'CapitalCamel'] = capitalCamel;
+      _json[r'CapitalCamel'] = capitalCamel;
     }
     if (smallSnake != null) {
-      json[r'small_Snake'] = smallSnake;
+      _json[r'small_Snake'] = smallSnake;
     }
     if (capitalSnake != null) {
-      json[r'Capital_Snake'] = capitalSnake;
+      _json[r'Capital_Snake'] = capitalSnake;
     }
     if (sCAETHFlowPoints != null) {
-      json[r'SCA_ETH_Flow_Points'] = sCAETHFlowPoints;
+      _json[r'SCA_ETH_Flow_Points'] = sCAETHFlowPoints;
     }
     if (ATT_NAME != null) {
-      json[r'ATT_NAME'] = ATT_NAME;
+      _json[r'ATT_NAME'] = ATT_NAME;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Capitalization] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
@@ -47,13 +47,13 @@ class Cat {
   String toString() => 'Cat[className=$className, color=$color, declawed=$declawed]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'className'] = className;
-      json[r'color'] = color;
+    final _json = <String, dynamic>{};
+      _json[r'className'] = className;
+      _json[r'color'] = color;
     if (declawed != null) {
-      json[r'declawed'] = declawed;
+      _json[r'declawed'] = declawed;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Cat] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat_all_of.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat_all_of.dart
@@ -37,11 +37,11 @@ class CatAllOf {
   String toString() => 'CatAllOf[declawed=$declawed]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (declawed != null) {
-      json[r'declawed'] = declawed;
+      _json[r'declawed'] = declawed;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [CatAllOf] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
@@ -42,12 +42,12 @@ class Category {
   String toString() => 'Category[id=$id, name=$name]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
-      json[r'name'] = name;
-    return json;
+      _json[r'name'] = name;
+    return _json;
   }
 
   /// Returns a new [Category] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
@@ -37,11 +37,11 @@ class ClassModel {
   String toString() => 'ClassModel[class_=$class_]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (class_ != null) {
-      json[r'_class'] = class_;
+      _json[r'_class'] = class_;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ClassModel] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
@@ -37,11 +37,11 @@ class DeprecatedObject {
   String toString() => 'DeprecatedObject[name=$name]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (name != null) {
-      json[r'name'] = name;
+      _json[r'name'] = name;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [DeprecatedObject] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
@@ -47,13 +47,13 @@ class Dog {
   String toString() => 'Dog[className=$className, color=$color, breed=$breed]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'className'] = className;
-      json[r'color'] = color;
+    final _json = <String, dynamic>{};
+      _json[r'className'] = className;
+      _json[r'color'] = color;
     if (breed != null) {
-      json[r'breed'] = breed;
+      _json[r'breed'] = breed;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Dog] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog_all_of.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog_all_of.dart
@@ -37,11 +37,11 @@ class DogAllOf {
   String toString() => 'DogAllOf[breed=$breed]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (breed != null) {
-      json[r'breed'] = breed;
+      _json[r'breed'] = breed;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [DogAllOf] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -36,12 +36,12 @@ class EnumArrays {
   String toString() => 'EnumArrays[justSymbol=$justSymbol, arrayEnum=$arrayEnum]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (justSymbol != null) {
-      json[r'just_symbol'] = justSymbol;
+      _json[r'just_symbol'] = justSymbol;
     }
-      json[r'array_enum'] = arrayEnum;
-    return json;
+      _json[r'array_enum'] = arrayEnum;
+    return _json;
   }
 
   /// Returns a new [EnumArrays] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -84,30 +84,30 @@ class EnumTest {
   String toString() => 'EnumTest[enumString=$enumString, enumStringRequired=$enumStringRequired, enumInteger=$enumInteger, enumNumber=$enumNumber, outerEnum=$outerEnum, outerEnumInteger=$outerEnumInteger, outerEnumDefaultValue=$outerEnumDefaultValue, outerEnumIntegerDefaultValue=$outerEnumIntegerDefaultValue]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (enumString != null) {
-      json[r'enum_string'] = enumString;
+      _json[r'enum_string'] = enumString;
     }
-      json[r'enum_string_required'] = enumStringRequired;
+      _json[r'enum_string_required'] = enumStringRequired;
     if (enumInteger != null) {
-      json[r'enum_integer'] = enumInteger;
+      _json[r'enum_integer'] = enumInteger;
     }
     if (enumNumber != null) {
-      json[r'enum_number'] = enumNumber;
+      _json[r'enum_number'] = enumNumber;
     }
     if (outerEnum != null) {
-      json[r'outerEnum'] = outerEnum;
+      _json[r'outerEnum'] = outerEnum;
     }
     if (outerEnumInteger != null) {
-      json[r'outerEnumInteger'] = outerEnumInteger;
+      _json[r'outerEnumInteger'] = outerEnumInteger;
     }
     if (outerEnumDefaultValue != null) {
-      json[r'outerEnumDefaultValue'] = outerEnumDefaultValue;
+      _json[r'outerEnumDefaultValue'] = outerEnumDefaultValue;
     }
     if (outerEnumIntegerDefaultValue != null) {
-      json[r'outerEnumIntegerDefaultValue'] = outerEnumIntegerDefaultValue;
+      _json[r'outerEnumIntegerDefaultValue'] = outerEnumIntegerDefaultValue;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [EnumTest] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -42,12 +42,12 @@ class FileSchemaTestClass {
   String toString() => 'FileSchemaTestClass[file=$file, files=$files]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (file != null) {
-      json[r'file'] = file;
+      _json[r'file'] = file;
     }
-      json[r'files'] = files;
-    return json;
+      _json[r'files'] = files;
+    return _json;
   }
 
   /// Returns a new [FileSchemaTestClass] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
@@ -31,9 +31,9 @@ class Foo {
   String toString() => 'Foo[bar=$bar]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'bar'] = bar;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'bar'] = bar;
+    return _json;
   }
 
   /// Returns a new [Foo] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -190,48 +190,48 @@ class FormatTest {
   String toString() => 'FormatTest[integer=$integer, int32=$int32, int64=$int64, number=$number, float=$float, double_=$double_, decimal=$decimal, string=$string, byte=$byte, binary=$binary, date=$date, dateTime=$dateTime, uuid=$uuid, password=$password, patternWithDigits=$patternWithDigits, patternWithDigitsAndDelimiter=$patternWithDigitsAndDelimiter]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (integer != null) {
-      json[r'integer'] = integer;
+      _json[r'integer'] = integer;
     }
     if (int32 != null) {
-      json[r'int32'] = int32;
+      _json[r'int32'] = int32;
     }
     if (int64 != null) {
-      json[r'int64'] = int64;
+      _json[r'int64'] = int64;
     }
-      json[r'number'] = number;
+      _json[r'number'] = number;
     if (float != null) {
-      json[r'float'] = float;
+      _json[r'float'] = float;
     }
     if (double_ != null) {
-      json[r'double'] = double_;
+      _json[r'double'] = double_;
     }
     if (decimal != null) {
-      json[r'decimal'] = decimal;
+      _json[r'decimal'] = decimal;
     }
     if (string != null) {
-      json[r'string'] = string;
+      _json[r'string'] = string;
     }
-      json[r'byte'] = byte;
+      _json[r'byte'] = byte;
     if (binary != null) {
-      json[r'binary'] = binary;
+      _json[r'binary'] = binary;
     }
-      json[r'date'] = _dateFormatter.format(date.toUtc());
+      _json[r'date'] = _dateFormatter.format(date.toUtc());
     if (dateTime != null) {
-      json[r'dateTime'] = dateTime!.toUtc().toIso8601String();
+      _json[r'dateTime'] = dateTime!.toUtc().toIso8601String();
     }
     if (uuid != null) {
-      json[r'uuid'] = uuid;
+      _json[r'uuid'] = uuid;
     }
-      json[r'password'] = password;
+      _json[r'password'] = password;
     if (patternWithDigits != null) {
-      json[r'pattern_with_digits'] = patternWithDigits;
+      _json[r'pattern_with_digits'] = patternWithDigits;
     }
     if (patternWithDigitsAndDelimiter != null) {
-      json[r'pattern_with_digits_and_delimiter'] = patternWithDigitsAndDelimiter;
+      _json[r'pattern_with_digits_and_delimiter'] = patternWithDigitsAndDelimiter;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [FormatTest] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -48,14 +48,14 @@ class HasOnlyReadOnly {
   String toString() => 'HasOnlyReadOnly[bar=$bar, foo=$foo]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (bar != null) {
-      json[r'bar'] = bar;
+      _json[r'bar'] = bar;
     }
     if (foo != null) {
-      json[r'foo'] = foo;
+      _json[r'foo'] = foo;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [HasOnlyReadOnly] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -31,11 +31,11 @@ class HealthCheckResult {
   String toString() => 'HealthCheckResult[nullableMessage=$nullableMessage]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (nullableMessage != null) {
-      json[r'NullableMessage'] = nullableMessage;
+      _json[r'NullableMessage'] = nullableMessage;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [HealthCheckResult] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_response_default.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_response_default.dart
@@ -37,11 +37,11 @@ class InlineResponseDefault {
   String toString() => 'InlineResponseDefault[string=$string]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (string != null) {
-      json[r'string'] = string;
+      _json[r'string'] = string;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [InlineResponseDefault] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -46,12 +46,12 @@ class MapTest {
   String toString() => 'MapTest[mapMapOfString=$mapMapOfString, mapOfEnumString=$mapOfEnumString, directMap=$directMap, indirectMap=$indirectMap]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'map_map_of_string'] = mapMapOfString;
-      json[r'map_of_enum_string'] = mapOfEnumString;
-      json[r'direct_map'] = directMap;
-      json[r'indirect_map'] = indirectMap;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'map_map_of_string'] = mapMapOfString;
+      _json[r'map_of_enum_string'] = mapOfEnumString;
+      _json[r'direct_map'] = directMap;
+      _json[r'indirect_map'] = indirectMap;
+    return _json;
   }
 
   /// Returns a new [MapTest] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -53,15 +53,15 @@ class MixedPropertiesAndAdditionalPropertiesClass {
   String toString() => 'MixedPropertiesAndAdditionalPropertiesClass[uuid=$uuid, dateTime=$dateTime, map=$map]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (uuid != null) {
-      json[r'uuid'] = uuid;
+      _json[r'uuid'] = uuid;
     }
     if (dateTime != null) {
-      json[r'dateTime'] = dateTime!.toUtc().toIso8601String();
+      _json[r'dateTime'] = dateTime!.toUtc().toIso8601String();
     }
-      json[r'map'] = map;
-    return json;
+      _json[r'map'] = map;
+    return _json;
   }
 
   /// Returns a new [MixedPropertiesAndAdditionalPropertiesClass] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -48,14 +48,14 @@ class Model200Response {
   String toString() => 'Model200Response[name=$name, class_=$class_]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (name != null) {
-      json[r'name'] = name;
+      _json[r'name'] = name;
     }
     if (class_ != null) {
-      json[r'class'] = class_;
+      _json[r'class'] = class_;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Model200Response] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
@@ -37,11 +37,11 @@ class ModelClient {
   String toString() => 'ModelClient[client=$client]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (client != null) {
-      json[r'client'] = client;
+      _json[r'client'] = client;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ModelClient] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
@@ -38,11 +38,11 @@ class ModelFile {
   String toString() => 'ModelFile[sourceURI=$sourceURI]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (sourceURI != null) {
-      json[r'sourceURI'] = sourceURI;
+      _json[r'sourceURI'] = sourceURI;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ModelFile] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
@@ -37,11 +37,11 @@ class ModelList {
   String toString() => 'ModelList[n123list=$n123list]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (n123list != null) {
-      json[r'123-list'] = n123list;
+      _json[r'123-list'] = n123list;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ModelList] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
@@ -37,11 +37,11 @@ class ModelReturn {
   String toString() => 'ModelReturn[return_=$return_]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (return_ != null) {
-      json[r'return'] = return_;
+      _json[r'return'] = return_;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ModelReturn] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
@@ -64,18 +64,18 @@ class Name {
   String toString() => 'Name[name=$name, snakeCase=$snakeCase, property=$property, n123number=$n123number]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'name'] = name;
+    final _json = <String, dynamic>{};
+      _json[r'name'] = name;
     if (snakeCase != null) {
-      json[r'snake_case'] = snakeCase;
+      _json[r'snake_case'] = snakeCase;
     }
     if (property != null) {
-      json[r'property'] = property;
+      _json[r'property'] = property;
     }
     if (n123number != null) {
-      json[r'123Number'] = n123number;
+      _json[r'123Number'] = n123number;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Name] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -86,40 +86,40 @@ class NullableClass {
   String toString() => 'NullableClass[integerProp=$integerProp, numberProp=$numberProp, booleanProp=$booleanProp, stringProp=$stringProp, dateProp=$dateProp, datetimeProp=$datetimeProp, arrayNullableProp=$arrayNullableProp, arrayAndItemsNullableProp=$arrayAndItemsNullableProp, arrayItemsNullable=$arrayItemsNullable, objectNullableProp=$objectNullableProp, objectAndItemsNullableProp=$objectAndItemsNullableProp, objectItemsNullable=$objectItemsNullable]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (integerProp != null) {
-      json[r'integer_prop'] = integerProp;
+      _json[r'integer_prop'] = integerProp;
     }
     if (numberProp != null) {
-      json[r'number_prop'] = numberProp;
+      _json[r'number_prop'] = numberProp;
     }
     if (booleanProp != null) {
-      json[r'boolean_prop'] = booleanProp;
+      _json[r'boolean_prop'] = booleanProp;
     }
     if (stringProp != null) {
-      json[r'string_prop'] = stringProp;
+      _json[r'string_prop'] = stringProp;
     }
     if (dateProp != null) {
-      json[r'date_prop'] = _dateFormatter.format(dateProp!.toUtc());
+      _json[r'date_prop'] = _dateFormatter.format(dateProp!.toUtc());
     }
     if (datetimeProp != null) {
-      json[r'datetime_prop'] = datetimeProp!.toUtc().toIso8601String();
+      _json[r'datetime_prop'] = datetimeProp!.toUtc().toIso8601String();
     }
     if (arrayNullableProp != null) {
-      json[r'array_nullable_prop'] = arrayNullableProp;
+      _json[r'array_nullable_prop'] = arrayNullableProp;
     }
     if (arrayAndItemsNullableProp != null) {
-      json[r'array_and_items_nullable_prop'] = arrayAndItemsNullableProp;
+      _json[r'array_and_items_nullable_prop'] = arrayAndItemsNullableProp;
     }
-      json[r'array_items_nullable'] = arrayItemsNullable;
+      _json[r'array_items_nullable'] = arrayItemsNullable;
     if (objectNullableProp != null) {
-      json[r'object_nullable_prop'] = objectNullableProp;
+      _json[r'object_nullable_prop'] = objectNullableProp;
     }
     if (objectAndItemsNullableProp != null) {
-      json[r'object_and_items_nullable_prop'] = objectAndItemsNullableProp;
+      _json[r'object_and_items_nullable_prop'] = objectAndItemsNullableProp;
     }
-      json[r'object_items_nullable'] = objectItemsNullable;
-    return json;
+      _json[r'object_items_nullable'] = objectItemsNullable;
+    return _json;
   }
 
   /// Returns a new [NullableClass] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -37,11 +37,11 @@ class NumberOnly {
   String toString() => 'NumberOnly[justNumber=$justNumber]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (justNumber != null) {
-      json[r'JustNumber'] = justNumber;
+      _json[r'JustNumber'] = justNumber;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [NumberOnly] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -64,18 +64,18 @@ class ObjectWithDeprecatedFields {
   String toString() => 'ObjectWithDeprecatedFields[uuid=$uuid, id=$id, deprecatedRef=$deprecatedRef, bars=$bars]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (uuid != null) {
-      json[r'uuid'] = uuid;
+      _json[r'uuid'] = uuid;
     }
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (deprecatedRef != null) {
-      json[r'deprecatedRef'] = deprecatedRef;
+      _json[r'deprecatedRef'] = deprecatedRef;
     }
-      json[r'bars'] = bars;
-    return json;
+      _json[r'bars'] = bars;
+    return _json;
   }
 
   /// Returns a new [ObjectWithDeprecatedFields] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -81,24 +81,24 @@ class Order {
   String toString() => 'Order[id=$id, petId=$petId, quantity=$quantity, shipDate=$shipDate, status=$status, complete=$complete]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (petId != null) {
-      json[r'petId'] = petId;
+      _json[r'petId'] = petId;
     }
     if (quantity != null) {
-      json[r'quantity'] = quantity;
+      _json[r'quantity'] = quantity;
     }
     if (shipDate != null) {
-      json[r'shipDate'] = shipDate!.toUtc().toIso8601String();
+      _json[r'shipDate'] = shipDate!.toUtc().toIso8601String();
     }
     if (status != null) {
-      json[r'status'] = status;
+      _json[r'status'] = status;
     }
-      json[r'complete'] = complete;
-    return json;
+      _json[r'complete'] = complete;
+    return _json;
   }
 
   /// Returns a new [Order] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -59,17 +59,17 @@ class OuterComposite {
   String toString() => 'OuterComposite[myNumber=$myNumber, myString=$myString, myBoolean=$myBoolean]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (myNumber != null) {
-      json[r'my_number'] = myNumber;
+      _json[r'my_number'] = myNumber;
     }
     if (myString != null) {
-      json[r'my_string'] = myString;
+      _json[r'my_string'] = myString;
     }
     if (myBoolean != null) {
-      json[r'my_boolean'] = myBoolean;
+      _json[r'my_boolean'] = myBoolean;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [OuterComposite] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
@@ -31,9 +31,9 @@ class OuterObjectWithEnumProperty {
   String toString() => 'OuterObjectWithEnumProperty[value=$value]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-      json[r'value'] = value;
-    return json;
+    final _json = <String, dynamic>{};
+      _json[r'value'] = value;
+    return _json;
   }
 
   /// Returns a new [OuterObjectWithEnumProperty] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -69,20 +69,20 @@ class Pet {
   String toString() => 'Pet[id=$id, category=$category, name=$name, photoUrls=$photoUrls, tags=$tags, status=$status]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (category != null) {
-      json[r'category'] = category;
+      _json[r'category'] = category;
     }
-      json[r'name'] = name;
-      json[r'photoUrls'] = photoUrls;
-      json[r'tags'] = tags;
+      _json[r'name'] = name;
+      _json[r'photoUrls'] = photoUrls;
+      _json[r'tags'] = tags;
     if (status != null) {
-      json[r'status'] = status;
+      _json[r'status'] = status;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Pet] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -48,14 +48,14 @@ class ReadOnlyFirst {
   String toString() => 'ReadOnlyFirst[bar=$bar, baz=$baz]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (bar != null) {
-      json[r'bar'] = bar;
+      _json[r'bar'] = bar;
     }
     if (baz != null) {
-      json[r'baz'] = baz;
+      _json[r'baz'] = baz;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [ReadOnlyFirst] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -37,11 +37,11 @@ class SpecialModelName {
   String toString() => 'SpecialModelName[dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket=$dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket != null) {
-      json[r'$special[property.name]'] = dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket;
+      _json[r'$special[property.name]'] = dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [SpecialModelName] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
@@ -48,14 +48,14 @@ class Tag {
   String toString() => 'Tag[id=$id, name=$name]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (name != null) {
-      json[r'name'] = name;
+      _json[r'name'] = name;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [Tag] instance and imports its values from

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
@@ -120,35 +120,35 @@ class User {
   String toString() => 'User[id=$id, username=$username, firstName=$firstName, lastName=$lastName, email=$email, password=$password, phone=$phone, userStatus=$userStatus, userType=$userType]';
 
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+    final _json = <String, dynamic>{};
     if (id != null) {
-      json[r'id'] = id;
+      _json[r'id'] = id;
     }
     if (username != null) {
-      json[r'username'] = username;
+      _json[r'username'] = username;
     }
     if (firstName != null) {
-      json[r'firstName'] = firstName;
+      _json[r'firstName'] = firstName;
     }
     if (lastName != null) {
-      json[r'lastName'] = lastName;
+      _json[r'lastName'] = lastName;
     }
     if (email != null) {
-      json[r'email'] = email;
+      _json[r'email'] = email;
     }
     if (password != null) {
-      json[r'password'] = password;
+      _json[r'password'] = password;
     }
     if (phone != null) {
-      json[r'phone'] = phone;
+      _json[r'phone'] = phone;
     }
     if (userStatus != null) {
-      json[r'userStatus'] = userStatus;
+      _json[r'userStatus'] = userStatus;
     }
     if (userType != null) {
-      json[r'userType'] = userType;
+      _json[r'userType'] = userType;
     }
-    return json;
+    return _json;
   }
 
   /// Returns a new [User] instance and imports its values from


### PR DESCRIPTION
This PR addresses #12127 , where the generated `toJson()` methods would shadow member fields named `json` and create unserializable datatypes.

The easy fix, as supported by @kuhnroyal, is to change references to the generated `json` variable to `_json` instead. 

* fixes https://github.com/OpenAPITools/openapi-generator/issues/12127

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard @josh-burton @amondnet @sbu-WBT  @kuhnroyal @agilob @ahmednfwela