### PR TITLE
[C][Client] Support free-form objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
@@ -4,28 +4,48 @@
 #include "object.h"
 
 object_t *object_create() {
-    object_t *object = malloc(sizeof(object_t));
+    object_t *object = calloc(1, sizeof(object_t));
 
     return object;
 }
 
 void object_free(object_t *object) {
+    if (!object) {
+        return ;
+    }
+
+    if (object->temporary) {
+        free(object->temporary);
+        object->temporary = NULL;
+    }
+
     free (object);
 }
 
 cJSON *object_convertToJSON(object_t *object) {
-    cJSON *item = cJSON_CreateObject();
+    if (!object) {
+        return NULL;
+    }
 
-    return item;
-fail:
-    cJSON_Delete(item);
-    return NULL;
+    if (!object->temporary) {
+        return cJSON_Parse("{}");
+    }
+
+    return cJSON_Parse(object->temporary);
 }
 
-object_t *object_parseFromJSON(char *jsonString){
-    object_t *object = NULL;
+object_t *object_parseFromJSON(cJSON *json){
+    if (!json) {
+        goto end;
+    }
 
+    object_t *object = object_create();
+    if (!object) {
+        goto end;
+    }
+    object->temporary = cJSON_Print(json);
     return object;
+
 end:
     return NULL;
 }

--- a/modules/openapi-generator/src/main/resources/C-libcurl/object-header.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/object-header.mustache
@@ -20,7 +20,7 @@ object_t *object_create();
 
 void object_free(object_t *object);
 
-object_t *object_parseFromJSON(char *jsonString);
+object_t *object_parseFromJSON(cJSON *json);
 
 cJSON *object_convertToJSON(object_t *object);
 

--- a/samples/client/petstore/c/model/object.c
+++ b/samples/client/petstore/c/model/object.c
@@ -4,28 +4,48 @@
 #include "object.h"
 
 object_t *object_create() {
-    object_t *object = malloc(sizeof(object_t));
+    object_t *object = calloc(1, sizeof(object_t));
 
     return object;
 }
 
 void object_free(object_t *object) {
+    if (!object) {
+        return ;
+    }
+
+    if (object->temporary) {
+        free(object->temporary);
+        object->temporary = NULL;
+    }
+
     free (object);
 }
 
 cJSON *object_convertToJSON(object_t *object) {
-    cJSON *item = cJSON_CreateObject();
+    if (!object) {
+        return NULL;
+    }
 
-    return item;
-fail:
-    cJSON_Delete(item);
-    return NULL;
+    if (!object->temporary) {
+        return cJSON_Parse("{}");
+    }
+
+    return cJSON_Parse(object->temporary);
 }
 
-object_t *object_parseFromJSON(char *jsonString){
-    object_t *object = NULL;
+object_t *object_parseFromJSON(cJSON *json){
+    if (!json) {
+        goto end;
+    }
 
+    object_t *object = object_create();
+    if (!object) {
+        goto end;
+    }
+    object->temporary = cJSON_Print(json);
     return object;
+
 end:
     return NULL;
 }

--- a/samples/client/petstore/c/model/object.h
+++ b/samples/client/petstore/c/model/object.h
@@ -20,7 +20,7 @@ object_t *object_create();
 
 void object_free(object_t *object);
 
-object_t *object_parseFromJSON(char *jsonString);
+object_t *object_parseFromJSON(cJSON *json);
 
 cJSON *object_convertToJSON(object_t *object);
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
@wing328 @zhemant @michelealbano

The PR https://github.com/OpenAPITools/openapi-generator/pull/12069 adds the support for free-form objects. That is a very useful feature.
I'd like to submit the code on behalf of the author @harlequin-tech. So I picked up the two files and updated them according to my thoughts. 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

