### PR TITLE
[csharp-netcore] HttpClient/Use a CancellationToken with a timeout

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
@@ -489,7 +489,7 @@ namespace {{packageName}}.Client
             {
                 var policy = RetryConfiguration.AsyncRetryPolicy;
                 var policyResult = await policy
-                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, cancellationToken))
+                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
                     .ConfigureAwait(false);
                 response = (policyResult.Outcome == OutcomeType.Successful) ?
                     policyResult.Result : new HttpResponseMessage()
@@ -501,7 +501,7 @@ namespace {{packageName}}.Client
             else
             {
 {{/supportsRetry}}
-                response = await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
 {{#supportsRetry}}
             }
 {{/supportsRetry}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
@@ -508,6 +508,14 @@ namespace {{packageName}}.Client
                 }
 {{/supportsRetry}}
             }
+            catch(OperationCanceledException)
+            {
+                if(timeoutTokenSource != null && timeoutTokenSource.IsCancellationRequested)
+                {
+                    throw new TimeoutException($"[{req.Method}] {req.RequestUri} is timeout.");
+                }
+                throw;
+            }
             finally
             {
                 timeoutTokenSource?.Dispose();

--- a/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore-functions/libraries/httpclient/ApiClient.mustache
@@ -450,14 +450,6 @@ namespace {{packageName}}.Client
         {
             var deserializer = new CustomJsonCodec(SerializerSettings, configuration);
 
-            var finalToken = cancellationToken;
-
-            if (configuration.Timeout > 0)
-            {
-                var tokenSource = new CancellationTokenSource(configuration.Timeout);
-                finalToken = CancellationTokenSource.CreateLinkedTokenSource(finalToken, tokenSource.Token).Token;
-            }
-
             if (configuration.Proxy != null)
             {
                 if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
@@ -484,27 +476,42 @@ namespace {{packageName}}.Client
             InterceptRequest(req);
 
             HttpResponseMessage response;
-{{#supportsRetry}}
-            if (RetryConfiguration.AsyncRetryPolicy != null)
+
+            var timeoutTokenSource = default(CancellationTokenSource);
+            try
             {
-                var policy = RetryConfiguration.AsyncRetryPolicy;
-                var policyResult = await policy
-                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
-                    .ConfigureAwait(false);
-                response = (policyResult.Outcome == OutcomeType.Successful) ?
-                    policyResult.Result : new HttpResponseMessage()
-                    {
-                        ReasonPhrase = policyResult.FinalException.ToString(),
-                        RequestMessage = req
-                    };
-            }
-            else
-            {
-{{/supportsRetry}}
-                response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
+                var finalToken = cancellationToken;
+                if (configuration.Timeout > 0)
+                {
+                    timeoutTokenSource = new CancellationTokenSource(configuration.Timeout);
+                    finalToken = CancellationTokenSource.CreateLinkedTokenSource(finalToken, timeoutTokenSource.Token).Token;
+                }
 {{#supportsRetry}}
-            }
+                if (RetryConfiguration.AsyncRetryPolicy != null)
+                {
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy
+                        .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
+                        .ConfigureAwait(false);
+                    response = (policyResult.Outcome == OutcomeType.Successful) ?
+                        policyResult.Result : new HttpResponseMessage()
+                        {
+                            ReasonPhrase = policyResult.FinalException.ToString(),
+                            RequestMessage = req
+                        };
+                }
+                else
+                {
 {{/supportsRetry}}
+                    response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
+{{#supportsRetry}}
+                }
+{{/supportsRetry}}
+            }
+            finally
+            {
+                timeoutTokenSource?.Dispose();
+            }
 
             if (!response.IsSuccessStatusCode)
             {

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -452,14 +452,6 @@ namespace {{packageName}}.Client
         {
             var deserializer = new CustomJsonCodec(SerializerSettings, configuration);
 
-            var finalToken = cancellationToken;
-
-            if (configuration.Timeout > 0)
-            {
-                var tokenSource = new CancellationTokenSource(configuration.Timeout);
-                finalToken = CancellationTokenSource.CreateLinkedTokenSource(finalToken, tokenSource.Token).Token;
-            }
-
             if (configuration.Proxy != null)
             {
                 if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
@@ -486,27 +478,42 @@ namespace {{packageName}}.Client
             InterceptRequest(req);
 
             HttpResponseMessage response;
-{{#supportsRetry}}
-            if (RetryConfiguration.AsyncRetryPolicy != null)
+
+            var timeoutTokenSource = default(CancellationTokenSource);
+            try
             {
-                var policy = RetryConfiguration.AsyncRetryPolicy;
-                var policyResult = await policy
-                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
-                    .ConfigureAwait(false);
-                response = (policyResult.Outcome == OutcomeType.Successful) ?
-                    policyResult.Result : new HttpResponseMessage()
-                    {
-                        ReasonPhrase = policyResult.FinalException.ToString(),
-                        RequestMessage = req
-                    };
-            }
-            else
-            {
-{{/supportsRetry}}
-                response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
+                var finalToken = cancellationToken;
+                if (configuration.Timeout > 0)
+                {
+                    timeoutTokenSource = new CancellationTokenSource(configuration.Timeout);
+                    finalToken = CancellationTokenSource.CreateLinkedTokenSource(finalToken, timeoutTokenSource.Token).Token;
+                }
 {{#supportsRetry}}
-            }
+                if (RetryConfiguration.AsyncRetryPolicy != null)
+                {
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy
+                        .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
+                        .ConfigureAwait(false);
+                    response = (policyResult.Outcome == OutcomeType.Successful) ?
+                        policyResult.Result : new HttpResponseMessage()
+                        {
+                            ReasonPhrase = policyResult.FinalException.ToString(),
+                            RequestMessage = req
+                        };
+                }
+                else
+                {
 {{/supportsRetry}}
+                    response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
+{{#supportsRetry}}
+                }
+{{/supportsRetry}}
+            }
+            finally
+            {
+                timeoutTokenSource?.Dispose();
+            }
 
             if (!response.IsSuccessStatusCode)
             {

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -491,7 +491,7 @@ namespace {{packageName}}.Client
             {
                 var policy = RetryConfiguration.AsyncRetryPolicy;
                 var policyResult = await policy
-                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, cancellationToken))
+                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
                     .ConfigureAwait(false);
                 response = (policyResult.Outcome == OutcomeType.Successful) ?
                     policyResult.Result : new HttpResponseMessage()
@@ -503,7 +503,7 @@ namespace {{packageName}}.Client
             else
             {
 {{/supportsRetry}}
-                response = await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
 {{#supportsRetry}}
             }
 {{/supportsRetry}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -510,6 +510,14 @@ namespace {{packageName}}.Client
                 }
 {{/supportsRetry}}
             }
+            catch(OperationCanceledException)
+            {
+                if(timeoutTokenSource != null && timeoutTokenSource.IsCancellationRequested)
+                {
+                    throw new TimeoutException($"[{req.Method}] {req.RequestUri} is timeout.");
+                }
+                throw;
+            }
             finally
             {
                 timeoutTokenSource?.Dispose();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -507,6 +507,14 @@ namespace Org.OpenAPITools.Client
                     response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
                 }
             }
+            catch(OperationCanceledException)
+            {
+                if(timeoutTokenSource != null && timeoutTokenSource.IsCancellationRequested)
+                {
+                    throw new TimeoutException($"[{req.Method}] {req.RequestUri} is timeout.");
+                }
+                throw;
+            }
             finally
             {
                 timeoutTokenSource?.Dispose();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -491,7 +491,7 @@ namespace Org.OpenAPITools.Client
             {
                 var policy = RetryConfiguration.AsyncRetryPolicy;
                 var policyResult = await policy
-                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, cancellationToken))
+                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
                     .ConfigureAwait(false);
                 response = (policyResult.Outcome == OutcomeType.Successful) ?
                     policyResult.Result : new HttpResponseMessage()
@@ -502,7 +502,7 @@ namespace Org.OpenAPITools.Client
             }
             else
             {
-                response = await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
+                response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
             }
 
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

**What is the issue**

- Configuration.Timeout is not applied correctly using HttpClient.

**Correction details**

Fixed to use CancellationToken generated when configuration.Timeout is set.
`Using Declaration` is not used for compatibility, and `finally` is used to avoid unnecessary allocations.

**How to validate the work**

- Set an extremely small value (e.g., 1 ms) in configuration.Timeout and execute the communication in production.
- At this time, check that a TaskCanceledException is thrown and the process is aborted.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language

@mandrean
@frankyjuang
@shibayan 
@Blackclaws 
@lucamazzanti 