### PR TITLE
[Python] Generated class methods without self parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/classvars.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/classvars.mustache
@@ -62,7 +62,7 @@
 
 {{#additionalProperties}}
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -81,7 +81,7 @@
     _nullable = {{#isNullable}}True{{/isNullable}}{{^isNullable}}False{{/isNullable}}
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -114,7 +114,7 @@
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
 {{^discriminator}}
         return None
 {{/discriminator}}

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_any_type.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_any_type.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_array.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_array.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesArray(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesArray(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesArray(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_boolean.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_boolean.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_class.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_class.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesClass(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class AdditionalPropertiesClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_integer.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_integer.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesInteger(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesInteger(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesInteger(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_number.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_number.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesNumber(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesNumber(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesNumber(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_object.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_object.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesObject(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesObject(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesObject(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_string.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_string.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesString(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesString(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesString(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/animal.py
+++ b/samples/client/petstore/python/petstore_api/model/animal.py
@@ -67,7 +67,7 @@ class Animal(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Animal(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class Animal(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'Cat': Cat,

--- a/samples/client/petstore/python/petstore_api/model/animal_farm.py
+++ b/samples/client/petstore/python/petstore_api/model/animal_farm.py
@@ -65,7 +65,7 @@ class AnimalFarm(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class AnimalFarm(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/api_response.py
+++ b/samples/client/petstore/python/petstore_api/model/api_response.py
@@ -61,7 +61,7 @@ class ApiResponse(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ApiResponse(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class ApiResponse(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
@@ -61,7 +61,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/array_of_number_only.py
+++ b/samples/client/petstore/python/petstore_api/model/array_of_number_only.py
@@ -61,7 +61,7 @@ class ArrayOfNumberOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ArrayOfNumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ArrayOfNumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/array_test.py
+++ b/samples/client/petstore/python/petstore_api/model/array_test.py
@@ -65,7 +65,7 @@ class ArrayTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class ArrayTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class ArrayTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/capitalization.py
+++ b/samples/client/petstore/python/petstore_api/model/capitalization.py
@@ -61,7 +61,7 @@ class Capitalization(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Capitalization(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class Capitalization(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/cat.py
+++ b/samples/client/petstore/python/petstore_api/model/cat.py
@@ -67,7 +67,7 @@ class Cat(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Cat(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class Cat(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python/petstore_api/model/cat_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/cat_all_of.py
@@ -61,7 +61,7 @@ class CatAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class CatAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class CatAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/category.py
+++ b/samples/client/petstore/python/petstore_api/model/category.py
@@ -61,7 +61,7 @@ class Category(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Category(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class Category(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/child.py
+++ b/samples/client/petstore/python/petstore_api/model/child.py
@@ -67,7 +67,7 @@ class Child(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Child(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class Child(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/child_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_all_of.py
@@ -61,7 +61,7 @@ class ChildAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ChildAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ChildAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/child_cat.py
+++ b/samples/client/petstore/python/petstore_api/model/child_cat.py
@@ -67,7 +67,7 @@ class ChildCat(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ChildCat(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class ChildCat(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python/petstore_api/model/child_cat_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_cat_all_of.py
@@ -61,7 +61,7 @@ class ChildCatAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ChildCatAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ChildCatAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/child_dog.py
+++ b/samples/client/petstore/python/petstore_api/model/child_dog.py
@@ -67,7 +67,7 @@ class ChildDog(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ChildDog(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class ChildDog(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python/petstore_api/model/child_dog_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_dog_all_of.py
@@ -61,7 +61,7 @@ class ChildDogAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ChildDogAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ChildDogAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/child_lizard.py
+++ b/samples/client/petstore/python/petstore_api/model/child_lizard.py
@@ -67,7 +67,7 @@ class ChildLizard(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ChildLizard(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class ChildLizard(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python/petstore_api/model/child_lizard_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_lizard_all_of.py
@@ -61,7 +61,7 @@ class ChildLizardAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ChildLizardAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ChildLizardAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/class_model.py
+++ b/samples/client/petstore/python/petstore_api/model/class_model.py
@@ -61,7 +61,7 @@ class ClassModel(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ClassModel(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ClassModel(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/client.py
+++ b/samples/client/petstore/python/petstore_api/model/client.py
@@ -61,7 +61,7 @@ class Client(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Client(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class Client(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/dog.py
+++ b/samples/client/petstore/python/petstore_api/model/dog.py
@@ -67,7 +67,7 @@ class Dog(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Dog(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class Dog(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python/petstore_api/model/dog_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/dog_all_of.py
@@ -61,7 +61,7 @@ class DogAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class DogAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class DogAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/enum_arrays.py
+++ b/samples/client/petstore/python/petstore_api/model/enum_arrays.py
@@ -69,7 +69,7 @@ class EnumArrays(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class EnumArrays(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class EnumArrays(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/model/enum_class.py
@@ -66,7 +66,7 @@ class EnumClass(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class EnumClass(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/enum_test.py
+++ b/samples/client/petstore/python/petstore_api/model/enum_test.py
@@ -83,7 +83,7 @@ class EnumTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class EnumTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -113,7 +113,7 @@ class EnumTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/file.py
+++ b/samples/client/petstore/python/petstore_api/model/file.py
@@ -61,7 +61,7 @@ class File(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class File(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class File(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/file_schema_test_class.py
+++ b/samples/client/petstore/python/petstore_api/model/file_schema_test_class.py
@@ -65,7 +65,7 @@ class FileSchemaTestClass(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class FileSchemaTestClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -92,7 +92,7 @@ class FileSchemaTestClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/format_test.py
+++ b/samples/client/petstore/python/petstore_api/model/format_test.py
@@ -96,7 +96,7 @@ class FormatTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -106,7 +106,7 @@ class FormatTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -132,7 +132,7 @@ class FormatTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/grandparent.py
+++ b/samples/client/petstore/python/petstore_api/model/grandparent.py
@@ -61,7 +61,7 @@ class Grandparent(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Grandparent(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class Grandparent(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/grandparent_animal.py
+++ b/samples/client/petstore/python/petstore_api/model/grandparent_animal.py
@@ -71,7 +71,7 @@ class GrandparentAnimal(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -82,7 +82,7 @@ class GrandparentAnimal(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -97,7 +97,7 @@ class GrandparentAnimal(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'ChildCat': ChildCat,

--- a/samples/client/petstore/python/petstore_api/model/has_only_read_only.py
+++ b/samples/client/petstore/python/petstore_api/model/has_only_read_only.py
@@ -61,7 +61,7 @@ class HasOnlyReadOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class HasOnlyReadOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class HasOnlyReadOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/list.py
+++ b/samples/client/petstore/python/petstore_api/model/list.py
@@ -61,7 +61,7 @@ class List(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class List(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class List(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/map_test.py
+++ b/samples/client/petstore/python/petstore_api/model/map_test.py
@@ -69,7 +69,7 @@ class MapTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class MapTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -98,7 +98,7 @@ class MapTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
@@ -65,7 +65,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/model200_response.py
+++ b/samples/client/petstore/python/petstore_api/model/model200_response.py
@@ -61,7 +61,7 @@ class Model200Response(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Model200Response(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class Model200Response(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/model_return.py
+++ b/samples/client/petstore/python/petstore_api/model/model_return.py
@@ -61,7 +61,7 @@ class ModelReturn(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ModelReturn(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ModelReturn(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/name.py
+++ b/samples/client/petstore/python/petstore_api/model/name.py
@@ -61,7 +61,7 @@ class Name(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Name(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -88,7 +88,7 @@ class Name(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/number_only.py
+++ b/samples/client/petstore/python/petstore_api/model/number_only.py
@@ -61,7 +61,7 @@ class NumberOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class NumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class NumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/number_with_validations.py
+++ b/samples/client/petstore/python/petstore_api/model/number_with_validations.py
@@ -65,7 +65,7 @@ class NumberWithValidations(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class NumberWithValidations(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
+++ b/samples/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
@@ -65,7 +65,7 @@ class ObjectModelWithRefProps(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class ObjectModelWithRefProps(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class ObjectModelWithRefProps(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/order.py
+++ b/samples/client/petstore/python/petstore_api/model/order.py
@@ -66,7 +66,7 @@ class Order(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class Order(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class Order(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/parent.py
+++ b/samples/client/petstore/python/petstore_api/model/parent.py
@@ -67,7 +67,7 @@ class Parent(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Parent(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class Parent(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/parent_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/parent_all_of.py
@@ -61,7 +61,7 @@ class ParentAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ParentAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ParentAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/parent_pet.py
+++ b/samples/client/petstore/python/petstore_api/model/parent_pet.py
@@ -71,7 +71,7 @@ class ParentPet(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -82,7 +82,7 @@ class ParentPet(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -97,7 +97,7 @@ class ParentPet(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'ChildCat': ChildCat,

--- a/samples/client/petstore/python/petstore_api/model/pet.py
+++ b/samples/client/petstore/python/petstore_api/model/pet.py
@@ -72,7 +72,7 @@ class Pet(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -83,7 +83,7 @@ class Pet(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -103,7 +103,7 @@ class Pet(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/player.py
+++ b/samples/client/petstore/python/petstore_api/model/player.py
@@ -61,7 +61,7 @@ class Player(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Player(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class Player(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/polygon.py
+++ b/samples/client/petstore/python/petstore_api/model/polygon.py
@@ -71,7 +71,7 @@ class Polygon(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -82,7 +82,7 @@ class Polygon(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -99,7 +99,7 @@ class Polygon(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/polygon_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/polygon_all_of.py
@@ -65,7 +65,7 @@ class PolygonAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -75,7 +75,7 @@ class PolygonAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class PolygonAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/read_only_first.py
+++ b/samples/client/petstore/python/petstore_api/model/read_only_first.py
@@ -61,7 +61,7 @@ class ReadOnlyFirst(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ReadOnlyFirst(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class ReadOnlyFirst(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/shape.py
+++ b/samples/client/petstore/python/petstore_api/model/shape.py
@@ -65,7 +65,7 @@ class Shape(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -75,7 +75,7 @@ class Shape(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class Shape(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/special_model_name.py
+++ b/samples/client/petstore/python/petstore_api/model/special_model_name.py
@@ -61,7 +61,7 @@ class SpecialModelName(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class SpecialModelName(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class SpecialModelName(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/square.py
+++ b/samples/client/petstore/python/petstore_api/model/square.py
@@ -70,7 +70,7 @@ class Square(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -81,7 +81,7 @@ class Square(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -98,7 +98,7 @@ class Square(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/square_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/square_all_of.py
@@ -64,7 +64,7 @@ class SquareAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -74,7 +74,7 @@ class SquareAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class SquareAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/string_boolean_map.py
+++ b/samples/client/petstore/python/petstore_api/model/string_boolean_map.py
@@ -61,7 +61,7 @@ class StringBooleanMap(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class StringBooleanMap(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class StringBooleanMap(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/string_enum.py
+++ b/samples/client/petstore/python/petstore_api/model/string_enum.py
@@ -66,7 +66,7 @@ class StringEnum(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class StringEnum(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/tag.py
+++ b/samples/client/petstore/python/petstore_api/model/tag.py
@@ -61,7 +61,7 @@ class Tag(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Tag(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class Tag(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/triangle.py
+++ b/samples/client/petstore/python/petstore_api/model/triangle.py
@@ -70,7 +70,7 @@ class Triangle(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -81,7 +81,7 @@ class Triangle(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -98,7 +98,7 @@ class Triangle(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/triangle_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/triangle_all_of.py
@@ -64,7 +64,7 @@ class TriangleAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -74,7 +74,7 @@ class TriangleAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class TriangleAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/type_holder_default.py
+++ b/samples/client/petstore/python/petstore_api/model/type_holder_default.py
@@ -61,7 +61,7 @@ class TypeHolderDefault(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class TypeHolderDefault(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class TypeHolderDefault(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/type_holder_example.py
+++ b/samples/client/petstore/python/petstore_api/model/type_holder_example.py
@@ -70,7 +70,7 @@ class TypeHolderExample(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class TypeHolderExample(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -98,7 +98,7 @@ class TypeHolderExample(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/user.py
+++ b/samples/client/petstore/python/petstore_api/model/user.py
@@ -61,7 +61,7 @@ class User(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class User(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -92,7 +92,7 @@ class User(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python/petstore_api/model/xml_item.py
+++ b/samples/client/petstore/python/petstore_api/model/xml_item.py
@@ -61,7 +61,7 @@ class XmlItem(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class XmlItem(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -113,7 +113,7 @@ class XmlItem(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_any_type.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_any_type.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_array.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_array.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesArray(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesArray(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesArray(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_boolean.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_boolean.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_class.py
@@ -65,7 +65,7 @@ class AdditionalPropertiesClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -89,7 +89,7 @@ class AdditionalPropertiesClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_integer.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_integer.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesInteger(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesInteger(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesInteger(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_number.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_number.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesNumber(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesNumber(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesNumber(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_object.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_object.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesObject(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesObject(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesObject(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_string.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_string.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesString(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesString(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class AdditionalPropertiesString(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal.py
@@ -71,7 +71,7 @@ class Animal(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class Animal(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'Cat': Cat,

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal_farm.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal_farm.py
@@ -65,7 +65,7 @@ class AnimalFarm(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class AnimalFarm(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/api_response.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/api_response.py
@@ -65,7 +65,7 @@ class ApiResponse(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -81,7 +81,7 @@ class ApiResponse(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_array_of_number_only.py
@@ -65,7 +65,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_number_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_number_only.py
@@ -65,7 +65,7 @@ class ArrayOfNumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ArrayOfNumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_test.py
@@ -69,7 +69,7 @@ class ArrayTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class ArrayTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/capitalization.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/capitalization.py
@@ -65,7 +65,7 @@ class Capitalization(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class Capitalization(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat.py
@@ -71,7 +71,7 @@ class Cat(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -88,7 +88,7 @@ class Cat(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat_all_of.py
@@ -65,7 +65,7 @@ class CatAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class CatAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/category.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/category.py
@@ -65,7 +65,7 @@ class Category(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class Category(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child.py
@@ -71,7 +71,7 @@ class Child(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -88,7 +88,7 @@ class Child(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_all_of.py
@@ -65,7 +65,7 @@ class ChildAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ChildAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat.py
@@ -71,7 +71,7 @@ class ChildCat(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class ChildCat(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat_all_of.py
@@ -65,7 +65,7 @@ class ChildCatAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ChildCatAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog.py
@@ -71,7 +71,7 @@ class ChildDog(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class ChildDog(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog_all_of.py
@@ -65,7 +65,7 @@ class ChildDogAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ChildDogAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard.py
@@ -71,7 +71,7 @@ class ChildLizard(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class ChildLizard(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard_all_of.py
@@ -65,7 +65,7 @@ class ChildLizardAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ChildLizardAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/class_model.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/class_model.py
@@ -65,7 +65,7 @@ class ClassModel(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ClassModel(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/client.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/client.py
@@ -65,7 +65,7 @@ class Client(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class Client(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog.py
@@ -71,7 +71,7 @@ class Dog(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -88,7 +88,7 @@ class Dog(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog_all_of.py
@@ -65,7 +65,7 @@ class DogAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class DogAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_arrays.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_arrays.py
@@ -73,7 +73,7 @@ class EnumArrays(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -88,7 +88,7 @@ class EnumArrays(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_class.py
@@ -66,7 +66,7 @@ class EnumClass(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class EnumClass(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_test.py
@@ -87,7 +87,7 @@ class EnumTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -106,7 +106,7 @@ class EnumTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file.py
@@ -65,7 +65,7 @@ class File(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class File(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file_schema_test_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file_schema_test_class.py
@@ -69,7 +69,7 @@ class FileSchemaTestClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class FileSchemaTestClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/format_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/format_test.py
@@ -100,7 +100,7 @@ class FormatTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -126,7 +126,7 @@ class FormatTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent.py
@@ -65,7 +65,7 @@ class Grandparent(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class Grandparent(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent_animal.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent_animal.py
@@ -75,7 +75,7 @@ class GrandparentAnimal(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class GrandparentAnimal(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'ChildCat': ChildCat,

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/has_only_read_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/has_only_read_only.py
@@ -65,7 +65,7 @@ class HasOnlyReadOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class HasOnlyReadOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/list.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/list.py
@@ -65,7 +65,7 @@ class List(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class List(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/map_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/map_test.py
@@ -73,7 +73,7 @@ class MapTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class MapTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/mixed_properties_and_additional_properties_class.py
@@ -69,7 +69,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model200_response.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model200_response.py
@@ -65,7 +65,7 @@ class Model200Response(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class Model200Response(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model_return.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model_return.py
@@ -65,7 +65,7 @@ class ModelReturn(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ModelReturn(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/name.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/name.py
@@ -65,7 +65,7 @@ class Name(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -82,7 +82,7 @@ class Name(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_only.py
@@ -65,7 +65,7 @@ class NumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class NumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_with_validations.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_with_validations.py
@@ -65,7 +65,7 @@ class NumberWithValidations(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class NumberWithValidations(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/object_model_with_ref_props.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/object_model_with_ref_props.py
@@ -69,7 +69,7 @@ class ObjectModelWithRefProps(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class ObjectModelWithRefProps(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/order.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/order.py
@@ -70,7 +70,7 @@ class Order(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -89,7 +89,7 @@ class Order(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent.py
@@ -71,7 +71,7 @@ class Parent(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class Parent(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_all_of.py
@@ -65,7 +65,7 @@ class ParentAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class ParentAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_pet.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_pet.py
@@ -75,7 +75,7 @@ class ParentPet(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class ParentPet(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'ChildCat': ChildCat,

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/pet.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/pet.py
@@ -76,7 +76,7 @@ class Pet(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -96,7 +96,7 @@ class Pet(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/player.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/player.py
@@ -65,7 +65,7 @@ class Player(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class Player(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/polygon.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/polygon.py
@@ -75,7 +75,7 @@ class Polygon(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -92,7 +92,7 @@ class Polygon(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/polygon_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/polygon_all_of.py
@@ -69,7 +69,7 @@ class PolygonAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class PolygonAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/read_only_first.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/read_only_first.py
@@ -65,7 +65,7 @@ class ReadOnlyFirst(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class ReadOnlyFirst(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/shape.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/shape.py
@@ -69,7 +69,7 @@ class Shape(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class Shape(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/special_model_name.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/special_model_name.py
@@ -65,7 +65,7 @@ class SpecialModelName(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class SpecialModelName(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/square.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/square.py
@@ -74,7 +74,7 @@ class Square(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class Square(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/square_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/square_all_of.py
@@ -68,7 +68,7 @@ class SquareAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class SquareAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_boolean_map.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_boolean_map.py
@@ -61,7 +61,7 @@ class StringBooleanMap(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class StringBooleanMap(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class StringBooleanMap(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_enum.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_enum.py
@@ -66,7 +66,7 @@ class StringEnum(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class StringEnum(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/tag.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/tag.py
@@ -65,7 +65,7 @@ class Tag(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -81,7 +81,7 @@ class Tag(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/triangle.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/triangle.py
@@ -74,7 +74,7 @@ class Triangle(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class Triangle(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/triangle_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/triangle_all_of.py
@@ -68,7 +68,7 @@ class TriangleAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class TriangleAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_default.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_default.py
@@ -65,7 +65,7 @@ class TypeHolderDefault(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class TypeHolderDefault(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_example.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_example.py
@@ -74,7 +74,7 @@ class TypeHolderExample(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -92,7 +92,7 @@ class TypeHolderExample(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/user.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/user.py
@@ -65,7 +65,7 @@ class User(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class User(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/xml_item.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/xml_item.py
@@ -65,7 +65,7 @@ class XmlItem(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -107,7 +107,7 @@ class XmlItem(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_class.py
@@ -61,7 +61,7 @@ class AdditionalPropertiesClass(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class AdditionalPropertiesClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -92,7 +92,7 @@ class AdditionalPropertiesClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_with_array_of_enums.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_with_array_of_enums.py
@@ -65,7 +65,7 @@ class AdditionalPropertiesWithArrayOfEnums(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class AdditionalPropertiesWithArrayOfEnums(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class AdditionalPropertiesWithArrayOfEnums(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/address.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/address.py
@@ -61,7 +61,7 @@ class Address(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Address(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class Address(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/animal.py
@@ -67,7 +67,7 @@ class Animal(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Animal(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class Animal(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'Cat': Cat,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/animal_farm.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/animal_farm.py
@@ -65,7 +65,7 @@ class AnimalFarm(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class AnimalFarm(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/api_response.py
@@ -61,7 +61,7 @@ class ApiResponse(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ApiResponse(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class ApiResponse(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/apple.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/apple.py
@@ -72,7 +72,7 @@ class Apple(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -82,7 +82,7 @@ class Apple(ModelNormal):
     _nullable = True
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -97,7 +97,7 @@ class Apple(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/apple_req.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/apple_req.py
@@ -65,7 +65,7 @@ class AppleReq(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class AppleReq(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
@@ -61,7 +61,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_of_enums.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_of_enums.py
@@ -65,7 +65,7 @@ class ArrayOfEnums(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class ArrayOfEnums(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_of_number_only.py
@@ -61,7 +61,7 @@ class ArrayOfNumberOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ArrayOfNumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ArrayOfNumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_test.py
@@ -65,7 +65,7 @@ class ArrayTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class ArrayTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class ArrayTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/banana.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/banana.py
@@ -61,7 +61,7 @@ class Banana(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Banana(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class Banana(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/banana_req.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/banana_req.py
@@ -65,7 +65,7 @@ class BananaReq(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class BananaReq(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/basque_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/basque_pig.py
@@ -61,7 +61,7 @@ class BasquePig(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class BasquePig(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class BasquePig(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/boolean_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/boolean_enum.py
@@ -64,7 +64,7 @@ class BooleanEnum(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class BooleanEnum(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/capitalization.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/capitalization.py
@@ -61,7 +61,7 @@ class Capitalization(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Capitalization(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class Capitalization(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/cat.py
@@ -67,7 +67,7 @@ class Cat(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Cat(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -96,7 +96,7 @@ class Cat(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/openapi3/client/petstore/python/petstore_api/model/cat_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/cat_all_of.py
@@ -61,7 +61,7 @@ class CatAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class CatAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class CatAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/category.py
@@ -61,7 +61,7 @@ class Category(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Category(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class Category(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/child_cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/child_cat.py
@@ -67,7 +67,7 @@ class ChildCat(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ChildCat(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class ChildCat(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/openapi3/client/petstore/python/petstore_api/model/child_cat_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/child_cat_all_of.py
@@ -61,7 +61,7 @@ class ChildCatAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ChildCatAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ChildCatAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/class_model.py
@@ -61,7 +61,7 @@ class ClassModel(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ClassModel(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ClassModel(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/client.py
@@ -61,7 +61,7 @@ class Client(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Client(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class Client(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/complex_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/complex_quadrilateral.py
@@ -67,7 +67,7 @@ class ComplexQuadrilateral(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ComplexQuadrilateral(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class ComplexQuadrilateral(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/composed_one_of_number_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/composed_one_of_number_with_validations.py
@@ -67,7 +67,7 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/composed_schema_with_props_and_no_add_props.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/composed_schema_with_props_and_no_add_props.py
@@ -69,7 +69,7 @@ class ComposedSchemaWithPropsAndNoAddProps(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class ComposedSchemaWithPropsAndNoAddProps(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/danish_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/danish_pig.py
@@ -61,7 +61,7 @@ class DanishPig(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class DanishPig(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class DanishPig(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/dog.py
@@ -69,7 +69,7 @@ class Dog(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class Dog(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -99,7 +99,7 @@ class Dog(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         val = {
         }
         if not val:

--- a/samples/openapi3/client/petstore/python/petstore_api/model/dog_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/dog_all_of.py
@@ -65,7 +65,7 @@ class DogAllOf(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class DogAllOf(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -92,7 +92,7 @@ class DogAllOf(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/drawing.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/drawing.py
@@ -71,7 +71,7 @@ class Drawing(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -82,7 +82,7 @@ class Drawing(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -100,7 +100,7 @@ class Drawing(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/egress_threshold_options.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/egress_threshold_options.py
@@ -61,7 +61,7 @@ class EgressThresholdOptions(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class EgressThresholdOptions(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class EgressThresholdOptions(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/enum_arrays.py
@@ -69,7 +69,7 @@ class EnumArrays(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class EnumArrays(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class EnumArrays(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/enum_class.py
@@ -66,7 +66,7 @@ class EnumClass(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class EnumClass(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/enum_test.py
@@ -98,7 +98,7 @@ class EnumTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -109,7 +109,7 @@ class EnumTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -136,7 +136,7 @@ class EnumTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/equilateral_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/equilateral_triangle.py
@@ -67,7 +67,7 @@ class EquilateralTriangle(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class EquilateralTriangle(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class EquilateralTriangle(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/file.py
@@ -61,7 +61,7 @@ class File(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class File(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class File(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/file_schema_test_class.py
@@ -65,7 +65,7 @@ class FileSchemaTestClass(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class FileSchemaTestClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -92,7 +92,7 @@ class FileSchemaTestClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/foo.py
@@ -61,7 +61,7 @@ class Foo(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Foo(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class Foo(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/foo_get_default_response.py
@@ -65,7 +65,7 @@ class FooGetDefaultResponse(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class FooGetDefaultResponse(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class FooGetDefaultResponse(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/foo_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/foo_object.py
@@ -61,7 +61,7 @@ class FooObject(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class FooObject(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class FooObject(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/format_test.py
@@ -104,7 +104,7 @@ class FormatTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -114,7 +114,7 @@ class FormatTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -143,7 +143,7 @@ class FormatTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/fruit.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/fruit.py
@@ -78,7 +78,7 @@ class Fruit(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -89,7 +89,7 @@ class Fruit(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -107,7 +107,7 @@ class Fruit(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/fruit_req.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/fruit_req.py
@@ -67,7 +67,7 @@ class FruitReq(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class FruitReq(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -96,7 +96,7 @@ class FruitReq(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit.py
@@ -78,7 +78,7 @@ class GmFruit(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -89,7 +89,7 @@ class GmFruit(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -107,7 +107,7 @@ class GmFruit(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit_no_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit_no_properties.py
@@ -78,7 +78,7 @@ class GmFruitNoProperties(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -89,7 +89,7 @@ class GmFruitNoProperties(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -106,7 +106,7 @@ class GmFruitNoProperties(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/grandparent_animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/grandparent_animal.py
@@ -67,7 +67,7 @@ class GrandparentAnimal(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class GrandparentAnimal(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class GrandparentAnimal(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'ChildCat': ChildCat,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/has_only_read_only.py
@@ -61,7 +61,7 @@ class HasOnlyReadOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class HasOnlyReadOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class HasOnlyReadOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/health_check_result.py
@@ -61,7 +61,7 @@ class HealthCheckResult(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class HealthCheckResult(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class HealthCheckResult(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/inline_additional_properties_ref_payload.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/inline_additional_properties_ref_payload.py
@@ -65,7 +65,7 @@ class InlineAdditionalPropertiesRefPayload(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class InlineAdditionalPropertiesRefPayload(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class InlineAdditionalPropertiesRefPayload(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum.py
@@ -66,7 +66,7 @@ class IntegerEnum(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class IntegerEnum(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_one_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_one_value.py
@@ -64,7 +64,7 @@ class IntegerEnumOneValue(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class IntegerEnumOneValue(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_with_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_with_default_value.py
@@ -66,7 +66,7 @@ class IntegerEnumWithDefaultValue(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class IntegerEnumWithDefaultValue(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/isosceles_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/isosceles_triangle.py
@@ -67,7 +67,7 @@ class IsoscelesTriangle(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class IsoscelesTriangle(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class IsoscelesTriangle(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/legs.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/legs.py
@@ -65,7 +65,7 @@ class Legs(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -75,7 +75,7 @@ class Legs(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class Legs(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/list.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/list.py
@@ -61,7 +61,7 @@ class List(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class List(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class List(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/mammal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/mammal.py
@@ -74,7 +74,7 @@ class Mammal(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class Mammal(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -103,7 +103,7 @@ class Mammal(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'Pig': Pig,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/map_test.py
@@ -69,7 +69,7 @@ class MapTest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class MapTest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -98,7 +98,7 @@ class MapTest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
@@ -65,7 +65,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/model200_response.py
@@ -61,7 +61,7 @@ class Model200Response(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Model200Response(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class Model200Response(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/model_return.py
@@ -61,7 +61,7 @@ class ModelReturn(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ModelReturn(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ModelReturn(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/mole.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/mole.py
@@ -61,7 +61,7 @@ class Mole(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Mole(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class Mole(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/name.py
@@ -61,7 +61,7 @@ class Name(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Name(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -88,7 +88,7 @@ class Name(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/nullable_class.py
@@ -61,7 +61,7 @@ class NullableClass(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class NullableClass(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -97,7 +97,7 @@ class NullableClass(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/nullable_shape.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/nullable_shape.py
@@ -67,7 +67,7 @@ class NullableShape(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class NullableShape(ModelComposed):
     _nullable = True
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class NullableShape(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'Quadrilateral': Quadrilateral,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/number_only.py
@@ -61,7 +61,7 @@ class NumberOnly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class NumberOnly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class NumberOnly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/number_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/number_with_validations.py
@@ -65,7 +65,7 @@ class NumberWithValidations(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -79,7 +79,7 @@ class NumberWithValidations(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/object_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/object_interface.py
@@ -61,7 +61,7 @@ class ObjectInterface(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ObjectInterface(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class ObjectInterface(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
@@ -67,7 +67,7 @@ class ObjectModelWithRefProps(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ObjectModelWithRefProps(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -96,7 +96,7 @@ class ObjectModelWithRefProps(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/object_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/object_with_validations.py
@@ -64,7 +64,7 @@ class ObjectWithValidations(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -74,7 +74,7 @@ class ObjectWithValidations(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class ObjectWithValidations(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/order.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/order.py
@@ -66,7 +66,7 @@ class Order(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class Order(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class Order(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/parent_pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/parent_pet.py
@@ -67,7 +67,7 @@ class ParentPet(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ParentPet(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class ParentPet(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'ChildCat': ChildCat,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/pet.py
@@ -72,7 +72,7 @@ class Pet(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -83,7 +83,7 @@ class Pet(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -103,7 +103,7 @@ class Pet(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/pig.py
@@ -67,7 +67,7 @@ class Pig(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Pig(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -93,7 +93,7 @@ class Pig(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'BasquePig': BasquePig,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/post_inline_additional_properties_payload_request.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/post_inline_additional_properties_payload_request.py
@@ -65,7 +65,7 @@ class PostInlineAdditionalPropertiesPayloadRequest(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class PostInlineAdditionalPropertiesPayloadRequest(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class PostInlineAdditionalPropertiesPayloadRequest(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/post_inline_additional_properties_payload_request_array_data_inner.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/post_inline_additional_properties_payload_request_array_data_inner.py
@@ -61,7 +61,7 @@ class PostInlineAdditionalPropertiesPayloadRequestArrayDataInner(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class PostInlineAdditionalPropertiesPayloadRequestArrayDataInner(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class PostInlineAdditionalPropertiesPayloadRequestArrayDataInner(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/publish_options.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/publish_options.py
@@ -65,7 +65,7 @@ class PublishOptions(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class PublishOptions(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class PublishOptions(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/publish_options_publish.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/publish_options_publish.py
@@ -61,7 +61,7 @@ class PublishOptionsPublish(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class PublishOptionsPublish(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class PublishOptionsPublish(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral.py
@@ -67,7 +67,7 @@ class Quadrilateral(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Quadrilateral(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class Quadrilateral(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'ComplexQuadrilateral': ComplexQuadrilateral,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral_interface.py
@@ -61,7 +61,7 @@ class QuadrilateralInterface(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class QuadrilateralInterface(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class QuadrilateralInterface(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/read_only_first.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/read_only_first.py
@@ -61,7 +61,7 @@ class ReadOnlyFirst(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ReadOnlyFirst(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class ReadOnlyFirst(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/readonly.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/readonly.py
@@ -61,7 +61,7 @@ class Readonly(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Readonly(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class Readonly(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/scalene_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/scalene_triangle.py
@@ -67,7 +67,7 @@ class ScaleneTriangle(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ScaleneTriangle(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class ScaleneTriangle(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape.py
@@ -67,7 +67,7 @@ class Shape(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class Shape(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class Shape(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'Quadrilateral': Quadrilateral,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape_interface.py
@@ -61,7 +61,7 @@ class ShapeInterface(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class ShapeInterface(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class ShapeInterface(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape_or_null.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape_or_null.py
@@ -67,7 +67,7 @@ class ShapeOrNull(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class ShapeOrNull(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -95,7 +95,7 @@ class ShapeOrNull(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'Quadrilateral': Quadrilateral,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/simple_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/simple_quadrilateral.py
@@ -67,7 +67,7 @@ class SimpleQuadrilateral(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -78,7 +78,7 @@ class SimpleQuadrilateral(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -94,7 +94,7 @@ class SimpleQuadrilateral(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/some_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/some_object.py
@@ -65,7 +65,7 @@ class SomeObject(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class SomeObject(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -90,7 +90,7 @@ class SomeObject(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/some_object_with_self_attr.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/some_object_with_self_attr.py
@@ -61,7 +61,7 @@ class SomeObjectWithSelfAttr(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class SomeObjectWithSelfAttr(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class SomeObjectWithSelfAttr(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/special_model_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/special_model_name.py
@@ -61,7 +61,7 @@ class SpecialModelName(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class SpecialModelName(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class SpecialModelName(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/stream_options.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/stream_options.py
@@ -69,7 +69,7 @@ class StreamOptions(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class StreamOptions(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -96,7 +96,7 @@ class StreamOptions(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_boolean_map.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_boolean_map.py
@@ -61,7 +61,7 @@ class StringBooleanMap(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class StringBooleanMap(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -84,7 +84,7 @@ class StringBooleanMap(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_enum.py
@@ -72,7 +72,7 @@ lines''',
     _nullable = True
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ lines''',
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_enum_with_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_enum_with_default_value.py
@@ -66,7 +66,7 @@ class StringEnumWithDefaultValue(ModelSimple):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class StringEnumWithDefaultValue(ModelSimple):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/tag.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/tag.py
@@ -61,7 +61,7 @@ class Tag(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Tag(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -86,7 +86,7 @@ class Tag(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/triangle.py
@@ -69,7 +69,7 @@ class Triangle(ModelComposed):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -80,7 +80,7 @@ class Triangle(ModelComposed):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -96,7 +96,7 @@ class Triangle(ModelComposed):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         lazy_import()
         val = {
             'EquilateralTriangle': EquilateralTriangle,

--- a/samples/openapi3/client/petstore/python/petstore_api/model/triangle_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/triangle_interface.py
@@ -61,7 +61,7 @@ class TriangleInterface(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class TriangleInterface(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -85,7 +85,7 @@ class TriangleInterface(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/user.py
@@ -61,7 +61,7 @@ class User(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class User(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -96,7 +96,7 @@ class User(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/whale.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/whale.py
@@ -61,7 +61,7 @@ class Whale(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -71,7 +71,7 @@ class Whale(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -87,7 +87,7 @@ class Whale(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/zebra.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/zebra.py
@@ -66,7 +66,7 @@ class Zebra(ModelNormal):
     }
 
     @cached_property
-    def additional_properties_type():
+    def additional_properties_type(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -76,7 +76,7 @@ class Zebra(ModelNormal):
     _nullable = False
 
     @cached_property
-    def openapi_types():
+    def openapi_types(self):
         """
         This must be a method because a model may have properties that are
         of type self, this must run after the class is loaded
@@ -91,7 +91,7 @@ class Zebra(ModelNormal):
         }
 
     @cached_property
-    def discriminator():
+    def discriminator(self):
         return None
 
 


### PR DESCRIPTION
@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @arun-nalla (2019/11) @spacether (2019/11)

Updated mustache template to include `self` parameter in the generated class methods

Fix #12559 


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
