### PR TITLE
[PHP] Replace @ character so we can use Hydra Jsonld models.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -401,6 +401,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toVarName(String name) {
+        // translate @ for properties (like @type) to at_.
+        // Otherwise an additional "type" property will leed to duplcates
+        name = name.replaceAll("^@", "at_");
+
         // sanitize name
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -416,7 +416,7 @@ public class PhpModelTest {
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "@id");
         Assert.assertEquals(property2.dataType, "string");
-        Assert.assertEquals(property2.name, "atId");
+        Assert.assertEquals(property2.name, "at_id");
         Assert.assertEquals(property2.defaultValue, null);
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.isPrimitiveType);
@@ -434,25 +434,25 @@ public class PhpModelTest {
         final CodegenProperty property4 = cm.vars.get(4);
         Assert.assertEquals(property4.baseName, "@type");
         Assert.assertEquals(property4.dataType, "string");
-        Assert.assertEquals(property4.name, "atType");
+        Assert.assertEquals(property4.name, "at_type");
         Assert.assertEquals(property4.defaultValue, null);
         Assert.assertEquals(property4.baseType, "string");
         Assert.assertTrue(property4.isPrimitiveType);
         Assert.assertFalse(property4.isContainer);
 
         final CodegenProperty property5 = cm.vars.get(5);
-        Assert.assertEquals(property5.baseName, "type");
+        Assert.assertEquals(property5.baseName, "context");
         Assert.assertEquals(property5.dataType, "string");
-        Assert.assertEquals(property5.name, "type");
+        Assert.assertEquals(property5.name, "context");
         Assert.assertEquals(property5.defaultValue, null);
         Assert.assertEquals(property5.baseType, "string");
         Assert.assertTrue(property5.isPrimitiveType);
         Assert.assertFalse(property5.isContainer);
 
         final CodegenProperty property6 = cm.vars.get(6);
-        Assert.assertEquals(property6.baseName, "@type");
+        Assert.assertEquals(property6.baseName, "@context");
         Assert.assertEquals(property6.dataType, "string");
-        Assert.assertEquals(property6.name, "atType");
+        Assert.assertEquals(property6.name, "at_context");
         Assert.assertEquals(property6.defaultValue, null);
         Assert.assertEquals(property6.baseType, "string");
         Assert.assertTrue(property6.isPrimitiveType);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -422,7 +422,7 @@ public class PhpModelTest {
         Assert.assertTrue(property2.isPrimitiveType);
         Assert.assertFalse(property2.isContainer);
 
-        final CodegenProperty property3 = cm.vars.get(3);
+        final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "type");
         Assert.assertEquals(property3.dataType, "string");
         Assert.assertEquals(property3.name, "type");
@@ -431,7 +431,7 @@ public class PhpModelTest {
         Assert.assertTrue(property3.isPrimitiveType);
         Assert.assertFalse(property3.isContainer);
 
-        final CodegenProperty property4 = cm.vars.get(4);
+        final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "@type");
         Assert.assertEquals(property4.dataType, "string");
         Assert.assertEquals(property4.name, "at_type");
@@ -440,7 +440,7 @@ public class PhpModelTest {
         Assert.assertTrue(property4.isPrimitiveType);
         Assert.assertFalse(property4.isContainer);
 
-        final CodegenProperty property5 = cm.vars.get(5);
+        final CodegenProperty property5 = cm.vars.get(4);
         Assert.assertEquals(property5.baseName, "context");
         Assert.assertEquals(property5.dataType, "string");
         Assert.assertEquals(property5.name, "context");
@@ -449,7 +449,7 @@ public class PhpModelTest {
         Assert.assertTrue(property5.isPrimitiveType);
         Assert.assertFalse(property5.isContainer);
 
-        final CodegenProperty property6 = cm.vars.get(6);
+        final CodegenProperty property6 = cm.vars.get(5);
         Assert.assertEquals(property6.baseName, "@context");
         Assert.assertEquals(property6.dataType, "string");
         Assert.assertEquals(property6.name, "at_context");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -383,4 +383,79 @@ public class PhpModelTest {
         Assert.assertEquals(op.returnType, "\\DateTime");
         Assert.assertEquals(op.bodyParam.dataType, "\\DateTime");
     }
+
+    @Test(description = "test @ character replacements used in Hydra")
+    public void simpleModelTest() {
+        final Schema model = new Schema()
+                .description("a hydra model")
+                .addProperties("id", new IntegerSchema())
+                .addProperties("@id", new StringSchema())
+                .addProperties("type", new StringSchema())
+                .addProperties("@type", new StringSchema())
+                .addProperties("context", new StringSchema())
+                .addProperties("@context", new StringSchema())
+                .addRequiredItem("id");
+        final DefaultCodegen codegen = new PhpClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.vars.size(), 6);
+
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.dataType, "int");
+        Assert.assertEquals(property1.name, "id");
+        Assert.assertEquals(property1.defaultValue, null);
+        Assert.assertEquals(property1.baseType, "int");
+        Assert.assertTrue(property1.required);
+        Assert.assertTrue(property1.isPrimitiveType);
+        Assert.assertFalse(property1.isContainer);
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "@id");
+        Assert.assertEquals(property2.dataType, "string");
+        Assert.assertEquals(property2.name, "atId");
+        Assert.assertEquals(property2.defaultValue, null);
+        Assert.assertEquals(property2.baseType, "string");
+        Assert.assertTrue(property2.isPrimitiveType);
+        Assert.assertFalse(property2.isContainer);
+
+        final CodegenProperty property3 = cm.vars.get(3);
+        Assert.assertEquals(property3.baseName, "type");
+        Assert.assertEquals(property3.dataType, "string");
+        Assert.assertEquals(property3.name, "type");
+        Assert.assertEquals(property3.defaultValue, null);
+        Assert.assertEquals(property3.baseType, "string");
+        Assert.assertTrue(property3.isPrimitiveType);
+        Assert.assertFalse(property3.isContainer);
+
+        final CodegenProperty property4 = cm.vars.get(4);
+        Assert.assertEquals(property4.baseName, "@type");
+        Assert.assertEquals(property4.dataType, "string");
+        Assert.assertEquals(property4.name, "atType");
+        Assert.assertEquals(property4.defaultValue, null);
+        Assert.assertEquals(property4.baseType, "string");
+        Assert.assertTrue(property4.isPrimitiveType);
+        Assert.assertFalse(property4.isContainer);
+
+        final CodegenProperty property5 = cm.vars.get(5);
+        Assert.assertEquals(property5.baseName, "type");
+        Assert.assertEquals(property5.dataType, "string");
+        Assert.assertEquals(property5.name, "type");
+        Assert.assertEquals(property5.defaultValue, null);
+        Assert.assertEquals(property5.baseType, "string");
+        Assert.assertTrue(property5.isPrimitiveType);
+        Assert.assertFalse(property5.isContainer);
+
+        final CodegenProperty property6 = cm.vars.get(6);
+        Assert.assertEquals(property6.baseName, "@type");
+        Assert.assertEquals(property6.dataType, "string");
+        Assert.assertEquals(property6.name, "atType");
+        Assert.assertEquals(property6.defaultValue, null);
+        Assert.assertEquals(property6.baseType, "string");
+        Assert.assertTrue(property6.isPrimitiveType);
+        Assert.assertFalse(property6.isContainer);
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -385,7 +385,7 @@ public class PhpModelTest {
     }
 
     @Test(description = "test @ character replacements used in Hydra")
-    public void simpleModelTest() {
+    public void hydraModelTest() {
         final Schema model = new Schema()
                 .description("a hydra model")
                 .addProperties("id", new IntegerSchema())


### PR DESCRIPTION
When using a Hydra schema, where you can have @id and id property in the model, the generated PHP code included duplicate id properties, getter and setter methods. The result was thus an invalid class. The Hydra schema is extensively used in the PHP Api Platform codebase. 

This change replaces the @ with at characters, just like it does in the Java generator and Rust generator. 

@jebentier  @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon
