### PR TITLE
Fix for cpp-rest-sdk-client generator producing uncompilable code

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
@@ -188,9 +188,9 @@ bool {{classname}}::fromJson(const web::json::value& val)
         const web::json::value& fieldValue = val.at(utility::conversions::to_string_t(U("{{baseName}}")));
         if(!fieldValue.is_null())
         {
-            {{{dataType}}} refVal_{{baseName}};
-            ok &= ModelBase::fromJson(fieldValue, refVal_{{baseName}});
-            {{setter}}(refVal_{{baseName}});
+            {{{dataType}}} refVal_{{setter}};
+            ok &= ModelBase::fromJson(fieldValue, refVal_{{setter}});
+            {{setter}}(refVal_{{setter}});
         }
     }{{/isInherited}}{{/vars}}
     return ok;
@@ -223,9 +223,9 @@ bool {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{#vars}}
     if(multipart->hasContent(utility::conversions::to_string_t(U("{{baseName}}"))))
     {
-        {{{dataType}}} refVal_{{baseName}};
-        ok &= ModelBase::fromHttpContent(multipart->getContent(utility::conversions::to_string_t(U("{{baseName}}"))), refVal_{{baseName}} );
-        {{setter}}(refVal_{{baseName}});
+        {{{dataType}}} refVal_{{setter}};
+        ok &= ModelBase::fromHttpContent(multipart->getContent(utility::conversions::to_string_t(U("{{baseName}}"))), refVal_{{setter}} );
+        {{setter}}(refVal_{{setter}});
     }
     {{/vars}}
     return ok;


### PR DESCRIPTION
### Issue: 
https://github.com/OpenAPITools/openapi-generator/issues/12289

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix for cpp-rest-sdk-client generator producing uncompilable code if there is a "-" (or other characters like a space etc.) in a property name of an object.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@ravinikam, @stkrwork, @etherealjoy, @martindelille, @muttleyxd