### PR TITLE
Switch Gradle plugin to use File/Directory properties instead of Strings

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -60,7 +60,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     project
             )
 
-            generate.outputDir.set("$buildDir/generate-resources/main")
+            generate.outputDir.set(project.layout.buildDirectory.dir("generate-resources/main"))
 
             tasks.apply {
                 register("openApiGenerators", GeneratorsTask::class.java).configure {

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -46,17 +46,17 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * The output target directory into which code will be generated.
      */
-    val outputDir = project.objects.property<String>()
+    val outputDir = project.objects.directoryProperty()
 
     /**
      * The Open API 2.0/3.x specification location.
      */
-    val inputSpec = project.objects.property<String>()
+    val inputSpec = project.objects.fileProperty()
 
     /**
      * The template directory holding a custom template.
      */
-    val templateDir = project.objects.property<String?>()
+    val templateDir = project.objects.directoryProperty()
 
     /**
      * Adds authorization headers when fetching the OpenAPI definitions remotely.
@@ -74,7 +74,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
      * File content should be in a json format { "optionKey":"optionValue", "optionKey1":"optionValue1"...}
      * Supported options can be different for each language. Run config-help -g {generator name} command for language specific config options.
      */
-    val configFile = project.objects.property<String>()
+    val configFile = project.objects.fileProperty()
 
     /**
      * Specifies if the existing files should be overwritten during the generation.
@@ -204,7 +204,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Specifies an override location for the .openapi-generator-ignore file. Most useful on initial generation.
      */
-    val ignoreFileOverride = project.objects.property<String?>()
+    val ignoreFileOverride = project.objects.fileProperty()
 
     /**
      * Remove prefix of operationId, e.g. config_getId => getId

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorMetaExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorMetaExtension.kt
@@ -38,11 +38,11 @@ open class OpenApiGeneratorMetaExtension(project: Project) {
     /**
      * Where to write the generated files (current dir by default).
      */
-    val outputFolder = project.objects.property<String>()
+    val outputFolder = project.objects.directoryProperty()
 
     init {
         generatorName.set("default")
         packageName.set("org.openapitools.codegen")
-        outputFolder.set("")
+        outputFolder.set(project.layout.projectDirectory)
     }
 }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
@@ -28,7 +28,7 @@ open class OpenApiGeneratorValidateExtension(project: Project) {
     /**
      * The input specification to validate. Supports all formats supported by the Parser.
      */
-    val inputSpec = project.objects.property<String>()
+    val inputSpec = project.objects.fileProperty()
 
     /**
      * Whether or not to offer recommendations related to the validated specification document.

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/MetaTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/MetaTask.kt
@@ -52,14 +52,14 @@ open class MetaTask : DefaultTask() {
     val packageName = project.objects.property<String>()
 
     @get:OutputDirectory
-    val outputFolder = project.objects.property<String>()
+    val outputFolder = project.objects.directoryProperty()
 
     @Suppress("unused")
     @TaskAction
     fun doWork() {
 
         val packageToPath = packageName.get().replace(".", File.separator)
-        val dir = File(outputFolder.get())
+        val dir = outputFolder.getAsFile().get()
         val klass = "${generatorName.get().titleCasedTextOnly()}Generator"
 
         val templateResourceDir = generatorName.get().hyphenatedTextOnly()

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
@@ -20,8 +20,10 @@ package org.openapitools.generator.gradle.plugin.tasks
 
 import io.swagger.parser.OpenAPIParser
 import io.swagger.v3.parser.core.models.ParseOptions
+import java.io.File;
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -56,7 +58,7 @@ import org.openapitools.codegen.validations.oas.RuleConfiguration
 open class ValidateTask : DefaultTask() {
     @get:InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    val inputSpec = project.objects.property<String>()
+    val inputSpec = project.objects.fileProperty()
 
     @Optional
     @Input
@@ -67,7 +69,7 @@ open class ValidateTask : DefaultTask() {
     @set:Option(option = "input", description = "The input specification.")
     var input: String? = null
         set(value) {
-            inputSpec.set(value)
+            inputSpec.set(File(value))
         }
 
     @Suppress("unused")
@@ -75,7 +77,7 @@ open class ValidateTask : DefaultTask() {
     fun doWork() {
         val logger = Logging.getLogger(javaClass)
 
-        val spec = inputSpec.get()
+        val spec = inputSpec.map(RegularFile::getAsFile).map(File::getAbsolutePath).get()
         val recommendations = recommend.get()
 
         logger.quiet("Validating spec $spec")

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
@@ -17,8 +17,8 @@ class GenerateTaskDslTest : TestBase() {
         }
         openApiGenerate {
             generatorName = "kotlin"
-            inputSpec = file("spec.yaml").absolutePath
-            outputDir = file("build/kotlin").absolutePath
+            inputSpec = file("spec.yaml")
+            outputDir = file("build/kotlin")
             apiPackage = "org.openapitools.example.api"
             invokerPackage = "org.openapitools.example.invoker"
             modelPackage = "org.openapitools.example.model"
@@ -80,8 +80,8 @@ class GenerateTaskDslTest : TestBase() {
         }
         openApiGenerate {
             generatorName = "java"
-            inputSpec = file("spec.yaml").absolutePath
-            outputDir = file("build/java").absolutePath
+            inputSpec = file("spec.yaml")
+            outputDir = file("build/java")
             apiPackage = "org.openapitools.example.api"
             invokerPackage = "org.openapitools.example.invoker"
             modelPackage = "org.openapitools.example.model"
@@ -216,8 +216,8 @@ class GenerateTaskDslTest : TestBase() {
         }
         openApiGenerate {
             generatorName = "kotlin"
-            inputSpec = file("spec.yaml").absolutePath
-            outputDir = file("build/kotlin").absolutePath
+            inputSpec = file("spec.yaml")
+            outputDir = file("build/kotlin")
             apiPackage = "org.openapitools.example.api"
             invokerPackage = "org.openapitools.example.invoker"
             modelPackage = "org.openapitools.example.model"
@@ -254,8 +254,8 @@ class GenerateTaskDslTest : TestBase() {
         }
         openApiGenerate {
             generatorName = "kotlin"
-            inputSpec = file("spec.yaml").absolutePath
-            outputDir = file("build/kotlin").absolutePath
+            inputSpec = file("spec.yaml")
+            outputDir = file("build/kotlin")
             apiPackage = "org.openapitools.example.api"
             invokerPackage = "org.openapitools.example.invoker"
             modelPackage = "org.openapitools.example.model"
@@ -291,8 +291,8 @@ class GenerateTaskDslTest : TestBase() {
         }
         openApiGenerate {
             generatorName = "kotlin"
-            inputSpec = file("spec.yaml").absolutePath
-            outputDir = file("build/kotlin").absolutePath
+            inputSpec = file("spec.yaml")
+            outputDir = file("build/kotlin")
             apiPackage = "org.openapitools.example.api"
             invokerPackage = "org.openapitools.example.invoker"
             modelPackage = "org.openapitools.example.model"

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/MetaTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/MetaTaskDslTest.kt
@@ -13,7 +13,6 @@ class MetaTaskDslTest : TestBase() {
     @Test
     fun `openApiMeta should generate desired project contents`() {
         // Arrange
-        val buildDirReplacement = "\$buildDir/meta"
         withProject("""
             | plugins {
             |   id 'org.openapi.generator'
@@ -22,7 +21,7 @@ class MetaTaskDslTest : TestBase() {
             | openApiMeta {
             |     generatorName = "Sample"
             |     packageName = "org.openapitools.example"
-            |     outputFolder = "$buildDirReplacement".toString()
+            |     outputFolder = project.layout.buildDirectory.dir("meta")
             | }
         """.trimMargin())
 

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
@@ -39,7 +39,7 @@ class ValidateTaskDslTest : TestBase() {
             | }
             |
             | openApiValidate {
-            |   inputSpec = "some_location"
+            |   inputSpec = file("some_location")
             | }
         """.trimMargin())
 
@@ -77,7 +77,7 @@ class ValidateTaskDslTest : TestBase() {
             | }
             |
             | openApiValidate {
-            |   inputSpec = file("spec.yaml").absolutePath
+            |   inputSpec = file("spec.yaml")
             | }
         """.trimMargin(), projectFiles)
 
@@ -106,7 +106,7 @@ class ValidateTaskDslTest : TestBase() {
             | }
             |
             | openApiValidate {
-            |   inputSpec = file('spec.yaml').absolutePath
+            |   inputSpec = file('spec.yaml')
             | }
         """.trimMargin(), projectFiles)
 


### PR DESCRIPTION
This PR switches the Gradle Plugin to rely on proper File properties rather than String location references. This results in a breaking change to the top level API, though for most users it will likely reduce the work they are doing to use the plugin rather than increase (see the changes in the test gradle files). Instead this conversion work is done *inside* the plugin before calling the core OpenAPI code.

Validation is done within the existing generator tests, which needed to be adapted to deal with file providers instead of string providers (though as mentioned it ends up being simpler from an API perspective).

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples: