### PR TITLE
Add new option to customize inline model naming convention

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
@@ -74,6 +74,9 @@ public class ConfigHelp extends OpenApiGeneratorCommand {
     @Option(name = {"--inline-schema-name-mappings"}, title = "inline schema name mappings", description = "displays the inline schema name mappings (none)")
     private Boolean inlineSchemaNameMappings;
 
+    @Option(name = {"--inline-schema-name-defaults"}, title = "inline schema name defaults", description = "default values used when naming inline schema name")
+    private Boolean inlineSchemaNameDefaults;
+
     @Option(name = {"--metadata"}, title = "metadata", description = "displays the generator metadata like the help txt for the generator and generator type etc")
     private Boolean metadata;
 
@@ -461,6 +464,18 @@ public class ConfigHelp extends OpenApiGeneratorCommand {
                         throw new IllegalStateException(String.format(Locale.ROOT, "Duplicated options! %s and %s", a, b));
                     }, TreeMap::new));
             writePlainTextFromMap(sb, map, optIndent, optNestedIndent, "Inline scheme name", "Mapped to");
+            sb.append(newline);
+        }
+
+        if (Boolean.TRUE.equals(inlineSchemaNameDefaults)) {
+            sb.append(newline).append("INLINE SCHEMA NAME DEFAULTS").append(newline).append(newline);
+            Map<String, String> map = config.inlineSchemaNameDefault()
+                    .entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> {
+                        throw new IllegalStateException(String.format(Locale.ROOT, "Duplicated options! %s and %s", a, b));
+                    }, TreeMap::new));
+            writePlainTextFromMap(sb, map, optIndent, optNestedIndent, "Inline scheme naming convention", "Defaulted to");
             sb.append(newline);
         }
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -169,8 +169,8 @@ public class Generate extends OpenApiGeneratorCommand {
     @Option(
             name = {"--inline-schema-name-defaults"},
             title = "inline schema name defaults",
-            description = "specifies the default values used when naming inline schema as such array items in the format of array_item_suffix=_inner,map_item_suffix=_value. "
-                    + " ONLY array_item_suffix, map_item_suffix at the moment.")
+            description = "specifies the default values used when naming inline schema as such array items in the format of arrayItemSuffix=_inner,mapItemSuffix=_value. "
+                    + " ONLY arrayItemSuffix, mapItemSuffix at the moment.")
     private List<String> inlineSchemaNameDefaults = new ArrayList<>();
 
     @Option(

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -167,6 +167,13 @@ public class Generate extends OpenApiGeneratorCommand {
     private List<String> inlineSchemaNameMappings = new ArrayList<>();
 
     @Option(
+            name = {"--inline-schema-name-defaults"},
+            title = "inline schema name defaults",
+            description = "specifies the default values used when naming inline schema as such array items in the format of array_item_suffix=_inner,map_item_suffix=_value. "
+                    + " ONLY array_item_suffix, map_item_suffix at the moment.")
+    private List<String> inlineSchemaNameDefaults = new ArrayList<>();
+
+    @Option(
             name = {"--server-variables"},
             title = "server variables",
             description = "sets server variables overrides for spec documents which support variable templating of servers.")
@@ -431,6 +438,7 @@ public class Generate extends OpenApiGeneratorCommand {
         applyInstantiationTypesKvpList(instantiationTypes, configurator);
         applyImportMappingsKvpList(importMappings, configurator);
         applyInlineSchemaNameMappingsKvpList(inlineSchemaNameMappings, configurator);
+        applyInlineSchemaNameDefaultsKvpList(inlineSchemaNameDefaults, configurator);
         applyTypeMappingsKvpList(typeMappings, configurator);
         applyAdditionalPropertiesKvpList(additionalProperties, configurator);
         applyLanguageSpecificPrimitivesCsvList(languageSpecificPrimitives, configurator);

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
@@ -51,6 +51,7 @@ public final class GeneratorSettings implements Serializable {
     private final Map<String, Object> additionalProperties;
     private final Map<String, String> importMappings;
     private final Map<String, String> inlineSchemaNameMappings;
+    private final Map<String, String> inlineSchemaNameDefaults;
     private final Set<String> languageSpecificPrimitives;
     private final Map<String, String> reservedWordsMappings;
     private final Map<String, String> serverVariables;
@@ -245,6 +246,15 @@ public final class GeneratorSettings implements Serializable {
     }
 
     /**
+     * Gets inline schema name defaults between an inline schema naming convention and the default values.
+     *
+     * @return the inline schema name defaults
+     */
+    public Map<String, String> getInlineSchemaNameDefaults() {
+        return inlineSchemaNameDefaults;
+    }
+
+    /**
      * Gets language specific primitives. These are in addition to the "base" primitives defined in a generator.
      * <p>
      * In general, a primitive defined here will indicate to the generator:
@@ -360,6 +370,7 @@ public final class GeneratorSettings implements Serializable {
         typeMappings = Collections.unmodifiableMap(builder.typeMappings);
         importMappings = Collections.unmodifiableMap(builder.importMappings);
         inlineSchemaNameMappings = Collections.unmodifiableMap(builder.inlineSchemaNameMappings);
+        inlineSchemaNameDefaults = Collections.unmodifiableMap(builder.inlineSchemaNameDefaults);
         languageSpecificPrimitives = Collections.unmodifiableSet(builder.languageSpecificPrimitives);
         reservedWordsMappings = Collections.unmodifiableMap(builder.reservedWordsMappings);
         serverVariables = Collections.unmodifiableMap(builder.serverVariables);
@@ -431,6 +442,7 @@ public final class GeneratorSettings implements Serializable {
         additionalProperties = Collections.unmodifiableMap(new HashMap<>(0));
         importMappings = Collections.unmodifiableMap(new HashMap<>(0));
         inlineSchemaNameMappings = Collections.unmodifiableMap(new HashMap<>(0));
+        inlineSchemaNameDefaults = Collections.unmodifiableMap(new HashMap<>(0));
         languageSpecificPrimitives = Collections.unmodifiableSet(new HashSet<>(0));
         reservedWordsMappings = Collections.unmodifiableMap(new HashMap<>(0));
         serverVariables = Collections.unmodifiableMap(new HashMap<>(0));
@@ -485,6 +497,9 @@ public final class GeneratorSettings implements Serializable {
         if (copy.getInlineSchemaNameMappings() != null) {
             builder.inlineSchemaNameMappings.putAll(copy.getInlineSchemaNameMappings());
         }
+        if (copy.getInlineSchemaNameDefaults() != null) {
+            builder.inlineSchemaNameDefaults.putAll(copy.getInlineSchemaNameDefaults());
+        }
         if (copy.getLanguageSpecificPrimitives() != null) {
             builder.languageSpecificPrimitives.addAll(copy.getLanguageSpecificPrimitives());
         }
@@ -525,6 +540,7 @@ public final class GeneratorSettings implements Serializable {
         private Map<String, Object> additionalProperties;
         private Map<String, String> importMappings;
         private Map<String, String> inlineSchemaNameMappings;
+        private Map<String, String> inlineSchemaNameDefaults;
         private Set<String> languageSpecificPrimitives;
         private Map<String, String> reservedWordsMappings;
         private Map<String, String> serverVariables;
@@ -543,6 +559,7 @@ public final class GeneratorSettings implements Serializable {
             additionalProperties = new HashMap<>();
             importMappings = new HashMap<>();
             inlineSchemaNameMappings = new HashMap<>();
+            inlineSchemaNameDefaults = new HashMap<>();
             languageSpecificPrimitives = new HashSet<>();
             reservedWordsMappings = new HashMap<>();
             serverVariables = new HashMap<>();
@@ -786,6 +803,32 @@ public final class GeneratorSettings implements Serializable {
         }
 
         /**
+         * Sets the {@code inlineSchemaNameDefaults} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param inlineSchemaNameDefaults the {@code inlineSchemaNameDefaults} to set
+         * @return a reference to this Builder
+         */
+        public Builder withInlineSchemaNameDefaults(Map<String, String> inlineSchemaNameDefaults) {
+            this.inlineSchemaNameDefaults = inlineSchemaNameDefaults;
+            return this;
+        }
+
+        /**
+         * Sets a single {@code inlineSchemaNameDefaults} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param key   Default naming convention
+         * @param value The value
+         * @return a reference to this Builder
+         */
+        public Builder withInlineSchemaNameDefault(String key, String value) {
+            if (this.inlineSchemaNameDefaults == null) {
+                this.inlineSchemaNameDefaults = new HashMap<>();
+            }
+            this.inlineSchemaNameDefaults.put(key, value);
+            return this;
+        }
+
+        /**
          * Sets the {@code inlineSchemaNameMappings} and returns a reference to this Builder so that the methods can be chained together.
          *
          * @param inlineSchemaNameMappings the {@code inlineSchemaNameMappings} to set
@@ -799,8 +842,8 @@ public final class GeneratorSettings implements Serializable {
         /**
          * Sets a single {@code inlineSchemaNameMappings} and returns a reference to this Builder so that the methods can be chained together.
          *
-         * @param key   A key for some import mapping
-         * @param value The value of some import mapping
+         * @param key   A key for the inline schema mapping
+         * @param value The value of inline schema mapping
          * @return a reference to this Builder
          */
         public Builder withInlineSchemaNameMapping(String key, String value) {
@@ -997,6 +1040,7 @@ public final class GeneratorSettings implements Serializable {
                 Objects.equals(getAdditionalProperties(), that.getAdditionalProperties()) &&
                 Objects.equals(getImportMappings(), that.getImportMappings()) &&
                 Objects.equals(getInlineSchemaNameMappings(), that.getInlineSchemaNameMappings()) &&
+                Objects.equals(getInlineSchemaNameDefaults(), that.getInlineSchemaNameDefaults()) &&
                 Objects.equals(getLanguageSpecificPrimitives(), that.getLanguageSpecificPrimitives()) &&
                 Objects.equals(getReservedWordsMappings(), that.getReservedWordsMappings()) &&
                 Objects.equals(getGitHost(), that.getGitHost()) &&
@@ -1026,6 +1070,7 @@ public final class GeneratorSettings implements Serializable {
                 getAdditionalProperties(),
                 getImportMappings(),
                 getInlineSchemaNameMappings(),
+                getInlineSchemaNameDefaults(),
                 getLanguageSpecificPrimitives(),
                 getReservedWordsMappings(),
                 getGitHost(),

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -114,6 +114,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     languageSpecificPrimitives.set(generate.languageSpecificPrimitives)
                     importMappings.set(generate.importMappings)
                     inlineSchemaNameMappings.set(generate.inlineSchemaNameMappings)
+                    inlineSchemaNameDefaults.set(generate.inlineSchemaNameDefaults)
                     invokerPackage.set(generate.invokerPackage)
                     groupId.set(generate.groupId)
                     id.set(generate.id)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -147,6 +147,11 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val inlineSchemaNameMappings = project.objects.mapProperty<String, String>()
 
     /**
+     * Specifies default values for inline schema naming convention
+     */
+    val inlineSchemaNameDefaults = project.objects.mapProperty<String, String>()
+
+    /**
      * Root package for generated code.
      */
     val invokerPackage = project.objects.property<String>()

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -227,6 +227,13 @@ open class GenerateTask : DefaultTask() {
     val inlineSchemaNameMappings = project.objects.mapProperty<String, String>()
 
     /**
+     * Specifies default values for inline schema naming convention
+     */
+    @Optional
+    @Input
+    val inlineSchemaNameDefaults = project.objects.mapProperty<String, String>()
+
+    /**
      * Root package for generated code.
      */
     @Optional
@@ -688,6 +695,12 @@ open class GenerateTask : DefaultTask() {
             if (inlineSchemaNameMappings.isPresent) {
                 inlineSchemaNameMappings.get().forEach { entry ->
                     configurator.addInlineSchemaNameMapping(entry.key, entry.value)
+                }
+            }
+
+            if (inlineSchemaNameDefaults.isPresent) {
+                inlineSchemaNameDefaults.get().forEach { entry ->
+                    configurator.addInlineSchemaNameDefault(entry.key, entry.value)
                 }
             }
 

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -305,6 +305,12 @@ public class CodeGenMojo extends AbstractMojo {
     private List<String> inlineSchemaNameMappings;
 
     /**
+     * A map of inline scheme naming convention and the value
+     */
+    @Parameter(name = "inlineSchemaNameDefaults", property = "openapi.generator.maven.plugin.inlineSchemaNameDefaults")
+    private List<String> inlineSchemaNameDefaults;
+
+    /**
      * A map of swagger spec types and the generated code types to use for them
      */
     @Parameter(name = "typeMappings", property = "openapi.generator.maven.plugin.typeMappings")
@@ -666,8 +672,14 @@ public class CodeGenMojo extends AbstractMojo {
                 }
 
                 // Retained for backwards-compatibility with configOptions -> inline-schema-name-mappings
-                if (importMappings == null && configOptions.containsKey("inline-schema-name-mappings")) {
+                if (inlineSchemaNameMappings == null && configOptions.containsKey("inline-schema-name-mappings")) {
                     applyInlineSchemaNameMappingsKvp(configOptions.get("inline-schema-name-mappings").toString(),
+                            configurator);
+                }
+
+                // Retained for backwards-compatibility with configOptions -> inline-schema-name-defaults
+                if (inlineSchemaNameDefaults == null && configOptions.containsKey("inline-schema-name-defaults")) {
+                    applyInlineSchemaNameDefaultsKvp(configOptions.get("inline-schema-name-defaults").toString(),
                             configurator);
                 }
 
@@ -712,6 +724,11 @@ public class CodeGenMojo extends AbstractMojo {
             // Apply Inline Schema Name Mappings
             if (inlineSchemaNameMappings != null && (configOptions == null || !configOptions.containsKey("inline-schema-name-mappings"))) {
                 applyInlineSchemaNameMappingsKvpList(inlineSchemaNameMappings, configurator);
+            }
+
+            // Apply Inline Schema Name Defaults
+            if (inlineSchemaNameDefaults != null && (configOptions == null || !configOptions.containsKey("inline-schema-name-defaults"))) {
+                applyInlineSchemaNameDefaultsKvpList(inlineSchemaNameDefaults, configurator);
             }
 
             // Apply Type Mappings

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -143,6 +143,8 @@ public interface CodegenConfig {
 
     Map<String, String> inlineSchemaNameMapping();
 
+    Map<String, String> inlineSchemaNameDefault();
+
     Map<String, String> apiTemplateFiles();
 
     Map<String, String> modelTemplateFiles();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -155,6 +155,8 @@ public class DefaultCodegen implements CodegenConfig {
     protected Map<String, String> importMapping = new HashMap<>();
     // a map to store the mappping between inline schema and the name provided by the user
     protected Map<String, String> inlineSchemaNameMapping = new HashMap<>();
+    // a map to store the inline schema naming conventions
+    protected Map<String, String> inlineSchemaNameDefault = new HashMap<>();
     protected String modelPackage = "", apiPackage = "", fileSuffix;
     protected String modelNamePrefix = "", modelNameSuffix = "";
     protected String apiNamePrefix = "", apiNameSuffix = "Api";
@@ -1061,6 +1063,11 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public Map<String, String> inlineSchemaNameMapping() {
         return inlineSchemaNameMapping;
+    }
+
+    @Override
+    public Map<String, String> inlineSchemaNameDefault() {
+        return inlineSchemaNameDefault;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2201,9 +2201,9 @@ public class DefaultCodegen implements CodegenConfig {
             // get the schema/model name from $ref
             String schemaName = ModelUtils.getSimpleRef(unaliasSchema.get$ref());
             if (StringUtils.isNotEmpty(schemaName)) {
-                if (importMapping.containsKey(schemaName)) {
+                /*if (importMapping.containsKey(schemaName)) {
                     return schemaName;
-                }
+                }*/
                 return getAlias(schemaName);
             } else {
                 LOGGER.warn("Error obtaining the datatype from ref: {}. Default to 'object'", unaliasSchema.get$ref());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2208,9 +2208,9 @@ public class DefaultCodegen implements CodegenConfig {
             // get the schema/model name from $ref
             String schemaName = ModelUtils.getSimpleRef(unaliasSchema.get$ref());
             if (StringUtils.isNotEmpty(schemaName)) {
-                /*if (importMapping.containsKey(schemaName)) {
+                if (importMapping.containsKey(schemaName)) {
                     return schemaName;
-                }*/
+                }
                 return getAlias(schemaName);
             } else {
                 LOGGER.warn("Error obtaining the datatype from ref: {}. Default to 'object'", unaliasSchema.get$ref());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -875,6 +875,7 @@ public class DefaultGenerator implements Generator {
         if (config.getUseInlineModelResolver()) {
             InlineModelResolver inlineModelResolver = new InlineModelResolver();
             inlineModelResolver.setInlineSchemaNameMapping(config.inlineSchemaNameMapping());
+            inlineModelResolver.setInlineSchemaNameDefault(config.inlineSchemaNameDefault());
             inlineModelResolver.flatten(openAPI);
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -875,7 +875,7 @@ public class DefaultGenerator implements Generator {
         if (config.getUseInlineModelResolver()) {
             InlineModelResolver inlineModelResolver = new InlineModelResolver();
             inlineModelResolver.setInlineSchemaNameMapping(config.inlineSchemaNameMapping());
-            inlineModelResolver.setInlineSchemaNameDefault(config.inlineSchemaNameDefault());
+            inlineModelResolver.setInlineSchemaNameDefaults(config.inlineSchemaNameDefault());
             inlineModelResolver.flatten(openAPI);
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -71,9 +71,8 @@ public class InlineModelResolver {
         this.inlineSchemaNameMappingValues = new HashSet<>(inlineSchemaNameMapping.values());
     }
 
-    public void setInlineSchemaNameDefault(Map inlineSchemaNameDefault) {
-        this.inlineSchemaNameMapping = inlineSchemaNameMapping;
-        this.inlineSchemaNameMappingValues = new HashSet<>(inlineSchemaNameMapping.values());
+    public void setInlineSchemaNameDefaults(Map inlineSchemaNameDefaults) {
+        this.inlineSchemaNameDefaults.putAll(inlineSchemaNameDefaults);
     }
 
     void flatten(OpenAPI openAPI) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -42,6 +42,7 @@ public class InlineModelResolver {
     private Map<String, Schema> addedModels = new HashMap<>();
     private Map<String, String> generatedSignature = new HashMap<>();
     private Map<String, String> inlineSchemaNameMapping = new HashMap<>();
+    private Map<String, String> inlineSchemaNameDefaults = new HashMap<>();
     private Set<String> inlineSchemaNameMappingValues = new HashSet<>();
     public boolean resolveInlineEnums = false;
 
@@ -60,7 +61,17 @@ public class InlineModelResolver {
 
     final Logger LOGGER = LoggerFactory.getLogger(InlineModelResolver.class);
 
+    public InlineModelResolver() {
+        this.inlineSchemaNameDefaults.put("arrayItemSuffix", "_inner");
+        this.inlineSchemaNameDefaults.put("mapItemSuffix", "_value");
+    }
+
     public void setInlineSchemaNameMapping(Map inlineSchemaNameMapping) {
+        this.inlineSchemaNameMapping = inlineSchemaNameMapping;
+        this.inlineSchemaNameMappingValues = new HashSet<>(inlineSchemaNameMapping.values());
+    }
+
+    public void setInlineSchemaNameDefault(Map inlineSchemaNameDefault) {
         this.inlineSchemaNameMapping = inlineSchemaNameMapping;
         this.inlineSchemaNameMappingValues = new HashSet<>(inlineSchemaNameMapping.values());
     }
@@ -230,7 +241,7 @@ public class InlineModelResolver {
             if (schema.getAdditionalProperties() != null) {
                 if (schema.getAdditionalProperties() instanceof Schema) {
                     Schema inner = (Schema) schema.getAdditionalProperties();
-                    String schemaName = resolveModelName(schema.getTitle(), modelPrefix + "_value");
+                    String schemaName = resolveModelName(schema.getTitle(), modelPrefix + this.inlineSchemaNameDefaults.get("mapItemSuffix"));
                     // Recurse to create $refs for inner models
                     gatherInlineModels(inner, schemaName);
                     if (isModelNeeded(inner)) {
@@ -265,7 +276,7 @@ public class InlineModelResolver {
                         " items must be defined for array schemas:\n " + schema.toString());
                 return;
             }
-            String schemaName = resolveModelName(items.getTitle(), modelPrefix + "_inner");
+            String schemaName = resolveModelName(items.getTitle(), modelPrefix + this.inlineSchemaNameDefaults.get("arrayItemSuffix"));
 
             // Recurse to create $refs for inner models
             gatherInlineModels(items, schemaName);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -69,6 +69,7 @@ public class CodegenConfigurator {
     private Map<String, Object> additionalProperties = new HashMap<>();
     private Map<String, String> importMappings = new HashMap<>();
     private Map<String, String> inlineSchemaNameMappings = new HashMap<>();
+    private Map<String, String> inlineSchemaNameDefaults = new HashMap<>();
     private Set<String> languageSpecificPrimitives = new HashSet<>();
     private Map<String, String> reservedWordsMappings = new HashMap<>();
     private Map<String, String> serverVariables = new HashMap<>();
@@ -187,6 +188,12 @@ public class CodegenConfigurator {
     public CodegenConfigurator addInlineSchemaNameMapping(String key, String value) {
         this.inlineSchemaNameMappings.put(key, value);
         generatorSettingsBuilder.withInlineSchemaNameMapping(key, value);
+        return this;
+    }
+
+    public CodegenConfigurator addInlineSchemaNameDefault(String key, String value) {
+        this.inlineSchemaNameDefaults.put(key, value);
+        generatorSettingsBuilder.withInlineSchemaNameDefault(key, value);
         return this;
     }
 
@@ -347,6 +354,12 @@ public class CodegenConfigurator {
     public CodegenConfigurator setInlineSchemaNameMappings(Map<String, String> inlineSchemaNameMappings) {
         this.inlineSchemaNameMappings = inlineSchemaNameMappings;
         generatorSettingsBuilder.withInlineSchemaNameMappings(inlineSchemaNameMappings);
+        return this;
+    }
+
+    public CodegenConfigurator setInlineSchemaNameDefaults(Map<String, String> inlineSchemaNameDefaults) {
+        this.inlineSchemaNameDefaults = inlineSchemaNameDefaults;
+        generatorSettingsBuilder.withInlineSchemaNameDefaults(inlineSchemaNameDefaults);
         return this;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -116,6 +116,9 @@ public class CodegenConfigurator {
             if(generatorSettings.getInlineSchemaNameMappings() != null) {
                 configurator.inlineSchemaNameMappings.putAll(generatorSettings.getInlineSchemaNameMappings());
             }
+            if(generatorSettings.getInlineSchemaNameDefaults() != null) {
+                configurator.inlineSchemaNameDefaults.putAll(generatorSettings.getInlineSchemaNameDefaults());
+            }
             if(generatorSettings.getLanguageSpecificPrimitives() != null) {
                 configurator.languageSpecificPrimitives.addAll(generatorSettings.getLanguageSpecificPrimitives());
             }
@@ -640,6 +643,7 @@ public class CodegenConfigurator {
         config.typeMapping().putAll(generatorSettings.getTypeMappings());
         config.importMapping().putAll(generatorSettings.getImportMappings());
         config.inlineSchemaNameMapping().putAll(generatorSettings.getInlineSchemaNameMappings());
+        config.inlineSchemaNameDefault().putAll(generatorSettings.getInlineSchemaNameDefaults());
         config.languageSpecificPrimitives().addAll(generatorSettings.getLanguageSpecificPrimitives());
         config.reservedWordsMappings().putAll(generatorSettings.getReservedWordsMappings());
         config.additionalProperties().putAll(generatorSettings.getAdditionalProperties());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
@@ -94,6 +94,19 @@ public final class CodegenConfiguratorUtils {
         }
     }
 
+    public static void applyInlineSchemaNameDefaultsKvpList(List<String> inlineSchemaNameDefaults, CodegenConfigurator configurator) {
+        for (String propString : inlineSchemaNameDefaults) {
+            applyInlineSchemaNameDefaultsKvp(propString, configurator);
+        }
+    }
+
+    public static void applyInlineSchemaNameDefaultsKvp(String inlineSchemaNameDefaults, CodegenConfigurator configurator) {
+        final Map<String, String> map = createMapFromKeyValuePairs(inlineSchemaNameDefaults);
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            configurator.addInlineSchemaNameDefault(entry.getKey().trim(), entry.getValue().trim());
+        }
+    }
+
     public static void applyTypeMappingsKvpList(List<String> typeMappings, CodegenConfigurator configurator) {
         for (String propString : typeMappings) {
             applyTypeMappingsKvp(propString, configurator);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1206,10 +1206,10 @@ public class ModelUtils {
 
         if (schema != null && StringUtils.isNotEmpty(schema.get$ref())) {
             String simpleRef = ModelUtils.getSimpleRef(schema.get$ref());
-            /*if (importMappings.containsKey(simpleRef)) {
-                LOGGER.info("Schema unaliasing of {} omitted because aliased class is to be mapped to {}", simpleRef, importMappings.get(simpleRef));
+            if (importMappings.containsKey(simpleRef)) {
+                LOGGER.debug("Schema unaliasing of {} omitted because aliased class is to be mapped to {}", simpleRef, importMappings.get(simpleRef));
                 return schema;
-            }*/
+            }
             Schema ref = allSchemas.get(simpleRef);
             if (ref == null) {
                 once(LOGGER).warn("{} is not defined", schema.get$ref());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1206,10 +1206,10 @@ public class ModelUtils {
 
         if (schema != null && StringUtils.isNotEmpty(schema.get$ref())) {
             String simpleRef = ModelUtils.getSimpleRef(schema.get$ref());
-            if (importMappings.containsKey(simpleRef)) {
-                LOGGER.debug("Schema unaliasing of {} omitted because aliased class is to be mapped to {}", simpleRef, importMappings.get(simpleRef));
+            /*if (importMappings.containsKey(simpleRef)) {
+                LOGGER.info("Schema unaliasing of {} omitted because aliased class is to be mapped to {}", simpleRef, importMappings.get(simpleRef));
                 return schema;
-            }
+            }*/
             Schema ref = allSchemas.get(simpleRef);
             if (ref == null) {
                 once(LOGGER).warn("{} is not defined", schema.get$ref());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
@@ -1021,6 +1021,23 @@ public class InlineModelResolverTest {
     }
 
     @Test
+    public void testInlineSchemaNameDefault() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
+        InlineModelResolver resolver = new InlineModelResolver();
+        Map<String, String> inlineSchemaNameDefaults = new HashMap<>();
+        inlineSchemaNameDefaults.put("arrayItemSuffix", "_something");
+        resolver.setInlineSchemaNameDefaults(inlineSchemaNameDefaults);
+        resolver.flatten(openAPI);
+
+        Schema schema = openAPI.getComponents().getSchemas().get("resolveInlineArrayRequestBody_request_something");
+        assertTrue(schema.getProperties().get("street") instanceof StringSchema);
+        assertTrue(schema.getProperties().get("city") instanceof StringSchema);
+
+        Schema nothingNew = openAPI.getComponents().getSchemas().get("arbitraryRequestBodyArrayProperty_request_something");
+        assertTrue(nothingNew.getProperties().get("arbitrary_request_body_array_property") instanceof ObjectSchema);
+    }
+
+    @Test
     public void resolveInlineRequestBodyAllOf() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/inline_model_resolver.yaml");
         new InlineModelResolver().flatten(openAPI);


### PR DESCRIPTION
- Add new option to customize inline model naming convention

e.g. ` --inline-schema-name-defaults arrayItemSuffix=_array_item` (the default is `_inner`)

Only arrayItemSuffix, mapItemSuffix are supported at the moment.

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] file the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

