### PR TITLE
Fixed enum values generation fo 'GraphQL NodeJS Express Server' generator.

### DIFF
--- a/modules/openapi-generator/src/main/resources/graphql-nodejs-express-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/graphql-nodejs-express-server/model.mustache
@@ -9,7 +9,7 @@ type {{classname}} {
   {{#description}}
   # {{{.}}}
   {{/description}}
-  {{baseName}}: {{#isEnum}}{{classname}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{datatypeWithEnum}}{{/isEnum}}
+  {{baseName}}: {{datatypeWithEnum}}
 {{/vars}}
 }
 
@@ -18,12 +18,11 @@ input {{classname}}Input {
     {{#description}}
     # {{{.}}}
     {{/description}}
-    {{baseName}}: {{#isEnum}}{{classname}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{#isContainer}}[{{datatypeWithEnum}}{{#complexType}}Input{{/complexType}}]{{/isContainer}}{{^isContainer}}{{datatypeWithEnum}}{{#isModel}}Input{{/isModel}}{{/isContainer}}{{/isEnum}}
+    {{baseName}}: {{#isContainer}}[{{datatypeWithEnum}}{{#complexType}}Input{{/complexType}}]{{/isContainer}}{{^isContainer}}{{datatypeWithEnum}}{{#isModel}}Input{{/isModel}}{{/isContainer}}
 {{/vars}}
 }
-{{#vars}}
-{{#isEnum}}
 
+{{#isEnum}}
 {{#description}}
 # {{{.}}}
 {{/description}}
@@ -35,6 +34,5 @@ enum {{classname}}{{enumName}} {
   {{/allowableValues}}
 }
 {{/isEnum}}
-{{/vars}}
 {{/model}}
 {{/models}}


### PR DESCRIPTION
This PR fixes the missing enums values generation for **GraphQL NodeJS Express Server** as described in https://github.com/OpenAPITools/openapi-generator/issues/5815 .

Previous output:

```json
enum MyEnum {
}
```

Fixed output:

```json
enum MyEnum {
  OPTION_1
  OPTION_2
}
```

