### PR TITLE
Fix issue with fastapi generator converting all fields to snake_case

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
@@ -41,6 +41,7 @@ router = APIRouter()
     {{#description}}
     description = "{{.}}",
     {{/description}}
+    response_model_by_alias=True,
 )
 async def {{operationId}}(
     {{#allParams}}

--- a/modules/openapi-generator/src/main/resources/python-fastapi/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/model.mustache
@@ -6,7 +6,7 @@ from datetime import date, datetime  # noqa: F401
 import re  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
-from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, validator  # noqa: F401
 {{#models}}
 {{#model}}
 {{#pyImports}}
@@ -31,7 +31,7 @@ class {{classname}}(BaseModel):
     """
 
 {{#vars}}
-    {{name}}: {{#required}}{{>model_field_type}}{{/required}}{{^required}}Optional[{{>model_field_type}}] = None{{/required}}
+    {{name}}: {{#required}}{{>model_field_type}}{{/required}}{{^required}}Optional[{{>model_field_type}}]{{/required}} = Field(alias="{{baseName}}"{{^required}}, default=None{{/required}})
 {{/vars}}
 {{#vars}}
 {{#maximum}}

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/pet_api.py
@@ -32,6 +32,7 @@ router = APIRouter()
     },
     tags=["pet"],
     summary="Add a new pet to the store",
+    response_model_by_alias=True,
 )
 async def add_pet(
     pet: Pet = Body(None, description="Pet object that needs to be added to the store"),
@@ -50,6 +51,7 @@ async def add_pet(
     },
     tags=["pet"],
     summary="Deletes a pet",
+    response_model_by_alias=True,
 )
 async def delete_pet(
     petId: int = Path(None, description="Pet id to delete"),
@@ -70,6 +72,7 @@ async def delete_pet(
     },
     tags=["pet"],
     summary="Finds Pets by status",
+    response_model_by_alias=True,
 )
 async def find_pets_by_status(
     status: List[str] = Query(None, description="Status values that need to be considered for filter"),
@@ -89,6 +92,7 @@ async def find_pets_by_status(
     },
     tags=["pet"],
     summary="Finds Pets by tags",
+    response_model_by_alias=True,
 )
 async def find_pets_by_tags(
     tags: List[str] = Query(None, description="Tags to filter by"),
@@ -109,6 +113,7 @@ async def find_pets_by_tags(
     },
     tags=["pet"],
     summary="Find pet by ID",
+    response_model_by_alias=True,
 )
 async def get_pet_by_id(
     petId: int = Path(None, description="ID of pet to return"),
@@ -130,6 +135,7 @@ async def get_pet_by_id(
     },
     tags=["pet"],
     summary="Update an existing pet",
+    response_model_by_alias=True,
 )
 async def update_pet(
     pet: Pet = Body(None, description="Pet object that needs to be added to the store"),
@@ -148,6 +154,7 @@ async def update_pet(
     },
     tags=["pet"],
     summary="Updates a pet in the store with form data",
+    response_model_by_alias=True,
 )
 async def update_pet_with_form(
     petId: int = Path(None, description="ID of pet that needs to be updated"),
@@ -168,6 +175,7 @@ async def update_pet_with_form(
     },
     tags=["pet"],
     summary="uploads an image",
+    response_model_by_alias=True,
 )
 async def upload_file(
     petId: int = Path(None, description="ID of pet to update"),

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/store_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/store_api.py
@@ -31,6 +31,7 @@ router = APIRouter()
     },
     tags=["store"],
     summary="Delete purchase order by ID",
+    response_model_by_alias=True,
 )
 async def delete_order(
     orderId: str = Path(None, description="ID of the order that needs to be deleted"),
@@ -46,6 +47,7 @@ async def delete_order(
     },
     tags=["store"],
     summary="Returns pet inventories by status",
+    response_model_by_alias=True,
 )
 async def get_inventory(
     token_api_key: TokenModel = Security(
@@ -65,6 +67,7 @@ async def get_inventory(
     },
     tags=["store"],
     summary="Find purchase order by ID",
+    response_model_by_alias=True,
 )
 async def get_order_by_id(
     orderId: int = Path(None, description="ID of pet that needs to be fetched", ge=1, le=5),
@@ -81,6 +84,7 @@ async def get_order_by_id(
     },
     tags=["store"],
     summary="Place an order for a pet",
+    response_model_by_alias=True,
 )
 async def place_order(
     order: Order = Body(None, description="order placed for purchasing the pet"),

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
@@ -30,6 +30,7 @@ router = APIRouter()
     },
     tags=["user"],
     summary="Create user",
+    response_model_by_alias=True,
 )
 async def create_user(
     user: User = Body(None, description="Created user object"),
@@ -48,6 +49,7 @@ async def create_user(
     },
     tags=["user"],
     summary="Creates list of users with given input array",
+    response_model_by_alias=True,
 )
 async def create_users_with_array_input(
     user: List[User] = Body(None, description="List of user object"),
@@ -66,6 +68,7 @@ async def create_users_with_array_input(
     },
     tags=["user"],
     summary="Creates list of users with given input array",
+    response_model_by_alias=True,
 )
 async def create_users_with_list_input(
     user: List[User] = Body(None, description="List of user object"),
@@ -85,6 +88,7 @@ async def create_users_with_list_input(
     },
     tags=["user"],
     summary="Delete user",
+    response_model_by_alias=True,
 )
 async def delete_user(
     username: str = Path(None, description="The name that needs to be deleted"),
@@ -105,6 +109,7 @@ async def delete_user(
     },
     tags=["user"],
     summary="Get user by user name",
+    response_model_by_alias=True,
 )
 async def get_user_by_name(
     username: str = Path(None, description="The name that needs to be fetched. Use user1 for testing."),
@@ -121,6 +126,7 @@ async def get_user_by_name(
     },
     tags=["user"],
     summary="Logs user into the system",
+    response_model_by_alias=True,
 )
 async def login_user(
     username: str = Query(None, description="The user name for login", regex=r"^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$"),
@@ -137,6 +143,7 @@ async def login_user(
     },
     tags=["user"],
     summary="Logs out current logged in user session",
+    response_model_by_alias=True,
 )
 async def logout_user(
     token_api_key: TokenModel = Security(
@@ -155,6 +162,7 @@ async def logout_user(
     },
     tags=["user"],
     summary="Updated user",
+    response_model_by_alias=True,
 )
 async def update_user(
     username: str = Path(None, description="name that need to be deleted"),

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/api_response.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/api_response.py
@@ -6,7 +6,7 @@ from datetime import date, datetime  # noqa: F401
 import re  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
-from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, validator  # noqa: F401
 
 
 class ApiResponse(BaseModel):
@@ -21,8 +21,8 @@ class ApiResponse(BaseModel):
         message: The message of this ApiResponse [Optional].
     """
 
-    code: Optional[int] = None
-    type: Optional[str] = None
-    message: Optional[str] = None
+    code: Optional[int] = Field(alias="code", default=None)
+    type: Optional[str] = Field(alias="type", default=None)
+    message: Optional[str] = Field(alias="message", default=None)
 
 ApiResponse.update_forward_refs()

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/category.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/category.py
@@ -6,7 +6,7 @@ from datetime import date, datetime  # noqa: F401
 import re  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
-from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, validator  # noqa: F401
 
 
 class Category(BaseModel):
@@ -20,8 +20,8 @@ class Category(BaseModel):
         name: The name of this Category [Optional].
     """
 
-    id: Optional[int] = None
-    name: Optional[str] = None
+    id: Optional[int] = Field(alias="id", default=None)
+    name: Optional[str] = Field(alias="name", default=None)
 
     @validator("name")
     def name_pattern(cls, value):

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/order.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/order.py
@@ -6,7 +6,7 @@ from datetime import date, datetime  # noqa: F401
 import re  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
-from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, validator  # noqa: F401
 
 
 class Order(BaseModel):
@@ -24,11 +24,11 @@ class Order(BaseModel):
         complete: The complete of this Order [Optional].
     """
 
-    id: Optional[int] = None
-    pet_id: Optional[int] = None
-    quantity: Optional[int] = None
-    ship_date: Optional[datetime] = None
-    status: Optional[str] = None
-    complete: Optional[bool] = None
+    id: Optional[int] = Field(alias="id", default=None)
+    pet_id: Optional[int] = Field(alias="petId", default=None)
+    quantity: Optional[int] = Field(alias="quantity", default=None)
+    ship_date: Optional[datetime] = Field(alias="shipDate", default=None)
+    status: Optional[str] = Field(alias="status", default=None)
+    complete: Optional[bool] = Field(alias="complete", default=None)
 
 Order.update_forward_refs()

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/pet.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/pet.py
@@ -6,7 +6,7 @@ from datetime import date, datetime  # noqa: F401
 import re  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
-from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, validator  # noqa: F401
 from openapi_server.models.category import Category
 from openapi_server.models.tag import Tag
 
@@ -26,11 +26,11 @@ class Pet(BaseModel):
         status: The status of this Pet [Optional].
     """
 
-    id: Optional[int] = None
-    category: Optional[Category] = None
-    name: str
-    photo_urls: List[str]
-    tags: Optional[List[Tag]] = None
-    status: Optional[str] = None
+    id: Optional[int] = Field(alias="id", default=None)
+    category: Optional[Category] = Field(alias="category", default=None)
+    name: str = Field(alias="name")
+    photo_urls: List[str] = Field(alias="photoUrls")
+    tags: Optional[List[Tag]] = Field(alias="tags", default=None)
+    status: Optional[str] = Field(alias="status", default=None)
 
 Pet.update_forward_refs()

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/tag.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/tag.py
@@ -6,7 +6,7 @@ from datetime import date, datetime  # noqa: F401
 import re  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
-from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, validator  # noqa: F401
 
 
 class Tag(BaseModel):
@@ -20,7 +20,7 @@ class Tag(BaseModel):
         name: The name of this Tag [Optional].
     """
 
-    id: Optional[int] = None
-    name: Optional[str] = None
+    id: Optional[int] = Field(alias="id", default=None)
+    name: Optional[str] = Field(alias="name", default=None)
 
 Tag.update_forward_refs()

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/user.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/user.py
@@ -6,7 +6,7 @@ from datetime import date, datetime  # noqa: F401
 import re  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
-from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
+from pydantic import AnyUrl, BaseModel, EmailStr, Field, validator  # noqa: F401
 
 
 class User(BaseModel):
@@ -26,13 +26,13 @@ class User(BaseModel):
         user_status: The user_status of this User [Optional].
     """
 
-    id: Optional[int] = None
-    username: Optional[str] = None
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
-    email: Optional[str] = None
-    password: Optional[str] = None
-    phone: Optional[str] = None
-    user_status: Optional[int] = None
+    id: Optional[int] = Field(alias="id", default=None)
+    username: Optional[str] = Field(alias="username", default=None)
+    first_name: Optional[str] = Field(alias="firstName", default=None)
+    last_name: Optional[str] = Field(alias="lastName", default=None)
+    email: Optional[str] = Field(alias="email", default=None)
+    password: Optional[str] = Field(alias="password", default=None)
+    phone: Optional[str] = Field(alias="phone", default=None)
+    user_status: Optional[int] = Field(alias="userStatus", default=None)
 
 User.update_forward_refs()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
I noticed that the Python-FastAPI generator converts all model field names to snake_case to match Python convention. While this is desireable from a code-style perspective, it breaks any API using a different convention for field names since it also affects the names of fields that get serialised to JSON. 

FastAPI uses Pydantic for its model classes, which supports setting an [alias](https://pydantic-docs.helpmanual.io/usage/models/#model-signature) value in order to deserialise a different name to what is used for the Python class, so I modified the generator to use this. Be default it will always be used during deserialisation but only during serialisation if the `by_alias=True` option is specified. Luckily, FastAPI includes an option we can set on endpoints that will use this for data returned by the endpoint, `response_model_by_alias=True`. 

I've enabled this everywhere because there's no harm in using it if the alias is the same as the name and it seemed like adding logic to specifically detect camelCase field names would overcomplicate things, plus this could potentially be useful if you have an OpenAPI spec that includes a field name that is a reserved word in Python, although I haven't tested it in that case.

Here's an example of some code before and after the change:
```py
# before:
class RenderClip(BaseModel):
    """NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).

    Do not edit the class manually.

    RenderClip - a model defined in OpenAPI

        focused_player_actor_id: The focused_player_actor_id of this RenderClip.
        time_range: The time_range of this RenderClip.
        ingredients: The ingredients of this RenderClip.
        output_length: The output_length of this RenderClip [Optional].
    """

    focused_player_actor_id: str
    time_range: GameTimeRange
    ingredients: List[Ingredient]
    output_length: Optional[float] = None

# after:
class RenderClip(BaseModel):
    """NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).

    Do not edit the class manually.

    RenderClip - a model defined in OpenAPI

        focused_player_actor_id: The focused_player_actor_id of this RenderClip.
        time_range: The time_range of this RenderClip.
        ingredients: The ingredients of this RenderClip.
        output_length: The output_length of this RenderClip [Optional].
    """

    focused_player_actor_id: str = Field(alias="focusedPlayerActorId")
    time_range: GameTimeRange = Field(alias="timeRange")
    ingredients: List[Ingredient] = Field(alias="ingredients")
    output_length: Optional[float] = Field(alias="outputLength", default=None)
```

This may also fix #11604 since it allows serializing/deserializing models with names in camelCase without requiring any additional options in the generator.

I've made this change on top of 5.4.x because that's what our team is using so if this could be included in a patch release of 5.4.x that would be ideal, although I have also tested on `master` and it works so if you think it would be more appropriate to commit there I'm happy to rebase.

<!-- Please check the completed items below -->
### PR checklist
 
- [✓] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [✓] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [✓] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [✓] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
*This change applies to the Python-FastAPI server generator* @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @arun-nalla @spacether
