### PR TITLE
#12490: Fix format 'date' serializing to day before desired date depending on the timezone/daylight-saving

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -124,7 +124,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{/isDateTime}}
             {{^isDateTime}}
             {{#isDate}}
-            queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substr(0,10);
+            queryParameters['{{baseName}}'] = new Date((requestParameters.{{paramName}} as Date).getTime() - (requestParameters.{{paramName}} as Date).getTimezoneOffset()*60000).toISOString().substr(0,10);
             {{/isDate}}
             {{^isDate}}
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}};

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -104,7 +104,7 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
         {{#vars}}
         {{^isReadOnly}}
         {{#isPrimitiveType}}
-        '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString().substr(0,10)){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString()){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
+        '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}new Date(value.{{name}}.getTime() - value.{{name}}.getTimezoneOffset()*60000).toISOString().substr(0,10)){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString()){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -172,7 +172,7 @@ export function FormatTestToJSON(value?: FormatTest | null): any {
         'string': value.string,
         'byte': value._byte,
         'binary': value.binary,
-        'date': (value.date.toISOString().substr(0,10)),
+        'date': (new Date(value.date.getTime() - value.date.getTimezoneOffset()*60000).toISOString().substr(0,10)),
         'dateTime': value.dateTime === undefined ? undefined : (value.dateTime.toISOString()),
         'uuid': value.uuid,
         'password': value.password,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -134,7 +134,7 @@ export function NullableClassToJSON(value?: NullableClass | null): any {
         'number_prop': value.numberProp,
         'boolean_prop': value.booleanProp,
         'string_prop': value.stringProp,
-        'date_prop': value.dateProp === undefined ? undefined : (value.dateProp === null ? null : value.dateProp.toISOString().substr(0,10)),
+        'date_prop': value.dateProp === undefined ? undefined : (value.dateProp === null ? null : new Date(value.dateProp.getTime() - value.dateProp.getTimezoneOffset()*60000).toISOString().substr(0,10)),
         'datetime_prop': value.datetimeProp === undefined ? undefined : (value.datetimeProp === null ? null : value.datetimeProp.toISOString()),
         'array_nullable_prop': value.arrayNullableProp,
         'array_and_items_nullable_prop': value.arrayAndItemsNullableProp,


### PR DESCRIPTION
Fix for https://github.com/OpenAPITools/openapi-generator/issues/12490.

Unfortunately, there is no test for "string, format=date" properties in `samples/client/petstore/typescript-fetch` which could ensure the change is not breaking anything. I tested the fix successfully using my project at which I discovered the bug:

*apis.mustache:* I added a request param 'xxx' and set it according to the issue description. The request was serialized like
`http://localhost:3000/api/v1/administration/member-onboarding/9fd4a12c-a879-469d-a602-0d78c6d62d54/take-over?xxx=2022-06-05`

*modelGeneric.mustache:* This is the place where I discovered the error. Now the date is correct sent as `birthdate: "2022-06-05"` instead of 2022-06-04.

@leonyu: Please review and merge that PR.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
