### PR TITLE
[java-micronaut] make parent with a discriminator abstract and sealed

### DIFF
--- a/bin/configs/java-micronaut-client.yaml
+++ b/bin/configs/java-micronaut-client.yaml
@@ -8,4 +8,5 @@ additionalProperties:
   build: "all"
   test: "spock"
   requiredPropertiesInConstructor: "false"
+  useSealed: "true"
   visitable: "true"

--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -77,6 +77,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |title|Client service name| |null|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useOptional|Use Optional container for optional parameters| |false|
+|useSealed|Use abstract sealed classes for subtypes with a discriminator| |false|
 |visitable|Generate visitor for subtypes with a discriminator| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 |wrapInHttpResponse|Wrap the response in HttpResponse object| |false|

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -80,6 +80,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useAuth|Whether to import authorization and to annotate controller methods accordingly| |true|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useOptional|Use Optional container for optional parameters| |false|
+|useSealed|Use abstract sealed classes for subtypes with a discriminator| |false|
 |visitable|Generate visitor for subtypes with a discriminator| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 |wrapInHttpResponse|Wrap the response in HttpResponse object| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenDiscriminator.java
@@ -40,6 +40,11 @@ public class CodegenDiscriminator {
 
     private Set<MappedModel> mappedModels = new TreeSet<>();
 
+    /**
+     * Indication if the mapping contains the parent model.
+     */
+    private boolean containsParent = false;
+
     public String getPropertyName() {
         return propertyName;
     }
@@ -86,6 +91,14 @@ public class CodegenDiscriminator {
 
     public void setMappedModels(Set<MappedModel> mappedModels) {
         this.mappedModels = mappedModels;
+    }
+
+    public boolean isContainsParent() {
+        return containsParent;
+    }
+
+    public void setContainsParent(boolean containsParent) {
+        this.containsParent = containsParent;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1279,6 +1279,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if ("BigDecimal".equals(codegenModel.dataType)) {
             codegenModel.imports.add("BigDecimal");
         }
+        if (codegenModel.discriminator != null) {
+            for (CodegenDiscriminator.MappedModel mapped : codegenModel.discriminator.getMappedModels()) {
+                if (name.equals(mapped.getModelName())) {
+                    codegenModel.discriminator.setContainsParent(true);
+                }
+            }
+        }
         return codegenModel;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
@@ -39,6 +39,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     public static final String OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR = "requiredPropertiesInConstructor";
     public static final String OPT_MICRONAUT_VERSION = "micronautVersion";
     public static final String OPT_USE_AUTH = "useAuth";
+    public static final String OPT_USE_SEALED = "useSealed";
     public static final String OPT_VISITABLE = "visitable";
     public static final String OPT_DATE_LIBRARY_JAVA8 = "java8";
     public static final String OPT_DATE_LIBRARY_JAVA8_LOCAL_DATETIME = "java8-localdatetime";
@@ -59,6 +60,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
     protected String title;
     protected boolean useBeanValidation;
     protected boolean useOptional;
+    protected boolean useSealed;
     protected boolean visitable;
     protected String buildTool;
     protected String testTool;
@@ -84,6 +86,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
         // Set all the fields
         useBeanValidation = true;
         useOptional = false;
+        useSealed = false;
         visitable = false;
         buildTool = OPT_BUILD_ALL;
         testTool = OPT_TEST_JUNIT;
@@ -138,6 +141,7 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
         cliOptions.add(new CliOption(OPT_APPLICATION_NAME, "Micronaut application name (Defaults to the " + CodegenConstants.ARTIFACT_ID + " value)").defaultValue(appName));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations", useBeanValidation));
         cliOptions.add(CliOption.newBoolean(USE_OPTIONAL, "Use Optional container for optional parameters", useOptional));
+        cliOptions.add(CliOption.newBoolean(OPT_USE_SEALED, "Use abstract sealed classes for subtypes with a discriminator", useSealed));
         cliOptions.add(CliOption.newBoolean(OPT_VISITABLE, "Generate visitor for subtypes with a discriminator", visitable));
         cliOptions.add(CliOption.newBoolean(OPT_REQUIRED_PROPERTIES_IN_CONSTRUCTOR, "Allow only to create models with all the required properties provided in constructor", requiredPropertiesInConstructor));
         cliOptions.add(CliOption.newBoolean(OPT_REACTIVE, "Make the responses use Reactor Mono as wrapper", reactive));
@@ -225,6 +229,11 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
             this.setUseOptional(convertPropertyToBoolean(USE_OPTIONAL));
         }
         writePropertyBack(USE_OPTIONAL, useOptional);
+
+        if (additionalProperties.containsKey(OPT_USE_SEALED)) {
+            this.setUseSealed(convertPropertyToBoolean(OPT_USE_SEALED));
+        }
+        writePropertyBack(OPT_USE_SEALED, useSealed);
 
         if (additionalProperties.containsKey(OPT_VISITABLE)) {
             this.setVisitable(convertPropertyToBoolean(OPT_VISITABLE));
@@ -422,6 +431,10 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
         this.useOptional = useOptional;
     }
 
+    public void setUseSealed(boolean useSealed) {
+        this.useSealed = useSealed;
+    }
+
     public void setVisitable(boolean visitable) {
         this.visitable = visitable;
     }
@@ -441,6 +454,10 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
 
     public boolean isUseOptional() {
         return useOptional;
+    }
+
+    public boolean isUseSealed() {
+        return useSealed;
     }
 
     public boolean isVisitable() {

--- a/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/common/model/pojo.mustache
@@ -20,14 +20,13 @@
 {{#additionalModelTypeAnnotations}}
 {{{.}}}
 {{/additionalModelTypeAnnotations}}
-{{>common/generatedAnnotation}}{{#discriminator}}{{>common/model/typeInfoAnnotation}}{{/discriminator}}{{>common/model/xmlAnnotation}}{{#useBeanValidation}}
-@Introspected
-{{/useBeanValidation}}
+{{>common/generatedAnnotation}}{{#discriminator}}{{>common/model/typeInfoAnnotation}}{{/discriminator}}{{>common/model/xmlAnnotation}}
+{{^discriminator}}@Introspected{{/discriminator}}{{#discriminator.containsParent}}@Introspected{{/discriminator.containsParent}}
 {{#vendorExtensions.x-class-extra-annotation}}
 {{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
 Declare the class with extends and implements
-}}public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
+}}public {{#useSealed}}{{#discriminator}}{{^containsParent}}abstract {{/containsParent}}sealed {{/discriminator}}{{/useSealed}}class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{{#useSealed}}{{#discriminator}}permits {{#discriminator.mappedModels}}{{modelName}} {{/discriminator.mappedModels}}{{/discriminator}}{{/useSealed}}{
     {{#serializableModel}}
     private static final long serialVersionUID = 1L;
 
@@ -375,9 +374,21 @@ Declare the class with extends and implements
      * @param <T> the return type of the visitor
      * @return the result from the visitor
      */
-    public <T> T accept(Visitor<T> visitor) {
-        return visitor.visit{{classname}}(this);
+    {{^containsParent}}
+        {{#sealed}}
+    public abstract <T> T accept(Visitor<T> visitor);
+        {{/sealed}}
+        {{^sealed}}
+    public <T> T accept({{{classname}}}.Visitor<T> visitor) {
+      return visitor.visit{{classname}}(this);
     }
+        {{/sealed}}
+    {{/containsParent}}
+    {{#containsParent}}
+    public <T> T accept({{{classname}}}.Visitor<T> visitor) {
+      return visitor.visit{{classname}}(this);
+    }
+    {{/containsParent}}
 
     /**
      * A {{classname}} visitor implementation allows visiting the various {{classname}} types.
@@ -388,7 +399,11 @@ Declare the class with extends and implements
         {{#discriminator.mappedModels}}
         R visit{{modelName}}({{modelName}} value);
         {{/discriminator.mappedModels}}
+        {{^containsParent}}
+          {{^sealed}}
         R visit{{classname}}({{classname}} value);
+          {{/sealed}}
+        {{/containsParent}}
     }
 
     {{/discriminator}}

--- a/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/client/petstore/java-micronaut-client/src/main/java/org/openapitools/model/Animal.java
@@ -44,8 +44,8 @@ import javax.annotation.Generated;
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
 })
 
-@Introspected
-public class Animal {
+
+public abstract sealed class Animal permits BigCat Cat Dog {
     public static final String JSON_PROPERTY_CLASS_NAME = "className";
     protected String className;
 
@@ -144,8 +144,8 @@ public class Animal {
      * @param <T> the return type of the visitor
      * @return the result from the visitor
      */
-    public <T> T accept(Visitor<T> visitor) {
-        return visitor.visitAnimal(this);
+    public <T> T accept(Animal.Visitor<T> visitor) {
+      return visitor.visitAnimal(this);
     }
 
     /**


### PR DESCRIPTION
Parent types with a discriminator which aren't part of the mapped types
should be abstract, since they can't be instantiated themself.

Furthermore an option is added which marks the parent class as sealed in
order to let the Java compiler know which subtypes exist.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@andriy-dmytruk