### PR TITLE
[java][jersey2] throw exception when failed to refresh token

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/OAuth.mustache
@@ -99,7 +99,7 @@ public class OAuth implements Authentication {
                 return service.refreshAccessToken(refreshToken);
             }
         } catch (OAuthException | InterruptedException | ExecutionException | IOException e) {
-            log.log(Level.FINE, "Refreshing the access token using the refresh token failed", e);
+            throw new ApiException("Refreshing the access token using the refresh token failed: " + e.toString());
         }
         try {
             switch (flow) {

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -110,7 +110,7 @@ public class OAuth implements Authentication {
                 return service.refreshAccessToken(refreshToken);
             }
         } catch (OAuthException | InterruptedException | ExecutionException | IOException e) {
-            log.log(Level.FINE, "Refreshing the access token using the refresh token failed", e);
+            throw new ApiException("Refreshing the access token using the refresh token failed: " + e.toString());
         }
         try {
             switch (flow) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -110,7 +110,7 @@ public class OAuth implements Authentication {
                 return service.refreshAccessToken(refreshToken);
             }
         } catch (OAuthException | InterruptedException | ExecutionException | IOException e) {
-            log.log(Level.FINE, "Refreshing the access token using the refresh token failed", e);
+            throw new ApiException("Refreshing the access token using the refresh token failed: " + e.toString());
         }
         try {
             switch (flow) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -110,7 +110,7 @@ public class OAuth implements Authentication {
                 return service.refreshAccessToken(refreshToken);
             }
         } catch (OAuthException | InterruptedException | ExecutionException | IOException e) {
-            log.log(Level.FINE, "Refreshing the access token using the refresh token failed", e);
+            throw new ApiException("Refreshing the access token using the refresh token failed: " + e.toString());
         }
         try {
             switch (flow) {


### PR DESCRIPTION
- throw exception instead of logging a warning when failed to refresh token

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
