### PR TITLE
Suggest Docker instead of Git BASH in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,6 @@
   This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
   These must match the expectations made by your contribution. 
   You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
-  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
+  For Windows users, please run the script in a [docker container](https://docs.docker.com/desktop/windows/install/). You can start one with `docker run -v <path\to\your\local\repo>:/git -it openjdk:8 /bin/bash`.
+  Running the scripts in the [Git BASH](https://gitforwindows.org/) or similar shells will contaminate the generated files with Windows path separators. (backslash)
 - [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


### PR DESCRIPTION
This PR is motivated by [this comment](https://github.com/OpenAPITools/openapi-generator/pull/12174#issuecomment-1109385680).

The PR template mentions that Windows users should use the Git BASH to run the scripts that generate samples and docs. However, when doing this, Windows path separators (backslashes) will creep into almost all of the generated files, which will result in unwanted changes.

This PR changes the PR template to instruct Windows users to run the scripts inside a docker container instead, which will prevent the above issue.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

(I skipped the build and gen scripts, since there are no changes to the actual project)