### PR TITLE
[Dart] Fix incorrect generation of additionalProperties:true (#12165)

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -171,7 +171,12 @@ class {{{classname}}} {
                   {{/items.complexType}}
                 {{/items.isMap}}
                 {{^items.isMap}}
-        {{{name}}}: mapValueOfType<{{{datatypeWithEnum}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                  {{#items.complexType}}
+        {{{name}}}: {{{items.complexType}}}.mapFromJson(json[r'{{{baseName}}}'{{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}}]) ?? {{{.}}}{{/defaultValue}}{{/required}},
+                  {{/items.complexType}}
+                  {{^items.complexType}}
+        {{{name}}}: mapCastOfType<String, {{items.dataType}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                  {{/items.complexType}}
                 {{/items.isMap}}
               {{/items.isArray}}
             {{/isMap}}

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -85,7 +85,7 @@ class MixedPropertiesAndAdditionalPropertiesClass {
       return MixedPropertiesAndAdditionalPropertiesClass(
         uuid: mapValueOfType<String>(json, r'uuid'),
         dateTime: mapDateTime(json, r'dateTime', ''),
-        map: mapValueOfType<Map<String, Animal>>(json, r'map') ?? const {},
+        map: Animal.mapFromJson(json[r'map']) ?? const {},
       );
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -152,9 +152,9 @@ class NullableClass {
         arrayNullableProp: Object.listFromJson(json[r'array_nullable_prop']) ?? const [],
         arrayAndItemsNullableProp: Object.listFromJson(json[r'array_and_items_nullable_prop']) ?? const [],
         arrayItemsNullable: Object.listFromJson(json[r'array_items_nullable']) ?? const [],
-        objectNullableProp: mapValueOfType<Map<String, Object>>(json, r'object_nullable_prop') ?? const {},
-        objectAndItemsNullableProp: mapValueOfType<Map<String, Object>>(json, r'object_and_items_nullable_prop') ?? const {},
-        objectItemsNullable: mapValueOfType<Map<String, Object>>(json, r'object_items_nullable') ?? const {},
+        objectNullableProp: mapCastOfType<String, Object>(json, r'object_nullable_prop') ?? const {},
+        objectAndItemsNullableProp: mapCastOfType<String, Object>(json, r'object_and_items_nullable_prop') ?? const {},
+        objectItemsNullable: mapCastOfType<String, Object>(json, r'object_items_nullable') ?? const {},
       );
     }
     return null;


### PR DESCRIPTION
fixes #12165 

This PR includes a patch to the `modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache` file which previously wasn't handling the deserialiation of `Map<String, Object>` types correctly.

Previously, the deserialization of such fields was being generated as `mapValueOfType<Map<String, Object>>(json, key)`,  but due to Dart using different internal map representations, this would always fail at runtime, meaning that such objects were not able to be generated by this project.

This change adjusts the mustache file to detect when a field is a complex map and uses `mapCastOfType<String, Object>(json[key])` instead, which does not crash at runtime.

The correctness of the change can be confirmed using the following test files:

spec.yaml:
```yaml
openapi: 3.0.3
info:
  version: "1.1"
  title: Dart AdditionaProperties True
servers:
  - url: 'localhost'
    variables:
      host:
        default: localhost
components:
  schemas:
    ItemsWithMapStringAnyWithPropsTrue:
      type: object
      description: "map-string-any defined with `additionalProperties: true`"
      properties:
        objectMap:
          type: object
          additionalProperties: true
    ItemWithMapStringAnyWithPropsObject:
      type: object
      description: "map-string-any defined with `additionalProperties: object`"
      properties:
        objectMap:
          type: object
          additionalProperties:
            type: object
paths:
  /items:
    get:
      operationId: GetItemWithMapStringObjects
      responses:
        "200":
          description: A list of ItemWithMapStringObject
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ItemWithMapStringAnyWithPropsObject'
```

Dart test file
```dart
//
// AUTO-GENERATED FILE, DO NOT MODIFY!
//
// @dart=2.12

// ignore_for_file: unused_element, unused_import
// ignore_for_file: always_put_required_named_parameters_first
// ignore_for_file: constant_identifier_names
// ignore_for_file: lines_longer_than_80_chars

import 'dart:convert';

import 'package:openapi/api.dart';
import 'package:test/test.dart';

// tests for ItemWithMapStringAnyWithPropsObject
void main() {
  // final instance = ItemWithMapStringAnyWithPropsObject();

  final String s = '{"objectMap": {"item_int": 1, "item_bool": true, "item_string": "str", "item_double": 4.3, "item_map": {"subProps": 1}, "item_array": [-1]}}';

  group('test ItemWithMapStringAnyWithPropsObject', () {
    // Map<String, Object> objectMap (default value: const {})
    test('to test the property `objectMap`', () async {
      final m = JsonDecoder().convert(s);
      final i = ItemsWithMapStringAnyWithPropsTrue.fromJson(m)!;
      assert(i.objectMap["item_int"] == 1);
      assert(i.objectMap["item_bool"] == true);
      assert(i.objectMap["item_string"] == "str");
      assert(i.objectMap["item_double"] == 4.3);
      assert((i.objectMap["item_map"] as Map)["subProps"] == 1);
      assert((i.objectMap["item_array"] as List)[0] == -1);
    });

    test('to test the property `objectMap`', () async {
      final m = JsonDecoder().convert(s);
      final i = ItemWithMapStringAnyWithPropsObject.fromJson(m)!;
      assert(i.objectMap["item_int"] == 1);
      assert(i.objectMap["item_bool"] == true);
      assert(i.objectMap["item_string"] == "str");
      assert(i.objectMap["item_double"] == 4.3);
      assert((i.objectMap["item_map"] as Map)["subProps"] == 1);
      assert((i.objectMap["item_array"] as List)[0] == -1);
    });
  });
}
```


@jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela