### PR TITLE
[java-micronaut] Allow default implementation to return HTTP 501

### DIFF
--- a/bin/configs/java-micronaut-server.yaml
+++ b/bin/configs/java-micronaut-server.yaml
@@ -8,3 +8,5 @@ additionalProperties:
   test: "spock"
   requiredPropertiesInConstructor: "true"
   useAuth: "false"
+  generateControllerAsAbstract: "false"
+  generateOperationsToReturnNotImplemented: "true"

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -44,6 +44,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |fullJavaUtil|whether to use fully qualified name for classes under java.util. This option only works for Java API client| |false|
 |generateControllerAsAbstract|Generate an abstract class for controller to be extended. (apiPackage is then used for the abstract class, and controllerPackage is used for implementation that extends it.)| |false|
 |generateControllerFromExamples|Generate the implementation of controller and tests from parameter and return examples that will verify that the api works as desired (for testing)| |false|
+|generateOperationsToReturnNotImplemented|Return HTTP 501 Not Implemented instead of an empty response in the generated controller methods.| |true|
 |groupId|groupId in generated pom.xml| |org.openapitools|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |false|
 |ignoreAnyOfInEnum|Ignore anyOf keyword in enum| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautServerCodegen.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -20,6 +19,7 @@ public class JavaMicronautServerCodegen extends JavaMicronautAbstractCodegen {
     public static final String OPT_CONTROLLER_PACKAGE = "controllerPackage";
     public static final String OPT_GENERATE_CONTROLLER_FROM_EXAMPLES = "generateControllerFromExamples";
     public static final String OPT_GENERATE_CONTROLLER_AS_ABSTRACT = "generateControllerAsAbstract";
+    public static final String OPT_GENERATE_OPERATIONS_TO_RETURN_NOT_IMPLEMENTED = "generateOperationsToReturnNotImplemented";
 
     public static final String EXTENSION_ROLES = "x-roles";
     public static final String ANONYMOUS_ROLE_KEY = "isAnonymous()";
@@ -35,6 +35,7 @@ public class JavaMicronautServerCodegen extends JavaMicronautAbstractCodegen {
 
     protected String controllerPackage = "org.openapitools.controller";
     protected boolean generateControllerAsAbstract = false;
+    protected boolean generateOperationsToReturnNotImplemented = true;
     protected boolean generateControllerFromExamples = false;
     protected boolean useAuth = true;
 
@@ -65,6 +66,10 @@ public class JavaMicronautServerCodegen extends JavaMicronautAbstractCodegen {
                 " is then used for the abstract class, and " + OPT_CONTROLLER_PACKAGE +
                 " is used for implementation that extends it.)",
                 generateControllerAsAbstract));
+        cliOptions.add(CliOption.newBoolean(OPT_GENERATE_OPERATIONS_TO_RETURN_NOT_IMPLEMENTED,
+                "Return HTTP 501 Not Implemented instead of an empty response in the generated controller methods.",
+                generateOperationsToReturnNotImplemented));
+
         cliOptions.add(CliOption.newBoolean(OPT_USE_AUTH, "Whether to import authorization and to annotate controller methods accordingly", useAuth));
 
         // Set the type mappings
@@ -95,6 +100,11 @@ public class JavaMicronautServerCodegen extends JavaMicronautAbstractCodegen {
             generateControllerAsAbstract = convertPropertyToBoolean(OPT_GENERATE_CONTROLLER_AS_ABSTRACT);
         }
         writePropertyBack(OPT_GENERATE_CONTROLLER_AS_ABSTRACT, generateControllerAsAbstract);
+
+        if (additionalProperties.containsKey(OPT_GENERATE_OPERATIONS_TO_RETURN_NOT_IMPLEMENTED)) {
+            generateOperationsToReturnNotImplemented = convertPropertyToBoolean(OPT_GENERATE_OPERATIONS_TO_RETURN_NOT_IMPLEMENTED);
+        }
+        writePropertyBack(OPT_GENERATE_OPERATIONS_TO_RETURN_NOT_IMPLEMENTED, generateOperationsToReturnNotImplemented);
 
         if (additionalProperties.containsKey(OPT_CONTROLLER_PACKAGE)) {
             controllerPackage = (String) additionalProperties.get(OPT_CONTROLLER_PACKAGE);

--- a/modules/openapi-generator/src/main/resources/java-micronaut/server/controller.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/server/controller.mustache
@@ -14,6 +14,10 @@ import reactor.core.publisher.Mono;
 {{#wrapInHttpResponse}}
 import io.micronaut.http.HttpResponse;
 {{/wrapInHttpResponse}}
+{{#generateOperationsToReturnNotImplemented}}
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
+{{/generateOperationsToReturnNotImplemented}}
 {{#imports}}
 import {{import}};
 {{/imports}}
@@ -119,8 +123,9 @@ public {{#generateControllerAsAbstract}}abstract {{/generateControllerAsAbstract
      *
      * This method will be delegated to when the controller gets a request
      */
-    public abstract {{>common/operationReturnType}} {{nickname}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
-    {{/generateControllerAsAbstract}}
+    public {{^generateOperationsToReturnNotImplemented}}abstract {{/generateOperationsToReturnNotImplemented}}{{>common/operationReturnType}} {{nickname}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}){{^generateOperationsToReturnNotImplemented}};{{/generateOperationsToReturnNotImplemented}}{{#generateOperationsToReturnNotImplemented}} {{openbrace}}
+    {{>server/controllerOperationBody}}
+    {{closebrace}}{{/generateOperationsToReturnNotImplemented}}{{/generateControllerAsAbstract}}
     {{^-last}}
 
     {{/-last}}

--- a/modules/openapi-generator/src/main/resources/java-micronaut/server/controllerOperationBody.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/server/controllerOperationBody.mustache
@@ -1,7 +1,12 @@
     {{^generateControllerFromExamples}}
         {{!The body needs to be implemented by user}}
         // TODO implement {{nickname}}();
+        {{^generateOperationsToReturnNotImplemented}}
         {{#reactive}}{{#wrapInHttpResponse}}return Mono.fromCallable(HttpResponse::ok);{{/wrapInHttpResponse}}{{^wrapInHttpResponse}}return Mono.empty();{{/wrapInHttpResponse}}{{/reactive}}{{^reactive}}{{#wrapInHttpResponse}}return HttpResponse.ok();{{/wrapInHttpResponse}}{{^wrapInHttpResponse}}{{#returnType}}return null;{{/returnType}}{{/wrapInHttpResponse}}{{/reactive}}
+        {{/generateOperationsToReturnNotImplemented}}
+        {{#generateOperationsToReturnNotImplemented}}
+        {{#reactive}}{{#wrapInHttpResponse}}return Mono.just(HttpResponse.status(HttpStatus.NOT_IMPLEMENTED));{{/wrapInHttpResponse}}{{^wrapInHttpResponse}}return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));{{/wrapInHttpResponse}}{{/reactive}}{{^reactive}}{{#wrapInHttpResponse}}return HttpResponse.status(HttpStatus.NOT_IMPLEMENTED);{{/wrapInHttpResponse}}{{^wrapInHttpResponse}}throw new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null);{{/wrapInHttpResponse}}{{/reactive}}
+        {{/generateOperationsToReturnNotImplemented}}
     {{/generateControllerFromExamples}}
     {{#generateControllerFromExamples}}
         {{!The body is generated to verify that example values are passed correctly}}

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/PetController.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/PetController.java
@@ -16,6 +16,8 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.Format;
 import reactor.core.publisher.Mono;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
@@ -60,8 +62,9 @@ public class PetController {
         @Body @NotNull @Valid Pet pet
     ) {
         // TODO implement addPet();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Deletes a pet
@@ -90,8 +93,9 @@ public class PetController {
         @Header(value="api_key") @Nullable String apiKey
     ) {
         // TODO implement deletePet();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Finds Pets by status
@@ -121,8 +125,9 @@ public class PetController {
         @QueryValue(value="status") @NotNull List<String> status
     ) {
         // TODO implement findPetsByStatus();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Finds Pets by tags
@@ -152,8 +157,9 @@ public class PetController {
         @QueryValue(value="tags") @NotNull List<String> tags
     ) {
         // TODO implement findPetsByTags();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Find pet by ID
@@ -181,8 +187,9 @@ public class PetController {
         @PathVariable(value="petId") @NotNull Long petId
     ) {
         // TODO implement getPetById();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Update an existing pet
@@ -215,8 +222,9 @@ public class PetController {
         @Body @NotNull @Valid Pet pet
     ) {
         // TODO implement updatePet();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Updates a pet in the store with form data
@@ -248,8 +256,9 @@ public class PetController {
         @Nullable String status
     ) {
         // TODO implement updatePetWithForm();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * uploads an image
@@ -283,6 +292,7 @@ public class PetController {
         @Nullable CompletedFileUpload _file
     ) {
         // TODO implement uploadFile();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 }

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/StoreController.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/StoreController.java
@@ -16,6 +16,8 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.Format;
 import reactor.core.publisher.Mono;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 import org.openapitools.model.Order;
 import javax.annotation.Generated;
 import java.util.ArrayList;
@@ -50,8 +52,9 @@ public class StoreController {
         @PathVariable(value="orderId") @NotNull String orderId
     ) {
         // TODO implement deleteOrder();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Returns pet inventories by status
@@ -75,8 +78,9 @@ public class StoreController {
     @Produces(value = {"application/json"})
     public Mono<Map<String, Integer>> getInventory() {
         // TODO implement getInventory();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Find purchase order by ID
@@ -102,8 +106,9 @@ public class StoreController {
         @PathVariable(value="orderId") @NotNull @Min(1L) @Max(5L) Long orderId
     ) {
         // TODO implement getOrderById();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Place an order for a pet
@@ -129,6 +134,7 @@ public class StoreController {
         @Body @NotNull @Valid Order order
     ) {
         // TODO implement placeOrder();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 }

--- a/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/UserController.java
+++ b/samples/server/petstore/java-micronaut-server/src/main/java/org/openapitools/controller/UserController.java
@@ -16,6 +16,8 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.Format;
 import reactor.core.publisher.Mono;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 import java.time.OffsetDateTime;
 import org.openapitools.model.User;
 import javax.annotation.Generated;
@@ -53,8 +55,9 @@ public class UserController {
         @Body @NotNull @Valid User user
     ) {
         // TODO implement createUser();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Creates list of users with given input array
@@ -79,8 +82,9 @@ public class UserController {
         @Body @NotNull List<User> user
     ) {
         // TODO implement createUsersWithArrayInput();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Creates list of users with given input array
@@ -105,8 +109,9 @@ public class UserController {
         @Body @NotNull List<User> user
     ) {
         // TODO implement createUsersWithListInput();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Delete user
@@ -131,8 +136,9 @@ public class UserController {
         @PathVariable(value="username") @NotNull String username
     ) {
         // TODO implement deleteUser();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Get user by user name
@@ -158,8 +164,9 @@ public class UserController {
         @PathVariable(value="username") @NotNull String username
     ) {
         // TODO implement getUserByName();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Logs user into the system
@@ -186,8 +193,9 @@ public class UserController {
         @QueryValue(value="password") @NotNull String password
     ) {
         // TODO implement loginUser();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Logs out current logged in user session
@@ -208,8 +216,9 @@ public class UserController {
     @Produces(value = {})
     public Mono<Void> logoutUser() {
         // TODO implement logoutUser();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 
     /**
      * Updated user
@@ -237,6 +246,7 @@ public class UserController {
         @Body @NotNull @Valid User user
     ) {
         // TODO implement updateUser();
-        return Mono.empty();
+        return Mono.error(new HttpStatusException(HttpStatus.NOT_IMPLEMENTED, null));
     }
+
 }


### PR DESCRIPTION
The default controller implementation returns an empty response. While
this might be an expected default for some users we want the default
implementation to return HTTP 501 Not Implemented instead. This will
support rapid development when the specs aren't finalized yet and thus
change often while preventing the methods from being unimplemented by
accident without the user of the API noticing it.

By adding a property which allows the generation of default methods
which return HTTP 501 developers can opt-in for this behavior.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@andriy-dmytruk