### PR TITLE
[python-flask] Support regeneration without overwriting implementation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -216,7 +216,6 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
         supportingFiles.add(new SupportingFile("typing_utils.mustache", packagePath(), "typing_utils.py"));
         supportingFiles.add(new SupportingFile("__init__.mustache", packagePath() + File.separatorChar + packageToPath(controllerPackage), "__init__.py"));
         supportingFiles.add(new SupportingFile("security_controller_.mustache", packagePath() + File.separatorChar + packageToPath(controllerPackage), "security_controller_.py"));
-        supportingFiles.add(new SupportingFile("__init__impl.mustache", packagePath() + File.separatorChar + "impl", "__init__.py"));
         supportingFiles.add(new SupportingFile("__init__model.mustache", packagePath() + File.separatorChar + packageToPath(modelPackage), "__init__.py"));
         supportingFiles.add(new SupportingFile("base_model_.mustache", packagePath() + File.separatorChar + packageToPath(modelPackage), "base_model_.py"));
         supportingFiles.add(new SupportingFile("openapi.mustache", packagePath() + File.separatorChar + "openapi", "openapi.yaml"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -216,6 +216,7 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
         supportingFiles.add(new SupportingFile("typing_utils.mustache", packagePath(), "typing_utils.py"));
         supportingFiles.add(new SupportingFile("__init__.mustache", packagePath() + File.separatorChar + packageToPath(controllerPackage), "__init__.py"));
         supportingFiles.add(new SupportingFile("security_controller_.mustache", packagePath() + File.separatorChar + packageToPath(controllerPackage), "security_controller_.py"));
+        supportingFiles.add(new SupportingFile("__init__impl.mustache", packagePath() + File.separatorChar + "impl", "__init__.py"));
         supportingFiles.add(new SupportingFile("__init__model.mustache", packagePath() + File.separatorChar + packageToPath(modelPackage), "__init__.py"));
         supportingFiles.add(new SupportingFile("base_model_.mustache", packagePath() + File.separatorChar + packageToPath(modelPackage), "base_model_.py"));
         supportingFiles.add(new SupportingFile("openapi.mustache", packagePath() + File.separatorChar + "openapi", "openapi.yaml"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
@@ -52,6 +52,7 @@ public class PythonFlaskConnexionServerCodegen extends AbstractPythonConnexionSe
         supportingFiles.add(new SupportingFile("encoder.mustache", packagePath(), "encoder.py"));
         supportingFiles.add(new SupportingFile("__init__test.mustache", packagePath() + File.separatorChar + testPackage, "__init__.py"));
         supportingFiles.add(new SupportingFile("__init__.mustache", packagePath(), "__init__.py"));
+        supportingFiles.add(new SupportingFile("__init__impl.mustache", packagePath() + File.separatorChar + "impl", "__init__.py"));
         testPackage = packageName + "." + testPackage;
     }
 

--- a/modules/openapi-generator/src/main/resources/python-flask/controller.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/controller.mustache
@@ -111,7 +111,16 @@ def {{operationId}}({{#allParams}}{{paramName}}{{^required}}=None{{/required}}{{
 
     return impl.{{operationId}}(
     {{#allParams}}
-        {{paramName}}{{^required}}={{paramName}}{{/required}},  # noqa: E501
+        {{! path params as positional}}
+        {{#isPathParam}}
+        {{paramName}},  # noqa: E501
+        {{/isPathParam}}
+    {{/allParams}}
+    {{#allParams}}
+        {{! query params etc. as kwargs}}
+        {{^isPathParam}}
+        {{paramName}}={{paramName}},  # noqa: E501
+        {{/isPathParam}}
     {{/allParams}}
     )
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/python-flask/controller.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/controller.mustache
@@ -3,6 +3,7 @@ import six
 
 {{#imports}}{{import}}  # noqa: E501
 {{/imports}}
+from {{packageName}} import impl
 from {{packageName}} import util
 {{#operations}}
 {{#operation}}
@@ -107,6 +108,11 @@ def {{operationId}}({{#allParams}}{{paramName}}{{^required}}=None{{/required}}{{
             {{/items}}
         {{/isMap}}
     {{/allParams}}
-    return 'do some magic!'
+
+    return impl.{{operationId}}(
+    {{#allParams}}
+        {{paramName}}{{^required}}={{paramName}}{{/required}},  # noqa: E501
+    {{/allParams}}
+    )
 {{/operation}}
 {{/operations}}

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/test/__init__.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/test/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import patch
 
 import connexion
 from flask_testing import TestCase
@@ -7,10 +8,14 @@ from openapi_server.encoder import JSONEncoder
 
 
 class BaseTestCase(TestCase):
-
     def create_app(self):
-        logging.getLogger('connexion.operation').setLevel('ERROR')
-        app = connexion.App(__name__, specification_dir='../openapi/')
+        logging.getLogger("connexion.operation").setLevel("ERROR")
+        app = connexion.App(__name__, specification_dir="../openapi/")
         app.app.json_encoder = JSONEncoder
-        app.add_api('openapi.yaml', pythonic_params=True)
+        app.add_api("openapi.yaml", pythonic_params=True)
         return app.app
+
+    def setUp(self):
+        impl_patcher = patch("openapi_server.impl", create=True)
+        impl_patcher.start()
+        self.addCleanup(impl_patcher)

--- a/samples/openapi3/server/petstore/python-flask/requirements.txt
+++ b/samples/openapi3/server/petstore/python-flask/requirements.txt
@@ -8,3 +8,4 @@ werkzeug == 0.16.1; python_version=="3.5" or python_version=="3.4"
 swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
+MarkupSafe<2.01 # needed for connexion->jinja2 (`markupsafe.soft_unicode`)

--- a/samples/openapi3/server/petstore/python-flask/test-requirements.txt
+++ b/samples/openapi3/server/petstore/python-flask/test-requirements.txt
@@ -1,4 +1,6 @@
+-r requirements.txt
 pytest~=4.6.7 # needed for python 2.7+3.4
 pytest-cov>=2.8.1
 pytest-randomly==1.2.3 # needed for python 2.7+3.4
 Flask-Testing==0.8.0
+flask<2.0.0 # needed for Flask-Testing (`flask.json_available`)

--- a/samples/server/petstore/python-flask/.openapi-generator/FILES
+++ b/samples/server/petstore/python-flask/.openapi-generator/FILES
@@ -12,6 +12,7 @@ openapi_server/controllers/security_controller_.py
 openapi_server/controllers/store_controller.py
 openapi_server/controllers/user_controller.py
 openapi_server/encoder.py
+openapi_server/impl/__init__.py
 openapi_server/models/__init__.py
 openapi_server/models/api_response.py
 openapi_server/models/base_model_.py

--- a/samples/server/petstore/python-flask/openapi_server/controllers/pet_controller.py
+++ b/samples/server/petstore/python-flask/openapi_server/controllers/pet_controller.py
@@ -3,6 +3,7 @@ import six
 
 from openapi_server.models.api_response import ApiResponse  # noqa: E501
 from openapi_server.models.pet import Pet  # noqa: E501
+from openapi_server import impl
 from openapi_server import util
 
 
@@ -18,7 +19,10 @@ def add_pet(body):  # noqa: E501
     """
     if connexion.request.is_json:
         body = Pet.from_dict(connexion.request.get_json())  # noqa: E501
-    return 'do some magic!'
+
+    return impl.add_pet(
+        body=body,  # noqa: E501
+    )
 
 
 def delete_pet(pet_id, api_key=None):  # noqa: E501
@@ -33,7 +37,11 @@ def delete_pet(pet_id, api_key=None):  # noqa: E501
 
     :rtype: None
     """
-    return 'do some magic!'
+
+    return impl.delete_pet(
+        pet_id,  # noqa: E501
+        api_key=api_key,  # noqa: E501
+    )
 
 
 def find_pets_by_status(status):  # noqa: E501
@@ -46,7 +54,10 @@ def find_pets_by_status(status):  # noqa: E501
 
     :rtype: List[Pet]
     """
-    return 'do some magic!'
+
+    return impl.find_pets_by_status(
+        status=status,  # noqa: E501
+    )
 
 
 def find_pets_by_tags(tags):  # noqa: E501
@@ -59,7 +70,10 @@ def find_pets_by_tags(tags):  # noqa: E501
 
     :rtype: List[Pet]
     """
-    return 'do some magic!'
+
+    return impl.find_pets_by_tags(
+        tags=tags,  # noqa: E501
+    )
 
 
 def get_pet_by_id(pet_id):  # noqa: E501
@@ -72,7 +86,10 @@ def get_pet_by_id(pet_id):  # noqa: E501
 
     :rtype: Pet
     """
-    return 'do some magic!'
+
+    return impl.get_pet_by_id(
+        pet_id,  # noqa: E501
+    )
 
 
 def update_pet(body):  # noqa: E501
@@ -87,7 +104,10 @@ def update_pet(body):  # noqa: E501
     """
     if connexion.request.is_json:
         body = Pet.from_dict(connexion.request.get_json())  # noqa: E501
-    return 'do some magic!'
+
+    return impl.update_pet(
+        body=body,  # noqa: E501
+    )
 
 
 def update_pet_with_form(pet_id, name=None, status=None):  # noqa: E501
@@ -104,7 +124,12 @@ def update_pet_with_form(pet_id, name=None, status=None):  # noqa: E501
 
     :rtype: None
     """
-    return 'do some magic!'
+
+    return impl.update_pet_with_form(
+        pet_id,  # noqa: E501
+        name=name,  # noqa: E501
+        status=status,  # noqa: E501
+    )
 
 
 def upload_file(pet_id, additional_metadata=None, file=None):  # noqa: E501
@@ -121,4 +146,9 @@ def upload_file(pet_id, additional_metadata=None, file=None):  # noqa: E501
 
     :rtype: ApiResponse
     """
-    return 'do some magic!'
+
+    return impl.upload_file(
+        pet_id,  # noqa: E501
+        additional_metadata=additional_metadata,  # noqa: E501
+        file=file,  # noqa: E501
+    )

--- a/samples/server/petstore/python-flask/openapi_server/controllers/store_controller.py
+++ b/samples/server/petstore/python-flask/openapi_server/controllers/store_controller.py
@@ -2,6 +2,7 @@ import connexion
 import six
 
 from openapi_server.models.order import Order  # noqa: E501
+from openapi_server import impl
 from openapi_server import util
 
 
@@ -15,7 +16,10 @@ def delete_order(order_id):  # noqa: E501
 
     :rtype: None
     """
-    return 'do some magic!'
+
+    return impl.delete_order(
+        order_id,  # noqa: E501
+    )
 
 
 def get_inventory():  # noqa: E501
@@ -26,7 +30,9 @@ def get_inventory():  # noqa: E501
 
     :rtype: Dict[str, int]
     """
-    return 'do some magic!'
+
+    return impl.get_inventory(
+    )
 
 
 def get_order_by_id(order_id):  # noqa: E501
@@ -39,7 +45,10 @@ def get_order_by_id(order_id):  # noqa: E501
 
     :rtype: Order
     """
-    return 'do some magic!'
+
+    return impl.get_order_by_id(
+        order_id,  # noqa: E501
+    )
 
 
 def place_order(body):  # noqa: E501
@@ -54,4 +63,7 @@ def place_order(body):  # noqa: E501
     """
     if connexion.request.is_json:
         body = Order.from_dict(connexion.request.get_json())  # noqa: E501
-    return 'do some magic!'
+
+    return impl.place_order(
+        body=body,  # noqa: E501
+    )

--- a/samples/server/petstore/python-flask/openapi_server/controllers/user_controller.py
+++ b/samples/server/petstore/python-flask/openapi_server/controllers/user_controller.py
@@ -2,6 +2,7 @@ import connexion
 import six
 
 from openapi_server.models.user import User  # noqa: E501
+from openapi_server import impl
 from openapi_server import util
 
 
@@ -17,7 +18,10 @@ def create_user(body):  # noqa: E501
     """
     if connexion.request.is_json:
         body = User.from_dict(connexion.request.get_json())  # noqa: E501
-    return 'do some magic!'
+
+    return impl.create_user(
+        body=body,  # noqa: E501
+    )
 
 
 def create_users_with_array_input(body):  # noqa: E501
@@ -32,7 +36,10 @@ def create_users_with_array_input(body):  # noqa: E501
     """
     if connexion.request.is_json:
         body = [User.from_dict(d) for d in connexion.request.get_json()]  # noqa: E501
-    return 'do some magic!'
+
+    return impl.create_users_with_array_input(
+        body=body,  # noqa: E501
+    )
 
 
 def create_users_with_list_input(body):  # noqa: E501
@@ -47,7 +54,10 @@ def create_users_with_list_input(body):  # noqa: E501
     """
     if connexion.request.is_json:
         body = [User.from_dict(d) for d in connexion.request.get_json()]  # noqa: E501
-    return 'do some magic!'
+
+    return impl.create_users_with_list_input(
+        body=body,  # noqa: E501
+    )
 
 
 def delete_user(username):  # noqa: E501
@@ -60,7 +70,10 @@ def delete_user(username):  # noqa: E501
 
     :rtype: None
     """
-    return 'do some magic!'
+
+    return impl.delete_user(
+        username,  # noqa: E501
+    )
 
 
 def get_user_by_name(username):  # noqa: E501
@@ -73,7 +86,10 @@ def get_user_by_name(username):  # noqa: E501
 
     :rtype: User
     """
-    return 'do some magic!'
+
+    return impl.get_user_by_name(
+        username,  # noqa: E501
+    )
 
 
 def login_user(username, password):  # noqa: E501
@@ -88,7 +104,11 @@ def login_user(username, password):  # noqa: E501
 
     :rtype: str
     """
-    return 'do some magic!'
+
+    return impl.login_user(
+        username=username,  # noqa: E501
+        password=password,  # noqa: E501
+    )
 
 
 def logout_user():  # noqa: E501
@@ -99,7 +119,9 @@ def logout_user():  # noqa: E501
 
     :rtype: None
     """
-    return 'do some magic!'
+
+    return impl.logout_user(
+    )
 
 
 def update_user(username, body):  # noqa: E501
@@ -116,4 +138,8 @@ def update_user(username, body):  # noqa: E501
     """
     if connexion.request.is_json:
         body = User.from_dict(connexion.request.get_json())  # noqa: E501
-    return 'do some magic!'
+
+    return impl.update_user(
+        username,  # noqa: E501
+        body=body,  # noqa: E501
+    )


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11)

Presently, running `generate` overwrites any existing implementation of the generated stubs. This fixes it by running an implementation function from another file instead of simply returning 'do some magic'; the user can ignore the `openapi_server/impl` directory and put the stub implementations there, allowing them to re-run `generate` as required without blowing them away.