### PR TITLE
[java-micronaut] Generate visitor for subtypes with a discriminator

### DIFF
--- a/bin/configs/java-micronaut-client.yaml
+++ b/bin/configs/java-micronaut-client.yaml
@@ -8,3 +8,4 @@ additionalProperties:
   build: "all"
   test: "spock"
   requiredPropertiesInConstructor: "false"
+  visitable: "true"

--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -73,6 +73,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |title|Client service name| |null|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useOptional|Use Optional container for optional parameters| |false|
+|visitable|Generate visitor for subtypes with a discriminator| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -75,6 +75,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useAuth|Whether to import authorization and to annotate controller methods accordingly| |true|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useOptional|Use Optional container for optional parameters| |false|
+|visitable|Generate visitor for subtypes with a discriminator| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
@@ -28,6 +28,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     public static final String OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR = "requiredPropertiesInConstructor";
     public static final String OPT_MICRONAUT_VERSION = "micronautVersion";
     public static final String OPT_USE_AUTH = "useAuth";
+    public static final String OPT_VISITABLE = "visitable";
     public static final String OPT_DATE_LIBRARY_JAVA8 = "java8";
     public static final String OPT_DATE_LIBRARY_JAVA8_LOCAL_DATETIME = "java8-localdatetime";
     public static final String OPT_DATE_FORMAT = "dateFormat";
@@ -36,6 +37,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     protected String title;
     protected boolean useBeanValidation;
     protected boolean useOptional;
+    protected boolean visitable;
     protected String buildTool;
     protected String testTool;
     protected boolean requiredPropertiesInConstructor = true;
@@ -55,6 +57,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
         // Set all the fields
         useBeanValidation = true;
         useOptional = false;
+        visitable = false;
         buildTool = OPT_BUILD_ALL;
         testTool = OPT_TEST_JUNIT;
         outputFolder = "generated-code/java-micronaut-client";
@@ -99,6 +102,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
         cliOptions.add(new CliOption(OPT_MICRONAUT_VERSION, "Micronaut version, only >=3.0.0 versions are supported").defaultValue(micronautVersion));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations", useBeanValidation));
         cliOptions.add(CliOption.newBoolean(USE_OPTIONAL, "Use Optional container for optional parameters", useOptional));
+        cliOptions.add(CliOption.newBoolean(OPT_VISITABLE, "Generate visitor for subtypes with a discriminator", visitable));
         cliOptions.add(CliOption.newBoolean(OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR, "Allow only to create models with all the required properties provided in constructor", requiredPropertiesInConstructor));
 
         CliOption buildToolOption = new CliOption(OPT_BUILD, "Specify for which build tool to generate files").defaultValue(buildTool);
@@ -166,6 +170,11 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
             this.setUseOptional(convertPropertyToBoolean(USE_OPTIONAL));
         }
         writePropertyBack(USE_OPTIONAL, useOptional);
+
+        if (additionalProperties.containsKey(OPT_VISITABLE)) {
+            this.setVisitable(convertPropertyToBoolean(OPT_VISITABLE));
+        }
+        writePropertyBack(OPT_VISITABLE, visitable);
 
         if (additionalProperties.containsKey(OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR)) {
             this.requiredPropertiesInConstructor = convertPropertyToBoolean(OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR);
@@ -320,6 +329,10 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
         this.useOptional = useOptional;
     }
 
+    public void setVisitable(boolean visitable) {
+        this.visitable = visitable;
+    }
+
     @Override
     public String toApiVarName(String name) {
         String apiVarName = super.toApiVarName(name);
@@ -335,6 +348,10 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
 
     public boolean isUseOptional() {
         return useOptional;
+    }
+
+    public boolean isVisitable() {
+        return visitable;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
@@ -355,4 +355,36 @@ Declare the class with extends and implements
         }
     };
     {{/parcelableModel}}
