### PR TITLE
[typescript-axios] properly handle type imports and avoid duplicate function parameters in generated client

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -3,8 +3,8 @@
 {{>licenseInfo}}
 
 {{^withSeparateModelsAndApi}}
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 {{#withNodeImports}}
 // URLSearchParams not necessarily used
 // @ts-ignore
@@ -17,7 +17,7 @@ import FormData from 'form-data'
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 {{#models}}
 {{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}{{/model}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -3,8 +3,8 @@
 /* eslint-disable */
 {{>licenseInfo}}
 
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
-import { Configuration } from '{{apiRelativeToRoot}}configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import type { Configuration } from '{{apiRelativeToRoot}}configuration';
 {{#withNodeImports}}
 // URLSearchParams not necessarily used
 // @ts-ignore
@@ -17,7 +17,7 @@ import FormData from 'form-data'
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '{{apiRelativeToRoot}}common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '{{apiRelativeToRoot}}base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from '{{apiRelativeToRoot}}base';
 {{#imports}}
 // @ts-ignore
 import { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
@@ -42,11 +42,11 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
          {{#allParams}}
          * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
          {{/allParams}}
-         * @param {*} [options] Override http request option.{{#isDeprecated}}
+         * @param {*} [axiosOptions] Override http request option.{{#isDeprecated}}
          * @deprecated{{/isDeprecated}}
          * @throws {RequiredError}
          */
-        {{nickname}}: async ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        {{nickname}}: async ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
     {{#allParams}}
     {{#required}}
             // verify required parameter '{{paramName}}' is not null or undefined
@@ -62,7 +62,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: '{{httpMethod}}', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: '{{httpMethod}}', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;{{#vendorExtensions}}{{#hasFormParams}}
             const localVarFormParams = new {{^multipartFormData}}URLSearchParams(){{/multipartFormData}}{{#multipartFormData}}((configuration && configuration.formDataCtor) || FormData)(){{/multipartFormData}};{{/hasFormParams}}{{/vendorExtensions}}
@@ -192,7 +192,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
     {{/bodyParam}}
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions,{{#hasFormParams}}{{#multipartFormData}} ...(localVarFormParams as any).getHeaders?.(),{{/multipartFormData}}{{/hasFormParams}} ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions,{{#hasFormParams}}{{#multipartFormData}} ...(localVarFormParams as any).getHeaders?.(),{{/multipartFormData}}{{/hasFormParams}} ...axiosOptions.headers};
     {{#hasFormParams}}
             localVarRequestOptions.data = localVarFormParams{{#vendorExtensions}}{{^multipartFormData}}.toString(){{/multipartFormData}}{{/vendorExtensions}};
     {{/hasFormParams}}
@@ -226,12 +226,12 @@ export const {{classname}}Fp = function(configuration?: Configuration) {
          {{#allParams}}
          * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
          {{/allParams}}
-         * @param {*} [options] Override http request option.{{#isDeprecated}}
+         * @param {*} [axiosOptions] Override http request option.{{#isDeprecated}}
          * @deprecated{{/isDeprecated}}
          * @throws {RequiredError}
          */
-        async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
+        async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     {{/operation}}
@@ -255,12 +255,12 @@ export const {{classname}}Factory = function (configuration?: Configuration, bas
          {{#allParams}}
          * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
          {{/allParams}}
-         * @param {*} [options] Override http request option.{{#isDeprecated}}
+         * @param {*} [axiosOptions] Override http request option.{{#isDeprecated}}
          * @deprecated{{/isDeprecated}}
          * @throws {RequiredError}
          */
-        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
-            return localVarFp.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options).then((request) => request(axios, basePath));
+        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}axiosOptions?: any): AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
+            return localVarFp.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}axiosOptions).then((request) => request(axios, basePath));
         },
     {{/operation}}
     };
@@ -283,12 +283,12 @@ export interface {{classname}}Interface {
      {{#allParams}}
      * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
      {{/allParams}}
-     * @param {*} [options] Override http request option.{{#isDeprecated}}
+     * @param {*} [axiosOptions] Override http request option.{{#isDeprecated}}
      * @deprecated{{/isDeprecated}}
      * @throws {RequiredError}
      * @memberof {{classname}}Interface
      */
-    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: AxiosRequestConfig): AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}>;
+    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}axiosOptions?: AxiosRequestConfig): AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}>;
 
 {{/operation}}
 }
@@ -348,19 +348,19 @@ export class {{classname}} extends BaseAPI {
      * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
      {{/allParams}}
      {{/useSingleRequestParameter}}
-     * @param {*} [options] Override http request option.{{#isDeprecated}}
+     * @param {*} [axiosOptions] Override http request option.{{#isDeprecated}}
      * @deprecated{{/isDeprecated}}
      * @throws {RequiredError}
      * @memberof {{classname}}
      */
     {{#useSingleRequestParameter}}
-    public {{nickname}}({{#allParams.0}}requestParameters: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}options?: AxiosRequestConfig) {
-        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams.0}}{{#allParams}}requestParameters.{{paramName}}, {{/allParams}}{{/allParams.0}}options).then((request) => request(this.axios, this.basePath));
+    public {{nickname}}({{#allParams.0}}requestParameters: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}axiosOptions?: AxiosRequestConfig) {
+        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams.0}}{{#allParams}}requestParameters.{{paramName}}, {{/allParams}}{{/allParams.0}}axiosOptions).then((request) => request(this.axios, this.basePath));
     }
     {{/useSingleRequestParameter}}
     {{^useSingleRequestParameter}}
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: AxiosRequestConfig) {
-        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options).then((request) => request(this.axios, this.basePath));
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}axiosOptions?: AxiosRequestConfig) {
+        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}axiosOptions).then((request) => request(this.axios, this.basePath));
     }
     {{/useSingleRequestParameter}}
     {{^-last}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/baseApi.mustache
@@ -2,10 +2,10 @@
 /* eslint-disable */
 {{>licenseInfo}}
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "{{{basePath}}}".replace(/\/+$/, "");
 

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -2,9 +2,9 @@
 /* eslint-disable */
 {{>licenseInfo}}
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 {{#withNodeImports}}
 import { URL, URLSearchParams } from 'url';
 {{/withNodeImports}}

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * 
@@ -186,10 +186,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         /**
          * 
          * @param {InlineObject} [inlineObject] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        filePost: async (inlineObject?: InlineObject, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        filePost: async (inlineObject?: InlineObject, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/file`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -198,7 +198,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -208,7 +208,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(inlineObject, localVarRequestOptions, configuration)
 
             return {
@@ -219,10 +219,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         /**
          * 
          * @param {PetByAge | PetByType} [petByAgePetByType] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        petsFilteredPatch: async (petByAgePetByType?: PetByAge | PetByType, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        petsFilteredPatch: async (petByAgePetByType?: PetByAge | PetByType, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/pets-filtered`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -231,7 +231,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -241,7 +241,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(petByAgePetByType, localVarRequestOptions, configuration)
 
             return {
@@ -252,10 +252,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         /**
          * 
          * @param {Cat | Dog} [catDog] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        petsPatch: async (catDog?: Cat | Dog, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        petsPatch: async (catDog?: Cat | Dog, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/pets`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -264,7 +264,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -274,7 +274,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(catDog, localVarRequestOptions, configuration)
 
             return {
@@ -295,31 +295,31 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @param {InlineObject} [inlineObject] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async filePost(inlineObject?: InlineObject, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.filePost(inlineObject, options);
+        async filePost(inlineObject?: InlineObject, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.filePost(inlineObject, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @param {PetByAge | PetByType} [petByAgePetByType] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async petsFilteredPatch(petByAgePetByType?: PetByAge | PetByType, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.petsFilteredPatch(petByAgePetByType, options);
+        async petsFilteredPatch(petByAgePetByType?: PetByAge | PetByType, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.petsFilteredPatch(petByAgePetByType, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @param {Cat | Dog} [catDog] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async petsPatch(catDog?: Cat | Dog, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.petsPatch(catDog, options);
+        async petsPatch(catDog?: Cat | Dog, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.petsPatch(catDog, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -335,29 +335,29 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         /**
          * 
          * @param {InlineObject} [inlineObject] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        filePost(inlineObject?: InlineObject, options?: any): AxiosPromise<void> {
-            return localVarFp.filePost(inlineObject, options).then((request) => request(axios, basePath));
+        filePost(inlineObject?: InlineObject, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.filePost(inlineObject, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @param {PetByAge | PetByType} [petByAgePetByType] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        petsFilteredPatch(petByAgePetByType?: PetByAge | PetByType, options?: any): AxiosPromise<void> {
-            return localVarFp.petsFilteredPatch(petByAgePetByType, options).then((request) => request(axios, basePath));
+        petsFilteredPatch(petByAgePetByType?: PetByAge | PetByType, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.petsFilteredPatch(petByAgePetByType, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @param {Cat | Dog} [catDog] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        petsPatch(catDog?: Cat | Dog, options?: any): AxiosPromise<void> {
-            return localVarFp.petsPatch(catDog, options).then((request) => request(axios, basePath));
+        petsPatch(catDog?: Cat | Dog, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.petsPatch(catDog, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -372,34 +372,34 @@ export class DefaultApi extends BaseAPI {
     /**
      * 
      * @param {InlineObject} [inlineObject] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public filePost(inlineObject?: InlineObject, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).filePost(inlineObject, options).then((request) => request(this.axios, this.basePath));
+    public filePost(inlineObject?: InlineObject, axiosOptions?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).filePost(inlineObject, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @param {PetByAge | PetByType} [petByAgePetByType] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public petsFilteredPatch(petByAgePetByType?: PetByAge | PetByType, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).petsFilteredPatch(petByAgePetByType, options).then((request) => request(this.axios, this.basePath));
+    public petsFilteredPatch(petByAgePetByType?: PetByAge | PetByType, axiosOptions?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).petsFilteredPatch(petByAgePetByType, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @param {Cat | Dog} [catDog] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public petsPatch(catDog?: Cat | Dog, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).petsPatch(catDog, options).then((request) => request(this.axios, this.basePath));
+    public petsPatch(catDog?: Cat | Dog, axiosOptions?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).petsPatch(catDog, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://api.example.xyz/v1".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/default/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -254,10 +254,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -268,7 +268,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -282,7 +282,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -295,10 +295,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -310,7 +310,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -326,7 +326,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -337,10 +337,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -351,7 +351,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -367,7 +367,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -378,11 +378,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -393,7 +393,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -409,7 +409,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -420,10 +420,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -435,7 +435,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -446,7 +446,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -457,10 +457,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -471,7 +471,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -485,7 +485,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -499,10 +499,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -514,7 +514,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -537,7 +537,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -551,10 +551,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -566,7 +566,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -589,7 +589,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -611,11 +611,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -623,56 +623,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -681,11 +681,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -694,11 +694,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -715,63 +715,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -779,11 +779,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -791,11 +791,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -811,12 +811,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -824,61 +824,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -887,12 +887,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -901,12 +901,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -921,10 +921,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -936,7 +936,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -944,7 +944,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -954,10 +954,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -966,7 +966,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -977,7 +977,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -988,10 +988,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1003,7 +1003,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1011,7 +1011,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1022,10 +1022,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('placeOrder', 'body', body)
             const localVarPath = `/store/order`;
@@ -1036,7 +1036,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1046,7 +1046,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1068,43 +1068,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1121,40 +1121,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1170,47 +1170,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} body order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(body: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(body: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1225,10 +1225,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -1239,7 +1239,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1249,7 +1249,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1261,10 +1261,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -1275,7 +1275,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1285,7 +1285,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1297,10 +1297,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -1311,7 +1311,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1321,7 +1321,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1333,10 +1333,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1348,7 +1348,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1356,7 +1356,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1367,10 +1367,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1382,7 +1382,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1390,7 +1390,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1402,10 +1402,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1418,7 +1418,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1434,7 +1434,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1444,10 +1444,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1456,7 +1456,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1464,7 +1464,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1476,10 +1476,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -1493,7 +1493,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1503,7 +1503,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1525,55 +1525,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1581,21 +1581,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1603,11 +1603,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1624,82 +1624,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1715,60 +1715,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1776,23 +1776,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1800,12 +1800,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/default/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -254,10 +254,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -268,7 +268,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -282,7 +282,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -295,10 +295,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -310,7 +310,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -326,7 +326,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -337,10 +337,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -351,7 +351,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -367,7 +367,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -378,11 +378,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -393,7 +393,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -409,7 +409,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -420,10 +420,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -435,7 +435,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -446,7 +446,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -457,10 +457,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -471,7 +471,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -485,7 +485,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -499,10 +499,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -514,7 +514,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -537,7 +537,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -551,10 +551,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -566,7 +566,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -589,7 +589,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -611,11 +611,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -623,56 +623,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -681,11 +681,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -694,11 +694,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -715,63 +715,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -779,11 +779,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -791,11 +791,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -811,12 +811,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -824,61 +824,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -887,12 +887,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -901,12 +901,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -921,10 +921,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -936,7 +936,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -944,7 +944,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -954,10 +954,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -966,7 +966,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -977,7 +977,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -988,10 +988,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1003,7 +1003,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1011,7 +1011,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1022,10 +1022,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('placeOrder', 'body', body)
             const localVarPath = `/store/order`;
@@ -1036,7 +1036,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1046,7 +1046,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1068,43 +1068,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1121,40 +1121,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1170,47 +1170,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} body order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(body: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(body: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1225,10 +1225,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -1239,7 +1239,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1249,7 +1249,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1261,10 +1261,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -1275,7 +1275,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1285,7 +1285,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1297,10 +1297,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -1311,7 +1311,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1321,7 +1321,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1333,10 +1333,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1348,7 +1348,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1356,7 +1356,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1367,10 +1367,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1382,7 +1382,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1390,7 +1390,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1402,10 +1402,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1418,7 +1418,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1434,7 +1434,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1444,10 +1444,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1456,7 +1456,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1464,7 +1464,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1476,10 +1476,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -1493,7 +1493,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1503,7 +1503,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1525,55 +1525,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1581,21 +1581,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1603,11 +1603,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1624,82 +1624,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1715,60 +1715,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1776,23 +1776,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1800,12 +1800,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * 
@@ -1741,10 +1741,10 @@ export const AnotherFakeApiAxiosParamCreator = function (configuration?: Configu
          * To test special tags and operation ID starting with number
          * @summary To test special tags
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        _123testSpecialTags: async (client: Client, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        _123testSpecialTags: async (client: Client, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'client' is not null or undefined
             assertParamExists('_123testSpecialTags', 'client', client)
             const localVarPath = `/another-fake/dummy`;
@@ -1755,7 +1755,7 @@ export const AnotherFakeApiAxiosParamCreator = function (configuration?: Configu
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1765,7 +1765,7 @@ export const AnotherFakeApiAxiosParamCreator = function (configuration?: Configu
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(client, localVarRequestOptions, configuration)
 
             return {
@@ -1787,11 +1787,11 @@ export const AnotherFakeApiFp = function(configuration?: Configuration) {
          * To test special tags and operation ID starting with number
          * @summary To test special tags
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async _123testSpecialTags(client: Client, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator._123testSpecialTags(client, options);
+        async _123testSpecialTags(client: Client, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator._123testSpecialTags(client, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1808,11 +1808,11 @@ export const AnotherFakeApiFactory = function (configuration?: Configuration, ba
          * To test special tags and operation ID starting with number
          * @summary To test special tags
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        _123testSpecialTags(client: Client, options?: any): AxiosPromise<Client> {
-            return localVarFp._123testSpecialTags(client, options).then((request) => request(axios, basePath));
+        _123testSpecialTags(client: Client, axiosOptions?: any): AxiosPromise<Client> {
+            return localVarFp._123testSpecialTags(client, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1828,12 +1828,12 @@ export class AnotherFakeApi extends BaseAPI {
      * To test special tags and operation ID starting with number
      * @summary To test special tags
      * @param {Client} client client model
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof AnotherFakeApi
      */
-    public _123testSpecialTags(client: Client, options?: AxiosRequestConfig) {
-        return AnotherFakeApiFp(this.configuration)._123testSpecialTags(client, options).then((request) => request(this.axios, this.basePath));
+    public _123testSpecialTags(client: Client, axiosOptions?: AxiosRequestConfig) {
+        return AnotherFakeApiFp(this.configuration)._123testSpecialTags(client, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1846,10 +1846,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
     return {
         /**
          * 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fooGet: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fooGet: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/foo`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1858,7 +1858,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1866,7 +1866,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1885,11 +1885,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fooGet(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<InlineResponseDefault>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fooGet(options);
+        async fooGet(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<InlineResponseDefault>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fooGet(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1904,11 +1904,11 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
     return {
         /**
          * 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fooGet(options?: any): AxiosPromise<InlineResponseDefault> {
-            return localVarFp.fooGet(options).then((request) => request(axios, basePath));
+        fooGet(axiosOptions?: any): AxiosPromise<InlineResponseDefault> {
+            return localVarFp.fooGet(axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1922,12 +1922,12 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
 export class DefaultApi extends BaseAPI {
     /**
      * 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public fooGet(options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).fooGet(options).then((request) => request(this.axios, this.basePath));
+    public fooGet(axiosOptions?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).fooGet(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1941,10 +1941,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Health check endpoint
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeHealthGet: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeHealthGet: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/health`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1953,7 +1953,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1961,7 +1961,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1971,10 +1971,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of outer boolean types
          * @param {boolean} [body] Input boolean as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterBooleanSerialize: async (body?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterBooleanSerialize: async (body?: boolean, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/boolean`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1983,7 +1983,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1993,7 +1993,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -2004,10 +2004,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of object with outer number type
          * @param {OuterComposite} [outerComposite] Input composite as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterCompositeSerialize: async (outerComposite?: OuterComposite, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterCompositeSerialize: async (outerComposite?: OuterComposite, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/composite`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2016,7 +2016,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2026,7 +2026,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(outerComposite, localVarRequestOptions, configuration)
 
             return {
@@ -2037,10 +2037,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of outer number types
          * @param {number} [body] Input number as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterNumberSerialize: async (body?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterNumberSerialize: async (body?: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/number`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2049,7 +2049,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2059,7 +2059,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -2070,10 +2070,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of outer string types
          * @param {string} [body] Input string as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterStringSerialize: async (body?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterStringSerialize: async (body?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/string`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2082,7 +2082,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2092,7 +2092,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -2103,10 +2103,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Array of Enums
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getArrayOfEnums: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getArrayOfEnums: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/array-of-enums`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2115,7 +2115,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2123,7 +2123,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -2133,10 +2133,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * For this test, the body for this request much reference a schema named `File`.
          * @param {FileSchemaTestClass} fileSchemaTestClass 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithFileSchema: async (fileSchemaTestClass: FileSchemaTestClass, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testBodyWithFileSchema: async (fileSchemaTestClass: FileSchemaTestClass, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'fileSchemaTestClass' is not null or undefined
             assertParamExists('testBodyWithFileSchema', 'fileSchemaTestClass', fileSchemaTestClass)
             const localVarPath = `/fake/body-with-file-schema`;
@@ -2147,7 +2147,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2157,7 +2157,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(fileSchemaTestClass, localVarRequestOptions, configuration)
 
             return {
@@ -2169,10 +2169,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @param {string} query 
          * @param {User} user 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithQueryParams: async (query: string, user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testBodyWithQueryParams: async (query: string, user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'query' is not null or undefined
             assertParamExists('testBodyWithQueryParams', 'query', query)
             // verify required parameter 'user' is not null or undefined
@@ -2185,7 +2185,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2199,7 +2199,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -2211,10 +2211,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * To test \"client\" model
          * @summary To test \"client\" model
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClientModel: async (client: Client, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testClientModel: async (client: Client, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'client' is not null or undefined
             assertParamExists('testClientModel', 'client', client)
             const localVarPath = `/fake`;
@@ -2225,7 +2225,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2235,7 +2235,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(client, localVarRequestOptions, configuration)
 
             return {
@@ -2260,10 +2260,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} [dateTime] None
          * @param {string} [password] None
          * @param {string} [callback] None
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEndpointParameters: async (number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testEndpointParameters: async (number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'number' is not null or undefined
             assertParamExists('testEndpointParameters', 'number', number)
             // verify required parameter '_double' is not null or undefined
@@ -2280,7 +2280,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -2351,7 +2351,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -2370,10 +2370,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
          * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
          * @param {string} [enumFormString] Form parameter enum test (string)
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEnumParameters: async (enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testEnumParameters: async (enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2382,7 +2382,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -2426,7 +2426,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -2443,10 +2443,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {number} [stringGroup] String in group parameters
          * @param {boolean} [booleanGroup] Boolean in group parameters
          * @param {number} [int64Group] Integer in group parameters
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testGroupParameters: async (requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testGroupParameters: async (requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'requiredStringGroup' is not null or undefined
             assertParamExists('testGroupParameters', 'requiredStringGroup', requiredStringGroup)
             // verify required parameter 'requiredBooleanGroup' is not null or undefined
@@ -2461,7 +2461,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2497,7 +2497,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -2508,10 +2508,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary test inline additionalProperties
          * @param {{ [key: string]: string; }} requestBody request body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testInlineAdditionalProperties: async (requestBody: { [key: string]: string; }, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testInlineAdditionalProperties: async (requestBody: { [key: string]: string; }, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'requestBody' is not null or undefined
             assertParamExists('testInlineAdditionalProperties', 'requestBody', requestBody)
             const localVarPath = `/fake/inline-additionalProperties`;
@@ -2522,7 +2522,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2532,7 +2532,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration)
 
             return {
@@ -2545,10 +2545,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary test json serialization of form data
          * @param {string} param field1
          * @param {string} param2 field2
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testJsonFormData: async (param: string, param2: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testJsonFormData: async (param: string, param2: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'param' is not null or undefined
             assertParamExists('testJsonFormData', 'param', param)
             // verify required parameter 'param2' is not null or undefined
@@ -2561,7 +2561,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -2580,7 +2580,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -2595,10 +2595,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {Array<string>} http 
          * @param {Array<string>} url 
          * @param {Array<string>} context 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testQueryParameterCollectionFormat: async (pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testQueryParameterCollectionFormat: async (pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pipe' is not null or undefined
             assertParamExists('testQueryParameterCollectionFormat', 'pipe', pipe)
             // verify required parameter 'ioutil' is not null or undefined
@@ -2617,7 +2617,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2645,7 +2645,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -2665,93 +2665,93 @@ export const FakeApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary Health check endpoint
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeHealthGet(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HealthCheckResult>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeHealthGet(options);
+        async fakeHealthGet(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HealthCheckResult>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeHealthGet(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of outer boolean types
          * @param {boolean} [body] Input boolean as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterBooleanSerialize(body?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterBooleanSerialize(body, options);
+        async fakeOuterBooleanSerialize(body?: boolean, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterBooleanSerialize(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of object with outer number type
          * @param {OuterComposite} [outerComposite] Input composite as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterCompositeSerialize(outerComposite?: OuterComposite, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OuterComposite>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterCompositeSerialize(outerComposite, options);
+        async fakeOuterCompositeSerialize(outerComposite?: OuterComposite, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OuterComposite>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterCompositeSerialize(outerComposite, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of outer number types
          * @param {number} [body] Input number as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterNumberSerialize(body?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<number>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterNumberSerialize(body, options);
+        async fakeOuterNumberSerialize(body?: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<number>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterNumberSerialize(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of outer string types
          * @param {string} [body] Input string as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterStringSerialize(body?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterStringSerialize(body, options);
+        async fakeOuterStringSerialize(body?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterStringSerialize(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Array of Enums
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getArrayOfEnums(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<OuterEnum>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getArrayOfEnums(options);
+        async getArrayOfEnums(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<OuterEnum>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getArrayOfEnums(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For this test, the body for this request much reference a schema named `File`.
          * @param {FileSchemaTestClass} fileSchemaTestClass 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithFileSchema(fileSchemaTestClass, options);
+        async testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithFileSchema(fileSchemaTestClass, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @param {string} query 
          * @param {User} user 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testBodyWithQueryParams(query: string, user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithQueryParams(query, user, options);
+        async testBodyWithQueryParams(query: string, user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithQueryParams(query, user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * To test \"client\" model
          * @summary To test \"client\" model
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testClientModel(client: Client, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testClientModel(client, options);
+        async testClientModel(client: Client, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testClientModel(client, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2771,11 +2771,11 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {string} [dateTime] None
          * @param {string} [password] None
          * @param {string} [callback] None
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, options);
+        async testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2789,11 +2789,11 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
          * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
          * @param {string} [enumFormString] Form parameter enum test (string)
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, options);
+        async testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2805,22 +2805,22 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {number} [stringGroup] String in group parameters
          * @param {boolean} [booleanGroup] Boolean in group parameters
          * @param {number} [int64Group] Integer in group parameters
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, options);
+        async testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary test inline additionalProperties
          * @param {{ [key: string]: string; }} requestBody request body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testInlineAdditionalProperties(requestBody: { [key: string]: string; }, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testInlineAdditionalProperties(requestBody, options);
+        async testInlineAdditionalProperties(requestBody: { [key: string]: string; }, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testInlineAdditionalProperties(requestBody, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2828,11 +2828,11 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @summary test json serialization of form data
          * @param {string} param field1
          * @param {string} param2 field2
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testJsonFormData(param: string, param2: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testJsonFormData(param, param2, options);
+        async testJsonFormData(param: string, param2: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testJsonFormData(param, param2, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2842,11 +2842,11 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {Array<string>} http 
          * @param {Array<string>} url 
          * @param {Array<string>} context 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, options);
+        async testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -2862,85 +2862,85 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
         /**
          * 
          * @summary Health check endpoint
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeHealthGet(options?: any): AxiosPromise<HealthCheckResult> {
-            return localVarFp.fakeHealthGet(options).then((request) => request(axios, basePath));
+        fakeHealthGet(axiosOptions?: any): AxiosPromise<HealthCheckResult> {
+            return localVarFp.fakeHealthGet(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of outer boolean types
          * @param {boolean} [body] Input boolean as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterBooleanSerialize(body?: boolean, options?: any): AxiosPromise<boolean> {
-            return localVarFp.fakeOuterBooleanSerialize(body, options).then((request) => request(axios, basePath));
+        fakeOuterBooleanSerialize(body?: boolean, axiosOptions?: any): AxiosPromise<boolean> {
+            return localVarFp.fakeOuterBooleanSerialize(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of object with outer number type
          * @param {OuterComposite} [outerComposite] Input composite as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterCompositeSerialize(outerComposite?: OuterComposite, options?: any): AxiosPromise<OuterComposite> {
-            return localVarFp.fakeOuterCompositeSerialize(outerComposite, options).then((request) => request(axios, basePath));
+        fakeOuterCompositeSerialize(outerComposite?: OuterComposite, axiosOptions?: any): AxiosPromise<OuterComposite> {
+            return localVarFp.fakeOuterCompositeSerialize(outerComposite, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of outer number types
          * @param {number} [body] Input number as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterNumberSerialize(body?: number, options?: any): AxiosPromise<number> {
-            return localVarFp.fakeOuterNumberSerialize(body, options).then((request) => request(axios, basePath));
+        fakeOuterNumberSerialize(body?: number, axiosOptions?: any): AxiosPromise<number> {
+            return localVarFp.fakeOuterNumberSerialize(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of outer string types
          * @param {string} [body] Input string as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterStringSerialize(body?: string, options?: any): AxiosPromise<string> {
-            return localVarFp.fakeOuterStringSerialize(body, options).then((request) => request(axios, basePath));
+        fakeOuterStringSerialize(body?: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.fakeOuterStringSerialize(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Array of Enums
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getArrayOfEnums(options?: any): AxiosPromise<Array<OuterEnum>> {
-            return localVarFp.getArrayOfEnums(options).then((request) => request(axios, basePath));
+        getArrayOfEnums(axiosOptions?: any): AxiosPromise<Array<OuterEnum>> {
+            return localVarFp.getArrayOfEnums(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For this test, the body for this request much reference a schema named `File`.
          * @param {FileSchemaTestClass} fileSchemaTestClass 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, options?: any): AxiosPromise<void> {
-            return localVarFp.testBodyWithFileSchema(fileSchemaTestClass, options).then((request) => request(axios, basePath));
+        testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testBodyWithFileSchema(fileSchemaTestClass, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @param {string} query 
          * @param {User} user 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithQueryParams(query: string, user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.testBodyWithQueryParams(query, user, options).then((request) => request(axios, basePath));
+        testBodyWithQueryParams(query: string, user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testBodyWithQueryParams(query, user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * To test \"client\" model
          * @summary To test \"client\" model
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClientModel(client: Client, options?: any): AxiosPromise<Client> {
-            return localVarFp.testClientModel(client, options).then((request) => request(axios, basePath));
+        testClientModel(client: Client, axiosOptions?: any): AxiosPromise<Client> {
+            return localVarFp.testClientModel(client, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -2959,11 +2959,11 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {string} [dateTime] None
          * @param {string} [password] None
          * @param {string} [callback] None
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, options).then((request) => request(axios, basePath));
+        testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * To test enum parameters
@@ -2976,11 +2976,11 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
          * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
          * @param {string} [enumFormString] Form parameter enum test (string)
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, options).then((request) => request(axios, basePath));
+        testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Fake endpoint to test group parameters (optional)
@@ -2991,32 +2991,32 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {number} [stringGroup] String in group parameters
          * @param {boolean} [booleanGroup] Boolean in group parameters
          * @param {number} [int64Group] Integer in group parameters
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any): AxiosPromise<void> {
-            return localVarFp.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, options).then((request) => request(axios, basePath));
+        testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary test inline additionalProperties
          * @param {{ [key: string]: string; }} requestBody request body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testInlineAdditionalProperties(requestBody: { [key: string]: string; }, options?: any): AxiosPromise<void> {
-            return localVarFp.testInlineAdditionalProperties(requestBody, options).then((request) => request(axios, basePath));
+        testInlineAdditionalProperties(requestBody: { [key: string]: string; }, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testInlineAdditionalProperties(requestBody, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary test json serialization of form data
          * @param {string} param field1
          * @param {string} param2 field2
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testJsonFormData(param: string, param2: string, options?: any): AxiosPromise<void> {
-            return localVarFp.testJsonFormData(param, param2, options).then((request) => request(axios, basePath));
+        testJsonFormData(param: string, param2: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testJsonFormData(param, param2, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * To test the collection format in query parameters
@@ -3025,11 +3025,11 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {Array<string>} http 
          * @param {Array<string>} url 
          * @param {Array<string>} context 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options?: any): AxiosPromise<void> {
-            return localVarFp.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, options).then((request) => request(axios, basePath));
+        testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -3044,102 +3044,102 @@ export class FakeApi extends BaseAPI {
     /**
      * 
      * @summary Health check endpoint
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeHealthGet(options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeHealthGet(options).then((request) => request(this.axios, this.basePath));
+    public fakeHealthGet(axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeHealthGet(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of outer boolean types
      * @param {boolean} [body] Input boolean as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterBooleanSerialize(body?: boolean, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterBooleanSerialize(body, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterBooleanSerialize(body?: boolean, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterBooleanSerialize(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of object with outer number type
      * @param {OuterComposite} [outerComposite] Input composite as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterCompositeSerialize(outerComposite?: OuterComposite, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterCompositeSerialize(outerComposite, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterCompositeSerialize(outerComposite?: OuterComposite, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterCompositeSerialize(outerComposite, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of outer number types
      * @param {number} [body] Input number as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterNumberSerialize(body?: number, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterNumberSerialize(body, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterNumberSerialize(body?: number, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterNumberSerialize(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of outer string types
      * @param {string} [body] Input string as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterStringSerialize(body?: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterStringSerialize(body, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterStringSerialize(body?: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterStringSerialize(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Array of Enums
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public getArrayOfEnums(options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).getArrayOfEnums(options).then((request) => request(this.axios, this.basePath));
+    public getArrayOfEnums(axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).getArrayOfEnums(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For this test, the body for this request much reference a schema named `File`.
      * @param {FileSchemaTestClass} fileSchemaTestClass 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testBodyWithFileSchema(fileSchemaTestClass, options).then((request) => request(this.axios, this.basePath));
+    public testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testBodyWithFileSchema(fileSchemaTestClass, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @param {string} query 
      * @param {User} user 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testBodyWithQueryParams(query: string, user: User, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testBodyWithQueryParams(query, user, options).then((request) => request(this.axios, this.basePath));
+    public testBodyWithQueryParams(query: string, user: User, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testBodyWithQueryParams(query, user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * To test \"client\" model
      * @summary To test \"client\" model
      * @param {Client} client client model
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testClientModel(client: Client, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testClientModel(client, options).then((request) => request(this.axios, this.basePath));
+    public testClientModel(client: Client, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testClientModel(client, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3159,12 +3159,12 @@ export class FakeApi extends BaseAPI {
      * @param {string} [dateTime] None
      * @param {string} [password] None
      * @param {string} [callback] None
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, options).then((request) => request(this.axios, this.basePath));
+    public testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3178,12 +3178,12 @@ export class FakeApi extends BaseAPI {
      * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
      * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
      * @param {string} [enumFormString] Form parameter enum test (string)
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, options).then((request) => request(this.axios, this.basePath));
+    public testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3195,24 +3195,24 @@ export class FakeApi extends BaseAPI {
      * @param {number} [stringGroup] String in group parameters
      * @param {boolean} [booleanGroup] Boolean in group parameters
      * @param {number} [int64Group] Integer in group parameters
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, options).then((request) => request(this.axios, this.basePath));
+    public testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary test inline additionalProperties
      * @param {{ [key: string]: string; }} requestBody request body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testInlineAdditionalProperties(requestBody: { [key: string]: string; }, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testInlineAdditionalProperties(requestBody, options).then((request) => request(this.axios, this.basePath));
+    public testInlineAdditionalProperties(requestBody: { [key: string]: string; }, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testInlineAdditionalProperties(requestBody, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3220,12 +3220,12 @@ export class FakeApi extends BaseAPI {
      * @summary test json serialization of form data
      * @param {string} param field1
      * @param {string} param2 field2
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testJsonFormData(param: string, param2: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testJsonFormData(param, param2, options).then((request) => request(this.axios, this.basePath));
+    public testJsonFormData(param: string, param2: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testJsonFormData(param, param2, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3235,12 +3235,12 @@ export class FakeApi extends BaseAPI {
      * @param {Array<string>} http 
      * @param {Array<string>} url 
      * @param {Array<string>} context 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, options).then((request) => request(this.axios, this.basePath));
+    public testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -3255,10 +3255,10 @@ export const FakeClassnameTags123ApiAxiosParamCreator = function (configuration?
          * To test class name in snake case
          * @summary To test class name in snake case
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClassname: async (client: Client, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testClassname: async (client: Client, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'client' is not null or undefined
             assertParamExists('testClassname', 'client', client)
             const localVarPath = `/fake_classname_test`;
@@ -3269,7 +3269,7 @@ export const FakeClassnameTags123ApiAxiosParamCreator = function (configuration?
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3282,7 +3282,7 @@ export const FakeClassnameTags123ApiAxiosParamCreator = function (configuration?
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(client, localVarRequestOptions, configuration)
 
             return {
@@ -3304,11 +3304,11 @@ export const FakeClassnameTags123ApiFp = function(configuration?: Configuration)
          * To test class name in snake case
          * @summary To test class name in snake case
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testClassname(client: Client, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testClassname(client, options);
+        async testClassname(client: Client, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testClassname(client, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -3325,11 +3325,11 @@ export const FakeClassnameTags123ApiFactory = function (configuration?: Configur
          * To test class name in snake case
          * @summary To test class name in snake case
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClassname(client: Client, options?: any): AxiosPromise<Client> {
-            return localVarFp.testClassname(client, options).then((request) => request(axios, basePath));
+        testClassname(client: Client, axiosOptions?: any): AxiosPromise<Client> {
+            return localVarFp.testClassname(client, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -3345,12 +3345,12 @@ export class FakeClassnameTags123Api extends BaseAPI {
      * To test class name in snake case
      * @summary To test class name in snake case
      * @param {Client} client client model
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeClassnameTags123Api
      */
-    public testClassname(client: Client, options?: AxiosRequestConfig) {
-        return FakeClassnameTags123ApiFp(this.configuration).testClassname(client, options).then((request) => request(this.axios, this.basePath));
+    public testClassname(client: Client, axiosOptions?: AxiosRequestConfig) {
+        return FakeClassnameTags123ApiFp(this.configuration).testClassname(client, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -3365,10 +3365,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (pet: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (pet: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pet' is not null or undefined
             assertParamExists('addPet', 'pet', pet)
             const localVarPath = `/pet`;
@@ -3379,7 +3379,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3395,7 +3395,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(pet, localVarRequestOptions, configuration)
 
             return {
@@ -3408,10 +3408,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -3423,7 +3423,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3439,7 +3439,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3450,10 +3450,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -3464,7 +3464,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3482,7 +3482,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3493,11 +3493,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -3508,7 +3508,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3526,7 +3526,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3537,10 +3537,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -3552,7 +3552,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3563,7 +3563,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3574,10 +3574,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (pet: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (pet: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pet' is not null or undefined
             assertParamExists('updatePet', 'pet', pet)
             const localVarPath = `/pet`;
@@ -3588,7 +3588,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3604,7 +3604,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(pet, localVarRequestOptions, configuration)
 
             return {
@@ -3618,10 +3618,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -3633,7 +3633,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -3656,7 +3656,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -3670,10 +3670,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -3685,7 +3685,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -3708,7 +3708,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -3722,10 +3722,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {any} requiredFile file to upload
          * @param {string} [additionalMetadata] Additional data to pass to server
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFileWithRequiredFile: async (petId: number, requiredFile: any, additionalMetadata?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFileWithRequiredFile: async (petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFileWithRequiredFile', 'petId', petId)
             // verify required parameter 'requiredFile' is not null or undefined
@@ -3739,7 +3739,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -3762,7 +3762,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -3784,11 +3784,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(pet: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, options);
+        async addPet(pet: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3796,56 +3796,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(pet: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(pet, options);
+        async updatePet(pet: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(pet, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3854,11 +3854,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3867,11 +3867,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3880,11 +3880,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {any} requiredFile file to upload
          * @param {string} [additionalMetadata] Additional data to pass to server
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, options);
+        async uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -3901,63 +3901,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(pet: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(pet, options).then((request) => request(axios, basePath));
+        addPet(pet: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(pet, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(pet: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(pet, options).then((request) => request(axios, basePath));
+        updatePet(pet: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(pet, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3965,11 +3965,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3977,11 +3977,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3989,11 +3989,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {any} requiredFile file to upload
          * @param {string} [additionalMetadata] Additional data to pass to server
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, options).then((request) => request(axios, basePath));
+        uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -4009,12 +4009,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} pet Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(pet: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(pet, options).then((request) => request(this.axios, this.basePath));
+    public addPet(pet: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(pet, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4022,61 +4022,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} pet Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(pet: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(pet, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(pet: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(pet, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4085,12 +4085,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4099,12 +4099,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4113,12 +4113,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {any} requiredFile file to upload
      * @param {string} [additionalMetadata] Additional data to pass to server
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, options).then((request) => request(this.axios, this.basePath));
+    public uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -4133,10 +4133,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{order_id}`
@@ -4148,7 +4148,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4156,7 +4156,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4166,10 +4166,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4178,7 +4178,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4189,7 +4189,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4200,10 +4200,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{order_id}`
@@ -4215,7 +4215,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4223,7 +4223,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4234,10 +4234,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (order: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (order: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'order' is not null or undefined
             assertParamExists('placeOrder', 'order', order)
             const localVarPath = `/store/order`;
@@ -4248,7 +4248,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4258,7 +4258,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(order, localVarRequestOptions, configuration)
 
             return {
@@ -4280,43 +4280,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(order: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(order, options);
+        async placeOrder(order: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(order, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -4333,40 +4333,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(order: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(order, options).then((request) => request(axios, basePath));
+        placeOrder(order: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(order, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -4382,47 +4382,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} order order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(order: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(order, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(order: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(order, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -4437,10 +4437,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUser', 'user', user)
             const localVarPath = `/user`;
@@ -4451,7 +4451,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4461,7 +4461,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4473,10 +4473,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (user: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (user: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'user', user)
             const localVarPath = `/user/createWithArray`;
@@ -4487,7 +4487,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4497,7 +4497,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4509,10 +4509,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (user: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (user: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUsersWithListInput', 'user', user)
             const localVarPath = `/user/createWithList`;
@@ -4523,7 +4523,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4533,7 +4533,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4545,10 +4545,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -4560,7 +4560,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4568,7 +4568,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4579,10 +4579,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -4594,7 +4594,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4602,7 +4602,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4614,10 +4614,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -4630,7 +4630,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4646,7 +4646,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4656,10 +4656,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4668,7 +4668,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4676,7 +4676,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4688,10 +4688,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'user' is not null or undefined
@@ -4705,7 +4705,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4715,7 +4715,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4737,55 +4737,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(user, options);
+        async createUser(user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(user: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(user, options);
+        async createUsersWithArrayInput(user: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(user: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(user, options);
+        async createUsersWithListInput(user: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4793,21 +4793,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4815,11 +4815,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, user, options);
+        async updateUser(username: string, user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -4836,82 +4836,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(user, options).then((request) => request(axios, basePath));
+        createUser(user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(user: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(user, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(user: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(user: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(user, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(user: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, user, options).then((request) => request(axios, basePath));
+        updateUser(username: string, user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, user, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -4927,60 +4927,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} user Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(user: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(user, options).then((request) => request(this.axios, this.basePath));
+    public createUser(user: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} user List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(user, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(user: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} user List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(user: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(user, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(user: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4988,23 +4988,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5012,12 +5012,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} user Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, user: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, user, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, user: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io:80/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -256,10 +256,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {Pet} pet Pet object that needs to be added to the store
          * @param {Pet} [header1] 
          * @param {Array<Pet>} [header2] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (pet: Pet, header1?: Pet, header2?: Array<Pet>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (pet: Pet, header1?: Pet, header2?: Array<Pet>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pet' is not null or undefined
             assertParamExists('addPet', 'pet', pet)
             const localVarPath = `/pet`;
@@ -270,7 +270,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -293,7 +293,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(pet, localVarRequestOptions, configuration)
 
             return {
@@ -306,10 +306,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -321,7 +321,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -337,7 +337,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -348,10 +348,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -362,7 +362,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -378,7 +378,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -389,11 +389,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -404,7 +404,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -420,7 +420,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -431,10 +431,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -446,7 +446,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -457,7 +457,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -468,10 +468,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (pet: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (pet: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pet' is not null or undefined
             assertParamExists('updatePet', 'pet', pet)
             const localVarPath = `/pet`;
@@ -482,7 +482,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -496,7 +496,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(pet, localVarRequestOptions, configuration)
 
             return {
@@ -510,10 +510,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -525,7 +525,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -548,7 +548,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -562,10 +562,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -577,7 +577,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -600,7 +600,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -624,11 +624,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {Pet} pet Pet object that needs to be added to the store
          * @param {Pet} [header1] 
          * @param {Array<Pet>} [header2] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, header1, header2, options);
+        async addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, header1, header2, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -636,56 +636,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(pet: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(pet, options);
+        async updatePet(pet: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(pet, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -694,11 +694,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -707,11 +707,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -730,63 +730,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {Pet} pet Pet object that needs to be added to the store
          * @param {Pet} [header1] 
          * @param {Array<Pet>} [header2] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(pet, header1, header2, options).then((request) => request(axios, basePath));
+        addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(pet, header1, header2, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(pet: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(pet, options).then((request) => request(axios, basePath));
+        updatePet(pet: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(pet, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -794,11 +794,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -806,11 +806,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -828,12 +828,12 @@ export class PetApi extends BaseAPI {
      * @param {Pet} pet Pet object that needs to be added to the store
      * @param {Pet} [header1] 
      * @param {Array<Pet>} [header2] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(pet, header1, header2, options).then((request) => request(this.axios, this.basePath));
+    public addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(pet, header1, header2, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -841,61 +841,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} pet Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(pet: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(pet, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(pet: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(pet, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -904,12 +904,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -918,12 +918,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -938,10 +938,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -953,7 +953,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -961,7 +961,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -971,10 +971,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -983,7 +983,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -994,7 +994,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1005,10 +1005,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1020,7 +1020,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1028,7 +1028,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1039,10 +1039,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (order: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (order: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'order' is not null or undefined
             assertParamExists('placeOrder', 'order', order)
             const localVarPath = `/store/order`;
@@ -1053,7 +1053,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1063,7 +1063,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(order, localVarRequestOptions, configuration)
 
             return {
@@ -1085,43 +1085,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(order: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(order, options);
+        async placeOrder(order: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(order, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1138,40 +1138,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(order: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(order, options).then((request) => request(axios, basePath));
+        placeOrder(order: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(order, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1187,47 +1187,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} order order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(order: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(order, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(order: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(order, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1242,10 +1242,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUser', 'user', user)
             const localVarPath = `/user`;
@@ -1256,7 +1256,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1266,7 +1266,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -1278,10 +1278,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (user: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (user: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'user', user)
             const localVarPath = `/user/createWithArray`;
@@ -1292,7 +1292,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1302,7 +1302,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -1314,10 +1314,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (user: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (user: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUsersWithListInput', 'user', user)
             const localVarPath = `/user/createWithList`;
@@ -1328,7 +1328,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1338,7 +1338,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -1350,10 +1350,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1365,7 +1365,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1373,7 +1373,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1384,10 +1384,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1399,7 +1399,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1407,7 +1407,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1419,10 +1419,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1435,7 +1435,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1451,7 +1451,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1461,10 +1461,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1473,7 +1473,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1481,7 +1481,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1493,10 +1493,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'user' is not null or undefined
@@ -1510,7 +1510,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1520,7 +1520,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -1542,55 +1542,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(user, options);
+        async createUser(user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(user: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(user, options);
+        async createUsersWithArrayInput(user: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(user: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(user, options);
+        async createUsersWithListInput(user: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1598,21 +1598,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1620,11 +1620,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, user, options);
+        async updateUser(username: string, user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1641,82 +1641,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(user, options).then((request) => request(axios, basePath));
+        createUser(user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(user: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(user, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(user: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(user: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(user, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(user: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, user, options).then((request) => request(axios, basePath));
+        updateUser(username: string, user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, user, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1732,60 +1732,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} user Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(user: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(user, options).then((request) => request(this.axios, this.basePath));
+    public createUser(user: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} user List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(user, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(user: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} user List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(user: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(user, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(user: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1793,23 +1793,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1817,12 +1817,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} user Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, user: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, user, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, user: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * 
@@ -1369,10 +1369,10 @@ export const AnotherFakeApiAxiosParamCreator = function (configuration?: Configu
          * To test special tags and operation ID starting with number
          * @summary To test special tags
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        _123testSpecialTags: async (client: Client, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        _123testSpecialTags: async (client: Client, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'client' is not null or undefined
             assertParamExists('_123testSpecialTags', 'client', client)
             const localVarPath = `/another-fake/dummy`;
@@ -1383,7 +1383,7 @@ export const AnotherFakeApiAxiosParamCreator = function (configuration?: Configu
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1393,7 +1393,7 @@ export const AnotherFakeApiAxiosParamCreator = function (configuration?: Configu
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(client, localVarRequestOptions, configuration)
 
             return {
@@ -1415,11 +1415,11 @@ export const AnotherFakeApiFp = function(configuration?: Configuration) {
          * To test special tags and operation ID starting with number
          * @summary To test special tags
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async _123testSpecialTags(client: Client, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator._123testSpecialTags(client, options);
+        async _123testSpecialTags(client: Client, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator._123testSpecialTags(client, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1436,11 +1436,11 @@ export const AnotherFakeApiFactory = function (configuration?: Configuration, ba
          * To test special tags and operation ID starting with number
          * @summary To test special tags
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        _123testSpecialTags(client: Client, options?: any): AxiosPromise<Client> {
-            return localVarFp._123testSpecialTags(client, options).then((request) => request(axios, basePath));
+        _123testSpecialTags(client: Client, axiosOptions?: any): AxiosPromise<Client> {
+            return localVarFp._123testSpecialTags(client, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1456,12 +1456,12 @@ export class AnotherFakeApi extends BaseAPI {
      * To test special tags and operation ID starting with number
      * @summary To test special tags
      * @param {Client} client client model
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof AnotherFakeApi
      */
-    public _123testSpecialTags(client: Client, options?: AxiosRequestConfig) {
-        return AnotherFakeApiFp(this.configuration)._123testSpecialTags(client, options).then((request) => request(this.axios, this.basePath));
+    public _123testSpecialTags(client: Client, axiosOptions?: AxiosRequestConfig) {
+        return AnotherFakeApiFp(this.configuration)._123testSpecialTags(client, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1474,10 +1474,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
     return {
         /**
          * 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fooGet: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fooGet: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/foo`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1486,7 +1486,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1494,7 +1494,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1513,11 +1513,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fooGet(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<InlineResponseDefault>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fooGet(options);
+        async fooGet(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<InlineResponseDefault>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fooGet(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1532,11 +1532,11 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
     return {
         /**
          * 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fooGet(options?: any): AxiosPromise<InlineResponseDefault> {
-            return localVarFp.fooGet(options).then((request) => request(axios, basePath));
+        fooGet(axiosOptions?: any): AxiosPromise<InlineResponseDefault> {
+            return localVarFp.fooGet(axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1550,12 +1550,12 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
 export class DefaultApi extends BaseAPI {
     /**
      * 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public fooGet(options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).fooGet(options).then((request) => request(this.axios, this.basePath));
+    public fooGet(axiosOptions?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).fooGet(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1569,10 +1569,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Health check endpoint
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeHealthGet: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeHealthGet: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/health`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1581,7 +1581,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1589,7 +1589,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1599,10 +1599,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of outer boolean types
          * @param {boolean} [body] Input boolean as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterBooleanSerialize: async (body?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterBooleanSerialize: async (body?: boolean, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/boolean`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1611,7 +1611,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1621,7 +1621,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1632,10 +1632,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of object with outer number type
          * @param {OuterComposite} [outerComposite] Input composite as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterCompositeSerialize: async (outerComposite?: OuterComposite, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterCompositeSerialize: async (outerComposite?: OuterComposite, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/composite`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1644,7 +1644,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1654,7 +1654,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(outerComposite, localVarRequestOptions, configuration)
 
             return {
@@ -1665,10 +1665,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of outer number types
          * @param {number} [body] Input number as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterNumberSerialize: async (body?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterNumberSerialize: async (body?: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/number`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1677,7 +1677,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1687,7 +1687,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1698,10 +1698,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * Test serialization of outer string types
          * @param {string} [body] Input string as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterStringSerialize: async (body?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        fakeOuterStringSerialize: async (body?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake/outer/string`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1710,7 +1710,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1720,7 +1720,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1731,10 +1731,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * For this test, the body for this request much reference a schema named `File`.
          * @param {FileSchemaTestClass} fileSchemaTestClass 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithFileSchema: async (fileSchemaTestClass: FileSchemaTestClass, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testBodyWithFileSchema: async (fileSchemaTestClass: FileSchemaTestClass, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'fileSchemaTestClass' is not null or undefined
             assertParamExists('testBodyWithFileSchema', 'fileSchemaTestClass', fileSchemaTestClass)
             const localVarPath = `/fake/body-with-file-schema`;
@@ -1745,7 +1745,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1755,7 +1755,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(fileSchemaTestClass, localVarRequestOptions, configuration)
 
             return {
@@ -1767,10 +1767,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @param {string} query 
          * @param {User} user 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithQueryParams: async (query: string, user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testBodyWithQueryParams: async (query: string, user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'query' is not null or undefined
             assertParamExists('testBodyWithQueryParams', 'query', query)
             // verify required parameter 'user' is not null or undefined
@@ -1783,7 +1783,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1797,7 +1797,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -1809,10 +1809,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * To test \"client\" model
          * @summary To test \"client\" model
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClientModel: async (client: Client, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testClientModel: async (client: Client, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'client' is not null or undefined
             assertParamExists('testClientModel', 'client', client)
             const localVarPath = `/fake`;
@@ -1823,7 +1823,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1833,7 +1833,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(client, localVarRequestOptions, configuration)
 
             return {
@@ -1858,10 +1858,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {string} [dateTime] None
          * @param {string} [password] None
          * @param {string} [callback] None
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEndpointParameters: async (number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testEndpointParameters: async (number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'number' is not null or undefined
             assertParamExists('testEndpointParameters', 'number', number)
             // verify required parameter '_double' is not null or undefined
@@ -1878,7 +1878,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -1949,7 +1949,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -1968,10 +1968,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
          * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
          * @param {string} [enumFormString] Form parameter enum test (string)
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEnumParameters: async (enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testEnumParameters: async (enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/fake`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1980,7 +1980,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -2024,7 +2024,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -2041,10 +2041,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {number} [stringGroup] String in group parameters
          * @param {boolean} [booleanGroup] Boolean in group parameters
          * @param {number} [int64Group] Integer in group parameters
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testGroupParameters: async (requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testGroupParameters: async (requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'requiredStringGroup' is not null or undefined
             assertParamExists('testGroupParameters', 'requiredStringGroup', requiredStringGroup)
             // verify required parameter 'requiredBooleanGroup' is not null or undefined
@@ -2059,7 +2059,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2095,7 +2095,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -2106,10 +2106,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary test inline additionalProperties
          * @param {{ [key: string]: string; }} requestBody request body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testInlineAdditionalProperties: async (requestBody: { [key: string]: string; }, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testInlineAdditionalProperties: async (requestBody: { [key: string]: string; }, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'requestBody' is not null or undefined
             assertParamExists('testInlineAdditionalProperties', 'requestBody', requestBody)
             const localVarPath = `/fake/inline-additionalProperties`;
@@ -2120,7 +2120,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2130,7 +2130,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration)
 
             return {
@@ -2143,10 +2143,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary test json serialization of form data
          * @param {string} param field1
          * @param {string} param2 field2
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testJsonFormData: async (param: string, param2: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testJsonFormData: async (param: string, param2: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'param' is not null or undefined
             assertParamExists('testJsonFormData', 'param', param)
             // verify required parameter 'param2' is not null or undefined
@@ -2159,7 +2159,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -2178,7 +2178,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -2193,10 +2193,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {Array<string>} http 
          * @param {Array<string>} url 
          * @param {Array<string>} context 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testQueryParameterCollectionFormat: async (pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testQueryParameterCollectionFormat: async (pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pipe' is not null or undefined
             assertParamExists('testQueryParameterCollectionFormat', 'pipe', pipe)
             // verify required parameter 'ioutil' is not null or undefined
@@ -2215,7 +2215,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2243,7 +2243,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -2254,10 +2254,10 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
          * To test unique items in header and query parameters
          * @param {Set<string>} queryUnique 
          * @param {Set<string>} headerUnique 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testUniqueItemsHeaderAndQueryParameterCollectionFormat: async (queryUnique: Set<string>, headerUnique: Set<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testUniqueItemsHeaderAndQueryParameterCollectionFormat: async (queryUnique: Set<string>, headerUnique: Set<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'queryUnique' is not null or undefined
             assertParamExists('testUniqueItemsHeaderAndQueryParameterCollectionFormat', 'queryUnique', queryUnique)
             // verify required parameter 'headerUnique' is not null or undefined
@@ -2270,7 +2270,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2287,7 +2287,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -2307,83 +2307,83 @@ export const FakeApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary Health check endpoint
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeHealthGet(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HealthCheckResult>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeHealthGet(options);
+        async fakeHealthGet(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HealthCheckResult>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeHealthGet(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of outer boolean types
          * @param {boolean} [body] Input boolean as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterBooleanSerialize(body?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterBooleanSerialize(body, options);
+        async fakeOuterBooleanSerialize(body?: boolean, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<boolean>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterBooleanSerialize(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of object with outer number type
          * @param {OuterComposite} [outerComposite] Input composite as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterCompositeSerialize(outerComposite?: OuterComposite, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OuterComposite>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterCompositeSerialize(outerComposite, options);
+        async fakeOuterCompositeSerialize(outerComposite?: OuterComposite, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OuterComposite>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterCompositeSerialize(outerComposite, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of outer number types
          * @param {number} [body] Input number as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterNumberSerialize(body?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<number>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterNumberSerialize(body, options);
+        async fakeOuterNumberSerialize(body?: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<number>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterNumberSerialize(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Test serialization of outer string types
          * @param {string} [body] Input string as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async fakeOuterStringSerialize(body?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterStringSerialize(body, options);
+        async fakeOuterStringSerialize(body?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.fakeOuterStringSerialize(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For this test, the body for this request much reference a schema named `File`.
          * @param {FileSchemaTestClass} fileSchemaTestClass 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithFileSchema(fileSchemaTestClass, options);
+        async testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithFileSchema(fileSchemaTestClass, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @param {string} query 
          * @param {User} user 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testBodyWithQueryParams(query: string, user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithQueryParams(query, user, options);
+        async testBodyWithQueryParams(query: string, user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testBodyWithQueryParams(query, user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * To test \"client\" model
          * @summary To test \"client\" model
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testClientModel(client: Client, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testClientModel(client, options);
+        async testClientModel(client: Client, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testClientModel(client, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2403,11 +2403,11 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {string} [dateTime] None
          * @param {string} [password] None
          * @param {string} [callback] None
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, options);
+        async testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2421,11 +2421,11 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
          * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
          * @param {string} [enumFormString] Form parameter enum test (string)
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, options);
+        async testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2437,22 +2437,22 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {number} [stringGroup] String in group parameters
          * @param {boolean} [booleanGroup] Boolean in group parameters
          * @param {number} [int64Group] Integer in group parameters
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, options);
+        async testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary test inline additionalProperties
          * @param {{ [key: string]: string; }} requestBody request body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testInlineAdditionalProperties(requestBody: { [key: string]: string; }, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testInlineAdditionalProperties(requestBody, options);
+        async testInlineAdditionalProperties(requestBody: { [key: string]: string; }, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testInlineAdditionalProperties(requestBody, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2460,11 +2460,11 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @summary test json serialization of form data
          * @param {string} param field1
          * @param {string} param2 field2
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testJsonFormData(param: string, param2: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testJsonFormData(param, param2, options);
+        async testJsonFormData(param: string, param2: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testJsonFormData(param, param2, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -2474,22 +2474,22 @@ export const FakeApiFp = function(configuration?: Configuration) {
          * @param {Array<string>} http 
          * @param {Array<string>} url 
          * @param {Array<string>} context 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, options);
+        async testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * To test unique items in header and query parameters
          * @param {Set<string>} queryUnique 
          * @param {Set<string>} headerUnique 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique: Set<string>, headerUnique: Set<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Set<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique, headerUnique, options);
+        async testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique: Set<string>, headerUnique: Set<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Set<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique, headerUnique, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -2505,76 +2505,76 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
         /**
          * 
          * @summary Health check endpoint
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeHealthGet(options?: any): AxiosPromise<HealthCheckResult> {
-            return localVarFp.fakeHealthGet(options).then((request) => request(axios, basePath));
+        fakeHealthGet(axiosOptions?: any): AxiosPromise<HealthCheckResult> {
+            return localVarFp.fakeHealthGet(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of outer boolean types
          * @param {boolean} [body] Input boolean as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterBooleanSerialize(body?: boolean, options?: any): AxiosPromise<boolean> {
-            return localVarFp.fakeOuterBooleanSerialize(body, options).then((request) => request(axios, basePath));
+        fakeOuterBooleanSerialize(body?: boolean, axiosOptions?: any): AxiosPromise<boolean> {
+            return localVarFp.fakeOuterBooleanSerialize(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of object with outer number type
          * @param {OuterComposite} [outerComposite] Input composite as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterCompositeSerialize(outerComposite?: OuterComposite, options?: any): AxiosPromise<OuterComposite> {
-            return localVarFp.fakeOuterCompositeSerialize(outerComposite, options).then((request) => request(axios, basePath));
+        fakeOuterCompositeSerialize(outerComposite?: OuterComposite, axiosOptions?: any): AxiosPromise<OuterComposite> {
+            return localVarFp.fakeOuterCompositeSerialize(outerComposite, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of outer number types
          * @param {number} [body] Input number as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterNumberSerialize(body?: number, options?: any): AxiosPromise<number> {
-            return localVarFp.fakeOuterNumberSerialize(body, options).then((request) => request(axios, basePath));
+        fakeOuterNumberSerialize(body?: number, axiosOptions?: any): AxiosPromise<number> {
+            return localVarFp.fakeOuterNumberSerialize(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Test serialization of outer string types
          * @param {string} [body] Input string as post body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        fakeOuterStringSerialize(body?: string, options?: any): AxiosPromise<string> {
-            return localVarFp.fakeOuterStringSerialize(body, options).then((request) => request(axios, basePath));
+        fakeOuterStringSerialize(body?: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.fakeOuterStringSerialize(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For this test, the body for this request much reference a schema named `File`.
          * @param {FileSchemaTestClass} fileSchemaTestClass 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, options?: any): AxiosPromise<void> {
-            return localVarFp.testBodyWithFileSchema(fileSchemaTestClass, options).then((request) => request(axios, basePath));
+        testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testBodyWithFileSchema(fileSchemaTestClass, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @param {string} query 
          * @param {User} user 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testBodyWithQueryParams(query: string, user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.testBodyWithQueryParams(query, user, options).then((request) => request(axios, basePath));
+        testBodyWithQueryParams(query: string, user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testBodyWithQueryParams(query, user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * To test \"client\" model
          * @summary To test \"client\" model
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClientModel(client: Client, options?: any): AxiosPromise<Client> {
-            return localVarFp.testClientModel(client, options).then((request) => request(axios, basePath));
+        testClientModel(client: Client, axiosOptions?: any): AxiosPromise<Client> {
+            return localVarFp.testClientModel(client, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -2593,11 +2593,11 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {string} [dateTime] None
          * @param {string} [password] None
          * @param {string} [callback] None
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, options).then((request) => request(axios, basePath));
+        testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * To test enum parameters
@@ -2610,11 +2610,11 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
          * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
          * @param {string} [enumFormString] Form parameter enum test (string)
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, options).then((request) => request(axios, basePath));
+        testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Fake endpoint to test group parameters (optional)
@@ -2625,32 +2625,32 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {number} [stringGroup] String in group parameters
          * @param {boolean} [booleanGroup] Boolean in group parameters
          * @param {number} [int64Group] Integer in group parameters
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any): AxiosPromise<void> {
-            return localVarFp.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, options).then((request) => request(axios, basePath));
+        testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary test inline additionalProperties
          * @param {{ [key: string]: string; }} requestBody request body
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testInlineAdditionalProperties(requestBody: { [key: string]: string; }, options?: any): AxiosPromise<void> {
-            return localVarFp.testInlineAdditionalProperties(requestBody, options).then((request) => request(axios, basePath));
+        testInlineAdditionalProperties(requestBody: { [key: string]: string; }, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testInlineAdditionalProperties(requestBody, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary test json serialization of form data
          * @param {string} param field1
          * @param {string} param2 field2
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testJsonFormData(param: string, param2: string, options?: any): AxiosPromise<void> {
-            return localVarFp.testJsonFormData(param, param2, options).then((request) => request(axios, basePath));
+        testJsonFormData(param: string, param2: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testJsonFormData(param, param2, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * To test the collection format in query parameters
@@ -2659,21 +2659,21 @@ export const FakeApiFactory = function (configuration?: Configuration, basePath?
          * @param {Array<string>} http 
          * @param {Array<string>} url 
          * @param {Array<string>} context 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options?: any): AxiosPromise<void> {
-            return localVarFp.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, options).then((request) => request(axios, basePath));
+        testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * To test unique items in header and query parameters
          * @param {Set<string>} queryUnique 
          * @param {Set<string>} headerUnique 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique: Set<string>, headerUnique: Set<string>, options?: any): AxiosPromise<Set<Pet>> {
-            return localVarFp.testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique, headerUnique, options).then((request) => request(axios, basePath));
+        testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique: Set<string>, headerUnique: Set<string>, axiosOptions?: any): AxiosPromise<Set<Pet>> {
+            return localVarFp.testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique, headerUnique, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -2688,91 +2688,91 @@ export class FakeApi extends BaseAPI {
     /**
      * 
      * @summary Health check endpoint
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeHealthGet(options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeHealthGet(options).then((request) => request(this.axios, this.basePath));
+    public fakeHealthGet(axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeHealthGet(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of outer boolean types
      * @param {boolean} [body] Input boolean as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterBooleanSerialize(body?: boolean, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterBooleanSerialize(body, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterBooleanSerialize(body?: boolean, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterBooleanSerialize(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of object with outer number type
      * @param {OuterComposite} [outerComposite] Input composite as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterCompositeSerialize(outerComposite?: OuterComposite, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterCompositeSerialize(outerComposite, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterCompositeSerialize(outerComposite?: OuterComposite, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterCompositeSerialize(outerComposite, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of outer number types
      * @param {number} [body] Input number as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterNumberSerialize(body?: number, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterNumberSerialize(body, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterNumberSerialize(body?: number, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterNumberSerialize(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Test serialization of outer string types
      * @param {string} [body] Input string as post body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public fakeOuterStringSerialize(body?: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).fakeOuterStringSerialize(body, options).then((request) => request(this.axios, this.basePath));
+    public fakeOuterStringSerialize(body?: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).fakeOuterStringSerialize(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For this test, the body for this request much reference a schema named `File`.
      * @param {FileSchemaTestClass} fileSchemaTestClass 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testBodyWithFileSchema(fileSchemaTestClass, options).then((request) => request(this.axios, this.basePath));
+    public testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testBodyWithFileSchema(fileSchemaTestClass, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @param {string} query 
      * @param {User} user 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testBodyWithQueryParams(query: string, user: User, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testBodyWithQueryParams(query, user, options).then((request) => request(this.axios, this.basePath));
+    public testBodyWithQueryParams(query: string, user: User, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testBodyWithQueryParams(query, user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * To test \"client\" model
      * @summary To test \"client\" model
      * @param {Client} client client model
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testClientModel(client: Client, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testClientModel(client, options).then((request) => request(this.axios, this.basePath));
+    public testClientModel(client: Client, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testClientModel(client, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2792,12 +2792,12 @@ export class FakeApi extends BaseAPI {
      * @param {string} [dateTime] None
      * @param {string} [password] None
      * @param {string} [callback] None
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, options).then((request) => request(this.axios, this.basePath));
+    public testEndpointParameters(number: number, _double: number, patternWithoutDelimiter: string, _byte: string, integer?: number, int32?: number, int64?: number, _float?: number, string?: string, binary?: any, date?: string, dateTime?: string, password?: string, callback?: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, callback, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2811,12 +2811,12 @@ export class FakeApi extends BaseAPI {
      * @param {1.1 | -1.2} [enumQueryDouble] Query parameter enum test (double)
      * @param {Array<string>} [enumFormStringArray] Form parameter enum test (string array)
      * @param {string} [enumFormString] Form parameter enum test (string)
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, options).then((request) => request(this.axios, this.basePath));
+    public testEnumParameters(enumHeaderStringArray?: Array<'>' | '$'>, enumHeaderString?: '_abc' | '-efg' | '(xyz)', enumQueryStringArray?: Array<'>' | '$'>, enumQueryString?: '_abc' | '-efg' | '(xyz)', enumQueryInteger?: 1 | -2, enumQueryDouble?: 1.1 | -1.2, enumFormStringArray?: Array<string>, enumFormString?: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2828,24 +2828,24 @@ export class FakeApi extends BaseAPI {
      * @param {number} [stringGroup] String in group parameters
      * @param {boolean} [booleanGroup] Boolean in group parameters
      * @param {number} [int64Group] Integer in group parameters
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, options).then((request) => request(this.axios, this.basePath));
+    public testGroupParameters(requiredStringGroup: number, requiredBooleanGroup: boolean, requiredInt64Group: number, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary test inline additionalProperties
      * @param {{ [key: string]: string; }} requestBody request body
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testInlineAdditionalProperties(requestBody: { [key: string]: string; }, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testInlineAdditionalProperties(requestBody, options).then((request) => request(this.axios, this.basePath));
+    public testInlineAdditionalProperties(requestBody: { [key: string]: string; }, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testInlineAdditionalProperties(requestBody, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2853,12 +2853,12 @@ export class FakeApi extends BaseAPI {
      * @summary test json serialization of form data
      * @param {string} param field1
      * @param {string} param2 field2
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testJsonFormData(param: string, param2: string, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testJsonFormData(param, param2, options).then((request) => request(this.axios, this.basePath));
+    public testJsonFormData(param: string, param2: string, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testJsonFormData(param, param2, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2868,24 +2868,24 @@ export class FakeApi extends BaseAPI {
      * @param {Array<string>} http 
      * @param {Array<string>} url 
      * @param {Array<string>} context 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, options).then((request) => request(this.axios, this.basePath));
+    public testQueryParameterCollectionFormat(pipe: Array<string>, ioutil: Array<string>, http: Array<string>, url: Array<string>, context: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * To test unique items in header and query parameters
      * @param {Set<string>} queryUnique 
      * @param {Set<string>} headerUnique 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeApi
      */
-    public testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique: Set<string>, headerUnique: Set<string>, options?: AxiosRequestConfig) {
-        return FakeApiFp(this.configuration).testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique, headerUnique, options).then((request) => request(this.axios, this.basePath));
+    public testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique: Set<string>, headerUnique: Set<string>, axiosOptions?: AxiosRequestConfig) {
+        return FakeApiFp(this.configuration).testUniqueItemsHeaderAndQueryParameterCollectionFormat(queryUnique, headerUnique, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -2900,10 +2900,10 @@ export const FakeClassnameTags123ApiAxiosParamCreator = function (configuration?
          * To test class name in snake case
          * @summary To test class name in snake case
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClassname: async (client: Client, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        testClassname: async (client: Client, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'client' is not null or undefined
             assertParamExists('testClassname', 'client', client)
             const localVarPath = `/fake_classname_test`;
@@ -2914,7 +2914,7 @@ export const FakeClassnameTags123ApiAxiosParamCreator = function (configuration?
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2927,7 +2927,7 @@ export const FakeClassnameTags123ApiAxiosParamCreator = function (configuration?
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(client, localVarRequestOptions, configuration)
 
             return {
@@ -2949,11 +2949,11 @@ export const FakeClassnameTags123ApiFp = function(configuration?: Configuration)
          * To test class name in snake case
          * @summary To test class name in snake case
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async testClassname(client: Client, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.testClassname(client, options);
+        async testClassname(client: Client, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testClassname(client, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -2970,11 +2970,11 @@ export const FakeClassnameTags123ApiFactory = function (configuration?: Configur
          * To test class name in snake case
          * @summary To test class name in snake case
          * @param {Client} client client model
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        testClassname(client: Client, options?: any): AxiosPromise<Client> {
-            return localVarFp.testClassname(client, options).then((request) => request(axios, basePath));
+        testClassname(client: Client, axiosOptions?: any): AxiosPromise<Client> {
+            return localVarFp.testClassname(client, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -2990,12 +2990,12 @@ export class FakeClassnameTags123Api extends BaseAPI {
      * To test class name in snake case
      * @summary To test class name in snake case
      * @param {Client} client client model
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof FakeClassnameTags123Api
      */
-    public testClassname(client: Client, options?: AxiosRequestConfig) {
-        return FakeClassnameTags123ApiFp(this.configuration).testClassname(client, options).then((request) => request(this.axios, this.basePath));
+    public testClassname(client: Client, axiosOptions?: AxiosRequestConfig) {
+        return FakeClassnameTags123ApiFp(this.configuration).testClassname(client, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -3010,10 +3010,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (pet: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (pet: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pet' is not null or undefined
             assertParamExists('addPet', 'pet', pet)
             const localVarPath = `/pet`;
@@ -3024,7 +3024,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3040,7 +3040,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(pet, localVarRequestOptions, configuration)
 
             return {
@@ -3053,10 +3053,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -3068,7 +3068,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3084,7 +3084,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3095,10 +3095,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -3109,7 +3109,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3127,7 +3127,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3138,11 +3138,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -3153,7 +3153,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3171,7 +3171,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3182,10 +3182,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -3197,7 +3197,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3208,7 +3208,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3219,10 +3219,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (pet: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (pet: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pet' is not null or undefined
             assertParamExists('updatePet', 'pet', pet)
             const localVarPath = `/pet`;
@@ -3233,7 +3233,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3249,7 +3249,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(pet, localVarRequestOptions, configuration)
 
             return {
@@ -3263,10 +3263,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -3278,7 +3278,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -3301,7 +3301,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -3315,10 +3315,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -3330,7 +3330,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -3353,7 +3353,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -3367,10 +3367,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {any} requiredFile file to upload
          * @param {string} [additionalMetadata] Additional data to pass to server
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFileWithRequiredFile: async (petId: number, requiredFile: any, additionalMetadata?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFileWithRequiredFile: async (petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFileWithRequiredFile', 'petId', petId)
             // verify required parameter 'requiredFile' is not null or undefined
@@ -3384,7 +3384,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -3407,7 +3407,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -3429,11 +3429,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(pet: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, options);
+        async addPet(pet: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3441,56 +3441,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(pet: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(pet, options);
+        async updatePet(pet: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(pet, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3499,11 +3499,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3512,11 +3512,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3525,11 +3525,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {any} requiredFile file to upload
          * @param {string} [additionalMetadata] Additional data to pass to server
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, options);
+        async uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -3546,63 +3546,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(pet: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(pet, options).then((request) => request(axios, basePath));
+        addPet(pet: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(pet, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} pet Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(pet: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(pet, options).then((request) => request(axios, basePath));
+        updatePet(pet: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(pet, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3610,11 +3610,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3622,11 +3622,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3634,11 +3634,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {any} requiredFile file to upload
          * @param {string} [additionalMetadata] Additional data to pass to server
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, options).then((request) => request(axios, basePath));
+        uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -3654,12 +3654,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} pet Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(pet: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(pet, options).then((request) => request(this.axios, this.basePath));
+    public addPet(pet: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(pet, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3667,61 +3667,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} pet Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(pet: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(pet, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(pet: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(pet, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3730,12 +3730,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3744,12 +3744,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3758,12 +3758,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {any} requiredFile file to upload
      * @param {string} [additionalMetadata] Additional data to pass to server
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, options).then((request) => request(this.axios, this.basePath));
+    public uploadFileWithRequiredFile(petId: number, requiredFile: any, additionalMetadata?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -3778,10 +3778,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{order_id}`
@@ -3793,7 +3793,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3801,7 +3801,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3811,10 +3811,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3823,7 +3823,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3834,7 +3834,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3845,10 +3845,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{order_id}`
@@ -3860,7 +3860,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3868,7 +3868,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3879,10 +3879,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (order: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (order: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'order' is not null or undefined
             assertParamExists('placeOrder', 'order', order)
             const localVarPath = `/store/order`;
@@ -3893,7 +3893,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -3903,7 +3903,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(order, localVarRequestOptions, configuration)
 
             return {
@@ -3925,43 +3925,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(order: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(order, options);
+        async placeOrder(order: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(order, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -3978,40 +3978,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} order order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(order: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(order, options).then((request) => request(axios, basePath));
+        placeOrder(order: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(order, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -4027,47 +4027,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} order order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(order: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(order, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(order: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(order, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -4082,10 +4082,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUser', 'user', user)
             const localVarPath = `/user`;
@@ -4096,7 +4096,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4106,7 +4106,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4118,10 +4118,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (user: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (user: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'user', user)
             const localVarPath = `/user/createWithArray`;
@@ -4132,7 +4132,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4142,7 +4142,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4154,10 +4154,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (user: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (user: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'user' is not null or undefined
             assertParamExists('createUsersWithListInput', 'user', user)
             const localVarPath = `/user/createWithList`;
@@ -4168,7 +4168,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4178,7 +4178,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4190,10 +4190,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -4205,7 +4205,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4213,7 +4213,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4224,10 +4224,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -4239,7 +4239,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4247,7 +4247,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4259,10 +4259,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -4275,7 +4275,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4291,7 +4291,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4301,10 +4301,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4313,7 +4313,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4321,7 +4321,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4333,10 +4333,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, user: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, user: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'user' is not null or undefined
@@ -4350,7 +4350,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -4360,7 +4360,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(user, localVarRequestOptions, configuration)
 
             return {
@@ -4382,55 +4382,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(user, options);
+        async createUser(user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(user: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(user, options);
+        async createUsersWithArrayInput(user: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(user: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(user, options);
+        async createUsersWithListInput(user: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4438,21 +4438,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4460,11 +4460,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, user: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, user, options);
+        async updateUser(username: string, user: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, user, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -4481,82 +4481,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} user Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(user, options).then((request) => request(axios, basePath));
+        createUser(user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(user: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(user, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(user: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} user List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(user: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(user, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(user: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(user, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} user Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, user: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, user, options).then((request) => request(axios, basePath));
+        updateUser(username: string, user: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, user, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -4572,60 +4572,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} user Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(user: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(user, options).then((request) => request(this.axios, this.basePath));
+    public createUser(user: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} user List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(user, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(user: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} user List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(user: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(user, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(user: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4633,23 +4633,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4657,12 +4657,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} user Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, user: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, user, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, user: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, user, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io:80/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -254,10 +254,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -268,7 +268,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -282,7 +282,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -295,10 +295,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -310,7 +310,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -326,7 +326,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -337,10 +337,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -351,7 +351,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -367,7 +367,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -378,11 +378,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -393,7 +393,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -409,7 +409,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -420,10 +420,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -435,7 +435,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -446,7 +446,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -457,10 +457,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -471,7 +471,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -485,7 +485,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -499,10 +499,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -514,7 +514,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -537,7 +537,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -551,10 +551,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -566,7 +566,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -589,7 +589,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -611,11 +611,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -623,56 +623,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -681,11 +681,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -694,11 +694,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -715,63 +715,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -779,11 +779,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -791,11 +791,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -810,63 +810,63 @@ export interface PetApiInterface {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    addPet(body: Pet, options?: AxiosRequestConfig): AxiosPromise<void>;
+    addPet(body: Pet, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * 
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): AxiosPromise<void>;
+    deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): AxiosPromise<Array<Pet>>;
+    findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): AxiosPromise<Array<Pet>>;
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): AxiosPromise<Array<Pet>>;
+    findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): AxiosPromise<Array<Pet>>;
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    getPetById(petId: number, options?: AxiosRequestConfig): AxiosPromise<Pet>;
+    getPetById(petId: number, axiosOptions?: AxiosRequestConfig): AxiosPromise<Pet>;
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    updatePet(body: Pet, options?: AxiosRequestConfig): AxiosPromise<void>;
+    updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * 
@@ -874,11 +874,11 @@ export interface PetApiInterface {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): AxiosPromise<void>;
+    updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * 
@@ -886,11 +886,11 @@ export interface PetApiInterface {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): AxiosPromise<ApiResponse>;
+    uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): AxiosPromise<ApiResponse>;
 
 }
 
@@ -905,12 +905,12 @@ export class PetApi extends BaseAPI implements PetApiInterface {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -918,61 +918,61 @@ export class PetApi extends BaseAPI implements PetApiInterface {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -981,12 +981,12 @@ export class PetApi extends BaseAPI implements PetApiInterface {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -995,12 +995,12 @@ export class PetApi extends BaseAPI implements PetApiInterface {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1015,10 +1015,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1030,7 +1030,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1038,7 +1038,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1048,10 +1048,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1060,7 +1060,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1071,7 +1071,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1082,10 +1082,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1097,7 +1097,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1105,7 +1105,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1116,10 +1116,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('placeOrder', 'body', body)
             const localVarPath = `/store/order`;
@@ -1130,7 +1130,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1140,7 +1140,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1162,43 +1162,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1215,40 +1215,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1263,40 +1263,40 @@ export interface StoreApiInterface {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    deleteOrder(orderId: string, options?: AxiosRequestConfig): AxiosPromise<void>;
+    deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    getInventory(options?: AxiosRequestConfig): AxiosPromise<{ [key: string]: number; }>;
+    getInventory(axiosOptions?: AxiosRequestConfig): AxiosPromise<{ [key: string]: number; }>;
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    getOrderById(orderId: number, options?: AxiosRequestConfig): AxiosPromise<Order>;
+    getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): AxiosPromise<Order>;
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} body order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    placeOrder(body: Order, options?: AxiosRequestConfig): AxiosPromise<Order>;
+    placeOrder(body: Order, axiosOptions?: AxiosRequestConfig): AxiosPromise<Order>;
 
 }
 
@@ -1311,47 +1311,47 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} body order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(body: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(body: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1366,10 +1366,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -1380,7 +1380,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1390,7 +1390,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1402,10 +1402,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -1416,7 +1416,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1426,7 +1426,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1438,10 +1438,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -1452,7 +1452,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1462,7 +1462,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1474,10 +1474,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1489,7 +1489,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1497,7 +1497,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1508,10 +1508,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1523,7 +1523,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1531,7 +1531,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1543,10 +1543,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1559,7 +1559,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1575,7 +1575,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1585,10 +1585,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1597,7 +1597,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1605,7 +1605,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1617,10 +1617,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -1634,7 +1634,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1644,7 +1644,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1666,55 +1666,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1722,21 +1722,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1744,11 +1744,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1765,82 +1765,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1855,82 +1855,82 @@ export interface UserApiInterface {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUser(body: User, options?: AxiosRequestConfig): AxiosPromise<void>;
+    createUser(body: User, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): AxiosPromise<void>;
+    createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): AxiosPromise<void>;
+    createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    deleteUser(username: string, options?: AxiosRequestConfig): AxiosPromise<void>;
+    deleteUser(username: string, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    getUserByName(username: string, options?: AxiosRequestConfig): AxiosPromise<User>;
+    getUserByName(username: string, axiosOptions?: AxiosRequestConfig): AxiosPromise<User>;
 
     /**
      * 
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    loginUser(username: string, password: string, options?: AxiosRequestConfig): AxiosPromise<string>;
+    loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): AxiosPromise<string>;
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    logoutUser(options?: AxiosRequestConfig): AxiosPromise<void>;
+    logoutUser(axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * This can only be done by the logged in user.
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    updateUser(username: string, body: User, options?: AxiosRequestConfig): AxiosPromise<void>;
+    updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): AxiosPromise<void>;
 
 }
 
@@ -1945,60 +1945,60 @@ export class UserApi extends BaseAPI implements UserApiInterface {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2006,23 +2006,23 @@ export class UserApi extends BaseAPI implements UserApiInterface {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2030,12 +2030,12 @@ export class UserApi extends BaseAPI implements UserApiInterface {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/api.ts
@@ -13,8 +13,8 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // URLSearchParams not necessarily used
 // @ts-ignore
 import { URL, URLSearchParams } from 'url';
@@ -23,7 +23,7 @@ import FormData from 'form-data'
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -258,10 +258,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -272,7 +272,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -286,7 +286,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -299,10 +299,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -314,7 +314,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -330,7 +330,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -341,10 +341,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -355,7 +355,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -371,7 +371,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -382,11 +382,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -397,7 +397,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -413,7 +413,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -424,10 +424,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -439,7 +439,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -450,7 +450,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -461,10 +461,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -475,7 +475,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -489,7 +489,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -503,10 +503,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -518,7 +518,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -541,7 +541,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...(localVarFormParams as any).getHeaders?.(), ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...(localVarFormParams as any).getHeaders?.(), ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -555,10 +555,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -570,7 +570,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -593,7 +593,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...(localVarFormParams as any).getHeaders?.(), ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...(localVarFormParams as any).getHeaders?.(), ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -615,11 +615,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -627,56 +627,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -685,11 +685,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -698,11 +698,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -719,63 +719,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -783,11 +783,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -795,11 +795,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -815,12 +815,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -828,61 +828,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -891,12 +891,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -905,12 +905,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -925,10 +925,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -940,7 +940,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -948,7 +948,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -958,10 +958,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -970,7 +970,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -981,7 +981,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -992,10 +992,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1007,7 +1007,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1015,7 +1015,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1026,10 +1026,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} [body] order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body?: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body?: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/order`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1038,7 +1038,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1048,7 +1048,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1070,43 +1070,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} [body] order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body?: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body?: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1123,40 +1123,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} [body] order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body?: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body?: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1172,47 +1172,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} [body] order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(body?: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(body?: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1227,10 +1227,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -1241,7 +1241,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1251,7 +1251,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1263,10 +1263,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -1277,7 +1277,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1287,7 +1287,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1299,10 +1299,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -1313,7 +1313,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1323,7 +1323,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1335,10 +1335,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1350,7 +1350,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1358,7 +1358,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1369,10 +1369,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1384,7 +1384,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1392,7 +1392,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1404,10 +1404,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1420,7 +1420,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1436,7 +1436,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1446,10 +1446,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1458,7 +1458,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1466,7 +1466,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1478,10 +1478,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -1495,7 +1495,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1505,7 +1505,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1527,55 +1527,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1583,21 +1583,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1605,11 +1605,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1626,82 +1626,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1717,60 +1717,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1778,23 +1778,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1802,12 +1802,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 import { URL, URLSearchParams } from 'url';
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
-import { Configuration } from '../../../configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import type { Configuration } from '../../../configuration';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '../../../common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '../../../base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from '../../../base';
 // @ts-ignore
 import { ApiResponse } from '../../../model/some/levels/deep';
 // @ts-ignore
@@ -34,10 +34,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -48,7 +48,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -62,7 +62,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -75,10 +75,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -90,7 +90,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -106,7 +106,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -117,10 +117,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -131,7 +131,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -147,7 +147,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -158,11 +158,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -173,7 +173,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -189,7 +189,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -200,10 +200,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -215,7 +215,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -226,7 +226,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -237,10 +237,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -251,7 +251,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -265,7 +265,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -279,10 +279,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -294,7 +294,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -317,7 +317,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -331,10 +331,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -346,7 +346,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -369,7 +369,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -391,11 +391,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -403,56 +403,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -461,11 +461,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -474,11 +474,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -495,63 +495,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -559,11 +559,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -571,11 +571,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -591,12 +591,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -604,61 +604,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -667,12 +667,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -681,11 +681,11 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/store-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/store-api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
-import { Configuration } from '../../../configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import type { Configuration } from '../../../configuration';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '../../../common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '../../../base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from '../../../base';
 // @ts-ignore
 import { Order } from '../../../model/some/levels/deep';
 /**
@@ -32,10 +32,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -47,7 +47,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -55,7 +55,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -65,10 +65,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -77,7 +77,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -88,7 +88,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -99,10 +99,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -114,7 +114,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -122,7 +122,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -133,10 +133,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('placeOrder', 'body', body)
             const localVarPath = `/store/order`;
@@ -147,7 +147,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -157,7 +157,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -179,43 +179,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -232,40 +232,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -281,46 +281,46 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} body order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(body: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(body: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/user-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/user-api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
-import { Configuration } from '../../../configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import type { Configuration } from '../../../configuration';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '../../../common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '../../../base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from '../../../base';
 // @ts-ignore
 import { User } from '../../../model/some/levels/deep';
 /**
@@ -32,10 +32,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -46,7 +46,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -56,7 +56,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -68,10 +68,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -82,7 +82,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -92,7 +92,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -104,10 +104,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -118,7 +118,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -128,7 +128,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -140,10 +140,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -155,7 +155,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -163,7 +163,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -174,10 +174,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -189,7 +189,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -197,7 +197,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -209,10 +209,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -225,7 +225,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -241,7 +241,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -251,10 +251,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -263,7 +263,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -271,7 +271,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -283,10 +283,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -300,7 +300,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -310,7 +310,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -332,55 +332,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -388,21 +388,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -410,11 +410,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -431,82 +431,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -522,60 +522,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -583,23 +583,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -607,11 +607,11 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -254,10 +254,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -268,7 +268,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -282,7 +282,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -295,10 +295,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -310,7 +310,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -326,7 +326,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -337,10 +337,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -351,7 +351,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -367,7 +367,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -378,11 +378,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -393,7 +393,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -409,7 +409,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -420,10 +420,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -435,7 +435,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -446,7 +446,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -457,10 +457,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -471,7 +471,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -485,7 +485,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -499,10 +499,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -514,7 +514,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -537,7 +537,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -551,10 +551,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -566,7 +566,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -589,7 +589,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -611,11 +611,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -623,56 +623,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -681,11 +681,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -694,11 +694,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -715,63 +715,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -779,11 +779,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -791,11 +791,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -811,12 +811,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -824,61 +824,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -887,12 +887,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -901,12 +901,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -921,10 +921,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -936,7 +936,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -944,7 +944,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -954,10 +954,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -966,7 +966,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -977,7 +977,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -988,10 +988,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1003,7 +1003,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1011,7 +1011,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1022,10 +1022,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('placeOrder', 'body', body)
             const localVarPath = `/store/order`;
@@ -1036,7 +1036,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1046,7 +1046,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1068,43 +1068,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1121,40 +1121,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1170,47 +1170,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} body order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(body: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(body: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1225,10 +1225,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -1239,7 +1239,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1249,7 +1249,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1261,10 +1261,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -1275,7 +1275,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1285,7 +1285,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1297,10 +1297,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -1311,7 +1311,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1321,7 +1321,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1333,10 +1333,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1348,7 +1348,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1356,7 +1356,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1367,10 +1367,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1382,7 +1382,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1390,7 +1390,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1402,10 +1402,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1418,7 +1418,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1434,7 +1434,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1444,10 +1444,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1456,7 +1456,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1464,7 +1464,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1476,10 +1476,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -1493,7 +1493,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1503,7 +1503,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1525,55 +1525,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1581,21 +1581,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1603,11 +1603,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1624,82 +1624,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1715,60 +1715,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1776,23 +1776,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1800,12 +1800,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -254,10 +254,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -268,7 +268,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -282,7 +282,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -295,10 +295,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -310,7 +310,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -326,7 +326,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -337,10 +337,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -351,7 +351,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -367,7 +367,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -378,11 +378,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -393,7 +393,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -409,7 +409,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -420,10 +420,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -435,7 +435,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -446,7 +446,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -457,10 +457,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -471,7 +471,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -485,7 +485,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -499,10 +499,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -514,7 +514,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -537,7 +537,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -551,10 +551,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -566,7 +566,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -589,7 +589,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -611,11 +611,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -623,56 +623,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -681,11 +681,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -694,11 +694,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -715,63 +715,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -779,11 +779,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -791,11 +791,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -958,97 +958,97 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {PetApiAddPetRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(requestParameters: PetApiAddPetRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(requestParameters.body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(requestParameters: PetApiAddPetRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(requestParameters.body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Deletes a pet
      * @param {PetApiDeletePetRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(requestParameters: PetApiDeletePetRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(requestParameters.petId, requestParameters.apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(requestParameters: PetApiDeletePetRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(requestParameters.petId, requestParameters.apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {PetApiFindPetsByStatusRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(requestParameters.status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(requestParameters.status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {PetApiFindPetsByTagsRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(requestParameters.tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(requestParameters.tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {PetApiGetPetByIdRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(requestParameters: PetApiGetPetByIdRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(requestParameters.petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(requestParameters: PetApiGetPetByIdRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(requestParameters.petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {PetApiUpdatePetRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(requestParameters: PetApiUpdatePetRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(requestParameters.body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(requestParameters: PetApiUpdatePetRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(requestParameters.body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Updates a pet in the store with form data
      * @param {PetApiUpdatePetWithFormRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(requestParameters.petId, requestParameters.name, requestParameters.status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(requestParameters.petId, requestParameters.name, requestParameters.status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary uploads an image
      * @param {PetApiUploadFileRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(requestParameters: PetApiUploadFileRequest, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(requestParameters.petId, requestParameters.additionalMetadata, requestParameters.file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(requestParameters: PetApiUploadFileRequest, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(requestParameters.petId, requestParameters.additionalMetadata, requestParameters.file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1063,10 +1063,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1078,7 +1078,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1086,7 +1086,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1096,10 +1096,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1108,7 +1108,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1119,7 +1119,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1130,10 +1130,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1145,7 +1145,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1153,7 +1153,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1164,10 +1164,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} [body] order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body?: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body?: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/order`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1176,7 +1176,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1186,7 +1186,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1208,43 +1208,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} [body] order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body?: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body?: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1261,40 +1261,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} [body] order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body?: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body?: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1352,47 +1352,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {StoreApiDeleteOrderRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(requestParameters: StoreApiDeleteOrderRequest, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(requestParameters.orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(requestParameters: StoreApiDeleteOrderRequest, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(requestParameters.orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {StoreApiGetOrderByIdRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(requestParameters: StoreApiGetOrderByIdRequest, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(requestParameters.orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(requestParameters: StoreApiGetOrderByIdRequest, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(requestParameters.orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {StoreApiPlaceOrderRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(requestParameters: StoreApiPlaceOrderRequest = {}, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(requestParameters.body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(requestParameters: StoreApiPlaceOrderRequest = {}, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(requestParameters.body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1407,10 +1407,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -1421,7 +1421,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1431,7 +1431,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1443,10 +1443,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -1457,7 +1457,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1467,7 +1467,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1479,10 +1479,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -1493,7 +1493,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1503,7 +1503,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1515,10 +1515,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1530,7 +1530,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1538,7 +1538,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1549,10 +1549,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1564,7 +1564,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1572,7 +1572,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1584,10 +1584,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1600,7 +1600,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1616,7 +1616,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1626,10 +1626,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1638,7 +1638,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1646,7 +1646,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1658,10 +1658,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -1675,7 +1675,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1685,7 +1685,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1707,55 +1707,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1763,21 +1763,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1785,11 +1785,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1806,82 +1806,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -2009,95 +2009,95 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {UserApiCreateUserRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(requestParameters: UserApiCreateUserRequest, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(requestParameters.body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(requestParameters: UserApiCreateUserRequest, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(requestParameters.body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {UserApiCreateUsersWithArrayInputRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(requestParameters.body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(requestParameters.body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {UserApiCreateUsersWithListInputRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(requestParameters.body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(requestParameters.body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {UserApiDeleteUserRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(requestParameters: UserApiDeleteUserRequest, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(requestParameters.username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(requestParameters: UserApiDeleteUserRequest, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(requestParameters.username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {UserApiGetUserByNameRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(requestParameters: UserApiGetUserByNameRequest, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(requestParameters.username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(requestParameters: UserApiGetUserByNameRequest, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(requestParameters.username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs user into the system
      * @param {UserApiLoginUserRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(requestParameters: UserApiLoginUserRequest, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(requestParameters.username, requestParameters.password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(requestParameters: UserApiLoginUserRequest, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(requestParameters.username, requestParameters.password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Updated user
      * @param {UserApiUpdateUserRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(requestParameters: UserApiUpdateUserRequest, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(requestParameters.username, requestParameters.body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(requestParameters: UserApiUpdateUserRequest, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(requestParameters.username, requestParameters.body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/api.ts
@@ -13,13 +13,13 @@
  */
 
 
-import { Configuration } from './configuration';
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Configuration } from './configuration';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError } from './base';
 
 /**
  * Describes the result of uploading an image resource
@@ -258,10 +258,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addPet', 'body', body)
             const localVarPath = `/pet`;
@@ -272,7 +272,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -286,7 +286,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -299,10 +299,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet: async (petId: number, apiKey?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deletePet: async (petId: number, apiKey?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('deletePet', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -314,7 +314,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -330,7 +330,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -341,10 +341,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByStatus: async (status: Array<'available' | 'pending' | 'sold'>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'status' is not null or undefined
             assertParamExists('findPetsByStatus', 'status', status)
             const localVarPath = `/pet/findByStatus`;
@@ -355,7 +355,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -371,7 +371,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -382,11 +382,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags: async (tags: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        findPetsByTags: async (tags: Array<string>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'tags' is not null or undefined
             assertParamExists('findPetsByTags', 'tags', tags)
             const localVarPath = `/pet/findByTags`;
@@ -397,7 +397,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -413,7 +413,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -424,10 +424,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById: async (petId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getPetById: async (petId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('getPetById', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -439,7 +439,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -450,7 +450,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -461,10 +461,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet: async (body: Pet, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePet: async (body: Pet, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePet', 'body', body)
             const localVarPath = `/pet`;
@@ -475,7 +475,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -489,7 +489,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -503,10 +503,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm: async (petId: number, name?: string, status?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePetWithForm: async (petId: number, name?: string, status?: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('updatePetWithForm', 'petId', petId)
             const localVarPath = `/pet/{petId}`
@@ -518,7 +518,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new URLSearchParams();
@@ -541,7 +541,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams.toString();
 
             return {
@@ -555,10 +555,10 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (petId: number, additionalMetadata?: string, file?: any, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'petId' is not null or undefined
             assertParamExists('uploadFile', 'petId', petId)
             const localVarPath = `/pet/{petId}/uploadImage`
@@ -570,7 +570,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
             const localVarFormParams = new ((configuration && configuration.formDataCtor) || FormData)();
@@ -593,7 +593,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = localVarFormParams;
 
             return {
@@ -615,11 +615,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, options);
+        async addPet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -627,56 +627,56 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, options);
+        async deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePet(petId, apiKey, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, options);
+        async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByStatus(status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        async findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, options);
+        async findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Pet>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.findPetsByTags(tags, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getPetById(petId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, options);
+        async getPetById(petId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Pet>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPetById(petId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePet(body: Pet, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, options);
+        async updatePet(body: Pet, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePet(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -685,11 +685,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, options);
+        async updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePetWithForm(petId, name, status, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -698,11 +698,11 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, options);
+        async uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(petId, additionalMetadata, file, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -719,63 +719,63 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * 
          * @summary Add a new pet to the store
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(body, options).then((request) => request(axios, basePath));
+        addPet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.addPet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Deletes a pet
          * @param {number} petId Pet id to delete
          * @param {string} [apiKey] 
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePet(petId, apiKey, options).then((request) => request(axios, basePath));
+        deletePet(petId: number, apiKey?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deletePet(petId, apiKey, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple status values can be provided with comma separated strings
          * @summary Finds Pets by status
          * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByStatus(status, options).then((request) => request(axios, basePath));
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByStatus(status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @summary Finds Pets by tags
          * @param {Array<string>} tags Tags to filter by
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @deprecated
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any): AxiosPromise<Array<Pet>> {
-            return localVarFp.findPetsByTags(tags, options).then((request) => request(axios, basePath));
+        findPetsByTags(tags: Array<string>, axiosOptions?: any): AxiosPromise<Array<Pet>> {
+            return localVarFp.findPetsByTags(tags, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a single pet
          * @summary Find pet by ID
          * @param {number} petId ID of pet to return
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any): AxiosPromise<Pet> {
-            return localVarFp.getPetById(petId, options).then((request) => request(axios, basePath));
+        getPetById(petId: number, axiosOptions?: any): AxiosPromise<Pet> {
+            return localVarFp.getPetById(petId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Update an existing pet
          * @param {Pet} body Pet object that needs to be added to the store
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePet(body, options).then((request) => request(axios, basePath));
+        updatePet(body: Pet, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePet(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -783,11 +783,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet that needs to be updated
          * @param {string} [name] Updated name of the pet
          * @param {string} [status] Updated status of the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.updatePetWithForm(petId, name, status, options).then((request) => request(axios, basePath));
+        updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -795,11 +795,11 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {number} petId ID of pet to update
          * @param {string} [additionalMetadata] Additional data to pass to server
          * @param {any} [file] file to upload
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any): AxiosPromise<ApiResponse> {
-            return localVarFp.uploadFile(petId, additionalMetadata, file, options).then((request) => request(axios, basePath));
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: any): AxiosPromise<ApiResponse> {
+            return localVarFp.uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -815,12 +815,12 @@ export class PetApi extends BaseAPI {
      * 
      * @summary Add a new pet to the store
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(body, options).then((request) => request(this.axios, this.basePath));
+    public addPet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -828,61 +828,61 @@ export class PetApi extends BaseAPI {
      * @summary Deletes a pet
      * @param {number} petId Pet id to delete
      * @param {string} [apiKey] 
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public deletePet(petId: number, apiKey?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).deletePet(petId, apiKey, options).then((request) => request(this.axios, this.basePath));
+    public deletePet(petId: number, apiKey?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).deletePet(petId, apiKey, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * @summary Finds Pets by status
      * @param {Array<'available' | 'pending' | 'sold'>} status Status values that need to be considered for filter
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByStatus(status, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByStatus(status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @summary Finds Pets by tags
      * @param {Array<string>} tags Tags to filter by
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @deprecated
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public findPetsByTags(tags: Array<string>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).findPetsByTags(tags, options).then((request) => request(this.axios, this.basePath));
+    public findPetsByTags(tags: Array<string>, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).findPetsByTags(tags, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a single pet
      * @summary Find pet by ID
      * @param {number} petId ID of pet to return
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public getPetById(petId: number, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).getPetById(petId, options).then((request) => request(this.axios, this.basePath));
+    public getPetById(petId: number, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).getPetById(petId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Update an existing pet
      * @param {Pet} body Pet object that needs to be added to the store
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePet(body: Pet, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePet(body, options).then((request) => request(this.axios, this.basePath));
+    public updatePet(body: Pet, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePet(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -891,12 +891,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet that needs to be updated
      * @param {string} [name] Updated name of the pet
      * @param {string} [status] Updated status of the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, options).then((request) => request(this.axios, this.basePath));
+    public updatePetWithForm(petId: number, name?: string, status?: string, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).updatePetWithForm(petId, name, status, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -905,12 +905,12 @@ export class PetApi extends BaseAPI {
      * @param {number} petId ID of pet to update
      * @param {string} [additionalMetadata] Additional data to pass to server
      * @param {any} [file] file to upload
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, axiosOptions?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).uploadFile(petId, additionalMetadata, file, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -925,10 +925,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder: async (orderId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteOrder: async (orderId: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('deleteOrder', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -940,7 +940,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -948,7 +948,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -958,10 +958,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getInventory: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/store/inventory`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -970,7 +970,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -981,7 +981,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -992,10 +992,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById: async (orderId: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getOrderById: async (orderId: number, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderById', 'orderId', orderId)
             const localVarPath = `/store/order/{orderId}`
@@ -1007,7 +1007,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1015,7 +1015,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1026,10 +1026,10 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder: async (body: Order, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        placeOrder: async (body: Order, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('placeOrder', 'body', body)
             const localVarPath = `/store/order`;
@@ -1040,7 +1040,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1050,7 +1050,7 @@ export const StoreApiAxiosParamCreator = function (configuration?: Configuration
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1072,43 +1072,43 @@ export const StoreApiFp = function(configuration?: Configuration) {
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteOrder(orderId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, options);
+        async deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteOrder(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getInventory(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(options);
+        async getInventory(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: number; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getInventory(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getOrderById(orderId: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, options);
+        async getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getOrderById(orderId, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async placeOrder(body: Order, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, options);
+        async placeOrder(body: Order, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Order>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.placeOrder(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1125,40 +1125,40 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          * @summary Delete purchase order by ID
          * @param {string} orderId ID of the order that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteOrder(orderId, options).then((request) => request(axios, basePath));
+        deleteOrder(orderId: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteOrder(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * Returns a map of status codes to quantities
          * @summary Returns pet inventories by status
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any): AxiosPromise<{ [key: string]: number; }> {
-            return localVarFp.getInventory(options).then((request) => request(axios, basePath));
+        getInventory(axiosOptions?: any): AxiosPromise<{ [key: string]: number; }> {
+            return localVarFp.getInventory(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
          * @summary Find purchase order by ID
          * @param {number} orderId ID of pet that needs to be fetched
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any): AxiosPromise<Order> {
-            return localVarFp.getOrderById(orderId, options).then((request) => request(axios, basePath));
+        getOrderById(orderId: number, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.getOrderById(orderId, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Place an order for a pet
          * @param {Order} body order placed for purchasing the pet
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any): AxiosPromise<Order> {
-            return localVarFp.placeOrder(body, options).then((request) => request(axios, basePath));
+        placeOrder(body: Order, axiosOptions?: any): AxiosPromise<Order> {
+            return localVarFp.placeOrder(body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1174,47 +1174,47 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param {string} orderId ID of the order that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public deleteOrder(orderId: string, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).deleteOrder(orderId, options).then((request) => request(this.axios, this.basePath));
+    public deleteOrder(orderId: string, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).deleteOrder(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getInventory(options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getInventory(options).then((request) => request(this.axios, this.basePath));
+    public getInventory(axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getInventory(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param {number} orderId ID of pet that needs to be fetched
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public getOrderById(orderId: number, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).getOrderById(orderId, options).then((request) => request(this.axios, this.basePath));
+    public getOrderById(orderId: number, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).getOrderById(orderId, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Place an order for a pet
      * @param {Order} body order placed for purchasing the pet
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof StoreApi
      */
-    public placeOrder(body: Order, options?: AxiosRequestConfig) {
-        return StoreApiFp(this.configuration).placeOrder(body, options).then((request) => request(this.axios, this.basePath));
+    public placeOrder(body: Order, axiosOptions?: AxiosRequestConfig) {
+        return StoreApiFp(this.configuration).placeOrder(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -1229,10 +1229,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser: async (body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUser: async (body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUser', 'body', body)
             const localVarPath = `/user`;
@@ -1243,7 +1243,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1253,7 +1253,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1265,10 +1265,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithArrayInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithArrayInput', 'body', body)
             const localVarPath = `/user/createWithArray`;
@@ -1279,7 +1279,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1289,7 +1289,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1301,10 +1301,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput: async (body: Array<User>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createUsersWithListInput: async (body: Array<User>, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUsersWithListInput', 'body', body)
             const localVarPath = `/user/createWithList`;
@@ -1315,7 +1315,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1325,7 +1325,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1337,10 +1337,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        deleteUser: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('deleteUser', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1352,7 +1352,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1360,7 +1360,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1371,10 +1371,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName: async (username: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getUserByName: async (username: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('getUserByName', 'username', username)
             const localVarPath = `/user/{username}`
@@ -1386,7 +1386,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1394,7 +1394,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1406,10 +1406,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser: async (username: string, password: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        loginUser: async (username: string, password: string, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('loginUser', 'username', username)
             // verify required parameter 'password' is not null or undefined
@@ -1422,7 +1422,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1438,7 +1438,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1448,10 +1448,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        logoutUser: async (axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/user/logout`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1460,7 +1460,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1468,7 +1468,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1480,10 +1480,10 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser: async (username: string, body: User, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateUser: async (username: string, body: User, axiosOptions: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'username' is not null or undefined
             assertParamExists('updateUser', 'username', username)
             // verify required parameter 'body' is not null or undefined
@@ -1497,7 +1497,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...axiosOptions};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -1507,7 +1507,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...axiosOptions.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
 
             return {
@@ -1529,55 +1529,55 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUser(body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, options);
+        async createUser(body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUser(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, options);
+        async createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithArrayInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, options);
+        async createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createUsersWithListInput(body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, options);
+        async deleteUser(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async getUserByName(username: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, options);
+        async getUserByName(username: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserByName(username, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1585,21 +1585,21 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async loginUser(username: string, password: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, options);
+        async loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.loginUser(username, password, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async logoutUser(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(options);
+        async logoutUser(axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logoutUser(axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -1607,11 +1607,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        async updateUser(username: string, body: User, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, options);
+        async updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateUser(username, body, axiosOptions);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -1628,82 +1628,82 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * This can only be done by the logged in user.
          * @summary Create user
          * @param {User} body Created user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.createUser(body, options).then((request) => request(axios, basePath));
+        createUser(body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUser(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithArrayInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithArrayInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithArrayInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Creates list of users with given input array
          * @param {Array<User>} body List of user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void> {
-            return localVarFp.createUsersWithListInput(body, options).then((request) => request(axios, basePath));
+        createUsersWithListInput(body: Array<User>, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.createUsersWithListInput(body, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteUser(username, options).then((request) => request(axios, basePath));
+        deleteUser(username: string, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.deleteUser(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Get user by user name
          * @param {string} username The name that needs to be fetched. Use user1 for testing.
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any): AxiosPromise<User> {
-            return localVarFp.getUserByName(username, options).then((request) => request(axios, basePath));
+        getUserByName(username: string, axiosOptions?: any): AxiosPromise<User> {
+            return localVarFp.getUserByName(username, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs user into the system
          * @param {string} username The user name for login
          * @param {string} password The password for login in clear text
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any): AxiosPromise<string> {
-            return localVarFp.loginUser(username, password, options).then((request) => request(axios, basePath));
+        loginUser(username: string, password: string, axiosOptions?: any): AxiosPromise<string> {
+            return localVarFp.loginUser(username, password, axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @summary Logs out current logged in user session
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any): AxiosPromise<void> {
-            return localVarFp.logoutUser(options).then((request) => request(axios, basePath));
+        logoutUser(axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.logoutUser(axiosOptions).then((request) => request(axios, basePath));
         },
         /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
          * @param {User} body Updated user object
-         * @param {*} [options] Override http request option.
+         * @param {*} [axiosOptions] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any): AxiosPromise<void> {
-            return localVarFp.updateUser(username, body, options).then((request) => request(axios, basePath));
+        updateUser(username: string, body: User, axiosOptions?: any): AxiosPromise<void> {
+            return localVarFp.updateUser(username, body, axiosOptions).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1719,60 +1719,60 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Create user
      * @param {User} body Created user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUser(body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUser(body, options).then((request) => request(this.axios, this.basePath));
+    public createUser(body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUser(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithArrayInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithArrayInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithArrayInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithArrayInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Creates list of users with given input array
      * @param {Array<User>} body List of user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public createUsersWithListInput(body: Array<User>, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).createUsersWithListInput(body, options).then((request) => request(this.axios, this.basePath));
+    public createUsersWithListInput(body: Array<User>, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).createUsersWithListInput(body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUser(username, options).then((request) => request(this.axios, this.basePath));
+    public deleteUser(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).deleteUser(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Get user by user name
      * @param {string} username The name that needs to be fetched. Use user1 for testing.
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public getUserByName(username: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUserByName(username, options).then((request) => request(this.axios, this.basePath));
+    public getUserByName(username: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).getUserByName(username, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1780,23 +1780,23 @@ export class UserApi extends BaseAPI {
      * @summary Logs user into the system
      * @param {string} username The user name for login
      * @param {string} password The password for login in clear text
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public loginUser(username: string, password: string, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).loginUser(username, password, options).then((request) => request(this.axios, this.basePath));
+    public loginUser(username: string, password: string, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).loginUser(username, password, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @summary Logs out current logged in user session
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public logoutUser(options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).logoutUser(options).then((request) => request(this.axios, this.basePath));
+    public logoutUser(axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).logoutUser(axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -1804,12 +1804,12 @@ export class UserApi extends BaseAPI {
      * @summary Updated user
      * @param {string} username name that need to be deleted
      * @param {User} body Updated user object
-     * @param {*} [options] Override http request option.
+     * @param {*} [axiosOptions] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public updateUser(username: string, body: User, options?: AxiosRequestConfig) {
-        return UserApiFp(this.configuration).updateUser(username, body, options).then((request) => request(this.axios, this.basePath));
+    public updateUser(username: string, body: User, axiosOptions?: AxiosRequestConfig) {
+        return UserApiFp(this.configuration).updateUser(username, body, axiosOptions).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/base.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/base.ts
@@ -13,10 +13,10 @@
  */
 
 
-import { Configuration } from "./configuration";
+import type { Configuration } from "./configuration";
 // Some imports not used depending on template conditions
 // @ts-ignore
-import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import globalAxios, { type AxiosPromise, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 export const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, "");
 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -13,9 +13,9 @@
  */
 
 
-import { Configuration } from "./configuration";
-import { RequiredError, RequestArgs } from "./base";
-import { AxiosInstance, AxiosResponse } from 'axios';
+import type { Configuration } from "./configuration";
+import { RequiredError, type RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
 
 /**
  *


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@amakhrov
@davidgamero
@mkusaka
