### PR TITLE
Allow the baseUrl of elixir APIs to be overridden

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/README.md.mustache
@@ -24,3 +24,11 @@ end
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/{{#underscored}}{{packageName}}{{/underscored}}](https://hexdocs.pm/{{#underscored}}{{packageName}}{{/underscored}}).
+
+
+## Configuration
+
+You can override the URL of your server (e.g. if you have a separate development and production server in your configuration files.
+```elixir
+config {{#underscored}}{{appName}}{{/underscored}}, base_url: "{{{basePath}}}"
+```

--- a/modules/openapi-generator/src/main/resources/elixir/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/README.md.mustache
@@ -30,5 +30,5 @@ be found at [https://hexdocs.pm/{{#underscored}}{{packageName}}{{/underscored}}]
 
 You can override the URL of your server (e.g. if you have a separate development and production server in your configuration files.
 ```elixir
-config {{#underscored}}{{appName}}{{/underscored}}, base_url: "{{{basePath}}}"
+config :{{#underscored}}{{appName}}{{/underscored}}, base_url: "{{{basePath}}}"
 ```

--- a/modules/openapi-generator/src/main/resources/elixir/config.exs.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/config.exs.mustache
@@ -21,6 +21,8 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
+config {{#underscored}}{{appName}}{{/underscored}}, base_url: "{{{basePath}}}"
+
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/modules/openapi-generator/src/main/resources/elixir/config.exs.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/config.exs.mustache
@@ -21,7 +21,7 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
-config {{#underscored}}{{appName}}{{/underscored}}, base_url: "{{{basePath}}}"
+config :{{#underscored}}{{appName}}{{/underscored}}, base_url: "{{{basePath}}}"
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -7,7 +7,7 @@ defmodule {{moduleName}}.Connection do
   use Tesla
 
   # Add any middleware here (authentication)
-  plug Tesla.Middleware.BaseUrl, Application.get_env(:{{#underscored}}{{appName}}{{/underscored}}, :base_url)
+  plug Tesla.Middleware.BaseUrl, Application.get_env(:{{#underscored}}{{appName}}{{/underscored}}, :base_url, "{{{basePath}}}")
   plug Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]
   plug Tesla.Middleware.EncodeJson, engine: Poison
 

--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -7,7 +7,7 @@ defmodule {{moduleName}}.Connection do
   use Tesla
 
   # Add any middleware here (authentication)
-  plug Tesla.Middleware.BaseUrl, "{{{basePath}}}"
+  plug Tesla.Middleware.BaseUrl, Application.get_env(:{{#underscored}}{{appName}}{{/underscored}}, :base_url)
   plug Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]
   plug Tesla.Middleware.EncodeJson, engine: Poison
 

--- a/samples/client/petstore/elixir/README.md
+++ b/samples/client/petstore/elixir/README.md
@@ -24,3 +24,11 @@ end
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/openapi_petstore](https://hexdocs.pm/openapi_petstore).
+
+
+## Configuration
+
+You can override the URL of your server (e.g. if you have a separate development and production server in your configuration files.
+```elixir
+config open_api_petstore, base_url: "http://petstore.swagger.io:80/v2"
+```

--- a/samples/client/petstore/elixir/README.md
+++ b/samples/client/petstore/elixir/README.md
@@ -30,5 +30,5 @@ be found at [https://hexdocs.pm/openapi_petstore](https://hexdocs.pm/openapi_pet
 
 You can override the URL of your server (e.g. if you have a separate development and production server in your configuration files.
 ```elixir
-config open_api_petstore, base_url: "http://petstore.swagger.io:80/v2"
+config :open_api_petstore, base_url: "http://petstore.swagger.io:80/v2"
 ```

--- a/samples/client/petstore/elixir/config/config.exs
+++ b/samples/client/petstore/elixir/config/config.exs
@@ -21,7 +21,7 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
-config open_api_petstore, base_url: "http://petstore.swagger.io:80/v2"
+config :open_api_petstore, base_url: "http://petstore.swagger.io:80/v2"
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/samples/client/petstore/elixir/config/config.exs
+++ b/samples/client/petstore/elixir/config/config.exs
@@ -21,6 +21,8 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
+config open_api_petstore, base_url: "http://petstore.swagger.io:80/v2"
+
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
@@ -10,7 +10,7 @@ defmodule OpenapiPetstore.Connection do
   use Tesla
 
   # Add any middleware here (authentication)
-  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io:80/v2"
+  plug Tesla.Middleware.BaseUrl, Application.get_env(:open_api_petstore, :base_url)
   plug Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]
   plug Tesla.Middleware.EncodeJson, engine: Poison
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
@@ -10,7 +10,7 @@ defmodule OpenapiPetstore.Connection do
   use Tesla
 
   # Add any middleware here (authentication)
-  plug Tesla.Middleware.BaseUrl, Application.get_env(:open_api_petstore, :base_url)
+  plug Tesla.Middleware.BaseUrl, Application.get_env(:open_api_petstore, :base_url, "http://petstore.swagger.io:80/v2")
   plug Tesla.Middleware.Headers, [{"user-agent", "Elixir"}]
   plug Tesla.Middleware.EncodeJson, engine: Poison
 


### PR DESCRIPTION
Elixir uses `config.exs` files to store most configuration values. This change allows the baseURL to be overridden with `dev.exs` and `prod.exs` in a project using the generated code.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mrmstn
