### PR TITLE
Fix problem when uploading file using form-data in jersey2 client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1222,7 +1222,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         serializeToString(body, formParams, contentType, isBodyNullable),
         {{/hasHttpSignatureMethods}}
         {{^hasHttpSignatureMethods}}
-        body,
+        null,
         {{/hasHttpSignatureMethods}}
         method,
         target.getUri());

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1218,7 +1218,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         queryParams,
         allHeaderParams,
         cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
+        //This param is only used by the http signature auth. The other authentication do not use it
+        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
         method,
         target.getUri());
 
@@ -1440,5 +1441,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
+  }
+
+  private boolean isHttpSignatureAuthPresent() {
+    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1218,8 +1218,12 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         queryParams,
         allHeaderParams,
         cookieParams,
-        //This param is only used by the http signature auth. The other authentication do not use it
-        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
+        {{#hasHttpSignatureMethods}}
+        serializeToString(body, formParams, contentType, isBodyNullable),
+        {{/hasHttpSignatureMethods}}
+        {{^hasHttpSignatureMethods}}
+        body,
+        {{/hasHttpSignatureMethods}}
         method,
         target.getUri());
 
@@ -1441,9 +1445,5 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
-  }
-
-  private boolean isHttpSignatureAuthPresent() {
-    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -1139,7 +1139,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        body,
+        null,
         method,
         target.getUri());
 

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -1139,8 +1139,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        //This param is only used by the http signature auth. The other authentication do not use it
-        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
+        body,
         method,
         target.getUri());
 
@@ -1360,9 +1359,5 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
-  }
-
-  private boolean isHttpSignatureAuthPresent() {
-    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -1139,7 +1139,8 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
+        //This param is only used by the http signature auth. The other authentication do not use it
+        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
         method,
         target.getUri());
 
@@ -1359,5 +1360,9 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
+  }
+
+  private boolean isHttpSignatureAuthPresent() {
+    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1139,7 +1139,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        body,
+        null,
         method,
         target.getUri());
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1139,8 +1139,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        //This param is only used by the http signature auth. The other authentication do not use it
-        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
+        body,
         method,
         target.getUri());
 
@@ -1360,9 +1359,5 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
-  }
-
-  private boolean isHttpSignatureAuthPresent() {
-    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1139,7 +1139,8 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
+        //This param is only used by the http signature auth. The other authentication do not use it
+        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
         method,
         target.getUri());
 
@@ -1359,5 +1360,9 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
+  }
+
+  private boolean isHttpSignatureAuthPresent() {
+    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1069,7 +1069,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        body,
+        null,
         method,
         target.getUri());
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1069,8 +1069,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        //This param is only used by the http signature auth. The other authentication do not use it
-        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
+        body,
         method,
         target.getUri());
 
@@ -1274,9 +1273,5 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
-  }
-
-  private boolean isHttpSignatureAuthPresent() {
-    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1069,7 +1069,8 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
+        //This param is only used by the http signature auth. The other authentication do not use it
+        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
         method,
         target.getUri());
 
@@ -1273,5 +1274,9 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
+  }
+
+  private boolean isHttpSignatureAuthPresent() {
+    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -1014,8 +1014,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        //This param is only used by the http signature auth. The other authentication do not use it
-        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
+        body,
         method,
         target.getUri());
 
@@ -1219,9 +1218,5 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
-  }
-
-  private boolean isHttpSignatureAuthPresent() {
-    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -1014,7 +1014,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        body,
+        null,
         method,
         target.getUri());
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -1014,7 +1014,8 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
+        //This param is only used by the http signature auth. The other authentication do not use it
+        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
         method,
         target.getUri());
 
@@ -1218,5 +1219,9 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
+  }
+
+  private boolean isHttpSignatureAuthPresent() {
+    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1223,8 +1223,7 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        //This param is only used by the http signature auth. The other authentication do not use it
-        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
+        serializeToString(body, formParams, contentType, isBodyNullable),
         method,
         target.getUri());
 
@@ -1444,9 +1443,5 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
-  }
-
-  private boolean isHttpSignatureAuthPresent() {
-    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -1223,7 +1223,8 @@ public class ApiClient extends JavaTimeFormatter {
         queryParams,
         allHeaderParams,
         cookieParams,
-        serializeToString(body, formParams, contentType, isBodyNullable),
+        //This param is only used by the http signature auth. The other authentication do not use it
+        isHttpSignatureAuthPresent() ? serializeToString(body, formParams, contentType, isBodyNullable) : null,
         method,
         target.getUri());
 
@@ -1443,5 +1444,9 @@ public class ApiClient extends JavaTimeFormatter {
       }
       auth.applyToParams(queryParams, headerParams, cookieParams, payload, method, uri);
     }
+  }
+
+  private boolean isHttpSignatureAuthPresent() {
+    return authentications.entrySet().stream().filter(auth -> auth instanceof HttpSignatureAuth).findFirst().isPresent();
   }
 }


### PR DESCRIPTION
Here is the problem:

* When uploading a file with "multipart/form-data" and the jersey2 client, we receive this error:

`multipart/form-data not yet supported for serializeToString (http signature authentication)`

This error doesn't make sense since we do not use http signature authentication in our project. After some digging, I discovered that since the OAuth has been added, the method `serializeToString` was added to support http signature authentication and this method do not support "multipart/form-data". To fix it, I just added the `serializeToString` call when we support http signature authentication.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
