### PR TITLE
[php] make ObjectSerializer::toString actually return a string

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -260,7 +260,7 @@ class ObjectSerializer
         } elseif (is_bool($value)) {
             return $value ? 'true' : 'false';
         } else {
-            return $value;
+            return (string) $value;
         }
     }
 

--- a/samples/client/petstore/php/OpenAPIClient-php/.openapi-generator/FILES
+++ b/samples/client/petstore/php/OpenAPIClient-php/.openapi-generator/FILES
@@ -58,6 +58,7 @@ docs/Model/Tag.md
 docs/Model/User.md
 docs/Model/UserType.md
 git_push.sh
+lib/ApiException.php
 lib/Api/AnotherFakeApi.php
 lib/Api/DefaultApi.php
 lib/Api/FakeApi.php
@@ -65,7 +66,6 @@ lib/Api/FakeClassnameTags123Api.php
 lib/Api/PetApi.php
 lib/Api/StoreApi.php
 lib/Api/UserApi.php
-lib/ApiException.php
 lib/Configuration.php
 lib/HeaderSelector.php
 lib/Model/AdditionalPropertiesClass.php

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -269,7 +269,7 @@ class ObjectSerializer
         } elseif (is_bool($value)) {
             return $value ? 'true' : 'false';
         } else {
-            return $value;
+            return (string) $value;
         }
     }
 

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -334,4 +334,44 @@ class ObjectSerializerTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideToStringInput
+     */
+    public function testToString($input, string $expected): void
+    {
+        $result = ObjectSerializer::toString($input);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function provideToStringInput(): array
+    {
+        return [
+            'int' => [
+                'input' => 1,
+                'expected' => '1',
+            ],
+            'int 0' => [
+                'input' => 0,
+                'expected' => '0',
+            ],
+            'false' => [
+                'input' => false,
+                'expected' => 'false',
+            ],
+            'true' => [
+                'input' => true,
+                'expected' => 'true',
+            ],
+            'some string' => [
+                'input' => 'some string',
+                'expected' => 'some string',
+            ],
+            'a date' => [
+                'input' => new \DateTime('14-04-2022'),
+                'expected' => '2022-04-14T00:00:00+00:00',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
## Problem

In our project, we use a CS tool that adds `declare(strict_types=1)` everywhere. [`ObjectSerializer::toPathValue`](https://github.com/OpenAPITools/openapi-generator/blob/v5.4.0/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache#L147) then throws a type error, if you for example have a field in your API that is an integer, as `rawurlencode` only accepts `string`s.

## Proposed Solution

Make [`ObjectSerializer::toString`](https://github.com/OpenAPITools/openapi-generator/blob/4a36be70025e9c0d3ff61731618b7fc2d942c4b6/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache#L216) actually return a string:
* Less surprises due to inconsistent types
* The function does what it promises

@jebentier , @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon 
