### PR TITLE
Using import type for types imports [typescript-fetch]

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -4,15 +4,19 @@
 
 import * as runtime from '../runtime';
 {{#imports.0}}
+import type {
+  {{#imports}}
+  {{className}},
+  {{/imports}}
+} from '../models';
+{{^withoutRuntimeChecks}}
 import {
     {{#imports}}
-    {{className}},
-    {{^withoutRuntimeChecks}}
     {{className}}FromJSON,
     {{className}}ToJSON,
-    {{/withoutRuntimeChecks}}
     {{/imports}}
 } from '../models';
+{{/withoutRuntimeChecks}}
 {{/imports.0}}
 
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -1,8 +1,8 @@
 import { exists, mapValues } from '../runtime';
 {{#hasImports}}
 {{#imports}}
+import type { {{{.}}} } from './{{.}}';
 import {
-    {{{.}}},
     {{.}}FromJSON,
     {{.}}FromJSONTyped,
     {{.}}ToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Client,
+} from '../models';
 import {
-    Client,
     ClientFromJSON,
     ClientToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  FooGetDefaultResponse,
+} from '../models';
 import {
-    FooGetDefaultResponse,
     FooGetDefaultResponseFromJSON,
     FooGetDefaultResponseToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -14,29 +14,31 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Client,
+  EnumClass,
+  FileSchemaTestClass,
+  HealthCheckResult,
+  OuterComposite,
+  OuterObjectWithEnumProperty,
+  Pet,
+  User,
+} from '../models';
 import {
-    Client,
     ClientFromJSON,
     ClientToJSON,
-    EnumClass,
     EnumClassFromJSON,
     EnumClassToJSON,
-    FileSchemaTestClass,
     FileSchemaTestClassFromJSON,
     FileSchemaTestClassToJSON,
-    HealthCheckResult,
     HealthCheckResultFromJSON,
     HealthCheckResultToJSON,
-    OuterComposite,
     OuterCompositeFromJSON,
     OuterCompositeToJSON,
-    OuterObjectWithEnumProperty,
     OuterObjectWithEnumPropertyFromJSON,
     OuterObjectWithEnumPropertyToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Client,
+} from '../models';
 import {
-    Client,
     ClientFromJSON,
     ClientToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  ModelApiResponse,
+  Pet,
+} from '../models';
 import {
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  User,
+} from '../models';
 import {
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { SingleRefType } from './SingleRefType';
 import {
-    SingleRefType,
     SingleRefTypeFromJSON,
     SingleRefTypeFromJSONTyped,
     SingleRefTypeToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { ReadOnlyFirst } from './ReadOnlyFirst';
 import {
-    ReadOnlyFirst,
     ReadOnlyFirstFromJSON,
     ReadOnlyFirstFromJSONTyped,
     ReadOnlyFirstToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Animal } from './Animal';
 import {
-    Animal,
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
 } from './Animal';
+import type { CatAllOf } from './CatAllOf';
 import {
-    CatAllOf,
     CatAllOfFromJSON,
     CatAllOfFromJSONTyped,
     CatAllOfToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Animal } from './Animal';
 import {
-    Animal,
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
 } from './Animal';
+import type { DogAllOf } from './DogAllOf';
 import {
-    DogAllOf,
     DogAllOfFromJSON,
     DogAllOfFromJSONTyped,
     DogAllOfToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -13,26 +13,26 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { OuterEnum } from './OuterEnum';
 import {
-    OuterEnum,
     OuterEnumFromJSON,
     OuterEnumFromJSONTyped,
     OuterEnumToJSON,
 } from './OuterEnum';
+import type { OuterEnumDefaultValue } from './OuterEnumDefaultValue';
 import {
-    OuterEnumDefaultValue,
     OuterEnumDefaultValueFromJSON,
     OuterEnumDefaultValueFromJSONTyped,
     OuterEnumDefaultValueToJSON,
 } from './OuterEnumDefaultValue';
+import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
-    OuterEnumInteger,
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
 } from './OuterEnumInteger';
+import type { OuterEnumIntegerDefaultValue } from './OuterEnumIntegerDefaultValue';
 import {
-    OuterEnumIntegerDefaultValue,
     OuterEnumIntegerDefaultValueFromJSON,
     OuterEnumIntegerDefaultValueFromJSONTyped,
     OuterEnumIntegerDefaultValueToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Foo } from './Foo';
 import {
-    Foo,
     FooFromJSON,
     FooFromJSONTyped,
     FooToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Decimal } from './Decimal';
 import {
-    Decimal,
     DecimalFromJSON,
     DecimalFromJSONTyped,
     DecimalToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Animal } from './Animal';
 import {
-    Animal,
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { DeprecatedObject } from './DeprecatedObject';
 import {
-    DeprecatedObject,
     DeprecatedObjectFromJSON,
     DeprecatedObjectFromJSONTyped,
     DeprecatedObjectToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
-    OuterEnumInteger,
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  ModelApiResponse,
+  Pet,
+} from '../models';
 import {
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  User,
+} from '../models';
 import {
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -14,17 +14,19 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  EnumPatternObject,
+  FakeEnumRequestGetInline200Response,
+  NumberEnum,
+  StringEnum,
+} from '../models';
 import {
-    EnumPatternObject,
     EnumPatternObjectFromJSON,
     EnumPatternObjectToJSON,
-    FakeEnumRequestGetInline200Response,
     FakeEnumRequestGetInline200ResponseFromJSON,
     FakeEnumRequestGetInline200ResponseToJSON,
-    NumberEnum,
     NumberEnumFromJSON,
     NumberEnumToJSON,
-    StringEnum,
     StringEnumFromJSON,
     StringEnumToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { NumberEnum } from './NumberEnum';
 import {
-    NumberEnum,
     NumberEnumFromJSON,
     NumberEnumFromJSONTyped,
     NumberEnumToJSON,
 } from './NumberEnum';
+import type { StringEnum } from './StringEnum';
 import {
-    StringEnum,
     StringEnumFromJSON,
     StringEnumFromJSONTyped,
     StringEnumToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  ModelApiResponse,
+  Pet,
+} from '../models';
 import {
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  User,
+} from '../models';
 import {
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  ModelApiResponse,
+  Pet,
+} from '../models';
 import {
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  User,
+} from '../models';
 import {
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  ModelApiResponse,
+  Pet,
+} from '../models';
 import {
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  User,
+} from '../models';
 import {
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  GetBehaviorPermissionsResponse,
+  GetBehaviorTypeResponse,
+} from '../models';
 import {
-    GetBehaviorPermissionsResponse,
     GetBehaviorPermissionsResponseFromJSON,
     GetBehaviorPermissionsResponseToJSON,
-    GetBehaviorTypeResponse,
     GetBehaviorTypeResponseFromJSON,
     GetBehaviorTypeResponseToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -14,23 +14,25 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Category,
+  FindPetsByStatusResponse,
+  FindPetsByUserResponse,
+  ModelApiResponse,
+  Pet,
+  PetRegionsResponse,
+} from '../models';
 import {
-    Category,
     CategoryFromJSON,
     CategoryToJSON,
-    FindPetsByStatusResponse,
     FindPetsByStatusResponseFromJSON,
     FindPetsByStatusResponseToJSON,
-    FindPetsByUserResponse,
     FindPetsByUserResponseFromJSON,
     FindPetsByUserResponseToJSON,
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
-    PetRegionsResponse,
     PetRegionsResponseFromJSON,
     PetRegionsResponseToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  GetMatchingPartsResponse,
+  GetPetPartTypeResponse,
+} from '../models';
 import {
-    GetMatchingPartsResponse,
     GetMatchingPartsResponseFromJSON,
     GetMatchingPartsResponseToJSON,
-    GetPetPartTypeResponse,
     GetPetPartTypeResponseFromJSON,
     GetPetPartTypeResponseToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  DefaultMetaOnlyResponse,
+  User,
+} from '../models';
 import {
-    DefaultMetaOnlyResponse,
     DefaultMetaOnlyResponseFromJSON,
     DefaultMetaOnlyResponseToJSON,
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Pet } from './Pet';
 import {
-    Pet,
     PetFromJSON,
     PetFromJSONTyped,
     PetToJSON,
 } from './Pet';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
 } from './ResponseMeta';
+import type { User } from './User';
 import {
-    User,
     UserFromJSON,
     UserFromJSONTyped,
     UserToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { BehaviorType } from './BehaviorType';
 import {
-    BehaviorType,
     BehaviorTypeFromJSON,
     BehaviorTypeFromJSONTyped,
     BehaviorTypeToJSON,
 } from './BehaviorType';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { MatchingParts } from './MatchingParts';
 import {
-    MatchingParts,
     MatchingPartsFromJSON,
     MatchingPartsFromJSONTyped,
     MatchingPartsToJSON,
 } from './MatchingParts';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { PetPartType } from './PetPartType';
 import {
-    PetPartType,
     PetPartTypeFromJSON,
     PetPartTypeFromJSONTyped,
     PetPartTypeToJSON,
 } from './PetPartType';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Part } from './Part';
 import {
-    Part,
     PartFromJSON,
     PartFromJSONTyped,
     PartToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { ItemId } from './ItemId';
 import {
-    ItemId,
     ItemIdFromJSON,
     ItemIdFromJSONTyped,
     ItemIdToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -13,26 +13,26 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { DeploymentRequestStatus } from './DeploymentRequestStatus';
 import {
-    DeploymentRequestStatus,
     DeploymentRequestStatusFromJSON,
     DeploymentRequestStatusFromJSONTyped,
     DeploymentRequestStatusToJSON,
 } from './DeploymentRequestStatus';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
 } from './Tag';
+import type { WarningCode } from './WarningCode';
 import {
-    WarningCode,
     WarningCodeFromJSON,
     WarningCodeFromJSONTyped,
     WarningCodeToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { ResponseMeta } from './ResponseMeta';
 import {
-    ResponseMeta,
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -13,8 +13,8 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { ErrorCode } from './ErrorCode';
 import {
-    ErrorCode,
     ErrorCodeFromJSON,
     ErrorCodeFromJSONTyped,
     ErrorCodeToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  ModelApiResponse,
+  Pet,
+} from '../models';
 import {
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  User,
+} from '../models';
 import {
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -14,11 +14,13 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  ModelApiResponse,
+  Pet,
+} from '../models';
 import {
-    ModelApiResponse,
     ModelApiResponseFromJSON,
     ModelApiResponseToJSON,
-    Pet,
     PetFromJSON,
     PetToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  Order,
+} from '../models';
 import {
-    Order,
     OrderFromJSON,
     OrderToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -14,8 +14,10 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  User,
+} from '../models';
 import {
-    User,
     UserFromJSON,
     UserToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Category } from './Category';
 import {
-    Category,
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
 } from './Category';
+import type { Tag } from './Tag';
 import {
-    Tag,
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
@@ -14,17 +14,19 @@
 
 
 import * as runtime from '../runtime';
+import type {
+  EnumPatternObject,
+  FakeEnumRequestGetInline200Response,
+  NumberEnum,
+  StringEnum,
+} from '../models';
 import {
-    EnumPatternObject,
     EnumPatternObjectFromJSON,
     EnumPatternObjectToJSON,
-    FakeEnumRequestGetInline200Response,
     FakeEnumRequestGetInline200ResponseFromJSON,
     FakeEnumRequestGetInline200ResponseToJSON,
-    NumberEnum,
     NumberEnumFromJSON,
     NumberEnumToJSON,
-    StringEnum,
     StringEnumFromJSON,
     StringEnumToJSON,
 } from '../models';

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -13,14 +13,14 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { NumberEnum } from './NumberEnum';
 import {
-    NumberEnum,
     NumberEnumFromJSON,
     NumberEnumFromJSONTyped,
     NumberEnumToJSON,
 } from './NumberEnum';
+import type { StringEnum } from './StringEnum';
 import {
-    StringEnum,
     StringEnumFromJSON,
     StringEnumFromJSONTyped,
     StringEnumToJSON,

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
@@ -14,9 +14,9 @@
 
 
 import * as runtime from '../runtime';
-import {
-    ModelApiResponse,
-    Pet,
+import type {
+  ModelApiResponse,
+  Pet,
 } from '../models';
 
 export interface AddPetRequest {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
@@ -14,8 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    Order,
+import type {
+  Order,
 } from '../models';
 
 export interface DeleteOrderRequest {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
@@ -14,8 +14,8 @@
 
 
 import * as runtime from '../runtime';
-import {
-    User,
+import type {
+  User,
 } from '../models';
 
 export interface CreateUserRequest {


### PR DESCRIPTION
When generating code with `typescript-fetch`, it creates imports of both types and values via `import` statement. This causes issues with modern toolset (e.g. Vite or esbuild) due to separate processing of individual modules and type erasure - as a result, `import` statement refers to no longer existing export.  

Typescript 3.8 introduces `import type` statement for importing types. `typescript-fetch` already generates Typescript 4.0 which has this support. Hence this PR suggests usage of `import type` statement for importing types during `typescript-fetch` generation.

See also #11179.