### PR TITLE
[R] Add support to download response as files

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -159,8 +159,8 @@
       }
     },
     {{#operation}}
-    {{{operationId}}} = function({{#requiredParams}}{{paramName}}, {{/requiredParams}}{{#optionalParams}}{{paramName}}={{^defaultValue}}NULL{{/defaultValue}}{{{defaultValue}}}, {{/optionalParams}}...){
-      apiResponse <- self${{{operationId}}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}...)
+    {{{operationId}}} = function({{#requiredParams}}{{paramName}}, {{/requiredParams}}{{#optionalParams}}{{paramName}}={{^defaultValue}}NULL{{/defaultValue}}{{{defaultValue}}}, {{/optionalParams}}{{#returnType}}data_file=NULL, {{/returnType}}...){
+      apiResponse <- self${{{operationId}}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}{{#returnType}}data_file=data_file, {{/returnType}}...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -173,7 +173,7 @@
       }
     },
 
-    {{{operationId}}}WithHttpInfo = function({{#requiredParams}}{{paramName}}, {{/requiredParams}}{{#optionalParams}}{{paramName}}={{^defaultValue}}NULL{{/defaultValue}}{{{defaultValue}}}, {{/optionalParams}}...){
+    {{{operationId}}}WithHttpInfo = function({{#requiredParams}}{{paramName}}, {{/requiredParams}}{{#optionalParams}}{{paramName}}={{^defaultValue}}NULL{{/defaultValue}}{{{defaultValue}}}, {{/optionalParams}}{{#returnType}}data_file=NULL, {{/returnType}}...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -279,9 +279,19 @@
         content <- httr::content(
             resp, "text", encoding = "UTF-8", simplifyVector = FALSE
         )
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(content, data_file)
+        }
+
         ApiResponse$new(content,resp)
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "{{returnType}}", loadNamespace("{{packageName}}")),
           error = function(e){

--- a/modules/openapi-generator/src/main/resources/r/testthat.mustache
+++ b/modules/openapi-generator/src/main/resources/r/testthat.mustache
@@ -1,4 +1,5 @@
 library(testthat)
+library(rjson)
 library({{{packageName}}})
 
 test_check("{{{packageName}}}")

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -432,8 +432,8 @@ PetApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    FindPetsByStatus = function(status, ...){
-      apiResponse <- self$FindPetsByStatusWithHttpInfo(status, ...)
+    FindPetsByStatus = function(status, data_file=NULL, ...){
+      apiResponse <- self$FindPetsByStatusWithHttpInfo(status, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -446,7 +446,7 @@ PetApi <- R6::R6Class(
       }
     },
 
-    FindPetsByStatusWithHttpInfo = function(status, ...){
+    FindPetsByStatusWithHttpInfo = function(status, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -470,6 +470,11 @@ PetApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "array[Pet]", loadNamespace("petstore")),
           error = function(e){
@@ -485,8 +490,8 @@ PetApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    FindPetsByTags = function(tags, ...){
-      apiResponse <- self$FindPetsByTagsWithHttpInfo(tags, ...)
+    FindPetsByTags = function(tags, data_file=NULL, ...){
+      apiResponse <- self$FindPetsByTagsWithHttpInfo(tags, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -499,7 +504,7 @@ PetApi <- R6::R6Class(
       }
     },
 
-    FindPetsByTagsWithHttpInfo = function(tags, ...){
+    FindPetsByTagsWithHttpInfo = function(tags, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -523,6 +528,11 @@ PetApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "array[Pet]", loadNamespace("petstore")),
           error = function(e){
@@ -538,8 +548,8 @@ PetApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    GetPetById = function(pet.id, ...){
-      apiResponse <- self$GetPetByIdWithHttpInfo(pet.id, ...)
+    GetPetById = function(pet.id, data_file=NULL, ...){
+      apiResponse <- self$GetPetByIdWithHttpInfo(pet.id, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -552,7 +562,7 @@ PetApi <- R6::R6Class(
       }
     },
 
-    GetPetByIdWithHttpInfo = function(pet.id, ...){
+    GetPetByIdWithHttpInfo = function(pet.id, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -580,6 +590,11 @@ PetApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "Pet", loadNamespace("petstore")),
           error = function(e){
@@ -698,8 +713,8 @@ PetApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    UploadFile = function(pet.id, additional.metadata=NULL, file=NULL, ...){
-      apiResponse <- self$UploadFileWithHttpInfo(pet.id, additional.metadata, file, ...)
+    UploadFile = function(pet.id, additional.metadata=NULL, file=NULL, data_file=NULL, ...){
+      apiResponse <- self$UploadFileWithHttpInfo(pet.id, additional.metadata, file, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -712,7 +727,7 @@ PetApi <- R6::R6Class(
       }
     },
 
-    UploadFileWithHttpInfo = function(pet.id, additional.metadata=NULL, file=NULL, ...){
+    UploadFileWithHttpInfo = function(pet.id, additional.metadata=NULL, file=NULL, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -742,6 +757,11 @@ PetApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "ModelApiResponse", loadNamespace("petstore")),
           error = function(e){

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -221,8 +221,8 @@ StoreApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    GetInventory = function(...){
-      apiResponse <- self$GetInventoryWithHttpInfo(...)
+    GetInventory = function(data_file=NULL, ...){
+      apiResponse <- self$GetInventoryWithHttpInfo(data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -235,7 +235,7 @@ StoreApi <- R6::R6Class(
       }
     },
 
-    GetInventoryWithHttpInfo = function(...){
+    GetInventoryWithHttpInfo = function(data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -255,6 +255,11 @@ StoreApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "map(integer)", loadNamespace("petstore")),
           error = function(e){
@@ -270,8 +275,8 @@ StoreApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    GetOrderById = function(order.id, ...){
-      apiResponse <- self$GetOrderByIdWithHttpInfo(order.id, ...)
+    GetOrderById = function(order.id, data_file=NULL, ...){
+      apiResponse <- self$GetOrderByIdWithHttpInfo(order.id, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -284,7 +289,7 @@ StoreApi <- R6::R6Class(
       }
     },
 
-    GetOrderByIdWithHttpInfo = function(order.id, ...){
+    GetOrderByIdWithHttpInfo = function(order.id, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -308,6 +313,11 @@ StoreApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "Order", loadNamespace("petstore")),
           error = function(e){
@@ -323,8 +333,8 @@ StoreApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    PlaceOrder = function(body, ...){
-      apiResponse <- self$PlaceOrderWithHttpInfo(body, ...)
+    PlaceOrder = function(body, data_file=NULL, ...){
+      apiResponse <- self$PlaceOrderWithHttpInfo(body, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -337,7 +347,7 @@ StoreApi <- R6::R6Class(
       }
     },
 
-    PlaceOrderWithHttpInfo = function(body, ...){
+    PlaceOrderWithHttpInfo = function(body, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -362,6 +372,11 @@ StoreApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "Order", loadNamespace("petstore")),
           error = function(e){

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -484,8 +484,8 @@ UserApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    GetUserByName = function(username, ...){
-      apiResponse <- self$GetUserByNameWithHttpInfo(username, ...)
+    GetUserByName = function(username, data_file=NULL, ...){
+      apiResponse <- self$GetUserByNameWithHttpInfo(username, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -498,7 +498,7 @@ UserApi <- R6::R6Class(
       }
     },
 
-    GetUserByNameWithHttpInfo = function(username, ...){
+    GetUserByNameWithHttpInfo = function(username, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -522,6 +522,11 @@ UserApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "User", loadNamespace("petstore")),
           error = function(e){
@@ -537,8 +542,8 @@ UserApi <- R6::R6Class(
         ApiResponse$new("API server error", resp)
       }
     },
-    LoginUser = function(username, password, ...){
-      apiResponse <- self$LoginUserWithHttpInfo(username, password, ...)
+    LoginUser = function(username, password, data_file=NULL, ...){
+      apiResponse <- self$LoginUserWithHttpInfo(username, password, data_file=data_file, ...)
       resp <- apiResponse$response
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         apiResponse$content
@@ -551,7 +556,7 @@ UserApi <- R6::R6Class(
       }
     },
 
-    LoginUserWithHttpInfo = function(username, password, ...){
+    LoginUserWithHttpInfo = function(username, password, data_file=NULL, ...){
       args <- list(...)
       queryParams <- list()
       headerParams <- c()
@@ -579,6 +584,11 @@ UserApi <- R6::R6Class(
                                  ...)
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+        }
+
         deserializedRespObj <- tryCatch(
           self$apiClient$deserialize(resp, "character", loadNamespace("petstore")),
           error = function(e){

--- a/samples/client/petstore/R/test_petstore.bash
+++ b/samples/client/petstore/R/test_petstore.bash
@@ -16,6 +16,7 @@ Rscript -e "install.packages('testthat', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('R6', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('base64enc', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('rlang', repos='$REPO', lib='$R_LIBS_USER')"
+Rscript -e "install.packages('rjson', repos='$REPO', lib='$R_LIBS_USER')"
 
 R CMD build .
 R CMD check *tar.gz --no-manual

--- a/samples/client/petstore/R/tests/testthat.R
+++ b/samples/client/petstore/R/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
+library(rjson)
 library(petstore)
 
 test_check("petstore")

--- a/samples/client/petstore/R/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R/tests/testthat/test_petstore.R
@@ -91,6 +91,15 @@ test_that("GetPetById", {
   )
 })
 
+test_that("GetPetById with data_file", {
+  # test to ensure json is saved to the file `get_pet_by_id.json`
+  petResponse <- petApi$GetPetById(petId, data_file="get_pet_by_id.json")
+  response <- fromJSON(file = "get_pet_by_id.json")
+  expect_true(!is.null(response))
+  expect_equal(response$id, petId)
+  expect_equal(response$name, "name_test")
+})
+
 #test_that("GetPetById", {
 #  pet.id <- pet.id
 #  pet <- Pet$new(pet.id, NULL, "name_test2",


### PR DESCRIPTION
- Added optional method argument "data_file" to methods that return data in order to support downloading the response body as files.
- Added test cases and tested locally.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
