### PR TITLE
[dart] fixed nullable issue for query parameters in dart generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/api.mustache
@@ -84,7 +84,7 @@ class {{classname}} {
 
     final _queryParameters = <String, dynamic>{
       {{#queryParams}}
-      {{^required}}{{^isNullable}}if ({{{paramName}}} != null) {{/isNullable}}{{/required}}r'{{baseName}}': {{#includeLibraryTemplate}}api/query_param{{/includeLibraryTemplate}},
+      {{^required}}{{#isNullable}}if ({{{paramName}}} != null) {{/isNullable}}{{/required}}r'{{baseName}}': {{#includeLibraryTemplate}}api/query_param{{/includeLibraryTemplate}},
       {{/queryParams}}
     };{{/hasQueryParams}}{{#hasBodyOrFormParams}}
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/api/fake_api.dart
@@ -149,7 +149,7 @@ class FakeApi {
     );
 
     final _queryParameters = <String, dynamic>{
-      if (query1 != null) r'query_1': encodeQueryParameter(_serializers, query1, const FullType(String)),
+      r'query_1': encodeQueryParameter(_serializers, query1, const FullType(String)),
     };
 
     dynamic _bodyData;
@@ -1099,11 +1099,11 @@ class FakeApi {
     );
 
     final _queryParameters = <String, dynamic>{
-      if (enumQueryStringArray != null) r'enum_query_string_array': encodeCollectionQueryParameter<String>(_serializers, enumQueryStringArray, const FullType(BuiltList, [FullType(String)]), format: ListFormat.multi,),
-      if (enumQueryString != null) r'enum_query_string': encodeQueryParameter(_serializers, enumQueryString, const FullType(String)),
-      if (enumQueryInteger != null) r'enum_query_integer': encodeQueryParameter(_serializers, enumQueryInteger, const FullType(int)),
-      if (enumQueryDouble != null) r'enum_query_double': encodeQueryParameter(_serializers, enumQueryDouble, const FullType(double)),
-      if (enumQueryModelArray != null) r'enum_query_model_array': encodeCollectionQueryParameter<ModelEnumClass>(_serializers, enumQueryModelArray, const FullType(BuiltList, [FullType(ModelEnumClass)]), format: ListFormat.multi,),
+      r'enum_query_string_array': encodeCollectionQueryParameter<String>(_serializers, enumQueryStringArray, const FullType(BuiltList, [FullType(String)]), format: ListFormat.multi,),
+      r'enum_query_string': encodeQueryParameter(_serializers, enumQueryString, const FullType(String)),
+      r'enum_query_integer': encodeQueryParameter(_serializers, enumQueryInteger, const FullType(int)),
+      r'enum_query_double': encodeQueryParameter(_serializers, enumQueryDouble, const FullType(double)),
+      r'enum_query_model_array': encodeCollectionQueryParameter<ModelEnumClass>(_serializers, enumQueryModelArray, const FullType(BuiltList, [FullType(ModelEnumClass)]), format: ListFormat.multi,),
     };
 
     dynamic _bodyData;
@@ -1196,8 +1196,8 @@ class FakeApi {
     final _queryParameters = <String, dynamic>{
       r'required_string_group': encodeQueryParameter(_serializers, requiredStringGroup, const FullType(int)),
       r'required_int64_group': encodeQueryParameter(_serializers, requiredInt64Group, const FullType(int)),
-      if (stringGroup != null) r'string_group': encodeQueryParameter(_serializers, stringGroup, const FullType(int)),
-      if (int64Group != null) r'int64_group': encodeQueryParameter(_serializers, int64Group, const FullType(int)),
+      r'string_group': encodeQueryParameter(_serializers, stringGroup, const FullType(int)),
+      r'int64_group': encodeQueryParameter(_serializers, int64Group, const FullType(int)),
     };
 
     final _response = await _dio.request<Object>(
@@ -1402,7 +1402,7 @@ class FakeApi {
       r'http': encodeCollectionQueryParameter<String>(_serializers, http, const FullType(BuiltList, [FullType(String)]), format: ListFormat.ssv,),
       r'url': encodeCollectionQueryParameter<String>(_serializers, url, const FullType(BuiltList, [FullType(String)]), format: ListFormat.csv,),
       r'context': encodeCollectionQueryParameter<String>(_serializers, context, const FullType(BuiltList, [FullType(String)]), format: ListFormat.multi,),
-      if (language != null) r'language': encodeQueryParameter(_serializers, language, const FullType(BuiltMap, [FullType(String), FullType(String)]), ),
+      r'language': encodeQueryParameter(_serializers, language, const FullType(BuiltMap, [FullType(String), FullType(String)]), ),
       r'allowEmpty': encodeQueryParameter(_serializers, allowEmpty, const FullType(String)),
     };
 


### PR DESCRIPTION
#### Desired Behaviour
The dart generator should only append the query parameter to the request if it is not required and nullable (like addressed in #8837).
A possible openapi configuration snippet would be the following:
```
"/api/v1/specific_endpoint/": {
      "get": {
        "parameters": [
          {
            "in": "query",
            "name": "specific_parameter",
            "required": false,
            "schema": {
              "type": "integer",
              "default": null,
              "nullable": true
            }
          }
        ],
```
#### Current Behaviour
The generator always adds the query parameter to the request map, even if it is nullable and not required.

#### Change
When investigating the respective template, I found that the generator would add the nullable check only, if the query parameter is not nullable. Therefore, I changed this so that the generator now adds the nullable check, if the query parameter is not required but nullable.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
