### PR TITLE
#12445 - avoid resolving ref schema to the actual schema for enum

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4623,7 +4623,7 @@ public class DefaultCodegen implements CodegenConfig {
                 // $ref (e.g. #components/schemas/Pet) to determine whether it's a model
                 prop = fromProperty(parameter.getName(), parameterSchema);
             } else if (getUseInlineModelResolver()) {
-                prop = fromProperty(parameter.getName(), ModelUtils.getReferencedSchema(openAPI, parameterSchema));
+                prop = fromProperty(parameter.getName(), getReferencedSchemaWhenNotEnum(parameterSchema));
             } else {
                 prop = fromProperty(parameter.getName(), parameterSchema);
             }
@@ -4671,7 +4671,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (getUseInlineModelResolver() && !(this instanceof RustServerCodegen)) {
             // for rust server, we cannot run the following as it uses
             // $ref (e.g. #components/schemas/Pet) to determine whether it's a model
-            parameterSchema = ModelUtils.getReferencedSchema(openAPI, parameterSchema);
+            parameterSchema = getReferencedSchemaWhenNotEnum(parameterSchema);
         }
 
         ModelUtils.syncValidationProperties(parameterSchema, codegenParameter);
@@ -4846,6 +4846,14 @@ public class DefaultCodegen implements CodegenConfig {
 
         finishUpdatingParameter(codegenParameter, parameter);
         return codegenParameter;
+    }
+
+    private Schema getReferencedSchemaWhenNotEnum(Schema parameterSchema) {
+        Schema referencedSchema = ModelUtils.getReferencedSchema(openAPI, parameterSchema);
+        if (referencedSchema.getEnum() != null && !referencedSchema.getEnum().isEmpty()) {
+            referencedSchema = parameterSchema;
+        }
+        return referencedSchema;
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -70,6 +70,16 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testEnumImports() {
+        final DefaultCodegen codegen = new DefaultCodegen();
+        final OpenAPI openApi = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_12445.yaml");
+        codegen.setOpenAPI(openApi);
+        PathItem path = openApi.getPaths().get("/pets/petType/{type}");
+        CodegenOperation operation = codegen.fromOperation("/pets/petType/{type}", "get", path.getGet(), path.getServers());
+        Assert.assertEquals(Sets.intersection(operation.imports, Sets.newHashSet("PetByType")).size(), 1);
+    }
+
+    @Test
     public void testHasBodyParameter() {
         final Schema refSchema = new Schema<>().$ref("#/components/schemas/Pet");
         Operation pingOperation = new Operation()

--- a/modules/openapi-generator/src/test/resources/3_0/issue_12445.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_12445.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /pets/petType/{type}:
+    get:
+      parameters:
+        - name: 'type'
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/PetByType'
+      responses:
+        '200':
+          description: 'get by type'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        petType:
+          $ref: '#/components/schemas/PetByType'
+      required:
+        - petType
+    Dog:
+      allOf:
+        # This field will not match to any type.
+        - description: Dog information
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            hunts:
+              type: boolean
+            age:
+              type: integer
+    PetByType:
+      type: string
+      enum: [Cat, Dog]

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -37,9 +37,9 @@ export interface FakeEnumRequestGetInlineRequest {
 }
 
 export interface FakeEnumRequestGetRefRequest {
-    stringEnum?: FakeEnumRequestGetRefStringEnumEnum;
+    stringEnum?: StringEnum;
     nullableStringEnum?: StringEnum | null;
-    numberEnum?: FakeEnumRequestGetRefNumberEnumEnum;
+    numberEnum?: NumberEnum;
     nullableNumberEnum?: NumberEnum | null;
 }
 
@@ -210,21 +210,3 @@ export const FakeEnumRequestGetInlineNumberEnumEnum = {
     NUMBER_3: 3
 } as const;
 export type FakeEnumRequestGetInlineNumberEnumEnum = typeof FakeEnumRequestGetInlineNumberEnumEnum[keyof typeof FakeEnumRequestGetInlineNumberEnumEnum];
-/**
- * @export
- */
-export const FakeEnumRequestGetRefStringEnumEnum = {
-    One: 'one',
-    Two: 'two',
-    Three: 'three'
-} as const;
-export type FakeEnumRequestGetRefStringEnumEnum = typeof FakeEnumRequestGetRefStringEnumEnum[keyof typeof FakeEnumRequestGetRefStringEnumEnum];
-/**
- * @export
- */
-export const FakeEnumRequestGetRefNumberEnumEnum = {
-    NUMBER_1: 1,
-    NUMBER_2: 2,
-    NUMBER_3: 3
-} as const;
-export type FakeEnumRequestGetRefNumberEnumEnum = typeof FakeEnumRequestGetRefNumberEnumEnum[keyof typeof FakeEnumRequestGetRefNumberEnumEnum];

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
@@ -37,9 +37,9 @@ export interface FakeEnumRequestGetInlineRequest {
 }
 
 export interface FakeEnumRequestGetRefRequest {
-    stringEnum?: FakeEnumRequestGetRefStringEnumEnum;
+    stringEnum?: StringEnum;
     nullableStringEnum?: StringEnum | null;
-    numberEnum?: FakeEnumRequestGetRefNumberEnumEnum;
+    numberEnum?: NumberEnum;
     nullableNumberEnum?: NumberEnum | null;
 }
 
@@ -206,24 +206,6 @@ export enum FakeEnumRequestGetInlineStringEnumEnum {
   * @enum {string}
   */
 export enum FakeEnumRequestGetInlineNumberEnumEnum {
-    NUMBER_1 = 1,
-    NUMBER_2 = 2,
-    NUMBER_3 = 3
-}
-/**
-  * @export
-  * @enum {string}
-  */
-export enum FakeEnumRequestGetRefStringEnumEnum {
-    One = 'one',
-    Two = 'two',
-    Three = 'three'
-}
-/**
-  * @export
-  * @enum {string}
-  */
-export enum FakeEnumRequestGetRefNumberEnumEnum {
     NUMBER_1 = 1,
     NUMBER_2 = 2,
     NUMBER_3 = 3


### PR DESCRIPTION
When "useInlineModelResolver" is true, avoid resolving ref schema of an enum to the actual schema for parameter of an operation, when we do resolve the enum will not be added to the imports.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
