### PR TITLE
[python-experimental] BoolSchema + NoneSchema improvements

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-experimental/schemas.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/schemas.handlebars
@@ -523,13 +523,19 @@ class BoolClass(Singleton):
 
 class BoolBase:
     def is_true(self) -> bool:
-        # True if the instance is a BoolClass True Singleton
+        """
+        A replacement for x is True
+        True if the instance is a BoolClass True Singleton
+        """
         if not issubclass(self.__class__, BoolClass):
             return False
         return bool(self)
 
     def is_false(self) -> bool:
-        # True if the instance is a BoolClass False Singleton
+        """
+        A replacement for x is False
+        True if the instance is a BoolClass False Singleton
+        """
         if not issubclass(self.__class__, BoolClass):
             return False
         return bool(self) is False
@@ -537,7 +543,10 @@ class BoolBase:
 
 class NoneBase:
     def is_none(self) -> bool:
-        # True if the instance is a NoneClass None Singleton
+        """
+        A replacement for x is None
+        True if the instance is a NoneClass None Singleton
+        """
         if issubclass(self.__class__, NoneClass):
             return True
         return False

--- a/modules/openapi-generator/src/main/resources/python-experimental/schemas.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/schemas.handlebars
@@ -471,10 +471,7 @@ class Singleton:
     """
     _instances = {}
 
-    def __new__(cls, *args, **kwargs):
-        if not args:
-            raise ValueError('arg must be passed')
-        arg = args[0]
+    def __new__(cls, arg: typing.Any, **kwargs):
         key = (cls, arg)
         if key not in cls._instances:
             if arg in {None, True, False}:
@@ -501,9 +498,6 @@ class NoneClass(Singleton):
     def NONE(cls):
         return cls(None)
 
-    def is_none(self) -> bool:
-        return True
-
     def __bool__(self) -> bool:
         return False
 
@@ -526,19 +520,27 @@ class BoolClass(Singleton):
                 return key[1]
         raise ValueError('Unable to find the boolean value of this instance')
 
-    def is_true(self):
-        return bool(self)
-
-    def is_false(self):
-        return bool(self)
-
 
 class BoolBase:
-    pass
+    def is_true(self) -> bool:
+        # True if the instance is a BoolClass True Singleton
+        if not issubclass(self.__class__, BoolClass):
+            return False
+        return bool(self)
+
+    def is_false(self) -> bool:
+        # True if the instance is a BoolClass False Singleton
+        if not issubclass(self.__class__, BoolClass):
+            return False
+        return bool(self) is False
 
 
 class NoneBase:
-    pass
+    def is_none(self) -> bool:
+        # True if the instance is a NoneClass None Singleton
+        if issubclass(self.__class__, NoneClass):
+            return True
+        return False
 
 
 class StrBase:

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/schemas.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/schemas.py
@@ -478,10 +478,7 @@ class Singleton:
     """
     _instances = {}
 
-    def __new__(cls, *args, **kwargs):
-        if not args:
-            raise ValueError('arg must be passed')
-        arg = args[0]
+    def __new__(cls, arg: typing.Any, **kwargs):
         key = (cls, arg)
         if key not in cls._instances:
             if arg in {None, True, False}:
@@ -508,9 +505,6 @@ class NoneClass(Singleton):
     def NONE(cls):
         return cls(None)
 
-    def is_none(self) -> bool:
-        return True
-
     def __bool__(self) -> bool:
         return False
 
@@ -533,19 +527,27 @@ class BoolClass(Singleton):
                 return key[1]
         raise ValueError('Unable to find the boolean value of this instance')
 
-    def is_true(self):
-        return bool(self)
-
-    def is_false(self):
-        return bool(self)
-
 
 class BoolBase:
-    pass
+    def is_true(self) -> bool:
+        # True if the instance is a BoolClass True Singleton
+        if not issubclass(self.__class__, BoolClass):
+            return False
+        return bool(self)
+
+    def is_false(self) -> bool:
+        # True if the instance is a BoolClass False Singleton
+        if not issubclass(self.__class__, BoolClass):
+            return False
+        return bool(self) is False
 
 
 class NoneBase:
