### PR TITLE
[C][Client] Eliminate compiler warnings

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -170,8 +170,8 @@ void replaceSpaceWithPlus(char *stringToProcess) {
     }
 }
 
-char *assembleTargetUrl(char    *basePath,
-                        char    *operationParameter,
+char *assembleTargetUrl(const char  *basePath,
+                        const char  *operationParameter,
                         list_t    *queryParameters) {
     int neededBufferSizeForQueryParameters = 0;
     listEntry_t *listEntry;
@@ -233,7 +233,7 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, char *bodyParameters) {
+void postData(CURL *handle, const char *bodyParameters) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      strlen(bodyParameters));
@@ -252,14 +252,14 @@ int lengthOfKeyPair(keyValuePair_t *keyPair) {
 
 
 void apiClient_invoke(apiClient_t    *apiClient,
-                      char        *operationParameter,
+                      const char    *operationParameter,
                       list_t        *queryParameters,
                       list_t        *headerParameters,
                       list_t        *formParameters,
                       list_t        *headerType,
                       list_t        *contentType,
-                      char        *bodyParameters,
-                      char        *requestType) {
+                      const char    *bodyParameters,
+                      const char    *requestType) {
     CURL *handle = curl_easy_init();
     CURLcode res;
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -59,7 +59,7 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);
+void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, const char *requestType);
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
 

--- a/samples/client/petstore/c/include/apiClient.h
+++ b/samples/client/petstore/c/include/apiClient.h
@@ -41,7 +41,7 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);
+void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, const char *requestType);
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
 

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -124,8 +124,8 @@ void replaceSpaceWithPlus(char *stringToProcess) {
     }
 }
 
-char *assembleTargetUrl(char    *basePath,
-                        char    *operationParameter,
+char *assembleTargetUrl(const char  *basePath,
+                        const char  *operationParameter,
                         list_t    *queryParameters) {
     int neededBufferSizeForQueryParameters = 0;
     listEntry_t *listEntry;
@@ -187,7 +187,7 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, char *bodyParameters) {
+void postData(CURL *handle, const char *bodyParameters) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      strlen(bodyParameters));
@@ -206,14 +206,14 @@ int lengthOfKeyPair(keyValuePair_t *keyPair) {
 
 
 void apiClient_invoke(apiClient_t    *apiClient,
-                      char        *operationParameter,
+                      const char    *operationParameter,
                       list_t        *queryParameters,
                       list_t        *headerParameters,
                       list_t        *formParameters,
                       list_t        *headerType,
                       list_t        *contentType,
-                      char        *bodyParameters,
-                      char        *requestType) {
+                      const char    *bodyParameters,
+                      const char    *requestType) {
     CURL *handle = curl_easy_init();
     CURLcode res;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
If we call `apiClient_invoke` with some `const char *` as parameters of the function, ( the complete source code is https://github.com/kubernetes-client/c/blob/master/kubernetes/src/generic.c)  then there are some warnings while compiling the C client library.
```bash
src/generic.c:57:38: warning: passing argument 2 of ‘apiClient_invoke’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     apiClient_invoke(client->client, path, queryParameters, headerParameters, formParameters, headerType, contentType, body, method);
                                      ^~~~
In file included from src/generic.c:1:0:
src/../include/apiClient.h:43:6: note: expected ‘char *’ but argument is of type ‘const char *’
 void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);
```
This PR eliminates these compiler warnings.

@wing328 @zhemant @michelealbano

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
