### PR TITLE
Log Warn Messages for ineffective Schema Validations

### DIFF
--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -278,6 +278,11 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.10</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
             <version>${slf4j.version}</version>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -25,11 +25,27 @@ import com.google.common.collect.ImmutableMap;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Mustache.Compiler;
 import com.samskivert.mustache.Mustache.Lambda;
-
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.callbacks.Callback;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.parameters.*;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.OAuthFlow;
+import io.swagger.v3.oas.models.security.OAuthFlows;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
+import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.text.StringEscapeUtils;
 import org.openapitools.codegen.CodegenDiscriminator.MappedModel;
 import org.openapitools.codegen.api.TemplatingEngineAdapter;
 import org.openapitools.codegen.config.GlobalSettings;
@@ -61,24 +77,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.swagger.v3.core.util.Json;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.PathItem;
-import io.swagger.v3.oas.models.callbacks.Callback;
-import io.swagger.v3.oas.models.examples.Example;
-import io.swagger.v3.oas.models.headers.Header;
-import io.swagger.v3.oas.models.media.*;
-import io.swagger.v3.oas.models.parameters.*;
-import io.swagger.v3.oas.models.responses.ApiResponse;
-import io.swagger.v3.oas.models.responses.ApiResponses;
-import io.swagger.v3.oas.models.security.OAuthFlow;
-import io.swagger.v3.oas.models.security.OAuthFlows;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.oas.models.servers.ServerVariable;
-import io.swagger.v3.parser.util.SchemaTypeUtil;
-
 import static org.openapitools.codegen.utils.OnceLogger.once;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -89,7 +87,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     // A cache of sanitized words. The sanitizeName() method is invoked many times with the same
     // arguments, this cache is used to optimized performance.
-    private static Cache<SanitizeNameOptions, String> sanitizedNameCache;
+    private static final Cache<SanitizeNameOptions, String> sanitizedNameCache;
 
     static {
         DefaultFeatureSet = FeatureSet.newBuilder()
@@ -570,7 +568,7 @@ public class DefaultCodegen implements CodegenConfig {
                 parent.hasChildren = true;
                 Schema parentSchema = this.openAPI.getComponents().getSchemas().get(parent.name);
                 if (parentSchema == null) {
-                    throw new NullPointerException(parent.name+" in "+this.openAPI.getComponents().getSchemas());
+                    throw new NullPointerException(parent.name + " in " + this.openAPI.getComponents().getSchemas());
                 }
                 if (parentSchema.getDiscriminator() == null) {
                     parent = allModels.get(parent.getParent());
@@ -1952,7 +1950,7 @@ public class DefaultCodegen implements CodegenConfig {
             if (encoding != null) {
                 boolean styleGiven = true;
                 Encoding.StyleEnum style = encoding.getStyle();
-                if(style == null || style == Encoding.StyleEnum.FORM) {
+                if (style == null || style == Encoding.StyleEnum.FORM) {
                     // (Unfortunately, swagger-parser-v3 will always provide 'form'
                     // when style is not specified, so we can't detect that)
                     style = Encoding.StyleEnum.FORM;
@@ -1960,12 +1958,12 @@ public class DefaultCodegen implements CodegenConfig {
                 }
                 boolean explodeGiven = true;
                 Boolean explode = encoding.getExplode();
-                if(explode == null) {
+                if (explode == null) {
                     explode = style == Encoding.StyleEnum.FORM; // Default to True when form, False otherwise
                     explodeGiven = false;
                 }
 
-                if(!styleGiven && !explodeGiven) {
+                if (!styleGiven && !explodeGiven) {
                     // Ignore contentType if style or explode are specified.
                     codegenParameter.contentType = encoding.getContentType();
                 }
@@ -1973,7 +1971,7 @@ public class DefaultCodegen implements CodegenConfig {
                 codegenParameter.style = style.toString();
                 codegenParameter.isDeepObject = Encoding.StyleEnum.DEEP_OBJECT == style;
 
-                if(codegenParameter.isContainer) {
+                if (codegenParameter.isContainer) {
                     codegenParameter.isExplode = explode;
                     String collectionFormat = getCollectionFormat(codegenParameter);
                     codegenParameter.collectionFormat = StringUtils.isEmpty(collectionFormat) ? "csv" : collectionFormat;
@@ -2449,8 +2447,8 @@ public class DefaultCodegen implements CodegenConfig {
             this.schema = s;
         }
 
-        private String name;
-        private Schema schema;
+        private final String name;
+        private final Schema schema;
 
         @Override
         public boolean equals(Object o) {
@@ -2817,7 +2815,6 @@ public class DefaultCodegen implements CodegenConfig {
             // referenced models here, component that refs another component which is a model
             // if a component references a schema which is not a generated model, the refed schema will be loaded into
             // schema by unaliasSchema and one of the above code paths will be taken
-            ;
         }
 
         if (schema instanceof ComposedSchema) {
@@ -3637,7 +3634,7 @@ public class DefaultCodegen implements CodegenConfig {
             }
             property.baseType = getSchemaType(p);
             if (p.getXml() != null) {
-                property.isXmlWrapped = p.getXml().getWrapped() == null ? false : p.getXml().getWrapped();
+                property.isXmlWrapped = p.getXml().getWrapped() != null && p.getXml().getWrapped();
                 property.xmlPrefix = p.getXml().getPrefix();
                 property.xmlNamespace = p.getXml().getNamespace();
                 property.xmlName = p.getXml().getName();
@@ -3661,7 +3658,6 @@ public class DefaultCodegen implements CodegenConfig {
             updatePropertyForAnyType(property, p);
         } else if (!ModelUtils.isNullType(p)) {
             // referenced model
-            ;
         }
 
         boolean isAnyTypeWithNothingElseSet = (ModelUtils.isAnyType(p) &&
@@ -4706,7 +4702,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         // the default value is false
         // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#user-content-parameterexplode
-        codegenParameter.isExplode = parameter.getExplode() == null ? false : parameter.getExplode();
+        codegenParameter.isExplode = parameter.getExplode() != null && parameter.getExplode();
 
         // TODO revise collectionFormat, default collection format in OAS 3 appears to multi at least for query parameters
         // https://swagger.io/docs/specification/serialization/
@@ -4735,7 +4731,6 @@ public class DefaultCodegen implements CodegenConfig {
                 if (ModelUtils.isShortSchema(parameterSchema)) { // int32/short format
                     codegenParameter.isShort = true;
                 } else { // unbounded integer
-                    ;
                 }
             }
         } else if (ModelUtils.isTypeObjectSchema(parameterSchema)) {
@@ -4747,7 +4742,6 @@ public class DefaultCodegen implements CodegenConfig {
             }
             addVarsRequiredVarsAdditionalProps(parameterSchema, codegenParameter);
         } else if (ModelUtils.isNullType(parameterSchema)) {
-            ;
         } else if (ModelUtils.isAnyType(parameterSchema)) {
             // any schema with no type set, composed schemas often do this
             if (ModelUtils.isMapSchema(parameterSchema)) { // for map parameter
@@ -4774,7 +4768,6 @@ public class DefaultCodegen implements CodegenConfig {
             }
         } else {
             // referenced schemas
-            ;
         }
 
         CodegenProperty codegenProperty = fromProperty(parameter.getName(), parameterSchema);
@@ -4783,7 +4776,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
         // TODO revise below which seems not working
         //if (parameterSchema.getRequired() != null && !parameterSchema.getRequired().isEmpty() && parameterSchema.getRequired().contains(codegenProperty.baseName)) {
-        codegenProperty.required = Boolean.TRUE.equals(parameter.getRequired()) ? true : false;
+        codegenProperty.required = Boolean.TRUE.equals(parameter.getRequired());
         //}
         //codegenProperty.required = true;
 
@@ -6443,7 +6436,6 @@ public class DefaultCodegen implements CodegenConfig {
                 if (ModelUtils.isShortSchema(ps)) { // int32/short format
                     codegenParameter.isShort = true;
                 } else { // unbounded integer
-                    ;
                 }
             }
         } else if (ModelUtils.isTypeObjectSchema(ps)) {
@@ -6451,10 +6443,8 @@ public class DefaultCodegen implements CodegenConfig {
                 codegenParameter.isFreeFormObject = true;
             }
         } else if (ModelUtils.isNullType(ps)) {
-            ;
         } else if (ModelUtils.isAnyType(ps)) {
             // any schema with no type set, composed schemas often do this
-            ;
         } else if (ModelUtils.isArraySchema(ps)) {
             Schema inner = getSchemaItems((ArraySchema) ps);
             CodegenProperty arrayInnerProperty = fromProperty("inner", inner);
@@ -6493,7 +6483,6 @@ public class DefaultCodegen implements CodegenConfig {
             }
         } else {
             // referenced schemas
-            ;
         }
 
         if (Boolean.TRUE.equals(codegenProperty.isModel)) {
@@ -7300,9 +7289,9 @@ public class DefaultCodegen implements CodegenConfig {
             return exceptions;
         }
 
-        private String name;
-        private String removeCharRegEx;
-        private List<String> exceptions;
+        private final String name;
+        private final String removeCharRegEx;
+        private final List<String> exceptions;
 
         @Override
         public boolean equals(Object o) {
@@ -7474,7 +7463,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     private CodegenComposedSchemas getComposedSchemas(Schema schema) {
-        if (!(schema instanceof ComposedSchema) && schema.getNot()==null) {
+        if (!(schema instanceof ComposedSchema) && schema.getNot() == null) {
             return null;
         }
         Schema notSchema = schema.getNot();
@@ -7534,5 +7523,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    public boolean getUseInlineModelResolver() { return true; }
+    public boolean getUseInlineModelResolver() {
+        return true;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1092,7 +1092,7 @@ public class ModelUtils {
      * @return boolean true if it has at least one self reference
      */
     public static boolean hasSelfReference(OpenAPI openAPI,
-                                       Schema schema) {
+                                           Schema schema) {
         return hasSelfReference(openAPI, schema, null);
     }
 
@@ -1105,8 +1105,8 @@ public class ModelUtils {
      * @return boolean true if it has at least one self reference
      */
     public static boolean hasSelfReference(OpenAPI openAPI,
-                                          Schema schema,
-                                          Set<String> visitedSchemaNames) {
+                                           Schema schema,
+                                           Set<String> visitedSchemaNames) {
         if (visitedSchemaNames == null) {
             visitedSchemaNames = new HashSet<String>();
         }
@@ -1165,7 +1165,7 @@ public class ModelUtils {
             return hasSelfReference(openAPI, schema.getNot(), visitedSchemaNames);
         } else if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
             // go through properties to see if there's any self-reference
-            for (Schema property : ((Map<String, Schema>)schema.getProperties()).values()) {
+            for (Schema property : ((Map<String, Schema>) schema.getProperties()).values()) {
                 if (hasSelfReference(openAPI, property, visitedSchemaNames)) {
                     return true;
                 }
@@ -1352,7 +1352,7 @@ public class ModelUtils {
 
         Map<String, List<Entry<String, Schema>>> groupedByParent = allSchemas.entrySet().stream()
                 .filter(entry -> isComposedSchema(entry.getValue()))
-                .filter(entry -> getParentName((ComposedSchema) entry.getValue(), allSchemas)!=null)
+                .filter(entry -> getParentName((ComposedSchema) entry.getValue(), allSchemas) != null)
                 .collect(Collectors.groupingBy(entry -> getParentName((ComposedSchema) entry.getValue(), allSchemas)));
 
         return groupedByParent.entrySet().stream()
@@ -1451,7 +1451,7 @@ public class ModelUtils {
             // allOf with a single $ref (no discriminator)
             // TODO to be removed in 5.x or 6.x release
             LOGGER.info("[deprecated] inheritance without use of 'discriminator.propertyName' has been deprecated" +
-                    " in the 5.x release. Composed schema name: {}. Title: {}",
+                            " in the 5.x release. Composed schema name: {}. Title: {}",
                     composedSchema.getName(), composedSchema.getTitle());
         }
 
@@ -1507,8 +1507,7 @@ public class ModelUtils {
     private static boolean hasOrInheritsDiscriminator(Schema schema, Map<String, Schema> allSchemas) {
         if (schema.getDiscriminator() != null && StringUtils.isNotEmpty(schema.getDiscriminator().getPropertyName())) {
             return true;
-        }
-        else if (StringUtils.isNotEmpty(schema.get$ref())) {
+        } else if (StringUtils.isNotEmpty(schema.get$ref())) {
             String parentName = getSimpleRef(schema.get$ref());
             Schema s = allSchemas.get(parentName);
             if (s != null) {
@@ -1622,6 +1621,7 @@ public class ModelUtils {
      * For when a type is not defined on a schema
      * Note: properties, additionalProperties, enums, validations, items, and composed schemas (oneOf/anyOf/allOf)
      * can be defined or omitted on these any type schemas
+     *
      * @param schema the schema that we are checking
      * @return boolean
      */
@@ -1631,213 +1631,163 @@ public class ModelUtils {
 
     public static void syncValidationProperties(Schema schema, IJsonSchemaValidationProperties target) {
         // TODO move this method to IJsonSchemaValidationProperties
-        if (schema != null && target != null) {
-            if (isNullType(schema) || schema.get$ref() != null || isBooleanSchema(schema)) {
-                return;
-            }
-            Integer minItems = schema.getMinItems();
-            Integer maxItems = schema.getMaxItems();
-            Boolean uniqueItems = schema.getUniqueItems();
-            Integer minProperties = schema.getMinProperties();
-            Integer maxProperties = schema.getMaxProperties();
-            Integer minLength = schema.getMinLength();
-            Integer maxLength = schema.getMaxLength();
-            String pattern = schema.getPattern();
-            BigDecimal multipleOf = schema.getMultipleOf();
-            BigDecimal minimum = schema.getMinimum();
-            BigDecimal maximum = schema.getMaximum();
-            Boolean exclusiveMinimum = schema.getExclusiveMinimum();
-            Boolean exclusiveMaximum = schema.getExclusiveMaximum();
+        if(schema == null ||
+                target == null ||
+                isNullType(schema) ||
+                schema.get$ref() != null ||
+                isBooleanSchema(schema))
+            return;
+        SchemaValidations.ValidationSetBuilder vSB = new SchemaValidations.ValidationSetBuilder();
 
-            if (isArraySchema(schema)) {
-                setArrayValidations(schema, target);
-            } else if (isTypeObjectSchema(schema)) {
-                setObjectValidations(schema, target);
-            } else if (isStringSchema(schema)) {
-                setStringValidations(schema, target);
-                if (isDecimalSchema(schema)) {
-                    setNumericValidations(schema, target);
-                }
-            } else if (isNumberSchema(schema) || isIntegerSchema(schema)) {
-                setNumericValidations(schema, target);
-            } else if (isAnyType(schema)) {
-                // anyType can have any validations set on it
-                setArrayValidations(schema, target);
-                setObjectValidations(schema, target);
-                setStringValidations(schema, target);
-                setNumericValidations(schema, target);
-            }
+        Integer minItems = schema.getMinItems();
+        if(minItems!=null) vSB.withMinItems();
 
-            if (maxItems != null || minItems != null || minProperties != null || maxProperties != null || minLength != null || maxLength != null || multipleOf != null || pattern != null || minimum != null || maximum != null || exclusiveMinimum != null || exclusiveMaximum != null || uniqueItems != null) {
-                target.setHasValidation(true);
+        Integer maxItems = schema.getMaxItems();
+        if(maxItems!=null) vSB.withMaxItems();
+
+        Boolean uniqueItems = schema.getUniqueItems();
+        if(uniqueItems!=null) vSB.withUniqueItems();
+
+        Integer minProperties = schema.getMinProperties();
+        if(minProperties!=null) vSB.withMinProperties();
+
+        Integer maxProperties = schema.getMaxProperties();
+        if(maxProperties!=null) vSB.withMaxProperties();
+
+        Integer minLength = schema.getMinLength();
+        if(minLength!=null) vSB.withMinLength();
+
+        Integer maxLength = schema.getMaxLength();
+        if(maxLength!=null) vSB.withMaxLength();
+
+        String pattern = schema.getPattern();
+        if(pattern!=null) vSB.withPattern();
+
+        BigDecimal multipleOf = schema.getMultipleOf();
+        if(multipleOf!=null) vSB.withMultipleOf();
+
+        BigDecimal minimum = schema.getMinimum();
+        if(minimum!=null) vSB.withMinimum();
+
+        BigDecimal maximum = schema.getMaximum();
+        if(maximum!=null) vSB.withMaximum();
+
+        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
+        if(exclusiveMinimum!=null) vSB.withExclusiveMinimum();
+
+        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
+        if(exclusiveMaximum!=null) vSB.withExclusiveMaximum();
+
+        Set<String> setValidations = vSB.build();
+
+        if (isArraySchema(schema)) {
+            logWarnMessagesForIneffectiveValidations(setValidations, schema, SchemaValidations.ARRAY_VALIDATIONS);
+            setArrayValidations(schema, target);
+        } else if (isTypeObjectSchema(schema)) {
+            logWarnMessagesForIneffectiveValidations(setValidations, schema, SchemaValidations.OBJECT_VALIDATIONS);
+            setObjectValidations(schema, target);
+        } else if (isStringSchema(schema)) {
+            setStringValidations(schema, target);
+            if (isDecimalSchema(schema)) {
+                setNumericValidations(schema, target);
+                logWarnMessagesForIneffectiveValidations(setValidations, schema, SchemaValidations.ARRAY_VALIDATIONS);
             }
+            else
+                logWarnMessagesForIneffectiveValidations(setValidations, schema, SchemaValidations.ARRAY_VALIDATIONS);
+
+        } else if (isNumberSchema(schema) || isIntegerSchema(schema)) {
+            setNumericValidations(schema, target);
+            logWarnMessagesForIneffectiveValidations(setValidations, schema, SchemaValidations.NUMERIC_VALIDATIONS);
+        } else if (isAnyType(schema)) {
+            // anyType can have any validations set on it
+            setArrayValidations(schema, target);
+            setObjectValidations(schema, target);
+            setStringValidations(schema, target);
+            setNumericValidations(schema, target);
+            logWarnMessagesForIneffectiveValidations(setValidations, schema, SchemaValidations.ALL_VALIDATIONS);
         }
+
+        if(!setValidations.isEmpty())
+            target.setHasValidation(true);
     }
 
     private static void setArrayValidations(Schema schema, IJsonSchemaValidationProperties target) {
 
-        boolean hasValidation=false;
+        boolean hasValidation = false;
 
         Integer minItems = schema.getMinItems();
         Integer maxItems = schema.getMaxItems();
         Boolean uniqueItems = schema.getUniqueItems();
-        Integer minProperties = schema.getMinProperties();
-        Integer maxProperties = schema.getMaxProperties();
-        Integer minLength = schema.getMinLength();
-        Integer maxLength = schema.getMaxLength();
-        String pattern = schema.getPattern();
-        BigDecimal multipleOf = schema.getMultipleOf();
-        BigDecimal minimum = schema.getMinimum();
-        BigDecimal maximum = schema.getMaximum();
-        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
-        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
 
-        // Generate Warn Messages for Validation constraints that have no effect on the datatype
-        if(minProperties!=null) LOGGER.warn("Validation constraint 'minProperties' has no effect on Array Schema. Ignoring!");
-        if(maxProperties!=null) LOGGER.warn("Validation constraint 'maxProperties' has no effect on Array Schema. Ignoring!");
-        if(minLength!=null) LOGGER.warn("Validation constraint 'minLength' has no effect on Array Schema. Ignoring!");
-        if(maxLength!=null) LOGGER.warn("Validation constraint 'maxLength' has no effect on Array Schema. Ignoring!");
-        if(pattern!=null) LOGGER.warn("Validation constraint 'pattern' has no effect on Array Schema. Ignoring!");
-        if(multipleOf!=null) LOGGER.warn("Validation constraint 'multipleOf' has no effect on Array Schema. Ignoring!");
-        if(minimum!=null) LOGGER.warn("Validation constraint 'minimum' has no effect on Array Schema. Ignoring!");
-        if(maximum!=null) LOGGER.warn("Validation constraint 'maximum' has no effect on Array Schema. Ignoring!");
-        if(exclusiveMinimum!=null) LOGGER.warn("Validation constraint 'exclusiveMinimum' has no effect on Array Schema. Ignoring!");
-        if(exclusiveMaximum!=null) LOGGER.warn("Validation constraint 'exclusiveMaximum' has no effect on Array Schema. Ignoring!");
-
-        if (minItems != null){
+        if (minItems != null) {
             target.setMinItems(minItems);
-            hasValidation=true;
+            hasValidation = true;
         }
-        if (maxItems != null){
+        if (maxItems != null) {
             target.setMaxItems(maxItems);
-            hasValidation=true;
+            hasValidation = true;
         }
-        if (uniqueItems != null){
+        if (uniqueItems != null) {
             target.setUniqueItems(uniqueItems);
-            hasValidation=true;
+            hasValidation = true;
         }
         target.setHasValidation(hasValidation);
     }
 
     private static void setObjectValidations(Schema schema, IJsonSchemaValidationProperties target) {
 
-        boolean hasValidation=false;
+        boolean hasValidation = false;
 
-        Integer minItems = schema.getMinItems();
-        Integer maxItems = schema.getMaxItems();
-        Boolean uniqueItems = schema.getUniqueItems();
         Integer minProperties = schema.getMinProperties();
         Integer maxProperties = schema.getMaxProperties();
-        Integer minLength = schema.getMinLength();
-        Integer maxLength = schema.getMaxLength();
-        String pattern = schema.getPattern();
-        BigDecimal multipleOf = schema.getMultipleOf();
-        BigDecimal minimum = schema.getMinimum();
-        BigDecimal maximum = schema.getMaximum();
-        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
-        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
 
-        // Generate Warn Messages for Validation constraints that have no effect on the datatype
-        if(minItems!=null) LOGGER.warn("Validation constraint 'minItems' has no effect on Object Schema. Ignoring!");
-        if(maxItems!=null) LOGGER.warn("Validation constraint 'maxItems' has no effect on Object Schema. Ignoring!");
-        if(uniqueItems!=null) LOGGER.warn("Validation constraint 'uniqueItems' has no effect on Object Schema. Ignoring!");
-        if(minLength!=null) LOGGER.warn("Validation constraint 'minLength' has no effect on Object Schema. Ignoring!");
-        if(maxLength!=null) LOGGER.warn("Validation constraint 'maxLength' has no effect on Object Schema. Ignoring!");
-        if(pattern!=null) LOGGER.warn("Validation constraint 'pattern' has no effect on Object Schema. Ignoring!");
-        if(multipleOf!=null) LOGGER.warn("Validation constraint 'multipleOf' has no effect on Object Schema. Ignoring!");
-        if(minimum!=null) LOGGER.warn("Validation constraint 'minimum' has no effect on Object Schema. Ignoring!");
-        if(maximum!=null) LOGGER.warn("Validation constraint 'maximum' has no effect on Object Schema. Ignoring!");
-        if(exclusiveMinimum!=null) LOGGER.warn("Validation constraint 'exclusiveMinimum' has no effect on Object Schema. Ignoring!");
-        if(exclusiveMaximum!=null) LOGGER.warn("Validation constraint 'exclusiveMaximum' has no effect on Object Schema. Ignoring!");
-        
-        if (minProperties != null){
+        if (minProperties != null) {
             target.setMinProperties(minProperties);
-            hasValidation=true;
+            hasValidation = true;
         }
-        if (maxProperties != null){
+        if (maxProperties != null) {
             target.setMaxProperties(maxProperties);
-            hasValidation=true;
+            hasValidation = true;
         }
         target.setHasValidation(hasValidation);
     }
 
     private static void setStringValidations(Schema schema, IJsonSchemaValidationProperties target) {
 
-        boolean hasValidation=false;
+        boolean hasValidation = false;
 
-        Integer minItems = schema.getMinItems();
-        Integer maxItems = schema.getMaxItems();
-        Boolean uniqueItems = schema.getUniqueItems();
-        Integer minProperties = schema.getMinProperties();
-        Integer maxProperties = schema.getMaxProperties();
         Integer minLength = schema.getMinLength();
         Integer maxLength = schema.getMaxLength();
         String pattern = schema.getPattern();
-        BigDecimal multipleOf = schema.getMultipleOf();
-        BigDecimal minimum = schema.getMinimum();
-        BigDecimal maximum = schema.getMaximum();
-        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
-        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
 
-        // Generate Warn Messages for Validation constraints that have no effect on the datatype
-        if(minItems!=null) LOGGER.warn("Validation constraint 'minItems' has no effect on String Schema. Ignoring!");
-        if(maxItems!=null) LOGGER.warn("Validation constraint 'maxItems' has no effect on String Schema. Ignoring!");
-        if(uniqueItems!=null) LOGGER.warn("Validation constraint 'uniqueItems' has no effect on String Schema. Ignoring!");
-        if(minProperties!=null) LOGGER.warn("Validation constraint 'minProperties' has no effect on String Schema. Ignoring!");
-        if(maxProperties!=null) LOGGER.warn("Validation constraint 'maxProperties' has no effect on String Schema. Ignoring!");
-        if(multipleOf!=null) LOGGER.warn("Validation constraint 'multipleOf' has no effect on String Schema. Ignoring!");
-        if(minimum!=null) LOGGER.warn("Validation constraint 'minimum' has no effect on String Schema. Ignoring!");
-        if(maximum!=null) LOGGER.warn("Validation constraint 'maximum' has no effect on String Schema. Ignoring!");
-        if(exclusiveMinimum!=null) LOGGER.warn("Validation constraint 'exclusiveMinimum' has no effect on String Schema. Ignoring!");
-        if(exclusiveMaximum!=null) LOGGER.warn("Validation constraint 'exclusiveMaximum' has no effect on String Schema. Ignoring!");
-        
-        if (minLength != null){
+        if (minLength != null) {
             target.setMinLength(minLength);
-            hasValidation=true;
+            hasValidation = true;
         }
-        if (maxLength != null){
+        if (maxLength != null) {
             target.setMaxLength(maxLength);
-            hasValidation=true;
+            hasValidation = true;
         }
         if (pattern != null) {
             target.setPattern(pattern);
-            hasValidation=true;
+            hasValidation = true;
         }
         target.setHasValidation(hasValidation);
     }
 
     private static void setNumericValidations(Schema schema, IJsonSchemaValidationProperties target) {
 
-        boolean hasValidation=false;
+        boolean hasValidation = false;
 
-        Integer minItems = schema.getMinItems();
-        Integer maxItems = schema.getMaxItems();
-        Boolean uniqueItems = schema.getUniqueItems();
-        Integer minProperties = schema.getMinProperties();
-        Integer maxProperties = schema.getMaxProperties();
-        Integer minLength = schema.getMinLength();
-        Integer maxLength = schema.getMaxLength();
-        String pattern = schema.getPattern();
         BigDecimal multipleOf = schema.getMultipleOf();
         BigDecimal minimum = schema.getMinimum();
         BigDecimal maximum = schema.getMaximum();
         Boolean exclusiveMinimum = schema.getExclusiveMinimum();
         Boolean exclusiveMaximum = schema.getExclusiveMaximum();
 
-        // Generate Warn Messages for Validation constraints that have no effect on the datatype
-        if(minItems!=null) LOGGER.warn("Validation constraint 'minItems' has no effect on Schema of Numeric type. Ignoring!");
-        if(maxItems!=null) LOGGER.warn("Validation constraint 'maxItems' has no effect on Schema of Numeric type. Ignoring!");
-        if(uniqueItems!=null) LOGGER.warn("Validation constraint 'uniqueItems' has no effect on Schema of Numeric type. Ignoring!");
-        if(minProperties!=null) LOGGER.warn("Validation constraint 'minProperties' has no effect on Schema of Numeric type. Ignoring!");
-        if(maxProperties!=null) LOGGER.warn("Validation constraint 'maxProperties' has no effect on Schema of Numeric type. Ignoring!");
-        if(minLength!=null) LOGGER.warn("Validation constraint 'minLength' has no effect on Schema of Numeric type. Ignoring!");
-        if(maxLength!=null) LOGGER.warn("Validation constraint 'maxLength' has no effect on Schema of Numeric type. Ignoring!");
-        if(pattern!=null) LOGGER.warn("Validation constraint 'pattern' has no effect on Schema of Numeric type. Ignoring!");
-        
-        
         if (multipleOf != null) {
             target.setMultipleOf(multipleOf);
-            hasValidation=true;
+            hasValidation = true;
         }
         if (minimum != null) {
             if (isIntegerSchema(schema)) {
@@ -1846,7 +1796,7 @@ public class ModelUtils {
                 target.setMinimum(String.valueOf(minimum));
             }
             if (exclusiveMinimum != null) target.setExclusiveMinimum(exclusiveMinimum);
-            hasValidation=true;
+            hasValidation = true;
         }
         if (maximum != null) {
             if (isIntegerSchema(schema)) {
@@ -1855,14 +1805,23 @@ public class ModelUtils {
                 target.setMaximum(String.valueOf(maximum));
             }
             if (exclusiveMaximum != null) target.setExclusiveMaximum(exclusiveMaximum);
-            hasValidation=true;
+            hasValidation = true;
         }
         target.setHasValidation(hasValidation);
     }
 
+    private static void logWarnMessagesForIneffectiveValidations(Set<String> setValidations, Schema schema, Set<String> effectiveValidations){
+        setValidations.removeAll(effectiveValidations);
+        setValidations.stream().forEach(validation-> {
+            LOGGER.warn("Validation '" + validation + "' has no effect on schema. Ignoring!");
+        });
+
+
+    }
+
     private static ObjectMapper getRightMapper(String data) {
         ObjectMapper mapper;
-        if(data.trim().startsWith("{")) {
+        if (data.trim().startsWith("{")) {
             mapper = JSON_MAPPER;
         } else {
             mapper = YAML_MAPPER;
@@ -1874,15 +1833,13 @@ public class ModelUtils {
      * Parse and return a JsonNode representation of the input OAS document.
      *
      * @param location the URL of the OAS document.
-     * @param auths the list of authorization values to access the remote URL.
-     *
-     * @throws java.lang.Exception if an error occurs while retrieving the OpenAPI document.
-     *
+     * @param auths    the list of authorization values to access the remote URL.
      * @return A JsonNode representation of the input OAS document.
+     * @throws java.lang.Exception if an error occurs while retrieving the OpenAPI document.
      */
     public static JsonNode readWithInfo(String location, List<AuthorizationValue> auths) throws Exception {
         String data;
-        location = location.replaceAll("\\\\","/");
+        location = location.replaceAll("\\\\", "/");
         if (location.toLowerCase(Locale.ROOT).startsWith("http")) {
             data = RemoteUrl.urlToString(location, auths);
         } else {
@@ -1936,5 +1893,108 @@ public class ModelUtils {
         //GlobalSettings.setProperty(openapiDocVersion, version);
 
         return new SemVer(version);
+    }
+
+    private static final class SchemaValidations {
+
+        public static Set<String> ARRAY_VALIDATIONS = new ValidationSetBuilder()
+                .withMinItems()
+                .withMaxItems()
+                .withUniqueItems()
+                .build();
+        public static Set<String> OBJECT_VALIDATIONS = new ValidationSetBuilder()
+                .withMinProperties()
+                .withMaxProperties()
+                .build();
+        public static Set<String> STRING_VALIDATIONS = new ValidationSetBuilder()
+                .withMinLength()
+                .withMaxLength()
+                .withPattern()
+                .build();
+        public static Set<String> NUMERIC_VALIDATIONS = new ValidationSetBuilder()
+                .withMultipleOf()
+                .withMinimum()
+                .withMaximum()
+                .withExclusiveMinimum()
+                .withExclusiveMaximum()
+                .build();
+
+        public static Set<String> ALL_VALIDATIONS;
+        static {
+            ALL_VALIDATIONS = new HashSet<>(ARRAY_VALIDATIONS);
+            ALL_VALIDATIONS.addAll(OBJECT_VALIDATIONS);
+            ALL_VALIDATIONS.addAll(STRING_VALIDATIONS);
+            ALL_VALIDATIONS.addAll(NUMERIC_VALIDATIONS);
+        }
+
+        SchemaValidations() {
+        }
+
+
+        public static class ValidationSetBuilder {
+            Set<String> validationSet;
+
+            ValidationSetBuilder() {
+                this.validationSet = new HashSet<String>();
+            }
+
+            public ValidationSetBuilder withMinItems() {
+                this.validationSet.add("minItems");
+                return this;
+            }
+
+            public ValidationSetBuilder withMaxItems() {
+                this.validationSet.add("maxItems");
+                return this;
+            }
+            public ValidationSetBuilder withUniqueItems() {
+                this.validationSet.add("uniqueItems");
+                return this;
+            }
+            public ValidationSetBuilder withMinProperties() {
+                this.validationSet.add("minProperties");
+                return this;
+            }
+            public ValidationSetBuilder withMaxProperties() {
+                this.validationSet.add("maxProperties");
+                return this;
+            }
+            public ValidationSetBuilder withMinLength() {
+                this.validationSet.add("minLength");
+                return this;
+            }
+            public ValidationSetBuilder withMaxLength() {
+                this.validationSet.add("maxLength");
+                return this;
+            }
+            public ValidationSetBuilder withPattern() {
+                this.validationSet.add("pattern");
+                return this;
+            }
+            public ValidationSetBuilder withMultipleOf() {
+                this.validationSet.add("multipleOf");
+                return this;
+            }
+            public ValidationSetBuilder withMinimum() {
+                this.validationSet.add("minimum");
+                return this;
+            }
+            public ValidationSetBuilder withMaximum() {
+                this.validationSet.add("maximum");
+                return this;
+            }
+            public ValidationSetBuilder withExclusiveMinimum() {
+                this.validationSet.add("exclusiveMinimum");
+                return this;
+            }
+            public ValidationSetBuilder withExclusiveMaximum() {
+                this.validationSet.add("exclusiveMaximum");
+                return this;
+            }
+
+            public Set<String> build() {
+                return this.validationSet;
+            }
+        }
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1615,18 +1615,18 @@ public class ModelUtils {
         Boolean exclusiveMaximum = schema.getExclusiveMaximum();
         if (exclusiveMaximum != null) vSB.withExclusiveMaximum();
 
-        Set<String> setValidations = vSB.build();
+        LinkedHashSet<String> setValidations = vSB.build();
 
         if (isBooleanSchema(schema) || isNullType(schema)) {
             logWarnMessagesForIneffectiveValidations(setValidations, schema, new HashSet<>());
         } else if (isArraySchema(schema)) {
             if (minItems != null || maxItems != null || uniqueItems != null)
                 setArrayValidations(minItems, maxItems, uniqueItems, target);
-            logWarnMessagesForIneffectiveValidations(new HashSet(setValidations), schema, SchemaValidations.ARRAY_VALIDATIONS);
+            logWarnMessagesForIneffectiveValidations(new LinkedHashSet(setValidations), schema, SchemaValidations.ARRAY_VALIDATIONS);
         } else if (isTypeObjectSchema(schema)) {
             if (minProperties != null || maxProperties != null)
                 setObjectValidations(minProperties, maxProperties, target);
-            logWarnMessagesForIneffectiveValidations(new HashSet(setValidations), schema, SchemaValidations.OBJECT_VALIDATIONS);
+            logWarnMessagesForIneffectiveValidations(new LinkedHashSet(setValidations), schema, SchemaValidations.OBJECT_VALIDATIONS);
         } else if (isStringSchema(schema)) {
             if (minLength != null || maxLength != null || pattern != null)
                 setStringValidations(minLength, maxLength, pattern, target);
@@ -1636,14 +1636,14 @@ public class ModelUtils {
 
                 Set<String> stringAndNumericValidations = new HashSet<>(SchemaValidations.STRING_VALIDATIONS);
                 stringAndNumericValidations.addAll(SchemaValidations.NUMERIC_VALIDATIONS);
-                logWarnMessagesForIneffectiveValidations(new HashSet(setValidations), schema, stringAndNumericValidations);
+                logWarnMessagesForIneffectiveValidations(new LinkedHashSet(setValidations), schema, stringAndNumericValidations);
             } else
-                logWarnMessagesForIneffectiveValidations(new HashSet(setValidations), schema, SchemaValidations.STRING_VALIDATIONS);
+                logWarnMessagesForIneffectiveValidations(new LinkedHashSet(setValidations), schema, SchemaValidations.STRING_VALIDATIONS);
 
         } else if (isNumberSchema(schema) || isIntegerSchema(schema)) {
             if (multipleOf != null || minimum != null || maximum != null || exclusiveMinimum != null || exclusiveMaximum != null)
                 setNumericValidations(schema, multipleOf, minimum, maximum, exclusiveMinimum, exclusiveMaximum, target);
-            logWarnMessagesForIneffectiveValidations(new HashSet(setValidations), schema, SchemaValidations.NUMERIC_VALIDATIONS);
+            logWarnMessagesForIneffectiveValidations(new LinkedHashSet(setValidations), schema, SchemaValidations.NUMERIC_VALIDATIONS);
         } else if (isAnyType(schema)) {
             // anyType can have any validations set on it
             setArrayValidations(minItems, maxItems, uniqueItems, target);
@@ -1825,10 +1825,10 @@ public class ModelUtils {
 
 
         public static class ValidationSetBuilder {
-            Set<String> validationSet;
+            LinkedHashSet<String> validationSet;
 
             ValidationSetBuilder() {
-                this.validationSet = new HashSet<String>();
+                this.validationSet = new LinkedHashSet<String>();
             }
 
             public ValidationSetBuilder withMinItems() {
@@ -1896,7 +1896,7 @@ public class ModelUtils {
                 return this;
             }
 
-            public Set<String> build() {
+            public LinkedHashSet<String> build() {
                 return this.validationSet;
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1650,22 +1650,22 @@ public class ModelUtils {
             Boolean exclusiveMaximum = schema.getExclusiveMaximum();
 
             if (isArraySchema(schema)) {
-                setArrayValidations(minItems, maxItems, uniqueItems, target);
+                setArrayValidations(schema, target);
             } else if (isTypeObjectSchema(schema)) {
-                setObjectValidations(minProperties, maxProperties, target);
+                setObjectValidations(schema, target);
             } else if (isStringSchema(schema)) {
-                setStringValidations(minLength, maxLength, pattern, target);
+                setStringValidations(schema, target);
                 if (isDecimalSchema(schema)) {
-                    setNumericValidations(schema, multipleOf, minimum, maximum, exclusiveMinimum, exclusiveMaximum, target);
+                    setNumericValidations(schema, target);
                 }
             } else if (isNumberSchema(schema) || isIntegerSchema(schema)) {
-                setNumericValidations(schema, multipleOf, minimum, maximum, exclusiveMinimum, exclusiveMaximum, target);
+                setNumericValidations(schema, target);
             } else if (isAnyType(schema)) {
                 // anyType can have any validations set on it
-                setArrayValidations(minItems, maxItems, uniqueItems, target);
-                setObjectValidations(minProperties, maxProperties, target);
-                setStringValidations(minLength, maxLength, pattern, target);
-                setNumericValidations(schema, multipleOf, minimum, maximum, exclusiveMinimum, exclusiveMaximum, target);
+                setArrayValidations(schema, target);
+                setObjectValidations(schema, target);
+                setStringValidations(schema, target);
+                setNumericValidations(schema, target);
             }
 
             if (maxItems != null || minItems != null || minProperties != null || maxProperties != null || minLength != null || maxLength != null || multipleOf != null || pattern != null || minimum != null || maximum != null || exclusiveMinimum != null || exclusiveMaximum != null || uniqueItems != null) {
@@ -1674,25 +1674,171 @@ public class ModelUtils {
         }
     }
 
-    private static void setArrayValidations(Integer minItems, Integer maxItems, Boolean uniqueItems, IJsonSchemaValidationProperties target) {
-        if (minItems != null) target.setMinItems(minItems);
-        if (maxItems != null) target.setMaxItems(maxItems);
-        if (uniqueItems != null) target.setUniqueItems(uniqueItems);
+    private static void setArrayValidations(Schema schema, IJsonSchemaValidationProperties target) {
+
+        boolean hasValidation=false;
+
+        Integer minItems = schema.getMinItems();
+        Integer maxItems = schema.getMaxItems();
+        Boolean uniqueItems = schema.getUniqueItems();
+        Integer minProperties = schema.getMinProperties();
+        Integer maxProperties = schema.getMaxProperties();
+        Integer minLength = schema.getMinLength();
+        Integer maxLength = schema.getMaxLength();
+        String pattern = schema.getPattern();
+        BigDecimal multipleOf = schema.getMultipleOf();
+        BigDecimal minimum = schema.getMinimum();
+        BigDecimal maximum = schema.getMaximum();
+        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
+        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
+
+        // Generate Warn Messages for Validation constraints that have no effect on the datatype
+        if(minProperties!=null) LOGGER.warn("Validation constraint 'minProperties' has no effect on Array Schema. Ignoring!");
+        if(maxProperties!=null) LOGGER.warn("Validation constraint 'maxProperties' has no effect on Array Schema. Ignoring!");
+        if(minLength!=null) LOGGER.warn("Validation constraint 'minLength' has no effect on Array Schema. Ignoring!");
+        if(maxLength!=null) LOGGER.warn("Validation constraint 'maxLength' has no effect on Array Schema. Ignoring!");
+        if(pattern!=null) LOGGER.warn("Validation constraint 'pattern' has no effect on Array Schema. Ignoring!");
+        if(multipleOf!=null) LOGGER.warn("Validation constraint 'multipleOf' has no effect on Array Schema. Ignoring!");
+        if(minimum!=null) LOGGER.warn("Validation constraint 'minimum' has no effect on Array Schema. Ignoring!");
+        if(maximum!=null) LOGGER.warn("Validation constraint 'maximum' has no effect on Array Schema. Ignoring!");
+        if(exclusiveMinimum!=null) LOGGER.warn("Validation constraint 'exclusiveMinimum' has no effect on Array Schema. Ignoring!");
+        if(exclusiveMaximum!=null) LOGGER.warn("Validation constraint 'exclusiveMaximum' has no effect on Array Schema. Ignoring!");
+
+        if (minItems != null){
+            target.setMinItems(minItems);
+            hasValidation=true;
+        }
+        if (maxItems != null){
+            target.setMaxItems(maxItems);
+            hasValidation=true;
+        }
+        if (uniqueItems != null){
+            target.setUniqueItems(uniqueItems);
+            hasValidation=true;
+        }
+        target.setHasValidation(hasValidation);
     }
 
-    private static void setObjectValidations(Integer minProperties, Integer maxProperties, IJsonSchemaValidationProperties target) {
-        if (minProperties != null) target.setMinProperties(minProperties);
-        if (maxProperties != null) target.setMaxProperties(maxProperties);
+    private static void setObjectValidations(Schema schema, IJsonSchemaValidationProperties target) {
+
+        boolean hasValidation=false;
+
+        Integer minItems = schema.getMinItems();
+        Integer maxItems = schema.getMaxItems();
+        Boolean uniqueItems = schema.getUniqueItems();
+        Integer minProperties = schema.getMinProperties();
+        Integer maxProperties = schema.getMaxProperties();
+        Integer minLength = schema.getMinLength();
+        Integer maxLength = schema.getMaxLength();
+        String pattern = schema.getPattern();
+        BigDecimal multipleOf = schema.getMultipleOf();
+        BigDecimal minimum = schema.getMinimum();
+        BigDecimal maximum = schema.getMaximum();
+        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
+        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
+
+        // Generate Warn Messages for Validation constraints that have no effect on the datatype
+        if(minItems!=null) LOGGER.warn("Validation constraint 'minItems' has no effect on Object Schema. Ignoring!");
+        if(maxItems!=null) LOGGER.warn("Validation constraint 'maxItems' has no effect on Object Schema. Ignoring!");
+        if(uniqueItems!=null) LOGGER.warn("Validation constraint 'uniqueItems' has no effect on Object Schema. Ignoring!");
+        if(minLength!=null) LOGGER.warn("Validation constraint 'minLength' has no effect on Object Schema. Ignoring!");
+        if(maxLength!=null) LOGGER.warn("Validation constraint 'maxLength' has no effect on Object Schema. Ignoring!");
+        if(pattern!=null) LOGGER.warn("Validation constraint 'pattern' has no effect on Object Schema. Ignoring!");
+        if(multipleOf!=null) LOGGER.warn("Validation constraint 'multipleOf' has no effect on Object Schema. Ignoring!");
+        if(minimum!=null) LOGGER.warn("Validation constraint 'minimum' has no effect on Object Schema. Ignoring!");
+        if(maximum!=null) LOGGER.warn("Validation constraint 'maximum' has no effect on Object Schema. Ignoring!");
+        if(exclusiveMinimum!=null) LOGGER.warn("Validation constraint 'exclusiveMinimum' has no effect on Object Schema. Ignoring!");
+        if(exclusiveMaximum!=null) LOGGER.warn("Validation constraint 'exclusiveMaximum' has no effect on Object Schema. Ignoring!");
+        
+        if (minProperties != null){
+            target.setMinProperties(minProperties);
+            hasValidation=true;
+        }
+        if (maxProperties != null){
+            target.setMaxProperties(maxProperties);
+            hasValidation=true;
+        }
+        target.setHasValidation(hasValidation);
     }
 
-    private static void setStringValidations(Integer minLength, Integer maxLength, String pattern, IJsonSchemaValidationProperties target) {
-        if (minLength != null) target.setMinLength(minLength);
-        if (maxLength != null) target.setMaxLength(maxLength);
-        if (pattern != null) target.setPattern(pattern);
+    private static void setStringValidations(Schema schema, IJsonSchemaValidationProperties target) {
+
+        boolean hasValidation=false;
+
+        Integer minItems = schema.getMinItems();
+        Integer maxItems = schema.getMaxItems();
+        Boolean uniqueItems = schema.getUniqueItems();
+        Integer minProperties = schema.getMinProperties();
+        Integer maxProperties = schema.getMaxProperties();
+        Integer minLength = schema.getMinLength();
+        Integer maxLength = schema.getMaxLength();
+        String pattern = schema.getPattern();
+        BigDecimal multipleOf = schema.getMultipleOf();
+        BigDecimal minimum = schema.getMinimum();
+        BigDecimal maximum = schema.getMaximum();
+        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
+        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
+
+        // Generate Warn Messages for Validation constraints that have no effect on the datatype
+        if(minItems!=null) LOGGER.warn("Validation constraint 'minItems' has no effect on String Schema. Ignoring!");
+        if(maxItems!=null) LOGGER.warn("Validation constraint 'maxItems' has no effect on String Schema. Ignoring!");
+        if(uniqueItems!=null) LOGGER.warn("Validation constraint 'uniqueItems' has no effect on String Schema. Ignoring!");
+        if(minProperties!=null) LOGGER.warn("Validation constraint 'minProperties' has no effect on String Schema. Ignoring!");
+        if(maxProperties!=null) LOGGER.warn("Validation constraint 'maxProperties' has no effect on String Schema. Ignoring!");
+        if(multipleOf!=null) LOGGER.warn("Validation constraint 'multipleOf' has no effect on String Schema. Ignoring!");
+        if(minimum!=null) LOGGER.warn("Validation constraint 'minimum' has no effect on String Schema. Ignoring!");
+        if(maximum!=null) LOGGER.warn("Validation constraint 'maximum' has no effect on String Schema. Ignoring!");
+        if(exclusiveMinimum!=null) LOGGER.warn("Validation constraint 'exclusiveMinimum' has no effect on String Schema. Ignoring!");
+        if(exclusiveMaximum!=null) LOGGER.warn("Validation constraint 'exclusiveMaximum' has no effect on String Schema. Ignoring!");
+        
+        if (minLength != null){
+            target.setMinLength(minLength);
+            hasValidation=true;
+        }
+        if (maxLength != null){
+            target.setMaxLength(maxLength);
+            hasValidation=true;
+        }
+        if (pattern != null) {
+            target.setPattern(pattern);
+            hasValidation=true;
+        }
+        target.setHasValidation(hasValidation);
     }
 
-    private static void setNumericValidations(Schema schema, BigDecimal multipleOf, BigDecimal minimum, BigDecimal maximum, Boolean exclusiveMinimum, Boolean exclusiveMaximum, IJsonSchemaValidationProperties target) {
-        if (multipleOf != null) target.setMultipleOf(multipleOf);
+    private static void setNumericValidations(Schema schema, IJsonSchemaValidationProperties target) {
+
+        boolean hasValidation=false;
+
+        Integer minItems = schema.getMinItems();
+        Integer maxItems = schema.getMaxItems();
+        Boolean uniqueItems = schema.getUniqueItems();
+        Integer minProperties = schema.getMinProperties();
+        Integer maxProperties = schema.getMaxProperties();
+        Integer minLength = schema.getMinLength();
+        Integer maxLength = schema.getMaxLength();
+        String pattern = schema.getPattern();
+        BigDecimal multipleOf = schema.getMultipleOf();
+        BigDecimal minimum = schema.getMinimum();
+        BigDecimal maximum = schema.getMaximum();
+        Boolean exclusiveMinimum = schema.getExclusiveMinimum();
+        Boolean exclusiveMaximum = schema.getExclusiveMaximum();
+
+        // Generate Warn Messages for Validation constraints that have no effect on the datatype
+        if(minItems!=null) LOGGER.warn("Validation constraint 'minItems' has no effect on Schema of Numeric type. Ignoring!");
+        if(maxItems!=null) LOGGER.warn("Validation constraint 'maxItems' has no effect on Schema of Numeric type. Ignoring!");
+        if(uniqueItems!=null) LOGGER.warn("Validation constraint 'uniqueItems' has no effect on Schema of Numeric type. Ignoring!");
+        if(minProperties!=null) LOGGER.warn("Validation constraint 'minProperties' has no effect on Schema of Numeric type. Ignoring!");
+        if(maxProperties!=null) LOGGER.warn("Validation constraint 'maxProperties' has no effect on Schema of Numeric type. Ignoring!");
+        if(minLength!=null) LOGGER.warn("Validation constraint 'minLength' has no effect on Schema of Numeric type. Ignoring!");
+        if(maxLength!=null) LOGGER.warn("Validation constraint 'maxLength' has no effect on Schema of Numeric type. Ignoring!");
+        if(pattern!=null) LOGGER.warn("Validation constraint 'pattern' has no effect on Schema of Numeric type. Ignoring!");
+        
+        
+        if (multipleOf != null) {
+            target.setMultipleOf(multipleOf);
+            hasValidation=true;
+        }
         if (minimum != null) {
             if (isIntegerSchema(schema)) {
                 target.setMinimum(String.valueOf(minimum.longValue()));
@@ -1700,6 +1846,7 @@ public class ModelUtils {
                 target.setMinimum(String.valueOf(minimum));
             }
             if (exclusiveMinimum != null) target.setExclusiveMinimum(exclusiveMinimum);
+            hasValidation=true;
         }
         if (maximum != null) {
             if (isIntegerSchema(schema)) {
@@ -1708,7 +1855,9 @@ public class ModelUtils {
                 target.setMaximum(String.valueOf(maximum));
             }
             if (exclusiveMaximum != null) target.setExclusiveMaximum(exclusiveMaximum);
+            hasValidation=true;
         }
+        target.setHasValidation(hasValidation);
     }
 
     private static ObjectMapper getRightMapper(String data) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4365,6 +4365,29 @@ public class DefaultCodegenTest {
         logsList.stream().forEach(log -> assertEquals(Level.WARN, log.getLevel()));
     }
 
+    @Test
+    public void nullSchemaWithIneffectiveConstraints() {
+
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        testLogger.addAppender(listAppender);
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName = "NullWithIneffectiveValidations";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel cm = codegen.fromModel(modelName, sc);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // JUnit assertions
+        assertEquals(0, logsList.size());
+    }
+
     public static class FromParameter {
         private CodegenParameter codegenParameter(String path) {
             final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/fromParameter.yaml");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4249,4 +4249,28 @@ public class DefaultCodegenTest {
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
     }
+
+    @Test
+    public void anySchemaWithIneffectiveConstraints(){
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName = "AnyTypeWithIneffectiveValidations";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel cm = codegen.fromModel(modelName, sc);
+    }
+
+    @Test
+    public void booleanSchemaWithIneffectiveConstraints(){
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName = "BooleanWithIneffectiveValidations";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel cm = codegen.fromModel(modelName, sc);
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4180,7 +4180,6 @@ public class DefaultCodegenTest {
         assertEquals(cp.baseName, "SchemaFor201ResponseBodyTextPlain");
         assertTrue(cp.isString);
     }
-
     @Test
     public void testUnalias() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/schema-unalias-test.yml");
@@ -4204,5 +4203,19 @@ public class DefaultCodegenTest {
 
         Assert.assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
         Assert.assertEquals(codegenParameter.getSchema(), null);
+    }
+
+    @Test
+    public void testArraySchemaWithIneffectiveConstraints(){
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName = "ArrayWithIneffectiveValidations";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel cm = codegen.fromModel(modelName, sc);
+
+
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -59,6 +59,8 @@ import static org.testng.Assert.*;
 
 public class DefaultCodegenTest {
 
+    private static final Logger testLogger = (Logger) LoggerFactory.getLogger(ModelUtils.class);
+
     @Test
     public void testDeeplyNestedAdditionalPropertiesImports() {
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -667,7 +669,6 @@ public class DefaultCodegenTest {
         }
         Assert.assertTrue(colorSeen);
     }
-
 
     @Test
     public void testEscapeText() {
@@ -1591,7 +1592,6 @@ public class DefaultCodegenTest {
         }});
         assertEquals(cm.discriminator, discriminator);
     }
-
 
     @Test
     public void testAllOfSingleRefNoOwnProps() {
@@ -4124,12 +4124,11 @@ public class DefaultCodegenTest {
     @Test
     public void testArraySchemaWithIneffectiveConstraints() {
 
-        Logger fooLogger = (Logger) LoggerFactory.getLogger(ModelUtils.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
         listAppender.start();
 
         // add the appender to the logger
-        fooLogger.addAppender(listAppender);
+        testLogger.addAppender(listAppender);
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4139,27 +4138,29 @@ public class DefaultCodegenTest {
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
 
-        // JUnit assertions
+
         List<ILoggingEvent> logsList = listAppender.list;
+
+        // JUnit assertions
         assertEquals(16, logsList.size());
-        assertEquals("Validation 'multipleOf' has no effect on schema. Ignoring!", logsList.get(0)
+        assertEquals("Validation 'minProperties' has no effect on schema. Ignoring!", logsList.get(0)
+                .getMessage());
+        assertEquals("Validation 'maxProperties' has no effect on schema. Ignoring!", logsList.get(1)
+                .getMessage());
+        assertEquals("Validation 'minLength' has no effect on schema. Ignoring!", logsList.get(2)
+                .getMessage());
+        assertEquals("Validation 'maxLength' has no effect on schema. Ignoring!", logsList.get(3)
+                .getMessage());
+        assertEquals("Validation 'pattern' has no effect on schema. Ignoring!", logsList.get(4)
+                .getMessage());
+        assertEquals("Validation 'multipleOf' has no effect on schema. Ignoring!", logsList.get(5)
+                .getMessage());
+        assertEquals("Validation 'minimum' has no effect on schema. Ignoring!", logsList.get(6)
+                .getMessage());
+        assertEquals("Validation 'maximum' has no effect on schema. Ignoring!", logsList.get(7)
                 .getMessage());
 
-        assertEquals("Validation 'minLength' has no effect on schema. Ignoring!", logsList.get(1)
-                .getMessage());
-        assertEquals("Validation 'pattern' has no effect on schema. Ignoring!", logsList.get(2)
-                .getMessage());
-        assertEquals("Validation 'maximum' has no effect on schema. Ignoring!", logsList.get(3)
-                .getMessage());
-        assertEquals("Validation 'maxProperties' has no effect on schema. Ignoring!", logsList.get(4)
-                .getMessage());
-        assertEquals("Validation 'minimum' has no effect on schema. Ignoring!", logsList.get(5)
-                .getMessage());
-        assertEquals("Validation 'maxLength' has no effect on schema. Ignoring!", logsList.get(6)
-                .getMessage());
-        assertEquals("Validation 'minProperties' has no effect on schema. Ignoring!", logsList.get(7)
-                .getMessage());
-
+        // Assert all logged messages are WARN messages
         logsList.stream().limit(8).forEach(log -> assertEquals(Level.WARN, log.getLevel()));
 
 
@@ -4168,6 +4169,12 @@ public class DefaultCodegenTest {
     @Test
     public void testObjectSchemaWithIneffectiveConstraints() {
 
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        testLogger.addAppender(listAppender);
+
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
@@ -4175,10 +4182,42 @@ public class DefaultCodegenTest {
         String modelName = "ObjectWithIneffectiveValidations";
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // JUnit assertions
+        assertEquals(9, logsList.size());
+        assertEquals("Validation 'minItems' has no effect on schema. Ignoring!", logsList.get(0)
+                .getMessage());
+        assertEquals("Validation 'maxItems' has no effect on schema. Ignoring!", logsList.get(1)
+                .getMessage());
+        assertEquals("Validation 'uniqueItems' has no effect on schema. Ignoring!", logsList.get(2)
+                .getMessage());
+        assertEquals("Validation 'minLength' has no effect on schema. Ignoring!", logsList.get(3)
+                .getMessage());
+        assertEquals("Validation 'maxLength' has no effect on schema. Ignoring!", logsList.get(4)
+                .getMessage());
+        assertEquals("Validation 'pattern' has no effect on schema. Ignoring!", logsList.get(5)
+                .getMessage());
+        assertEquals("Validation 'multipleOf' has no effect on schema. Ignoring!", logsList.get(6)
+                .getMessage());
+        assertEquals("Validation 'minimum' has no effect on schema. Ignoring!", logsList.get(7)
+                .getMessage());
+        assertEquals("Validation 'maximum' has no effect on schema. Ignoring!", logsList.get(8)
+                .getMessage());
+
+        // Assert all logged messages are WARN messages
+        logsList.stream().forEach(log -> assertEquals(Level.WARN, log.getLevel()));
     }
 
     @Test
     public void testStringSchemaWithIneffectiveConstraints() {
+
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        testLogger.addAppender(listAppender);
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4187,10 +4226,40 @@ public class DefaultCodegenTest {
         String modelName = "StringWithIneffectiveValidations";
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // JUnit assertions
+        assertEquals(8, logsList.size());
+        assertEquals("Validation 'minItems' has no effect on schema. Ignoring!", logsList.get(0)
+                .getMessage());
+        assertEquals("Validation 'maxItems' has no effect on schema. Ignoring!", logsList.get(1)
+                .getMessage());
+        assertEquals("Validation 'uniqueItems' has no effect on schema. Ignoring!", logsList.get(2)
+                .getMessage());
+        assertEquals("Validation 'minProperties' has no effect on schema. Ignoring!", logsList.get(3)
+                .getMessage());
+        assertEquals("Validation 'maxProperties' has no effect on schema. Ignoring!", logsList.get(4)
+                .getMessage());
+        assertEquals("Validation 'multipleOf' has no effect on schema. Ignoring!", logsList.get(5)
+                .getMessage());
+        assertEquals("Validation 'minimum' has no effect on schema. Ignoring!", logsList.get(6)
+                .getMessage());
+        assertEquals("Validation 'maximum' has no effect on schema. Ignoring!", logsList.get(7)
+                .getMessage());
+
+        // Assert all logged messages are WARN messages
+        logsList.stream().forEach(log -> assertEquals(Level.WARN, log.getLevel()));
     }
 
     @Test
     public void testIntegerSchemaWithIneffectiveConstraints() {
+
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        testLogger.addAppender(listAppender);
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4199,10 +4268,40 @@ public class DefaultCodegenTest {
         String modelName = "IntegerWithIneffectiveValidations";
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // JUnit assertions
+        assertEquals(8, logsList.size());
+        assertEquals("Validation 'minItems' has no effect on schema. Ignoring!", logsList.get(0)
+                .getMessage());
+        assertEquals("Validation 'maxItems' has no effect on schema. Ignoring!", logsList.get(1)
+                .getMessage());
+        assertEquals("Validation 'uniqueItems' has no effect on schema. Ignoring!", logsList.get(2)
+                .getMessage());
+        assertEquals("Validation 'minProperties' has no effect on schema. Ignoring!", logsList.get(3)
+                .getMessage());
+        assertEquals("Validation 'maxProperties' has no effect on schema. Ignoring!", logsList.get(4)
+                .getMessage());
+        assertEquals("Validation 'minLength' has no effect on schema. Ignoring!", logsList.get(5)
+                .getMessage());
+        assertEquals("Validation 'maxLength' has no effect on schema. Ignoring!", logsList.get(6)
+                .getMessage());
+        assertEquals("Validation 'pattern' has no effect on schema. Ignoring!", logsList.get(7)
+                .getMessage());
+
+        // Assert all logged messages are WARN messages
+        logsList.stream().forEach(log -> assertEquals(Level.WARN, log.getLevel()));
     }
 
     @Test
     public void anySchemaWithIneffectiveConstraints() {
+
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        testLogger.addAppender(listAppender);
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4211,10 +4310,21 @@ public class DefaultCodegenTest {
         String modelName = "AnyTypeWithIneffectiveValidations";
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // JUnit assertions
+        assertEquals(0, logsList.size());
     }
 
     @Test
     public void booleanSchemaWithIneffectiveConstraints() {
+
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        testLogger.addAppender(listAppender);
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4223,6 +4333,36 @@ public class DefaultCodegenTest {
         String modelName = "BooleanWithIneffectiveValidations";
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
+
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // JUnit assertions
+        assertEquals(11, logsList.size());
+        assertEquals("Validation 'minItems' has no effect on schema. Ignoring!", logsList.get(0)
+                .getMessage());
+        assertEquals("Validation 'maxItems' has no effect on schema. Ignoring!", logsList.get(1)
+                .getMessage());
+        assertEquals("Validation 'uniqueItems' has no effect on schema. Ignoring!", logsList.get(2)
+                .getMessage());
+        assertEquals("Validation 'minProperties' has no effect on schema. Ignoring!", logsList.get(3)
+                .getMessage());
+        assertEquals("Validation 'maxProperties' has no effect on schema. Ignoring!", logsList.get(4)
+                .getMessage());
+        assertEquals("Validation 'minLength' has no effect on schema. Ignoring!", logsList.get(5)
+                .getMessage());
+        assertEquals("Validation 'maxLength' has no effect on schema. Ignoring!", logsList.get(6)
+                .getMessage());
+        assertEquals("Validation 'pattern' has no effect on schema. Ignoring!", logsList.get(7)
+                .getMessage());
+        assertEquals("Validation 'multipleOf' has no effect on schema. Ignoring!", logsList.get(8)
+                .getMessage());
+        assertEquals("Validation 'minimum' has no effect on schema. Ignoring!", logsList.get(9)
+                .getMessage());
+        assertEquals("Validation 'maximum' has no effect on schema. Ignoring!", logsList.get(10)
+                .getMessage());
+
+        // Assert all logged messages are WARN messages
+        logsList.stream().forEach(log -> assertEquals(Level.WARN, log.getLevel()));
     }
 
     public static class FromParameter {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4215,7 +4215,38 @@ public class DefaultCodegenTest {
         String modelName = "ArrayWithIneffectiveValidations";
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
+    }
+    @Test
+    public void testObjectSchemaWithIneffectiveConstraints(){
 
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
 
+        String modelName = "ObjectWithIneffectiveValidations";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel cm = codegen.fromModel(modelName, sc);
+    }
+    @Test
+    public void testStringSchemaWithIneffectiveConstraints(){
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName = "StringWithIneffectiveValidations";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel cm = codegen.fromModel(modelName, sc);
+    }
+    @Test
+    public void testIntegerSchemaWithIneffectiveConstraints(){
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName = "IntegerWithIneffectiveValidations";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel cm = codegen.fromModel(modelName, sc);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -22,8 +22,6 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.Sets;
 import com.samskivert.mustache.Mustache.Lambda;
 import io.swagger.parser.OpenAPIParser;
@@ -46,6 +44,7 @@ import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.templating.mustache.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.SemVer;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
@@ -1607,14 +1606,6 @@ public class DefaultCodegenTest {
         Assert.assertNull(model.allParents);
     }
 
-    class CodegenWithMultipleInheritance extends DefaultCodegen {
-        public CodegenWithMultipleInheritance() {
-            super();
-            supportsInheritance = true;
-            supportsMultipleInheritance = true;
-        }
-    }
-
     @Test
     public void testAllOfParent() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf-required-parent.yaml");
@@ -2222,83 +2213,6 @@ public class DefaultCodegenTest {
         codegen.setApiNameSuffix("Test");
         assertEquals(codegen.toApiName("Fake"), "FakeTest");
         assertEquals(codegen.toApiName(""), "DefaultApi");
-    }
-
-    public static class FromParameter {
-        private CodegenParameter codegenParameter(String path) {
-            final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/fromParameter.yaml");
-            new InlineModelResolver().flatten(openAPI);
-            final DefaultCodegen codegen = new DefaultCodegen();
-            codegen.setOpenAPI(openAPI);
-
-            return codegen
-                    .fromParameter(
-                            openAPI
-                                    .getPaths()
-                                    .get(path)
-                                    .getGet()
-                                    .getParameters()
-                                    .get(0),
-                            new HashSet<>()
-                    );
-        }
-
-        @Test
-        public void setStyle() {
-            CodegenParameter parameter = codegenParameter("/set_style");
-            assertEquals(parameter.style, "form");
-        }
-
-        @Test
-        public void setShouldExplode() {
-            CodegenParameter parameter = codegenParameter("/set_should_explode");
-            assertTrue(parameter.isExplode);
-        }
-
-        @Test
-        public void testConvertPropertyToBooleanAndWriteBack_Boolean_true() {
-            final DefaultCodegen codegen = new DefaultCodegen();
-            Map<String, Object> additionalProperties = codegen.additionalProperties();
-            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, true);
-            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            Assert.assertTrue(result);
-        }
-
-        @Test
-        public void testConvertPropertyToBooleanAndWriteBack_Boolean_false() {
-            final DefaultCodegen codegen = new DefaultCodegen();
-            Map<String, Object> additionalProperties = codegen.additionalProperties();
-            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, false);
-            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            Assert.assertFalse(result);
-        }
-
-        @Test
-        public void testConvertPropertyToBooleanAndWriteBack_String_true() {
-            final DefaultCodegen codegen = new DefaultCodegen();
-            Map<String, Object> additionalProperties = codegen.additionalProperties();
-            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "true");
-            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            Assert.assertTrue(result);
-        }
-
-        @Test
-        public void testConvertPropertyToBooleanAndWriteBack_String_false() {
-            final DefaultCodegen codegen = new DefaultCodegen();
-            Map<String, Object> additionalProperties = codegen.additionalProperties();
-            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "false");
-            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            Assert.assertFalse(result);
-        }
-
-        @Test
-        public void testConvertPropertyToBooleanAndWriteBack_String_blibb() {
-            final DefaultCodegen codegen = new DefaultCodegen();
-            Map<String, Object> additionalProperties = codegen.additionalProperties();
-            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "blibb");
-            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
-            Assert.assertFalse(result);
-        }
     }
 
     @Test
@@ -3718,7 +3632,7 @@ public class DefaultCodegenTest {
         modelName = "ObjectWithComposedProperties";
         CodegenModel m = codegen.fromModel(modelName, openAPI.getComponents().getSchemas().get(modelName));
         /* TODO inline allOf schema are created as separate models and the following assumptions that
-           the properties are non-model are no longer valid and need to be revised 
+           the properties are non-model are no longer valid and need to be revised
         assertTrue(m.vars.get(0).getIsMap());
         assertTrue(m.vars.get(1).getIsNumber());
         assertTrue(m.vars.get(2).getIsUnboundedInteger());
@@ -4181,6 +4095,7 @@ public class DefaultCodegenTest {
         assertEquals(cp.baseName, "SchemaFor201ResponseBodyTextPlain");
         assertTrue(cp.isString);
     }
+
     @Test
     public void testUnalias() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/schema-unalias-test.yml");
@@ -4207,7 +4122,7 @@ public class DefaultCodegenTest {
     }
 
     @Test
-    public void testArraySchemaWithIneffectiveConstraints(){
+    public void testArraySchemaWithIneffectiveConstraints() {
 
         Logger fooLogger = (Logger) LoggerFactory.getLogger(ModelUtils.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
@@ -4226,7 +4141,7 @@ public class DefaultCodegenTest {
 
         // JUnit assertions
         List<ILoggingEvent> logsList = listAppender.list;
-        assertEquals(16,logsList.size());
+        assertEquals(16, logsList.size());
         assertEquals("Validation 'multipleOf' has no effect on schema. Ignoring!", logsList.get(0)
                 .getMessage());
 
@@ -4251,7 +4166,7 @@ public class DefaultCodegenTest {
     }
 
     @Test
-    public void testObjectSchemaWithIneffectiveConstraints(){
+    public void testObjectSchemaWithIneffectiveConstraints() {
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4261,8 +4176,9 @@ public class DefaultCodegenTest {
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
     }
+
     @Test
-    public void testStringSchemaWithIneffectiveConstraints(){
+    public void testStringSchemaWithIneffectiveConstraints() {
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4272,8 +4188,9 @@ public class DefaultCodegenTest {
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
     }
+
     @Test
-    public void testIntegerSchemaWithIneffectiveConstraints(){
+    public void testIntegerSchemaWithIneffectiveConstraints() {
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4285,7 +4202,7 @@ public class DefaultCodegenTest {
     }
 
     @Test
-    public void anySchemaWithIneffectiveConstraints(){
+    public void anySchemaWithIneffectiveConstraints() {
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4297,7 +4214,7 @@ public class DefaultCodegenTest {
     }
 
     @Test
-    public void booleanSchemaWithIneffectiveConstraints(){
+    public void booleanSchemaWithIneffectiveConstraints() {
 
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue6491.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();
@@ -4306,5 +4223,90 @@ public class DefaultCodegenTest {
         String modelName = "BooleanWithIneffectiveValidations";
         Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
+    }
+
+    public static class FromParameter {
+        private CodegenParameter codegenParameter(String path) {
+            final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/fromParameter.yaml");
+            new InlineModelResolver().flatten(openAPI);
+            final DefaultCodegen codegen = new DefaultCodegen();
+            codegen.setOpenAPI(openAPI);
+
+            return codegen
+                    .fromParameter(
+                            openAPI
+                                    .getPaths()
+                                    .get(path)
+                                    .getGet()
+                                    .getParameters()
+                                    .get(0),
+                            new HashSet<>()
+                    );
+        }
+
+        @Test
+        public void setStyle() {
+            CodegenParameter parameter = codegenParameter("/set_style");
+            assertEquals(parameter.style, "form");
+        }
+
+        @Test
+        public void setShouldExplode() {
+            CodegenParameter parameter = codegenParameter("/set_should_explode");
+            assertTrue(parameter.isExplode);
+        }
+
+        @Test
+        public void testConvertPropertyToBooleanAndWriteBack_Boolean_true() {
+            final DefaultCodegen codegen = new DefaultCodegen();
+            Map<String, Object> additionalProperties = codegen.additionalProperties();
+            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, true);
+            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
+            Assert.assertTrue(result);
+        }
+
+        @Test
+        public void testConvertPropertyToBooleanAndWriteBack_Boolean_false() {
+            final DefaultCodegen codegen = new DefaultCodegen();
+            Map<String, Object> additionalProperties = codegen.additionalProperties();
+            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, false);
+            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
+            Assert.assertFalse(result);
+        }
+
+        @Test
+        public void testConvertPropertyToBooleanAndWriteBack_String_true() {
+            final DefaultCodegen codegen = new DefaultCodegen();
+            Map<String, Object> additionalProperties = codegen.additionalProperties();
+            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "true");
+            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
+            Assert.assertTrue(result);
+        }
+
+        @Test
+        public void testConvertPropertyToBooleanAndWriteBack_String_false() {
+            final DefaultCodegen codegen = new DefaultCodegen();
+            Map<String, Object> additionalProperties = codegen.additionalProperties();
+            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "false");
+            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
+            Assert.assertFalse(result);
+        }
+
+        @Test
+        public void testConvertPropertyToBooleanAndWriteBack_String_blibb() {
+            final DefaultCodegen codegen = new DefaultCodegen();
+            Map<String, Object> additionalProperties = codegen.additionalProperties();
+            additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, "blibb");
+            boolean result = codegen.convertPropertyToBooleanAndWriteBack(CodegenConstants.SERIALIZABLE_MODEL);
+            Assert.assertFalse(result);
+        }
+    }
+
+    class CodegenWithMultipleInheritance extends DefaultCodegen {
+        public CodegenWithMultipleInheritance() {
+            super();
+            supportsInheritance = true;
+            supportsMultipleInheritance = true;
+        }
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue6491.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue6491.yaml
@@ -75,3 +75,50 @@ components:
       minLength: 1
       maxLength: 10
       pattern: 'abcde'
+
+    AnyTypeWithIneffectiveValidations:
+      minItems: 1
+      maxItems: 5
+      uniqueItems: true
+      minProperties: 1
+      maxProperties: 5
+      minLength: 1
+      maxLength: 10
+      pattern: 'abcde'
+      multipleOf: 4
+      minimum: 1
+      maximum: 99
+      exclusiveMinimum: 0
+      exclusiveMaximum: 100
+
+    BooleanWithIneffectiveValidations:
+      type: boolean
+      minItems: 1
+      maxItems: 5
+      uniqueItems: true
+      minProperties: 1
+      maxProperties: 5
+      minLength: 1
+      maxLength: 10
+      pattern: 'abcde'
+      multipleOf: 4
+      minimum: 1
+      maximum: 99
+      exclusiveMinimum: 0
+      exclusiveMaximum: 100
+
+    NullWithIneffectiveValidations:
+      type: null
+      minItems: 1
+      maxItems: 5
+      uniqueItems: true
+      minProperties: 1
+      maxProperties: 5
+      minLength: 1
+      maxLength: 10
+      pattern: 'abcde'
+      multipleOf: 4
+      minimum: 1
+      maximum: 99
+      exclusiveMinimum: 0
+      exclusiveMaximum: 100

--- a/modules/openapi-generator/src/test/resources/3_0/issue6491.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue6491.yaml
@@ -31,3 +31,47 @@ components:
       maximum: 10
       exclusiveMinimum: 0
       exclusiveMaximum: 100
+
+    ObjectWithIneffectiveValidations:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+      minItems: 1
+      maxItems: 5
+      uniqueItems: true
+      minLength: 1
+      maxLength: 10
+      pattern: 'abcde'
+      multipleOf: 3
+      minimum: 1
+      maximum: 10
+      exclusiveMinimum: 1
+      exclusiveMaximum: 10
+
+
+    StringWithIneffectiveValidations:
+      type: string
+      minItems: 1
+      maxItems: 5
+      uniqueItems: true
+      minProperties: 1
+      maxProperties: 5
+      multipleOf: 3
+      minimum: 1
+      maximum: 10
+      exclusiveMinimum: 0
+      exclusiveMaximum: 100
+
+    IntegerWithIneffectiveValidations:
+      type: integer
+      minItems: 1
+      maxItems: 5
+      uniqueItems: true
+      minProperties: 1
+      maxProperties: 5
+      minLength: 1
+      maxLength: 10
+      pattern: 'abcde'

--- a/modules/openapi-generator/src/test/resources/3_0/issue6491.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue6491.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.1
+info:
+  title: My title
+  description: API under test
+  version: 1.0.7
+servers:
+  - url: https://localhost:9999/root
+paths:
+  /location:
+    get:
+      operationId: getLocation
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayWithIneffectiveValidations'
+components:
+  schemas:
+    ArrayWithIneffectiveValidations:
+      type: array
+      items: {}
+      minProperties: 1
+      maxProperties: 5
+      minLength: 1
+      maxLength: 5
+      pattern: 'abcde'
+      multipleOf: 3
+      minimum: 1
+      maximum: 10
+      exclusiveMinimum: 0
+      exclusiveMaximum: 100

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>5</version>
-        <relativePath/><!-- lookup parent from repository -->
+        <relativePath/>
+    <!-- lookup parent from repository -->
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openapitools</groupId>


### PR DESCRIPTION
Log WARN messages for schema validations that have no effect on datatype.
[ISSUE 6491](https://github.com/OpenAPITools/openapi-generator/issues/6491)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