-    pass
+    def is_none(self) -> bool:
+        # True if the instance is a NoneClass None Singleton
+        if issubclass(self.__class__, NoneClass):
+            return True
+        return False
 
 
 class StrBase:

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/schemas.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/schemas.py
@@ -530,13 +530,19 @@ class BoolClass(Singleton):
 
 class BoolBase:
     def is_true(self) -> bool:
-        # True if the instance is a BoolClass True Singleton
+        """
+        A replacement for x is True
+        True if the instance is a BoolClass True Singleton
+        """
         if not issubclass(self.__class__, BoolClass):
             return False
         return bool(self)
 
     def is_false(self) -> bool:
-        # True if the instance is a BoolClass False Singleton
+        """
+        A replacement for x is False
+        True if the instance is a BoolClass False Singleton
+        """
         if not issubclass(self.__class__, BoolClass):
             return False
         return bool(self) is False
@@ -544,7 +550,10 @@ class BoolBase:
 
 class NoneBase:
     def is_none(self) -> bool:
-        # True if the instance is a NoneClass None Singleton
+        """
+        A replacement for x is None
+        True if the instance is a NoneClass None Singleton
+        """
         if issubclass(self.__class__, NoneClass):
             return True
         return False

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_boolean_enum.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_boolean_enum.py
@@ -29,6 +29,8 @@ class TestBooleanEnum(unittest.TestCase):
         """Test BooleanEnum"""
         model = BooleanEnum(True)
         assert model is BooleanEnum.TRUE
+        assert model.is_true()
+        assert model.is_false() is False
         assert repr(model) == '<DynamicBooleanEnum: True>'
         with self.assertRaises(petstore_api.ApiValueError):
             BooleanEnum(False)

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_composed_bool.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_composed_bool.py
@@ -10,7 +10,6 @@
 """
 
 
-import sys
 import unittest
 
 import petstore_api
@@ -28,14 +27,22 @@ class TestComposedBool(unittest.TestCase):
 
     def test_ComposedBool(self):
         """Test ComposedBool"""
-        valid_values = [True, False]
         all_values = [None, True, False, 2, 3.14, '', {}, []]
         for value in all_values:
-            if value not in valid_values:
-                with self.assertRaises(petstore_api.ApiTypeError):
-                    model = ComposedBool(value)
+            if isinstance(value, bool):
+                model = ComposedBool(value)
+                if value is True:
+                    self.assertTrue(bool(model))
+                    self.assertTrue(model.is_true())
+                    self.assertFalse(model.is_false())
+                else:
+                    self.assertTrue(model.is_false())
+                    self.assertFalse(model.is_true())
+                    self.assertFalse(bool(model))
                 continue
-            model = ComposedBool(value)
+            with self.assertRaises(petstore_api.ApiTypeError):
+                ComposedBool(value)
+            continue
 
 
 if __name__ == '__main__':

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_nullable_string.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_nullable_string.py
@@ -36,6 +36,7 @@ class TestNullableString(unittest.TestCase):
         assert repr(inst) == '<DynamicNullableString: None>'
 
         inst = NullableString('approved')
+        assert inst.is_none() is False
         assert isinstance(inst, NullableString)
         assert isinstance(inst, Schema)
         assert isinstance(inst, str)


### PR DESCRIPTION
- Fixes https://github.com/OpenAPITools/openapi-generator/issues/12388
- is_none moved from NoneClass into NoneBase so now it is visible as a method in pycharm, + docstring added
- is_true moved from BoolClass into BoolBase so now it is visible as a method in pycharm, + docstring added
- is_false moved from BoolClass into BoolBase so now it is visible as a method in pycharm, + docstring added
- Values for is_false fixed
- tests updated to test is_none, is_true, and is_false

If I don't hear back from @meawoppl in a day or two I will merge this in

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
