### PR TITLE
[Dart][Client] Support parsing DateTime 

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -183,6 +183,8 @@ class ApiClient {
           }
           final valueString = '$value'.toLowerCase();
           return valueString == 'true' || valueString == '1';
+        case 'DateTime':
+          return value is DateTime ? value : DateTime.tryParse(value);
         {{#models}}
           {{#model}}
         case '{{{classname}}}':

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -190,6 +190,8 @@ class ApiClient {
           }
           final valueString = '$value'.toLowerCase();
           return valueString == 'true' || valueString == '1';
+        case 'DateTime':
+          return value is DateTime ? value : DateTime.tryParse(value);
         case 'ApiResponse':
           return ApiResponse.fromJson(value);
         case 'Category':

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
@@ -190,6 +190,8 @@ class ApiClient {
           }
           final valueString = '$value'.toLowerCase();
           return valueString == 'true' || valueString == '1';
+        case 'DateTime':
+          return value is DateTime ? value : DateTime.tryParse(value);
         case 'AdditionalPropertiesClass':
           return AdditionalPropertiesClass.fromJson(value);
         case 'AllOfWithSingleRef':


### PR DESCRIPTION
I've got an issue while parsing an Array of Strings in date-time format

```yaml
        content:
            application/json:
              schema:
                type: array
                items:
                  type: string
                  format: date-time
```

 which the generator translates into a `List<DateTime>`. 
When the List is unwrapped and then it tries to _deserialize the `DateTime` it does not find any suitable parser.

This just fixes it

@ahmednfwela

<!-- Please check the completed items below -->
### PR checklist
 
- [v] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [v] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