+    {{#visitable}}
+    {{#discriminator}}
+    /**
+     * Accept the visitor and invoke it for the specific {{classname}} type.
+     *
+     * @param visitor the {{classname}} visitor
+     * @param <T> the return type of the visitor
+     * @return the result from the visitor
+     */
+    public abstract <T> T accept(Visitor<T> visitor);
+
+    /**
+     * A {{classname}} visitor implementation allows visiting the various {{classname}} types.
+     *
+     * @param <R> the return type of the visitor
+     */
+    public interface Visitor<R> {
+        {{#discriminator.mappedModels}}
+        public R visit{{modelName}}({{modelName}} value);
+        {{/discriminator.mappedModels}}
+    }
+
+    {{/discriminator}}
+    {{#parent}}
+        {{#interfaces.0}}
+    @Override
+    public <T> T accept({{{parent}}}.Visitor<T> visitor) {
+        return visitor.visit{{classname}}(this);
+    }
+        {{/interfaces.0}}
+    {{/parent}}
+    {{/visitable}}
 }

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
@@ -373,7 +373,7 @@ Declare the class with extends and implements
      */
     public interface Visitor<R> {
         {{#discriminator.mappedModels}}
-        public R visit{{modelName}}({{modelName}} value);
+        R visit{{modelName}}({{modelName}} value);
         {{/discriminator.mappedModels}}
     }
 

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Animal.java
@@ -141,4 +141,24 @@ public class Animal {
         return o.toString().replace("\n", "\n    ");
     }
 
+    /**
+     * Accept the visitor and invoke it for the specific Animal type.
+     *
+     * @param visitor the Animal visitor
+     * @param <T> the return type of the visitor
+     * @return the result from the visitor
+     */
+    public abstract <T> T accept(Visitor<T> visitor);
+
+    /**
+     * A Animal visitor implementation allows visiting the various Animal types.
+     *
+     * @param <R> the return type of the visitor
+     */
+    public interface Visitor<R> {
+        public R visitBigCat(BigCat value);
+        public R visitCat(Cat value);
+        public R visitDog(Dog value);
+    }
+
 }

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Animal.java
@@ -156,9 +156,9 @@ public class Animal {
      * @param <R> the return type of the visitor
      */
     public interface Visitor<R> {
-        public R visitBigCat(BigCat value);
-        public R visitCat(Cat value);
-        public R visitDog(Dog value);
+        R visitBigCat(BigCat value);
+        R visitCat(Cat value);
+        R visitDog(Dog value);
     }
 
 }

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/BigCat.java
@@ -138,4 +138,8 @@ public class BigCat extends Cat {
         return o.toString().replace("\n", "\n    ");
     }
 
+    @Override
+    public <T> T accept(Cat.Visitor<T> visitor) {
+        return visitor.visitBigCat(this);
+    }
 }

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Cat.java
@@ -103,4 +103,8 @@ public class Cat extends Animal {
         return o.toString().replace("\n", "\n    ");
     }
 
+    @Override
+    public <T> T accept(Animal.Visitor<T> visitor) {
+        return visitor.visitCat(this);
+    }
 }

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Dog.java
@@ -103,4 +103,8 @@ public class Dog extends Animal {
         return o.toString().replace("\n", "\n    ");
     }
 
+    @Override
+    public <T> T accept(Animal.Visitor<T> visitor) {
+        return visitor.visitDog(this);
+    }
 }


### PR DESCRIPTION
When types which extend a common type and are distinguished based on a
discriminator are consumed they are often cast to their specific Java
type which results in error prone boilerplate code.

By generating a visitor for those kind of types the various subtypes can
be consumed in a type safe manner.

This change is based on the same implementation I made for the [Kokuwa.io](https://github.com/kokuwaio/micronaut-openapi-codegen/pull/66)
version of the micronaut openapi plugin.

Note that there is also a pull request for the [typescript-angular](https://github.com/OpenAPITools/openapi-generator/pull/9278) implementation.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@andriy-dmytruk