### PR TITLE
[dart] Bump min dio version to prevent unused import

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
@@ -12,7 +12,7 @@ environment:
 {{/useJsonSerializable}}
 
 dependencies:
-  dio: '>=4.0.0 <5.0.0'
+  dio: '>=4.0.1 <5.0.0'
 {{#useBuiltValue}}
   built_value: '>=8.1.0 <9.0.0'
   built_collection: '>=5.1.0 <6.0.0'

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/api_util.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/api_util.mustache
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:dio/dio.dart';
-import 'package:dio/src/parameter.dart';
 
 /// Format the given form parameter object into something that Dio can handle.
 /// Returns primitive or String.

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  dio: '>=4.0.0 <5.0.0'
+  dio: '>=4.0.1 <5.0.0'
   json_annotation: '^4.4.0'
 
 dev_dependencies:

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api_util.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/api_util.dart
@@ -8,7 +8,6 @@ import 'dart:typed_data';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:dio/dio.dart';
-import 'package:dio/src/parameter.dart';
 
 /// Format the given form parameter object into something that Dio can handle.
 /// Returns primitive or String.

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dio: '>=4.0.0 <5.0.0'
+  dio: '>=4.0.1 <5.0.0'
   built_value: '>=8.1.0 <9.0.0'
   built_collection: '>=5.1.0 <6.0.0'
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dev_dependencies:
   built_collection: 5.1.0
   built_value: 8.1.0
-  dio: 4.0.0
+  dio: 4.0.1
   http_mock_adapter: 0.3.2
   mockito: 5.0.11
   openapi:


### PR DESCRIPTION
Just a minor bump to prevent some import warnings.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)