### PR TITLE
Add new method to detect self-referencing in ModelUtils

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1131,7 +1131,7 @@ public class ModelUtils {
                 }
             } else if (isObjectSchema(ref)) { // model
                 if (ref.getProperties() != null && !ref.getProperties().isEmpty()) { // has at least one property
-                    return schema;
+                    return ref;
                 } else { // free form object (type: object)
                     return unaliasSchema(openAPI, allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref())),
                             importMappings);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4125,4 +4125,26 @@ public class DefaultCodegenTest {
         assertEquals(cp.baseName, "SchemaFor201ResponseBodyTextPlain");
         assertTrue(cp.isString);
     }
+
+    @Test
+    public void testUnalias() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/schema-unalias-test.yml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Schema requestBodySchema = ModelUtils.getSchemaFromRequestBody(
+                openAPI.getPaths().get("/thingy/{date}").getPost().getRequestBody());
+        Assert.assertEquals(requestBodySchema.get$ref(), "#/components/schemas/updatePetWithForm_request");
+        Assert.assertEquals(ModelUtils.getSimpleRef(requestBodySchema.get$ref()), "updatePetWithForm_request");
+        Assert.assertNotNull(openAPI.getComponents().getSchemas().get(ModelUtils.getSimpleRef(requestBodySchema.get$ref())));
+
+        Schema requestBodySchema2 = ModelUtils.unaliasSchema(openAPI, requestBodySchema);
+        // get$ref should be null
+        Assert.assertNull(requestBodySchema2.get$ref());
+        CodegenParameter codegenParameter = codegen.fromFormProperty("visitDate",
+                (Schema) requestBodySchema2.getProperties().get("visitDate"), new HashSet<>());
+
+        Assert.assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
+        Assert.assertEquals(codegenParameter.getSchema(), null);
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4139,10 +4139,13 @@ public class DefaultCodegenTest {
         Assert.assertNotNull(openAPI.getComponents().getSchemas().get(ModelUtils.getSimpleRef(requestBodySchema.get$ref())));
 
         Schema requestBodySchema2 = ModelUtils.unaliasSchema(openAPI, requestBodySchema);
-        // get$ref should be null
-        Assert.assertNull(requestBodySchema2.get$ref());
+        // get$ref is not null as unaliasSchem returns the schema with the last $ref to the actual schema
+        Assert.assertNotNull(requestBodySchema2.get$ref());
+        Assert.assertEquals(requestBodySchema2.get$ref(), "#/components/schemas/updatePetWithForm_request");
+
+        Schema requestBodySchema3 = ModelUtils.getReferencedSchema(openAPI, requestBodySchema);
         CodegenParameter codegenParameter = codegen.fromFormProperty("visitDate",
-                (Schema) requestBodySchema2.getProperties().get("visitDate"), new HashSet<>());
+                (Schema) requestBodySchema3.getProperties().get("visitDate"), new HashSet<>());
 
         Assert.assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
         Assert.assertEquals(codegenParameter.getSchema(), null);

--- a/modules/openapi-generator/src/test/resources/3_0/schema-unalias-test.yml
+++ b/modules/openapi-generator/src/test/resources/3_0/schema-unalias-test.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  description: Test schema unalias
+    types
+  title: Api Documentation
+  version: "1.0"
+servers:
+- url: /
+paths:
+  /thingy/{date}:
+    post:
+      description: update with form data
+      operationId: updatePetWithForm
+      parameters:
+      - description: A date path parameter
+        explode: false
+        in: path
+        name: date
+        required: true
+        schema:
+          default: 1969-12-31T16:00:00.000+00:00
+          example: 2021-01-01
+          format: date
+          type: string
+        style: simple
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/updatePetWithForm_request'
+      responses:
+        "405":
+          description: Invalid input
+components:
+  schemas:
+    updatePetWithForm_request:
+      properties:
+        visitDate:
+          default: 1971-12-19T03:39:57-08:00
+          description: Updated last vist timestamp
+          format: date-time
+          type: string
+      type: object


### PR DESCRIPTION
- Add new method to detect self-refernecing in ModelUtils
- Add tests

(self referencing is already tested by crashSwift5ExampleCodeGenerationStackOverflowTest and crashSwift5ExampleCodeGenerationStackOverflowBug_2Test)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @OpenAPITools/generator-core-team 