### PR TITLE
 Put null values into serialized output in dart2 generator 

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -90,11 +90,15 @@ class {{{classname}}} {
       {{/isDate}}
     {{/isDateTime}}
     {{#isNullable}}
+    } else {
+      _json[r'{{{baseName}}}'] = null;
     }
     {{/isNullable}}
     {{^isNullable}}
       {{^required}}
         {{^defaultValue}}
+    } else {
+      _json[r'{{{baseName}}}'] = null;
     }
         {{/defaultValue}}
       {{/required}}

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -62,12 +62,18 @@ class ApiResponse {
     final _json = <String, dynamic>{};
     if (code != null) {
       _json[r'code'] = code;
+    } else {
+      _json[r'code'] = null;
     }
     if (type != null) {
       _json[r'type'] = type;
+    } else {
+      _json[r'type'] = null;
     }
     if (message != null) {
       _json[r'message'] = message;
+    } else {
+      _json[r'message'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -51,9 +51,13 @@ class Category {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (name != null) {
       _json[r'name'] = name;
+    } else {
+      _json[r'name'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -84,18 +84,28 @@ class Order {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (petId != null) {
       _json[r'petId'] = petId;
+    } else {
+      _json[r'petId'] = null;
     }
     if (quantity != null) {
       _json[r'quantity'] = quantity;
+    } else {
+      _json[r'quantity'] = null;
     }
     if (shipDate != null) {
       _json[r'shipDate'] = shipDate!.toUtc().toIso8601String();
+    } else {
+      _json[r'shipDate'] = null;
     }
     if (status != null) {
       _json[r'status'] = status;
+    } else {
+      _json[r'status'] = null;
     }
       _json[r'complete'] = complete;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -72,15 +72,21 @@ class Pet {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (category != null) {
       _json[r'category'] = category;
+    } else {
+      _json[r'category'] = null;
     }
       _json[r'name'] = name;
       _json[r'photoUrls'] = photoUrls;
       _json[r'tags'] = tags;
     if (status != null) {
       _json[r'status'] = status;
+    } else {
+      _json[r'status'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -51,9 +51,13 @@ class Tag {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (name != null) {
       _json[r'name'] = name;
+    } else {
+      _json[r'name'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -118,27 +118,43 @@ class User {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (username != null) {
       _json[r'username'] = username;
+    } else {
+      _json[r'username'] = null;
     }
     if (firstName != null) {
       _json[r'firstName'] = firstName;
+    } else {
+      _json[r'firstName'] = null;
     }
     if (lastName != null) {
       _json[r'lastName'] = lastName;
+    } else {
+      _json[r'lastName'] = null;
     }
     if (email != null) {
       _json[r'email'] = email;
+    } else {
+      _json[r'email'] = null;
     }
     if (password != null) {
       _json[r'password'] = password;
+    } else {
+      _json[r'password'] = null;
     }
     if (phone != null) {
       _json[r'phone'] = phone;
+    } else {
+      _json[r'phone'] = null;
     }
     if (userStatus != null) {
       _json[r'userStatus'] = userStatus;
+    } else {
+      _json[r'userStatus'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
@@ -45,9 +45,13 @@ class AllOfWithSingleRef {
     final _json = <String, dynamic>{};
     if (username != null) {
       _json[r'username'] = username;
+    } else {
+      _json[r'username'] = null;
     }
     if (singleRefType != null) {
       _json[r'SingleRefType'] = singleRefType;
+    } else {
+      _json[r'SingleRefType'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
@@ -62,12 +62,18 @@ class ApiResponse {
     final _json = <String, dynamic>{};
     if (code != null) {
       _json[r'code'] = code;
+    } else {
+      _json[r'code'] = null;
     }
     if (type != null) {
       _json[r'type'] = type;
+    } else {
+      _json[r'type'] = null;
     }
     if (message != null) {
       _json[r'message'] = message;
+    } else {
+      _json[r'message'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -96,21 +96,33 @@ class Capitalization {
     final _json = <String, dynamic>{};
     if (smallCamel != null) {
       _json[r'smallCamel'] = smallCamel;
+    } else {
+      _json[r'smallCamel'] = null;
     }
     if (capitalCamel != null) {
       _json[r'CapitalCamel'] = capitalCamel;
+    } else {
+      _json[r'CapitalCamel'] = null;
     }
     if (smallSnake != null) {
       _json[r'small_Snake'] = smallSnake;
+    } else {
+      _json[r'small_Snake'] = null;
     }
     if (capitalSnake != null) {
       _json[r'Capital_Snake'] = capitalSnake;
+    } else {
+      _json[r'Capital_Snake'] = null;
     }
     if (sCAETHFlowPoints != null) {
       _json[r'SCA_ETH_Flow_Points'] = sCAETHFlowPoints;
+    } else {
+      _json[r'SCA_ETH_Flow_Points'] = null;
     }
     if (ATT_NAME != null) {
       _json[r'ATT_NAME'] = ATT_NAME;
+    } else {
+      _json[r'ATT_NAME'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
@@ -52,6 +52,8 @@ class Cat {
       _json[r'color'] = color;
     if (declawed != null) {
       _json[r'declawed'] = declawed;
+    } else {
+      _json[r'declawed'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat_all_of.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat_all_of.dart
@@ -40,6 +40,8 @@ class CatAllOf {
     final _json = <String, dynamic>{};
     if (declawed != null) {
       _json[r'declawed'] = declawed;
+    } else {
+      _json[r'declawed'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
@@ -45,6 +45,8 @@ class Category {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
       _json[r'name'] = name;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
@@ -40,6 +40,8 @@ class ClassModel {
     final _json = <String, dynamic>{};
     if (class_ != null) {
       _json[r'_class'] = class_;
+    } else {
+      _json[r'_class'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
@@ -40,6 +40,8 @@ class DeprecatedObject {
     final _json = <String, dynamic>{};
     if (name != null) {
       _json[r'name'] = name;
+    } else {
+      _json[r'name'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
@@ -52,6 +52,8 @@ class Dog {
       _json[r'color'] = color;
     if (breed != null) {
       _json[r'breed'] = breed;
+    } else {
+      _json[r'breed'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog_all_of.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog_all_of.dart
@@ -40,6 +40,8 @@ class DogAllOf {
     final _json = <String, dynamic>{};
     if (breed != null) {
       _json[r'breed'] = breed;
+    } else {
+      _json[r'breed'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -39,6 +39,8 @@ class EnumArrays {
     final _json = <String, dynamic>{};
     if (justSymbol != null) {
       _json[r'just_symbol'] = justSymbol;
+    } else {
+      _json[r'just_symbol'] = null;
     }
       _json[r'array_enum'] = arrayEnum;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -87,25 +87,39 @@ class EnumTest {
     final _json = <String, dynamic>{};
     if (enumString != null) {
       _json[r'enum_string'] = enumString;
+    } else {
+      _json[r'enum_string'] = null;
     }
       _json[r'enum_string_required'] = enumStringRequired;
     if (enumInteger != null) {
       _json[r'enum_integer'] = enumInteger;
+    } else {
+      _json[r'enum_integer'] = null;
     }
     if (enumNumber != null) {
       _json[r'enum_number'] = enumNumber;
+    } else {
+      _json[r'enum_number'] = null;
     }
     if (outerEnum != null) {
       _json[r'outerEnum'] = outerEnum;
+    } else {
+      _json[r'outerEnum'] = null;
     }
     if (outerEnumInteger != null) {
       _json[r'outerEnumInteger'] = outerEnumInteger;
+    } else {
+      _json[r'outerEnumInteger'] = null;
     }
     if (outerEnumDefaultValue != null) {
       _json[r'outerEnumDefaultValue'] = outerEnumDefaultValue;
+    } else {
+      _json[r'outerEnumDefaultValue'] = null;
     }
     if (outerEnumIntegerDefaultValue != null) {
       _json[r'outerEnumIntegerDefaultValue'] = outerEnumIntegerDefaultValue;
+    } else {
+      _json[r'outerEnumIntegerDefaultValue'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -45,6 +45,8 @@ class FileSchemaTestClass {
     final _json = <String, dynamic>{};
     if (file != null) {
       _json[r'file'] = file;
+    } else {
+      _json[r'file'] = null;
     }
       _json[r'files'] = files;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
@@ -40,6 +40,8 @@ class FooGetDefaultResponse {
     final _json = <String, dynamic>{};
     if (string != null) {
       _json[r'string'] = string;
+    } else {
+      _json[r'string'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -193,43 +193,67 @@ class FormatTest {
     final _json = <String, dynamic>{};
     if (integer != null) {
       _json[r'integer'] = integer;
+    } else {
+      _json[r'integer'] = null;
     }
     if (int32 != null) {
       _json[r'int32'] = int32;
+    } else {
+      _json[r'int32'] = null;
     }
     if (int64 != null) {
       _json[r'int64'] = int64;
+    } else {
+      _json[r'int64'] = null;
     }
       _json[r'number'] = number;
     if (float != null) {
       _json[r'float'] = float;
+    } else {
+      _json[r'float'] = null;
     }
     if (double_ != null) {
       _json[r'double'] = double_;
+    } else {
+      _json[r'double'] = null;
     }
     if (decimal != null) {
       _json[r'decimal'] = decimal;
+    } else {
+      _json[r'decimal'] = null;
     }
     if (string != null) {
       _json[r'string'] = string;
+    } else {
+      _json[r'string'] = null;
     }
       _json[r'byte'] = byte;
     if (binary != null) {
       _json[r'binary'] = binary;
+    } else {
+      _json[r'binary'] = null;
     }
       _json[r'date'] = _dateFormatter.format(date.toUtc());
     if (dateTime != null) {
       _json[r'dateTime'] = dateTime!.toUtc().toIso8601String();
+    } else {
+      _json[r'dateTime'] = null;
     }
     if (uuid != null) {
       _json[r'uuid'] = uuid;
+    } else {
+      _json[r'uuid'] = null;
     }
       _json[r'password'] = password;
     if (patternWithDigits != null) {
       _json[r'pattern_with_digits'] = patternWithDigits;
+    } else {
+      _json[r'pattern_with_digits'] = null;
     }
     if (patternWithDigitsAndDelimiter != null) {
       _json[r'pattern_with_digits_and_delimiter'] = patternWithDigitsAndDelimiter;
+    } else {
+      _json[r'pattern_with_digits_and_delimiter'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -51,9 +51,13 @@ class HasOnlyReadOnly {
     final _json = <String, dynamic>{};
     if (bar != null) {
       _json[r'bar'] = bar;
+    } else {
+      _json[r'bar'] = null;
     }
     if (foo != null) {
       _json[r'foo'] = foo;
+    } else {
+      _json[r'foo'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -34,6 +34,8 @@ class HealthCheckResult {
     final _json = <String, dynamic>{};
     if (nullableMessage != null) {
       _json[r'NullableMessage'] = nullableMessage;
+    } else {
+      _json[r'NullableMessage'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -56,9 +56,13 @@ class MixedPropertiesAndAdditionalPropertiesClass {
     final _json = <String, dynamic>{};
     if (uuid != null) {
       _json[r'uuid'] = uuid;
+    } else {
+      _json[r'uuid'] = null;
     }
     if (dateTime != null) {
       _json[r'dateTime'] = dateTime!.toUtc().toIso8601String();
+    } else {
+      _json[r'dateTime'] = null;
     }
       _json[r'map'] = map;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -51,9 +51,13 @@ class Model200Response {
     final _json = <String, dynamic>{};
     if (name != null) {
       _json[r'name'] = name;
+    } else {
+      _json[r'name'] = null;
     }
     if (class_ != null) {
       _json[r'class'] = class_;
+    } else {
+      _json[r'class'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
@@ -40,6 +40,8 @@ class ModelClient {
     final _json = <String, dynamic>{};
     if (client != null) {
       _json[r'client'] = client;
+    } else {
+      _json[r'client'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
@@ -41,6 +41,8 @@ class ModelFile {
     final _json = <String, dynamic>{};
     if (sourceURI != null) {
       _json[r'sourceURI'] = sourceURI;
+    } else {
+      _json[r'sourceURI'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
@@ -40,6 +40,8 @@ class ModelList {
     final _json = <String, dynamic>{};
     if (n123list != null) {
       _json[r'123-list'] = n123list;
+    } else {
+      _json[r'123-list'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
@@ -40,6 +40,8 @@ class ModelReturn {
     final _json = <String, dynamic>{};
     if (return_ != null) {
       _json[r'return'] = return_;
+    } else {
+      _json[r'return'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
@@ -68,12 +68,18 @@ class Name {
       _json[r'name'] = name;
     if (snakeCase != null) {
       _json[r'snake_case'] = snakeCase;
+    } else {
+      _json[r'snake_case'] = null;
     }
     if (property != null) {
       _json[r'property'] = property;
+    } else {
+      _json[r'property'] = null;
     }
     if (n123number != null) {
       _json[r'123Number'] = n123number;
+    } else {
+      _json[r'123Number'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -89,34 +89,54 @@ class NullableClass {
     final _json = <String, dynamic>{};
     if (integerProp != null) {
       _json[r'integer_prop'] = integerProp;
+    } else {
+      _json[r'integer_prop'] = null;
     }
     if (numberProp != null) {
       _json[r'number_prop'] = numberProp;
+    } else {
+      _json[r'number_prop'] = null;
     }
     if (booleanProp != null) {
       _json[r'boolean_prop'] = booleanProp;
+    } else {
+      _json[r'boolean_prop'] = null;
     }
     if (stringProp != null) {
       _json[r'string_prop'] = stringProp;
+    } else {
+      _json[r'string_prop'] = null;
     }
     if (dateProp != null) {
       _json[r'date_prop'] = _dateFormatter.format(dateProp!.toUtc());
+    } else {
+      _json[r'date_prop'] = null;
     }
     if (datetimeProp != null) {
       _json[r'datetime_prop'] = datetimeProp!.toUtc().toIso8601String();
+    } else {
+      _json[r'datetime_prop'] = null;
     }
     if (arrayNullableProp != null) {
       _json[r'array_nullable_prop'] = arrayNullableProp;
+    } else {
+      _json[r'array_nullable_prop'] = null;
     }
     if (arrayAndItemsNullableProp != null) {
       _json[r'array_and_items_nullable_prop'] = arrayAndItemsNullableProp;
+    } else {
+      _json[r'array_and_items_nullable_prop'] = null;
     }
       _json[r'array_items_nullable'] = arrayItemsNullable;
     if (objectNullableProp != null) {
       _json[r'object_nullable_prop'] = objectNullableProp;
+    } else {
+      _json[r'object_nullable_prop'] = null;
     }
     if (objectAndItemsNullableProp != null) {
       _json[r'object_and_items_nullable_prop'] = objectAndItemsNullableProp;
+    } else {
+      _json[r'object_and_items_nullable_prop'] = null;
     }
       _json[r'object_items_nullable'] = objectItemsNullable;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -40,6 +40,8 @@ class NumberOnly {
     final _json = <String, dynamic>{};
     if (justNumber != null) {
       _json[r'JustNumber'] = justNumber;
+    } else {
+      _json[r'JustNumber'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -67,12 +67,18 @@ class ObjectWithDeprecatedFields {
     final _json = <String, dynamic>{};
     if (uuid != null) {
       _json[r'uuid'] = uuid;
+    } else {
+      _json[r'uuid'] = null;
     }
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (deprecatedRef != null) {
       _json[r'deprecatedRef'] = deprecatedRef;
+    } else {
+      _json[r'deprecatedRef'] = null;
     }
       _json[r'bars'] = bars;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -84,18 +84,28 @@ class Order {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (petId != null) {
       _json[r'petId'] = petId;
+    } else {
+      _json[r'petId'] = null;
     }
     if (quantity != null) {
       _json[r'quantity'] = quantity;
+    } else {
+      _json[r'quantity'] = null;
     }
     if (shipDate != null) {
       _json[r'shipDate'] = shipDate!.toUtc().toIso8601String();
+    } else {
+      _json[r'shipDate'] = null;
     }
     if (status != null) {
       _json[r'status'] = status;
+    } else {
+      _json[r'status'] = null;
     }
       _json[r'complete'] = complete;
     return _json;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -62,12 +62,18 @@ class OuterComposite {
     final _json = <String, dynamic>{};
     if (myNumber != null) {
       _json[r'my_number'] = myNumber;
+    } else {
+      _json[r'my_number'] = null;
     }
     if (myString != null) {
       _json[r'my_string'] = myString;
+    } else {
+      _json[r'my_string'] = null;
     }
     if (myBoolean != null) {
       _json[r'my_boolean'] = myBoolean;
+    } else {
+      _json[r'my_boolean'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -72,15 +72,21 @@ class Pet {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (category != null) {
       _json[r'category'] = category;
+    } else {
+      _json[r'category'] = null;
     }
       _json[r'name'] = name;
       _json[r'photoUrls'] = photoUrls;
       _json[r'tags'] = tags;
     if (status != null) {
       _json[r'status'] = status;
+    } else {
+      _json[r'status'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -51,9 +51,13 @@ class ReadOnlyFirst {
     final _json = <String, dynamic>{};
     if (bar != null) {
       _json[r'bar'] = bar;
+    } else {
+      _json[r'bar'] = null;
     }
     if (baz != null) {
       _json[r'baz'] = baz;
+    } else {
+      _json[r'baz'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -40,6 +40,8 @@ class SpecialModelName {
     final _json = <String, dynamic>{};
     if (dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket != null) {
       _json[r'$special[property.name]'] = dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket;
+    } else {
+      _json[r'$special[property.name]'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
@@ -51,9 +51,13 @@ class Tag {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (name != null) {
       _json[r'name'] = name;
+    } else {
+      _json[r'name'] = null;
     }
     return _json;
   }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
@@ -118,27 +118,43 @@ class User {
     final _json = <String, dynamic>{};
     if (id != null) {
       _json[r'id'] = id;
+    } else {
+      _json[r'id'] = null;
     }
     if (username != null) {
       _json[r'username'] = username;
+    } else {
+      _json[r'username'] = null;
     }
     if (firstName != null) {
       _json[r'firstName'] = firstName;
+    } else {
+      _json[r'firstName'] = null;
     }
     if (lastName != null) {
       _json[r'lastName'] = lastName;
+    } else {
+      _json[r'lastName'] = null;
     }
     if (email != null) {
       _json[r'email'] = email;
+    } else {
+      _json[r'email'] = null;
     }
     if (password != null) {
       _json[r'password'] = password;
+    } else {
+      _json[r'password'] = null;
     }
     if (phone != null) {
       _json[r'phone'] = phone;
+    } else {
+      _json[r'phone'] = null;
     }
     if (userStatus != null) {
       _json[r'userStatus'] = userStatus;
+    } else {
+      _json[r'userStatus'] = null;
     }
     return _json;
   }


### PR DESCRIPTION
This change makes the output of deserialization the same as the raw response.  
I'm not sure you will accept this, but it's quite useful and also very logical to have.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela