### PR TITLE
Add a test to set the httpUserAgent in R client

### DIFF
--- a/bin/configs/r-client.yaml
+++ b/bin/configs/r-client.yaml
@@ -2,5 +2,6 @@ generatorName: r
 outputDir: samples/client/petstore/R
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/r
+httpUserAgent: PetstoreAgent
 additionalProperties:
   packageName: petstore

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -41,7 +41,7 @@ ApiClient  <- R6::R6Class(
     # base path of all requests
     basePath = "http://petstore.swagger.io/v2",
     # user agent in the HTTP request
-    userAgent = "OpenAPI-Generator/1.0.0/r",
+    userAgent = "PetstoreAgent",
     # default headers in the HTTP request
     defaultHeaders = NULL,
     # username (HTTP basic authentication)


### PR DESCRIPTION
Add a test to set the httpUserAgent in r client

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
