### PR TITLE
[Java] Ignore return value for Java file assert classes

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/AbstractAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/AbstractAnnotationAssert.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.ListAssert;
+import org.assertj.core.util.CanIgnoreReturnValue;
 
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
@@ -15,6 +16,7 @@ import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.google.common.collect.ImmutableMap;
 
+@CanIgnoreReturnValue
 public abstract class AbstractAnnotationAssert<ACTUAL extends AbstractAnnotationAssert<ACTUAL>> extends ListAssert<AnnotationExpr> {
 
     protected AbstractAnnotationAssert(final List<AnnotationExpr> annotationExpr) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/JavaFileAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/JavaFileAssert.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.util.CanIgnoreReturnValue;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -17,6 +18,7 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 
+@CanIgnoreReturnValue
 public class JavaFileAssert extends AbstractAssert<JavaFileAssert, CompilationUnit> {
 
     private JavaFileAssert(final CompilationUnit actual) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/MethodAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/MethodAnnotationAssert.java
@@ -2,8 +2,11 @@ package org.openapitools.codegen.java.assertions;
 
 import java.util.List;
 
+import org.assertj.core.util.CanIgnoreReturnValue;
+
 import com.github.javaparser.ast.expr.AnnotationExpr;
 
+@CanIgnoreReturnValue
 public class MethodAnnotationAssert extends AbstractAnnotationAssert<MethodAnnotationAssert> {
 
     private final MethodAssert methodAssert;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/MethodAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/MethodAssert.java
@@ -6,13 +6,14 @@ import java.util.stream.Collectors;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.util.CanIgnoreReturnValue;
 
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 
+@CanIgnoreReturnValue
 public class MethodAssert extends AbstractAssert<MethodAssert, MethodDeclaration> {
 
     private final JavaFileAssert fileAssert;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ParameterAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ParameterAnnotationAssert.java
@@ -2,8 +2,11 @@ package org.openapitools.codegen.java.assertions;
 
 import java.util.List;
 
+import org.assertj.core.util.CanIgnoreReturnValue;
+
 import com.github.javaparser.ast.expr.AnnotationExpr;
 
+@CanIgnoreReturnValue
 public class ParameterAnnotationAssert extends AbstractAnnotationAssert<ParameterAnnotationAssert> {
 
     private final ParameterAssert parameterAssert;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ParameterAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ParameterAssert.java
@@ -2,9 +2,11 @@ package org.openapitools.codegen.java.assertions;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.util.CanIgnoreReturnValue;
 
 import com.github.javaparser.ast.body.Parameter;
 
+@CanIgnoreReturnValue
 public class ParameterAssert extends ObjectAssert<Parameter> {
 
     private final MethodAssert methodAssert;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/PropertyAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/PropertyAnnotationAssert.java
@@ -2,8 +2,11 @@ package org.openapitools.codegen.java.assertions;
 
 import java.util.List;
 
+import org.assertj.core.util.CanIgnoreReturnValue;
+
 import com.github.javaparser.ast.expr.AnnotationExpr;
 
+@CanIgnoreReturnValue
 public class PropertyAnnotationAssert extends AbstractAnnotationAssert<PropertyAnnotationAssert> {
 
     private final PropertyAssert propertyAssert;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/PropertyAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/PropertyAssert.java
@@ -2,10 +2,11 @@ package org.openapitools.codegen.java.assertions;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.util.CanIgnoreReturnValue;
 
 import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.Parameter;
 
+@CanIgnoreReturnValue
 public class PropertyAssert extends ObjectAssert<FieldDeclaration> {
 
     private final JavaFileAssert javaFileAssert;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/TypeAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/TypeAnnotationAssert.java
@@ -2,8 +2,11 @@ package org.openapitools.codegen.java.assertions;
 
 import java.util.List;
 
+import org.assertj.core.util.CanIgnoreReturnValue;
+
 import com.github.javaparser.ast.expr.AnnotationExpr;
 
+@CanIgnoreReturnValue
 public class TypeAnnotationAssert extends AbstractAnnotationAssert<TypeAnnotationAssert> {
 
     private final JavaFileAssert fileAssert;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Small improvement to reduce warnings from JavaFileAssert unit

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
