### PR TITLE
[php-slim4] Add post install Composer script

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/composer.mustache
@@ -47,6 +47,9 @@
     "psr-4": { "{{escapedInvokerPackage}}\\": "{{testBasePath}}/" }
   },
   "scripts": {
+    "post-install-cmd": [
+      "php -r \"chmod('./logs', 0777);\""
+    ],
     {{#generateTests}}
     "test": [
       "phpunit"

--- a/samples/server/petstore/php-slim4/composer.json
+++ b/samples/server/petstore/php-slim4/composer.json
@@ -32,6 +32,9 @@
     "psr-4": { "OpenAPIServer\\": "tests/" }
   },
   "scripts": {
+    "post-install-cmd": [
+      "php -r \"chmod('./logs', 0777);\""
+    ],
     "test": [
       "phpunit"
     ],


### PR DESCRIPTION
Makes `logs` folder writable after `composer install` finishes. Easier installation.

cc @jebentier @dkarlovi @mandrean @jfastnacht @renepardon

Refs:
- [Scripts - Composer](https://getcomposer.org/doc/articles/scripts.md#command-events)
- [PHP: chmod](https://www.php.net/manual/en/function.chmod.php)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
