### PR TITLE
[rust] fix unusable oneOf generation

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -71,7 +71,7 @@ pub struct {{{classname}}} {
     /// {{{.}}}
     {{/description}}
     #[serde(rename = "{{{baseName}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
-    pub {{{name}}}: {{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^required}}Option<{{/required}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{{dataType}}}{{/isModel}}{{/isEnum}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^required}}>{{/required}},
+    pub {{{name}}}: {{^oneOf.isEmpty}}Option<{{/oneOf.isEmpty}}{{#oneOf.isEmpty}}{{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{/oneOf.isEmpty}}{{#isEnum}}{{#isArray}}{{#uniqueItems}}std::collections::HashSet<{{/uniqueItems}}{{^uniqueItems}}Vec<{{/uniqueItems}}{{/isArray}}{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{#isModel}}Box<{{{dataType}}}>{{/isModel}}{{^isModel}}{{{dataType}}}{{/isModel}}{{/isEnum}}{{^oneOf.isEmpty}}>{{/oneOf.isEmpty}}{{#oneOf.isEmpty}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{/oneOf.isEmpty}},
 {{/vars}}
 }
 
@@ -79,7 +79,7 @@ impl {{{classname}}} {
     {{#description}}
     /// {{{.}}}
     {{/description}}
-    pub fn new({{#requiredVars}}{{{name}}}: {{#isNullable}}Option<{{/isNullable}}{{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}}>{{/isNullable}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{{classname}}} {
+    pub fn new({{#requiredVars}}{{{name}}}: {{^oneOf.isEmpty}}Option<{{/oneOf.isEmpty}}{{#oneOf.isEmpty}}{{#isNullable}}Option<{{/isNullable}}{{/oneOf.isEmpty}}{{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^oneOf.isEmpty}}>{{/oneOf.isEmpty}}{{#oneOf.isEmpty}}{{#isNullable}}>{{/isNullable}}{{/oneOf.isEmpty}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{{classname}}} {
         {{{classname}}} {
             {{#vars}}
             {{{name}}}{{^required}}{{#isArray}}: None{{/isArray}}{{#isMap}}: None{{/isMap}}{{^isContainer}}: None{{/isContainer}}{{/required}}{{#required}}{{#isModel}}: Box::new({{{name}}}){{/isModel}}{{/required}},


### PR DESCRIPTION
When generating the combined oneOf struct ensure the struct can form a valid request.

Reproduction steps:
- `java -jar ./modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g rust -i ./openapi.yaml`
```yaml
openapi: 3.0.1

info:
  version: "1"
  title: rust one-of fix
paths: {}
components:
  schemas:
    Foo:
      x-one-of-name: Foo
      oneOf:
        - type: object
          required:
            - field_one
          properties:
            field_one:
              type: string
            field_two:
              type: string
        - type: object
          required:
            - field_three
          properties:
            field_three:
              type: number
    Bar:
      type: object
      required:
        - two
      properties:
        one:
          type: string
        two:
          type: string
```
- Observe `./src/models/foo.rs`

Expected behavior: Able to fill in struct fields in such a way that creates a valid request
Actual behavior: Impossible to fill the struct Foo to make it a valid schema (as BOTH required fields (field_one and field_three) are required to be filled in rust, yet the openapi schema only allows one or the other to be set.

Related issue: https://github.com/OpenAPITools/openapi-generator/issues/9497

Ideally oneOf would be represented as an enum. Presently the oneOf implementation is unusable (as described by @cortopy), this PR would at least makes it usable, but requires the rust api consumer to know what a valid schema object is (aka which optional types to populate to form a valid response). 

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. (cc @frol @farcaller @richardwhiuk @paladinzh )
