### PR TITLE
Add - Status colors in Wiki, Example per parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/confluenceWikiDocs/index.mustache
+++ b/modules/openapi-generator/src/main/resources/confluenceWikiDocs/index.mustache
@@ -22,37 +22,37 @@ h3. {{nickname}}
     || Protocol | {noformat:nopanel=true}{{scheme}}{noformat} |
     || Path | {noformat:nopanel=true}{{path}}{noformat} |
     || Base Path | {noformat:nopanel=true}{{basePath}}{noformat} |
-    {{#hasProduces}}|| Produces | {noformat:nopanel=true}{{#produces}}{{mediaType}}{{/produces}}{noformat} |{{/hasProduces}}
+    {{#hasProduces}}|| Produces | {noformat:nopanel=true}{{#produces}}{{mediaType}} {{/produces}}{noformat} |{{/hasProduces}}
 ----
 h4. Parameters
     {{#hasPathParams}}
 h5. Path Parameters
-        ||Name||Description||Type||Required||Default||Pattern||Enum||
+        ||Name||Description||Type||Required||Default||Pattern||Enum||Example||
         {{#pathParams}}{{>param}}{{/pathParams}}
     {{/hasPathParams}}
 
     {{#hasBodyParam}}
 h5. Body Parameter
-        ||Name||Description||Type||Required||Default||Pattern||Enum||
+        ||Name||Description||Type||Required||Default||Pattern||Enum||Example||
         {{#bodyParams}}{{>param}}{{/bodyParams}}
     {{/hasBodyParam}}
 
     {{#hasHeaderParams}}
 h5. Header Parameters
-        ||Name||Description||Required||Default||Pattern||
+        ||Name||Description||Type||Required||Default||Pattern||Enum||Example||
         {{#headerParams}}{{>param}}{{/headerParams}}
     {{/hasHeaderParams}}
 
     {{#hasQueryParams}}
 h5. Query Parameters
-        ||Name||Description||Required||Default||Pattern||
+        ||Name||Description||Type||Required||Default||Pattern||Enum||Example||
         {{#queryParams}}{{>param}}{{/queryParams}}
     {{/hasQueryParams}}
 ----
 h4. Responses
     {{#responses}}
 
-    	|| Status Code | {status:colour=Green|title={{code}}|subtle=false} |
+    	|| Status Code | {status:colour={{#is2xx}}Green{{/is2xx}}{{^is2xx}}{{#is4xx}}Orange{{/is4xx}}{{^is4xx}}Red{{/is4xx}}{{/is2xx}}|title={{code}}|subtle=false} |
     	|| Message | {{message}} |
     	|| Response Type | {{{dataType}}} |
     	|| Response Model | [{{dataType}} Model|#{{dataType}}ModelAnchor|Jump to model] |
@@ -81,8 +81,8 @@ h2. Models
         {{#allowableValues}} {{#enumVars}} |{{{name}}} |{{{value}}} |{{{enumDescription}}} |
         {{/enumVars}}
         {{/allowableValues}} {{/isEnum}}
-        {{^isEnum}}||Field Name||Required||Type||Description||Enum||
-        {{#vars}} |{{baseName}} |{{#required}}(/){{/required}}{{^required}}(x){{/required}} |{noformat:nopanel=true}{{{dataType}}}{noformat} |{{description}} | {{#isEnum}} {{_enum}} {{/isEnum}} |
+        {{^isEnum}}||Field Name||Required||Type||Description||Enum||Example||
+        {{#vars}} |{{baseName}} |{{#required}}(/){{/required}}{{^required}}(x){{/required}} |{noformat:nopanel=true}{{{dataType}}}{noformat} | {{description}} | {{#isEnum}} {{_enum}} {{/isEnum}} | {{example}}
         {{/vars}} {{/isEnum}}
     {{/model}}
 {{/models}}


### PR DESCRIPTION
This are small (but visually nice) improvements:
- Add colors: 200 = green, 300 = blue, 400 = red
- Add an example per parameter for better understanding

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request: @jhitchcock
