### PR TITLE
[java-micronaut] Support Optional for non-required properties

### DIFF
--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -72,6 +72,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
 |title|Client service name| |null|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useOptional|Use Optional container for optional parameters| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -74,6 +74,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |title|Client service name| |null|
 |useAuth|Whether to import authorization and to annotate controller methods accordingly| |true|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|useOptional|Use Optional container for optional parameters| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
@@ -3,6 +3,7 @@ package org.openapitools.codegen.languages;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
+import org.openapitools.codegen.languages.features.OptionalFeatures;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.model.ModelMap;
@@ -15,7 +16,7 @@ import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.CodegenConstants.INVOKER_PACKAGE;
 
-public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen implements BeanValidationFeatures {
+public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen implements BeanValidationFeatures, OptionalFeatures {
     public static final String OPT_TITLE = "title";
     public static final String OPT_BUILD = "build";
     public static final String OPT_BUILD_GRADLE = "gradle";
@@ -34,6 +35,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
 
     protected String title;
     protected boolean useBeanValidation;
+    protected boolean useOptional;
     protected String buildTool;
     protected String testTool;
     protected boolean requiredPropertiesInConstructor = true;
@@ -52,6 +54,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
 
         // Set all the fields
         useBeanValidation = true;
+        useOptional = false;
         buildTool = OPT_BUILD_ALL;
         testTool = OPT_TEST_JUNIT;
         outputFolder = "generated-code/java-micronaut-client";
@@ -95,6 +98,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
         cliOptions.add(new CliOption(OPT_TITLE, "Client service name").defaultValue(title));
         cliOptions.add(new CliOption(OPT_MICRONAUT_VERSION, "Micronaut version, only >=3.0.0 versions are supported").defaultValue(micronautVersion));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations", useBeanValidation));
+        cliOptions.add(CliOption.newBoolean(USE_OPTIONAL, "Use Optional container for optional parameters", useOptional));
         cliOptions.add(CliOption.newBoolean(OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR, "Allow only to create models with all the required properties provided in constructor", requiredPropertiesInConstructor));
 
         CliOption buildToolOption = new CliOption(OPT_BUILD, "Specify for which build tool to generate files").defaultValue(buildTool);
@@ -157,6 +161,11 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
             this.setUseBeanValidation(convertPropertyToBoolean(USE_BEANVALIDATION));
         }
         writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
+
+        if (additionalProperties.containsKey(USE_OPTIONAL)) {
+            this.setUseOptional(convertPropertyToBoolean(USE_OPTIONAL));
+        }
+        writePropertyBack(USE_OPTIONAL, useOptional);
 
         if (additionalProperties.containsKey(OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR)) {
             this.requiredPropertiesInConstructor = convertPropertyToBoolean(OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR);
@@ -307,6 +316,11 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     }
 
     @Override
+    public void setUseOptional(boolean useOptional) {
+        this.useOptional = useOptional;
+    }
+
+    @Override
     public String toApiVarName(String name) {
         String apiVarName = super.toApiVarName(name);
         if (reservedWords.contains(apiVarName)) {
@@ -317,6 +331,10 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
 
     public boolean isUseBeanValidation() {
         return useBeanValidation;
+    }
+
+    public boolean isUseOptional() {
+        return useOptional;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/beanValidation.mustache
@@ -5,8 +5,8 @@ validate all pojos and enums
 nullable & nonnull
 }}{{#required}}{{#isNullable}}    @Nullable
 {{/isNullable}}{{^isNullable}}    @NotNull
-{{/isNullable}}{{/required}}{{^required}}    @Nullable
-{{/required}}{{!
+{{/isNullable}}{{/required}}{{^required}}{{^useOptional}}    @Nullable
+{{/useOptional}}{{/required}}{{!
 pattern
 }}{{#pattern}}{{^isByteArray}}    @Pattern(regexp="{{{pattern}}}")
 {{/isByteArray}}{{/pattern}}{{!

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/model.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/model.mustache
@@ -7,6 +7,9 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 {{/useReflectionEqualsHashCode}}
 import java.util.Objects;
 import java.util.Arrays;
+{{#useOptional}}
+import java.util.Optional;
+{{/useOptional}}
 {{#imports}}
 import {{import}};
 {{/imports}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
@@ -186,7 +186,7 @@ Declare the class with extends and implements
         {{/vendorExtensions.x-is-jackson-optional-nullable}}
         {{^vendorExtensions.x-is-jackson-optional-nullable}}
             {{#jackson}}
-{{>common/model/jackson_annotations}}{{/jackson}}{{/vendorExtensions.x-is-jackson-optional-nullable}}       public {{{datatypeWithEnum}}} {{getter}}() {
+{{>common/model/jackson_annotations}}{{/jackson}}{{/vendorExtensions.x-is-jackson-optional-nullable}}    public {{#useOptional}}{{^required}}Optional<{{/required}}{{/useOptional}}{{{datatypeWithEnum}}}{{#useOptional}}{{^required}}>{{/required}}{{/useOptional}} {{getter}}() {
         {{#vendorExtensions.x-is-jackson-optional-nullable}}
             {{#isReadOnly}}
 {{! A readonly attribute doesn't have setter => jackson will set null directly if explicitly returned by API, so make sure we have an empty JsonNullable}}    if ({{name}} == null) {
@@ -196,7 +196,17 @@ Declare the class with extends and implements
         return {{name}}.orElse(null);
         {{/vendorExtensions.x-is-jackson-optional-nullable}}
         {{^vendorExtensions.x-is-jackson-optional-nullable}}
+          {{#useOptional}}
+            {{#required}}
         return {{name}};
+            {{/required}}
+            {{^required}}
+        return Optional.ofNullable({{name}});
+            {{/required}}
+          {{/useOptional}}
+          {{^useOptional}}
+        return {{name}};
+          {{/useOptional}}
         {{/vendorExtensions.x-is-jackson-optional-nullable}}
     }
 


### PR DESCRIPTION
The Micronaut generator by default adds the `@Nullable` annotation to
non-required properties and allows using the Jackson JsonNullable
wrapper but it is not possible to use java.util.Optional as a wrapper
for optional properties.

This change adds support for using the Optional wrapper for non-required
properties.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee]@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @wing328 