### PR TITLE
[BUG][python] Fix PEP8 E111 issue in rest.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -290,10 +290,10 @@ def is_ipv4(target):
     """ Test if IPv4 address or not
     """
     try:
-       chk = ipaddress.IPv4Address(target)
-       return True
+        chk = ipaddress.IPv4Address(target)
+        return True
     except ipaddress.AddressValueError:
-       return False
+        return False
 
 def in_ipv4net(target, net):
     """ Test if target belongs to given IPv4 network
@@ -333,6 +333,6 @@ def should_bypass_proxies(url, no_proxy=None):
 
     if is_ipv4(parsed.hostname):
         for item in entries:
-           if in_ipv4net(parsed.hostname, item):
-               return True
+            if in_ipv4net(parsed.hostname, item):
+                return True
     return proxy_bypass_environment(parsed.hostname, {'no': no_proxy} )

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -298,10 +298,10 @@ def is_ipv4(target):
     """ Test if IPv4 address or not
     """
     try:
-       chk = ipaddress.IPv4Address(target)
-       return True
+        chk = ipaddress.IPv4Address(target)
+        return True
     except ipaddress.AddressValueError:
-       return False
+        return False
 
 def in_ipv4net(target, net):
     """ Test if target belongs to given IPv4 network
@@ -341,6 +341,6 @@ def should_bypass_proxies(url, no_proxy=None):
 
     if is_ipv4(parsed.hostname):
         for item in entries:
-           if in_ipv4net(parsed.hostname, item):
-               return True
+            if in_ipv4net(parsed.hostname, item):
+                return True
     return proxy_bypass_environment(parsed.hostname, {'no': no_proxy} )

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/rest.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/rest.py
@@ -298,10 +298,10 @@ def is_ipv4(target):
     """ Test if IPv4 address or not
     """
     try:
-       chk = ipaddress.IPv4Address(target)
-       return True
+        chk = ipaddress.IPv4Address(target)
+        return True
     except ipaddress.AddressValueError:
-       return False
+        return False
 
 def in_ipv4net(target, net):
     """ Test if target belongs to given IPv4 network
@@ -341,6 +341,6 @@ def should_bypass_proxies(url, no_proxy=None):
 
     if is_ipv4(parsed.hostname):
         for item in entries:
-           if in_ipv4net(parsed.hostname, item):
-               return True
+            if in_ipv4net(parsed.hostname, item):
+                return True
     return proxy_bypass_environment(parsed.hostname, {'no': no_proxy} )

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
@@ -298,10 +298,10 @@ def is_ipv4(target):
     """ Test if IPv4 address or not
     """
     try:
-       chk = ipaddress.IPv4Address(target)
-       return True
+        chk = ipaddress.IPv4Address(target)
+        return True
     except ipaddress.AddressValueError:
-       return False
+        return False
 
 def in_ipv4net(target, net):
     """ Test if target belongs to given IPv4 network
@@ -341,6 +341,6 @@ def should_bypass_proxies(url, no_proxy=None):
 
     if is_ipv4(parsed.hostname):
         for item in entries:
-           if in_ipv4net(parsed.hostname, item):
-               return True
+            if in_ipv4net(parsed.hostname, item):
+                return True
     return proxy_bypass_environment(parsed.hostname, {'no': no_proxy} )

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
@@ -298,10 +298,10 @@ def is_ipv4(target):
     """ Test if IPv4 address or not
     """
     try:
-       chk = ipaddress.IPv4Address(target)
-       return True
+        chk = ipaddress.IPv4Address(target)
+        return True
     except ipaddress.AddressValueError:
-       return False
+        return False
 
 def in_ipv4net(target, net):
     """ Test if target belongs to given IPv4 network
@@ -341,6 +341,6 @@ def should_bypass_proxies(url, no_proxy=None):
 
     if is_ipv4(parsed.hostname):
         for item in entries:
-           if in_ipv4net(parsed.hostname, item):
-               return True
+            if in_ipv4net(parsed.hostname, item):
+                return True
     return proxy_bypass_environment(parsed.hostname, {'no': no_proxy} )

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -298,10 +298,10 @@ def is_ipv4(target):
     """ Test if IPv4 address or not
     """
     try:
-       chk = ipaddress.IPv4Address(target)
-       return True
+        chk = ipaddress.IPv4Address(target)
+        return True
     except ipaddress.AddressValueError:
-       return False
+        return False
 
 def in_ipv4net(target, net):
     """ Test if target belongs to given IPv4 network
@@ -341,6 +341,6 @@ def should_bypass_proxies(url, no_proxy=None):
 
     if is_ipv4(parsed.hostname):
         for item in entries:
-           if in_ipv4net(parsed.hostname, item):
-               return True
+            if in_ipv4net(parsed.hostname, item):
+                return True
     return proxy_bypass_environment(parsed.hostname, {'no': no_proxy} )


### PR DESCRIPTION
Hello! I fixed PEP8 E111 issue in [rest.mustache](https://github.com/OpenAPITools/openapi-generator/blob/85df431ebf7b2fbdb8fa95ba90d153df8a4ef98c/modules/openapi-generator/src/main/resources/python/rest.mustache).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11)