### PR TITLE
[java][spring] added springdoc support for service metadata and security

### DIFF
--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -11,7 +11,7 @@ title: Documentation for the spring Generator
 | generator type | SERVER | |
 | generator language | Java | |
 | generator default templating engine | mustache | |
-| helpTxt | Generates a Java SpringBoot Server application using the SpringFox integration. | |
+| helpTxt | Generates a Java SpringBoot Server application using the SpringDoc integration. | |
 
 ## CONFIG OPTIONS
 These options may be applied as additional-properties (cli) or configOptions (plugins). Refer to [configuration docs](https://openapi-generator.tech/docs/configuration) for more details.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4930,7 +4930,7 @@ public class DefaultCodegen implements CodegenConfig {
     private CodegenSecurity defaultCodegenSecurity(String key, SecurityScheme securityScheme) {
         final CodegenSecurity cs = CodegenModelFactory.newInstance(CodegenModelType.SECURITY);
         cs.name = key;
-        cs.type = StringUtils.upperCase(securityScheme.getType().toString());
+        cs.type = securityScheme.getType().toString();
         cs.isCode = cs.isPassword = cs.isApplication = cs.isImplicit = false;
         cs.isHttpSignature = false;
         cs.isBasicBasic = cs.isBasicBearer = false;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4930,7 +4930,7 @@ public class DefaultCodegen implements CodegenConfig {
     private CodegenSecurity defaultCodegenSecurity(String key, SecurityScheme securityScheme) {
         final CodegenSecurity cs = CodegenModelFactory.newInstance(CodegenModelType.SECURITY);
         cs.name = key;
-        cs.type = securityScheme.getType().toString();
+        cs.type = StringUtils.upperCase(securityScheme.getType().toString());
         cs.isCode = cs.isPassword = cs.isApplication = cs.isImplicit = false;
         cs.isHttpSignature = false;
         cs.isBasicBasic = cs.isBasicBearer = false;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -228,7 +228,7 @@ public class SpringCodegen extends AbstractJavaCodegen
 
     @Override
     public String getHelp() {
-        return "Generates a Java SpringBoot Server application using the SpringFox integration.";
+        return "Generates a Java SpringBoot Server application using the SpringDoc integration.";
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -471,10 +471,16 @@ public class SpringCodegen extends AbstractJavaCodegen
                         "HomeController.java"));
                 supportingFiles.add(new SupportingFile("openapi.mustache",
                         ("src/main/resources").replace("/", java.io.File.separator), "openapi.yaml"));
-                if (DocumentationProvider.SPRINGFOX.equals(getDocumentationProvider()) && !reactive && !apiFirst) {
-                    supportingFiles.add(new SupportingFile("openapiDocumentationConfig.mustache",
-                        (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator),
-                        "SpringFoxConfiguration.java"));
+                if (!reactive && !apiFirst){
+                    if (DocumentationProvider.SPRINGDOC.equals(getDocumentationProvider())){
+                        supportingFiles.add(new SupportingFile("springdocDocumentationConfig.mustache",
+                            (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator),
+                            "SpringDocConfiguration.java"));
+                    } else if (DocumentationProvider.SPRINGFOX.equals(getDocumentationProvider())) {
+                        supportingFiles.add(new SupportingFile("openapiDocumentationConfig.mustache",
+                            (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator),
+                            "SpringFoxConfiguration.java"));
+                    }
                 }
             }
         }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
@@ -1,0 +1,49 @@
+package {{configPackage}};
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info(){{#appName}}
+                                .title("{{appName}}"){{/appName}}{{#appDescription}}
+                                .description("{{appDescription}}"){{/appDescription}}{{#termsOfService}}
+                                .termsOfService("{{termsOfService}}"){{/termsOfService}}{{#openAPI}}{{#info}}{{#contact}}
+                                .contact(
+                                        new Contact(){{#infoName}}
+                                                .name("{{infoName}}"){{/infoName}}{{#infoUrl}}
+                                                .url("{{infoUrl}}"){{/infoUrl}}{{#infoEmail}}
+                                                .email("{{infoEmail}}"){{/infoEmail}}
+                                ){{/contact}}{{#license}}
+                                .license(
+                                        new License()
+                                                {{#licenseInfo}}.name("{{licenseInfo}}")
+                                                {{/licenseInfo}}{{#licenseUrl}}.url("{{licenseUrl}}")
+                                                {{/licenseUrl}}
+                                ){{/license}}{{/info}}{{/openAPI}}
+                                .version("{{appVersion}}")
+                ){{#hasAuthMethods}}
+                .components(
+                        new Components(){{#authMethods}}
+                                .addSecuritySchemes("{{name}}", new SecurityScheme()
+                                        .name("{{name}}")
+                                        .type(SecurityScheme.Type.{{type}})
+                                        .description("Didn't set this up yet or the rest of the weird security scheme stuff"){{#scheme}}
+                                        .scheme("{{scheme}}"){{/scheme}}
+                                ){{/authMethods}}
+                ){{/hasAuthMethods}}
+        ;
+    }
+}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
@@ -38,10 +38,14 @@ public class SpringDocConfiguration {
                 .components(
                         new Components(){{#authMethods}}
                                 .addSecuritySchemes("{{name}}", new SecurityScheme()
-                                        .name("{{name}}")
-                                        .type(SecurityScheme.Type.{{type}})
-                                        .description("Didn't set this up yet or the rest of the weird security scheme stuff"){{#scheme}}
-                                        .scheme("{{scheme}}"){{/scheme}}
+                                        .type(SecurityScheme.Type.{{type}}){{#scheme}}
+                                        .scheme("{{scheme}}"){{/scheme}}{{#keyParamName}}
+                                        .name("{{keyParamName}}"){{/keyParamName}}{{#isKeyInHeader}}
+                                        .in(SecurityScheme.In.HEADER){{/isKeyInHeader}}{{#isKeyInQuery}}
+                                        .in(SecurityScheme.In.QUERY){{/isKeyInQuery}}{{#isKeyInCookie}}
+                                        .in(SecurityScheme.In.COOKIE){{/isKeyInCookie}}{{#bearerFormat}}
+                                        .bearerFormat("{{bearerFormat}}"){{/bearerFormat}}{{#openIdConnectUrl}}
+                                        .openIdConnectUrl("{{openIdConnectUrl}}"){{/openIdConnectUrl}}
                                 ){{/authMethods}}
                 ){{/hasAuthMethods}}
         ;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
@@ -44,8 +44,7 @@ public class SpringDocConfiguration {
                                         .in(SecurityScheme.In.HEADER){{/isKeyInHeader}}{{#isKeyInQuery}}
                                         .in(SecurityScheme.In.QUERY){{/isKeyInQuery}}{{#isKeyInCookie}}
                                         .in(SecurityScheme.In.COOKIE){{/isKeyInCookie}}{{#bearerFormat}}
-                                        .bearerFormat("{{bearerFormat}}"){{/bearerFormat}}{{#openIdConnectUrl}}
-                                        .openIdConnectUrl("{{openIdConnectUrl}}"){{/openIdConnectUrl}}
+                                        .bearerFormat("{{bearerFormat}}"){{/bearerFormat}}
                                 ){{/authMethods}}
                 ){{/hasAuthMethods}}
         ;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
@@ -18,8 +18,8 @@ public class SpringDocConfiguration {
         return new OpenAPI()
                 .info(
                         new Info(){{#appName}}
-                                .title("{{appName}}"){{/appName}}{{#appDescription}}
-                                .description("{{{appDescription}}}"){{/appDescription}}{{#termsOfService}}
+                                .title("{{appName}}"){{/appName}}
+                                .description("{{{appDescription}}}"){{#termsOfService}}
                                 .termsOfService("{{termsOfService}}"){{/termsOfService}}{{#openAPI}}{{#info}}{{#contact}}
                                 .contact(
                                         new Contact(){{#infoName}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
@@ -37,14 +37,16 @@ public class SpringDocConfiguration {
                 ){{#hasAuthMethods}}
                 .components(
                         new Components(){{#authMethods}}
-                                .addSecuritySchemes("{{name}}", new SecurityScheme()
-                                        .type(SecurityScheme.Type.{{type}}){{#scheme}}
-                                        .scheme("{{scheme}}"){{/scheme}}{{#keyParamName}}
-                                        .name("{{keyParamName}}"){{/keyParamName}}{{#isKeyInHeader}}
+                                .addSecuritySchemes("{{name}}", new SecurityScheme(){{#isBasic}}
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("{{scheme}}"){{#bearerFormat}}
+                                        .bearerFormat("{{bearerFormat}}"){{/bearerFormat}}{{/isBasic}}{{#isApiKey}}
+                                        .type(SecurityScheme.Type.APIKEY){{#isKeyInHeader}}
                                         .in(SecurityScheme.In.HEADER){{/isKeyInHeader}}{{#isKeyInQuery}}
                                         .in(SecurityScheme.In.QUERY){{/isKeyInQuery}}{{#isKeyInCookie}}
-                                        .in(SecurityScheme.In.COOKIE){{/isKeyInCookie}}{{#bearerFormat}}
-                                        .bearerFormat("{{bearerFormat}}"){{/bearerFormat}}
+                                        .in(SecurityScheme.In.COOKIE){{/isKeyInCookie}}
+                                        .name("{{keyParamName}}"){{/isApiKey}}{{#isOAuth}}
+                                        .type(SecurityScheme.Type.OAUTH2){{/isOAuth}}
                                 ){{/authMethods}}
                 ){{/hasAuthMethods}}
         ;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/springdocDocumentationConfig.mustache
@@ -19,7 +19,7 @@ public class SpringDocConfiguration {
                 .info(
                         new Info(){{#appName}}
                                 .title("{{appName}}"){{/appName}}{{#appDescription}}
-                                .description("{{appDescription}}"){{/appDescription}}{{#termsOfService}}
+                                .description("{{{appDescription}}}"){{/appDescription}}{{#termsOfService}}
                                 .termsOfService("{{termsOfService}}"){{/termsOfService}}{{#openAPI}}{{#info}}{{#contact}}
                                 .contact(
                                         new Contact(){{#infoName}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -848,20 +848,35 @@ public class SpringCodegenTest {
 
     }
 
-    /**define the destinationFilename*/
-    private final static String DESTINATIONFILE = "SpringFoxConfiguration.java";
-    /**define the templateFile*/
-    private final static String TEMPLATEFILE = "openapiDocumentationConfig.mustache";
+    /**Define documentation providers to test */
+    private final static String SPRINGFOX = "springfox";
+    private final static String SPRINGFOX_DESTINATIONFILE = "SpringFoxConfiguration.java";
+    private final static String SPRINGFOX_TEMPLATEFILE = "openapiDocumentationConfig.mustache";
+    private final static String SPRINGDOC = "springdoc";
+    private final static String SPRINGDOC_DESTINATIONFILE = "SpringDocConfiguration.java";
+    private final static String SPRINGDOC_TEMPLATEFILE = "springdocDocumentationConfig.mustache";
 
     /**
      * test whether OpenAPIDocumentationConfig.java is generated
      * fix issue #10287
      */
     @Test
-    public void testConfigFileGeneration() {
+    public void testConfigFileGeneration_springfox() {
+        testConfigFileCommon(SPRINGFOX, SPRINGFOX_DESTINATIONFILE, SPRINGFOX_TEMPLATEFILE);
+    }
 
+    /**
+     * test whether SpringDocDocumentationConfig.java is generated
+     * fix issue #12220
+     */
+    @Test
+    public void testConfigFileGeneration_springdoc() {
+        testConfigFileCommon(SPRINGDOC, SPRINGDOC_DESTINATIONFILE, SPRINGDOC_TEMPLATEFILE);
+    }
+
+    private void testConfigFileCommon(String documentationProvider, String destinationFile, String templateFileName){
         final SpringCodegen codegen = new SpringCodegen();
-        codegen.additionalProperties().put(DOCUMENTATION_PROVIDER, "springfox");
+        codegen.additionalProperties().put(DOCUMENTATION_PROVIDER, documentationProvider);
         codegen.additionalProperties().put(SpringCodegen.INTERFACE_ONLY, false);
         codegen.additionalProperties().put(SpringCodegen.SPRING_CLOUD_LIBRARY, "spring-cloud");
         codegen.additionalProperties().put(SpringCodegen.REACTIVE, false);
@@ -877,13 +892,13 @@ public class SpringCodegenTest {
             tmpFile = s.getTemplateFile();
             desFile = s.getDestinationFilename();
 
-            if (TEMPLATEFILE.equals(tmpFile)) {
+            if (templateFileName.equals(tmpFile)) {
                 flag = true;
-                assertEquals(desFile, DESTINATIONFILE);
+                assertEquals(desFile, destinationFile);
             }
         }
         if (!flag) {
-            fail("OpenAPIDocumentationConfig.java not generated");
+            fail(templateFileName + " not generated");
         }
     }
 

--- a/samples/openapi3/server/petstore/spring-boot-oneof/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/.openapi-generator/FILES
@@ -8,6 +8,7 @@ src/main/java/org/openapitools/api/BarApiController.java
 src/main/java/org/openapitools/api/FooApi.java
 src/main/java/org/openapitools/api/FooApiController.java
 src/main/java/org/openapitools/configuration/HomeController.java
+src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
 src/main/java/org/openapitools/model/Addressable.java
 src/main/java/org/openapitools/model/Bar.java
 src/main/java/org/openapitools/model/BarCreate.java

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -1,0 +1,27 @@
+package org.openapitools.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("ByRefOrValue")
+                                .description("This tests for a oneOf interface representation ")
+                                .version("0.0.1")
+                )
+        ;
+    }
+}

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/.openapi-generator/FILES
@@ -10,6 +10,7 @@ src/main/java/org/openapitools/api/StoreApiController.java
 src/main/java/org/openapitools/api/UserApi.java
 src/main/java/org/openapitools/api/UserApiController.java
 src/main/java/org/openapitools/configuration/HomeController.java
+src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
 src/main/java/org/openapitools/model/Category.java
 src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/Order.java

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -19,7 +19,7 @@ public class SpringDocConfiguration {
                 .info(
                         new Info()
                                 .title("OpenAPI Petstore")
-                                .description("This is a sample server Petstore server. For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.")
+                                .description("This is a sample server Petstore server. For this sample, you can use the api key `special-key` to test the authorization filters.")
                                 .license(
                                         new License()
                                                 .name("Apache-2.0")

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -1,0 +1,43 @@
+package org.openapitools.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("OpenAPI Petstore")
+                                .description("This is a sample server Petstore server. For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.")
+                                .license(
+                                        new License()
+                                                .name("Apache-2.0")
+                                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")
+                                )
+                                .version("1.0.0")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes("api_key", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("api_key")
+                                )
+                                .addSecuritySchemes("petstore_auth", new SecurityScheme()
+                                        .type(SecurityScheme.Type.OAUTH2)
+                                )
+                )
+        ;
+    }
+}

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/.openapi-generator/FILES
@@ -16,6 +16,7 @@ src/main/java/org/openapitools/api/StoreApiController.java
 src/main/java/org/openapitools/api/UserApi.java
 src/main/java/org/openapitools/api/UserApiController.java
 src/main/java/org/openapitools/configuration/HomeController.java
+src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
 src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
 src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
 src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -19,7 +19,7 @@ public class SpringDocConfiguration {
                 .info(
                         new Info()
                                 .title("OpenAPI Petstore")
-                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\")
                                 .license(
                                         new License()
                                                 .name("Apache-2.0")

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -1,0 +1,52 @@
+package org.openapitools.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("OpenAPI Petstore")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .license(
+                                        new License()
+                                                .name("Apache-2.0")
+                                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")
+                                )
+                                .version("1.0.0")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes("api_key", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("api_key")
+                                )
+                                .addSecuritySchemes("api_key_query", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.QUERY)
+                                        .name("api_key_query")
+                                )
+                                .addSecuritySchemes("http_basic_test", new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("basic")
+                                )
+                                .addSecuritySchemes("petstore_auth", new SecurityScheme()
+                                        .type(SecurityScheme.Type.OAUTH2)
+                                )
+                )
+        ;
+    }
+}

--- a/samples/openapi3/server/petstore/springboot-delegate/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/springboot-delegate/.openapi-generator/FILES
@@ -22,6 +22,7 @@ src/main/java/org/openapitools/api/UserApi.java
 src/main/java/org/openapitools/api/UserApiController.java
 src/main/java/org/openapitools/api/UserApiDelegate.java
 src/main/java/org/openapitools/configuration/HomeController.java
+src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
 src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
 src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
 src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -19,7 +19,7 @@ public class SpringDocConfiguration {
                 .info(
                         new Info()
                                 .title("OpenAPI Petstore")
-                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\")
                                 .license(
                                         new License()
                                                 .name("Apache-2.0")

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -1,0 +1,52 @@
+package org.openapitools.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("OpenAPI Petstore")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .license(
+                                        new License()
+                                                .name("Apache-2.0")
+                                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")
+                                )
+                                .version("1.0.0")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes("api_key", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("api_key")
+                                )
+                                .addSecuritySchemes("api_key_query", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.QUERY)
+                                        .name("api_key_query")
+                                )
+                                .addSecuritySchemes("http_basic_test", new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("basic")
+                                )
+                                .addSecuritySchemes("petstore_auth", new SecurityScheme()
+                                        .type(SecurityScheme.Type.OAUTH2)
+                                )
+                )
+        ;
+    }
+}

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/.openapi-generator/FILES
@@ -16,6 +16,7 @@ src/main/java/org/openapitools/api/StoreApiController.java
 src/main/java/org/openapitools/api/UserApi.java
 src/main/java/org/openapitools/api/UserApiController.java
 src/main/java/org/openapitools/configuration/HomeController.java
+src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
 src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
 src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
 src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -19,7 +19,7 @@ public class SpringDocConfiguration {
                 .info(
                         new Info()
                                 .title("OpenAPI Petstore")
-                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\")
                                 .license(
                                         new License()
                                                 .name("Apache-2.0")

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -1,0 +1,52 @@
+package org.openapitools.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("OpenAPI Petstore")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .license(
+                                        new License()
+                                                .name("Apache-2.0")
+                                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")
+                                )
+                                .version("1.0.0")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes("api_key", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("api_key")
+                                )
+                                .addSecuritySchemes("api_key_query", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.QUERY)
+                                        .name("api_key_query")
+                                )
+                                .addSecuritySchemes("http_basic_test", new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("basic")
+                                )
+                                .addSecuritySchemes("petstore_auth", new SecurityScheme()
+                                        .type(SecurityScheme.Type.OAUTH2)
+                                )
+                )
+        ;
+    }
+}

--- a/samples/openapi3/server/petstore/springboot-useoptional/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/springboot-useoptional/.openapi-generator/FILES
@@ -16,6 +16,7 @@ src/main/java/org/openapitools/api/StoreApiController.java
 src/main/java/org/openapitools/api/UserApi.java
 src/main/java/org/openapitools/api/UserApiController.java
 src/main/java/org/openapitools/configuration/HomeController.java
+src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
 src/main/java/org/openapitools/model/AdditionalPropertiesAnyType.java
 src/main/java/org/openapitools/model/AdditionalPropertiesArray.java
 src/main/java/org/openapitools/model/AdditionalPropertiesBoolean.java

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -19,7 +19,7 @@ public class SpringDocConfiguration {
                 .info(
                         new Info()
                                 .title("OpenAPI Petstore")
-                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\")
                                 .license(
                                         new License()
                                                 .name("Apache-2.0")

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -1,0 +1,52 @@
+package org.openapitools.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("OpenAPI Petstore")
+                                .description("This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\")
+                                .license(
+                                        new License()
+                                                .name("Apache-2.0")
+                                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")
+                                )
+                                .version("1.0.0")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes("api_key", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("api_key")
+                                )
+                                .addSecuritySchemes("api_key_query", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.QUERY)
+                                        .name("api_key_query")
+                                )
+                                .addSecuritySchemes("http_basic_test", new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("basic")
+                                )
+                                .addSecuritySchemes("petstore_auth", new SecurityScheme()
+                                        .type(SecurityScheme.Type.OAUTH2)
+                                )
+                )
+        ;
+    }
+}

--- a/samples/openapi3/server/petstore/springboot/.openapi-generator/FILES
+++ b/samples/openapi3/server/petstore/springboot/.openapi-generator/FILES
@@ -10,6 +10,7 @@ src/main/java/org/openapitools/api/StoreApiController.java
 src/main/java/org/openapitools/api/UserApi.java
 src/main/java/org/openapitools/api/UserApiController.java
 src/main/java/org/openapitools/configuration/HomeController.java
+src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
 src/main/java/org/openapitools/model/Category.java
 src/main/java/org/openapitools/model/ModelApiResponse.java
 src/main/java/org/openapitools/model/Order.java

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -19,7 +19,7 @@ public class SpringDocConfiguration {
                 .info(
                         new Info()
                                 .title("OpenAPI Petstore")
-                                .description("This is a sample server Petstore server. For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.")
+                                .description("This is a sample server Petstore server. For this sample, you can use the api key `special-key` to test the authorization filters.")
                                 .license(
                                         new License()
                                                 .name("Apache-2.0")

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java
@@ -1,0 +1,43 @@
+package org.openapitools.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+
+    @Bean
+    OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("OpenAPI Petstore")
+                                .description("This is a sample server Petstore server. For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.")
+                                .license(
+                                        new License()
+                                                .name("Apache-2.0")
+                                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")
+                                )
+                                .version("1.0.0")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes("api_key", new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name("api_key")
+                                )
+                                .addSecuritySchemes("petstore_auth", new SecurityScheme()
+                                        .type(SecurityScheme.Type.OAUTH2)
+                                )
+                )
+        ;
+    }
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
- Added the auto-generated OpenAPI 3 support for service metadata and security, using springdoc.
  - Changes made to `SpringCodegen` to add the new documentation config file (`SpringDocConfiguration.java`) to the list of auto-generated files
  - Added new template file: `springdocDocumentationProvider.mustache` for the Spring generator which builds `SpringDocConfiguration.java`
  - This can be validated by generating a java spring API using the default documentation provider, and examining `target/generated-sources/openapi/src/main/java/org/openapitools/configuration/SpringDocConfiguration.java` in the resulting API.
  - Updated spring samples in this PR can also be checked to see some examples of the new springdoc configuration files.
- `CodegenSecurityTest` was updated to test the new addition of the SpringDoc configuration, and test was cleaned up to reduce duplication when adding the additional documentation provider test.
- Fixed a piece of documentation and the connected code in `SpringCodegen` which still used Springfox verbiage, even though the default documentation provider is springdoc.

Some notes on the implementation:

- Did not remove Springfox, since it's marked for removal in 7.0.0: https://github.com/OpenAPITools/openapi-generator/issues/11553
- Current pull request supports basic and API key fully with the security info. Does not yet support Oauth2 completely since it would require a bunch more work into the template. Would affect the ability to use auth on the swagger-ui with Oauth2
- `CodegenSecurity` doesn't support a description field yet for the auth method, so as of now that support remains the same

Closes https://github.com/OpenAPITools/openapi-generator/issues/12220

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02)