### PR TITLE
Support snake_case path parameters and fix path building with base URL

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CsharpNetcoreFunctionsServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CsharpNetcoreFunctionsServerCodegen.java
@@ -403,6 +403,15 @@ public class CsharpNetcoreFunctionsServerCodegen extends AbstractCSharpCodegen {
             if (operations != null) {
                 List<CodegenOperation> ops = operations.getOperation();
                 for (CodegenOperation operation : ops) {
+
+
+                    for (CodegenParameter param : operation.allParams) {
+                        if (param.isPathParam)
+                        {
+                            param.paramName = unCamelize(param.paramName);
+                        }
+                    }
+
                     if (operation.consumes == null) {
                         continue;
                     }
@@ -594,10 +603,15 @@ public class CsharpNetcoreFunctionsServerCodegen extends AbstractCSharpCodegen {
             if (apiBasePath.startsWith("/"))
                 apiBasePath = apiBasePath.substring(1);
 
-            if (apiBasePath.endsWith("/"))
-                apiBasePath = apiBasePath.substring(0, apiBasePath.lastIndexOf("/"));
+            if (!apiBasePath.endsWith("/"))
+                apiBasePath += "/";
         }
 
         additionalProperties.put("apiBasePath", apiBasePath);
+    }
+
+
+    private String unCamelize(String name) {
+        return name.replaceAll("(.)(\\p{Upper})", "$1_$2").toLowerCase(Locale.ROOT);
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The parameter named in a route must have the same name as the variable for an Azure Function HttpTrigger, otherwise it won't bind properly. The current `master` `csharp-netcore-functions` generator will will camelize the bound parameter but leave the parameter in the path as snake_case.

Also resolves an issue when a base server URL is provided with a forward-slash going missing.

For example, given the following schema:
```yaml
openapi: 3.0.0
info:
  description: Example underscored path
  title: Underscore Path Parameter example
  version: 1.0.0
servers:
  - url: /api/v1
paths:
  /accounts/{account_id}:
    get:
      parameters:
        - description: Get by ID
          name: account_id
          in: path
          required: true
          schema:
            type: string
      responses:
        200:
          description: Eerything OK
          content:
            application/json:
              schema:
                type: object
```
The `csharp-netcore-functions` generator would produce:
```csharp
public partial class DefaultApi
{ 
    [FunctionName("DefaultApi_AccountsAccountIdGet")]
    public async Task<IActionResult> _AccountsAccountIdGet([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "api/v1accounts/{account_id}")]HttpRequest req, ExecutionContext context, string accountId)
    {
        var method = this.GetType().GetMethod("AccountsAccountIdGet");

        return method != null 
            ? (await ((Task<IActionResult>)method.Invoke(this, new object[] { req, context, accountId })).ConfigureAwait(false))
            : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
    }
}
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
