### PR TITLE
Fix directory name to match package

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcorefunctions/CsharpNetcoreFunctionsServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcorefunctions/CsharpNetcoreFunctionsServerCodegenTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.openapitools.codegen.CsharpNetcoreFunctionsServerCodegen;
+package org.openapitools.codegen.csharpnetcorefunctions;
 
 import org.openapitools.codegen.languages.CsharpNetcoreFunctionsServerCodegen;
 import org.testng.Assert;


### PR DESCRIPTION
I'm not sure how this ever compiled, but it causes a build failure for me and the fix is easy and non-invasive.
