### PR TITLE
[GO] GoClient codegen: allow specifying location of the generated model files

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -50,6 +50,7 @@ public class GoClientCodegenTest {
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertTrue(codegen.isHideGenerationTimestamp());
+        Assert.assertNull(codegen.additionalProperties().get(GoClientCodegen.MODEL_FILE_FOLDER));
     }
 
     @Test
@@ -202,4 +203,14 @@ public class GoClientCodegenTest {
 
         TestUtils.assertFileContains(Paths.get(output + "/api_pet.go"), "type PetApiAddPetRequest struct");
     }
+
+    @Test
+    public void testAdditionalPropertiesModelFileFolder() throws Exception {
+        final GoClientCodegen codegen = new GoClientCodegen();
+        codegen.additionalProperties().put(GoClientCodegen.MODEL_FILE_FOLDER, "model_dir");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelFileFolder(), "generated-code/go/model_dir/");
+    }
+
 }


### PR DESCRIPTION
@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04)

The changes allow specifying in which folder the model files should be placed during the code generation.
The default location can be overridden by passing the sub-directory in the additional properties ie `--additional-properties=modelFileFolder=model`

How to validate the changes? 

Generate models passing `--additional-properties=modelFileFolder=model`


Fix #12307