### PR TITLE
[cpp-rest-sdk-client] handling datetime type

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
@@ -64,6 +64,7 @@ public:
     static web::json::value toJson( const std::shared_ptr<HttpContent>& val );
     template<typename T>
     static web::json::value toJson( const std::shared_ptr<T>& val );
+    static web::json::value toJson( const std::shared_ptr<utility::datetime>& val );
     template<typename T>
     static web::json::value toJson( const std::vector<T>& val );
     template<typename T>
@@ -80,6 +81,7 @@ public:
     static bool fromString( const utility::string_t& val, std::shared_ptr<HttpContent> & );
     template<typename T>
     static bool fromString( const utility::string_t& val, std::shared_ptr<T>& );
+    static bool fromString( const utility::string_t& val, std::shared_ptr<utility::datetime>& outVal );
     template<typename T>
     static bool fromString( const utility::string_t& val, std::vector<T> & );
     template<typename T>
@@ -96,6 +98,7 @@ public:
     static bool fromJson( const web::json::value& val, std::shared_ptr<HttpContent> & );
     template<typename T>
     static bool fromJson( const web::json::value& val, std::shared_ptr<T>& );
+    static bool fromJson( const web::json::value& val, std::shared_ptr<utility::datetime> &outVal );
     template<typename T>
     static bool fromJson( const web::json::value& val, std::vector<T> & );
     template<typename T>
@@ -113,6 +116,7 @@ public:
     static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const std::shared_ptr<HttpContent>& );
     template <typename T>
     static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const std::shared_ptr<T>& , const utility::string_t& contentType = utility::conversions::to_string_t("application/json") );
+    static std::shared_ptr<HttpContent> toHttpContent(const utility::string_t& name, const std::shared_ptr<utility::datetime>& value , const utility::string_t& contentType = utility::conversions::to_string_t("application/json") );
     template <typename T>
     static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const std::vector<T>& value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
     template <typename T>

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-source.mustache
@@ -112,6 +112,15 @@ web::json::value ModelBase::toJson( const std::shared_ptr<HttpContent>& content 
     }
     return value;
 }
+web::json::value ModelBase::toJson( const std::shared_ptr<utility::datetime>& val )
+{
+    web::json::value retVal;
+    if(val != nullptr)
+    {
+        retVal = toJson(*val);
+    }
+    return retVal;
+}
 bool ModelBase::fromString( const utility::string_t& val, bool &outVal )
 {
     utility::stringstream_t ss(val);
@@ -242,6 +251,19 @@ bool ModelBase::fromString( const utility::string_t& val, std::shared_ptr<HttpCo
     }
     return ok;
 }
+bool ModelBase::fromString( const utility::string_t& val, std::shared_ptr<utility::datetime>& outVal )
+{
+    bool ok = false;
+    if(outVal == nullptr)
+    {
+        outVal = std::shared_ptr<utility::datetime>(new utility::datetime());
+    }
+    if( outVal != nullptr )
+    {
+        ok = fromJson(web::json::value::parse(val), *outVal);
+    }
+    return ok;
+}
 bool ModelBase::fromJson( const web::json::value& val, bool & outVal )
 {
     outVal = !val.is_boolean() ? false : val.as_bool();
@@ -318,6 +340,19 @@ bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<HttpConte
         }
     }
     return result;
+}
+bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<utility::datetime> &outVal )
+{
+    bool ok = false;
+    if(outVal == nullptr)
+    {
+        outVal = std::shared_ptr<utility::datetime>(new utility::datetime());
+    }
+    if( outVal != nullptr )
+    {
+        ok = fromJson(val, *outVal);
+    }
+    return ok;
 }
 std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& name, bool value, const utility::string_t& contentType )
 {
@@ -411,6 +446,18 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
         content->setContentType( value->getContentType() );
         content->setData( value->getData() );
         content->setFileName( value->getFileName() );
+    }
+    return content;
+}
+std::shared_ptr<HttpContent> ModelBase::toHttpContent(const utility::string_t& name, const std::shared_ptr<utility::datetime>& value , const utility::string_t& contentType )
+{
+    std::shared_ptr<HttpContent> content( new HttpContent );
+    if (value != nullptr )
+    {
+        content->setName( name );
+        content->setContentDisposition( utility::conversions::to_string_t("form-data") );
+        content->setContentType( contentType );
+        content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string( toJson(*value).serialize() ) ) ) );
     }
     return content;
 }


### PR DESCRIPTION
A specialization for the `shared_ptr<datetime>` data type was added to
ModelBase member functions fromString, fromJson, toJson and
toHttpContent.

This should fix compilation errors on generated source code.
See https://github.com/coinapi/coinapi-sdk/pull/130

@muttleyxd