### PR TITLE
[java][okhttp-gson] Remove errorObjectType as it's not used

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -333,7 +333,6 @@ public class {{classname}} {
             return localVarApiClient.executeStream(localVarCall, localVarReturnType);
         } catch (ApiException e) {
             e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}>(){}.getType()));
-            e.setErrorObjectType(new GenericType<{{{errorObjectType}}}>(){});
             throw e;
         }
         {{/errorObjectType}}
@@ -355,7 +354,6 @@ public class {{classname}} {
             return localVarApiClient.execute(localVarCall, localVarReturnType);
         } catch (ApiException e) {
             e.setErrorObject(localVarApiClient.getJSON().getGson().fromJson(e.getResponseBody(), new TypeToken<{{{errorObjectType}}}>(){}.getType()));
-            e.setErrorObjectType(new GenericType<{{{errorObjectType}}}>(){});
             throw e;
         }
         {{/errorObjectType}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -22,7 +22,6 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     private String responseBody = null;
     {{#errorObjectType}}
     private {{{errorObjectType}}} errorObject = null;
-    private GenericType errorObjectType = null;
     {{/errorObjectType}}
  
     /**
@@ -173,24 +172,6 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
                 super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
     }
     {{#errorObjectType}}
-
-    /**
-     * Get the error object type.
-     *
-     * @return Error object type
-     */
-    public GenericType getErrorObjectType() {
-        return errorObjectType;
-    }
-
-    /**
-     * Set the error object type.
-     *
-     * @param errorObjectType object type
-     */
-    public void setErrorObjectType(GenericType errorObjectType) {
-        this.errorObjectType = errorObjectType;
-    }
 
     /**
      * Get the error object.


### PR DESCRIPTION
Remove errorObjectType as it's not used

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
