### PR TITLE
[Java][OkHTTP] Include HTTP response data in ApiException getMessage()

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -169,7 +169,7 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
      * @return The exception message
      */
     public String getMessage() {
-        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+        return String.format("Message: %s%nHTTP response code: %s%nHTTP response body: %s%nHTTP response headers: %s",
                 super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
     }
     {{#errorObjectType}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -162,6 +162,16 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     public String getResponseBody() {
         return responseBody;
     }
+
+    /**
+     * Get the exception message including HTTP response data.
+     *
+     * @return The exception message
+     */
+    public String getMessage() {
+        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+                super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
+    }
     {{#errorObjectType}}
 
     /**

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
@@ -153,4 +153,14 @@ public class ApiException extends Exception {
     public String getResponseBody() {
         return responseBody;
     }
+
+    /**
+     * Get the exception message including HTTP response data.
+     *
+     * @return The exception message
+     */
+    public String getMessage() {
+        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+                super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
+    }
 }

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
@@ -160,7 +160,7 @@ public class ApiException extends Exception {
      * @return The exception message
      */
     public String getMessage() {
-        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+        return String.format("Message: %s%nHTTP response code: %s%nHTTP response body: %s%nHTTP response headers: %s",
                 super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
@@ -153,4 +153,14 @@ public class ApiException extends Exception {
     public String getResponseBody() {
         return responseBody;
     }
+
+    /**
+     * Get the exception message including HTTP response data.
+     *
+     * @return The exception message
+     */
+    public String getMessage() {
+        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+                super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
+    }
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
@@ -160,7 +160,7 @@ public class ApiException extends Exception {
      * @return The exception message
      */
     public String getMessage() {
-        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+        return String.format("Message: %s%nHTTP response code: %s%nHTTP response body: %s%nHTTP response headers: %s",
                 super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
     }
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
@@ -153,4 +153,14 @@ public class ApiException extends Exception {
     public String getResponseBody() {
         return responseBody;
     }
+
+    /**
+     * Get the exception message including HTTP response data.
+     *
+     * @return The exception message
+     */
+    public String getMessage() {
+        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+                super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
+    }
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
@@ -160,7 +160,7 @@ public class ApiException extends Exception {
      * @return The exception message
      */
     public String getMessage() {
-        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+        return String.format("Message: %s%nHTTP response code: %s%nHTTP response body: %s%nHTTP response headers: %s",
                 super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
     }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
@@ -153,4 +153,14 @@ public class ApiException extends Exception {
     public String getResponseBody() {
         return responseBody;
     }
+
+    /**
+     * Get the exception message including HTTP response data.
+     *
+     * @return The exception message
+     */
+    public String getMessage() {
+        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+                super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
+    }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
@@ -160,7 +160,7 @@ public class ApiException extends Exception {
      * @return The exception message
      */
     public String getMessage() {
-        return String.format("Message: %s\nHTTP response code: %s\nHTTP response body: %s\nHTTP response headers: %s",
+        return String.format("Message: %s%nHTTP response code: %s%nHTTP response body: %s%nHTTP response headers: %s",
                 super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
     }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -222,7 +222,8 @@ public class PetApiTest {
         } while (result.isEmpty());
         assertNotNull(exception);
         assertEquals(404, exception.getCode());
-        assertEquals("Not Found", exception.getMessage());
+        String pattern = "^Message: .*\\RHTTP response code: 404\\RHTTP response body: .*\\RHTTP response headers: .*$";
+        assertTrue(exception.getMessage().matches(pattern));
         assertEquals("application/json", exception.getResponseHeaders().get("Content-Type").get(0));
         api.deletePet(pet.getId(), null);
     }

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -222,7 +222,7 @@ public class PetApiTest {
         } while (result.isEmpty());
         assertNotNull(exception);
         assertEquals(404, exception.getCode());
-        String pattern = "^Message: .*\\RHTTP response code: 404\\RHTTP response body: .*\\RHTTP response headers: .*$";
+        String pattern = "^Message: Not Found\\RHTTP response code: 404\\RHTTP response body: .*\\RHTTP response headers: .*$";
         assertTrue(exception.getMessage().matches(pattern));
         assertEquals("application/json", exception.getResponseHeaders().get("Content-Type").get(0));
         api.deletePet(pet.getId(), null);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Addresses #12205

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
