### PR TITLE
[ts-angular]: added ts-ignore directive to `addToHttpParams` to avoid compilation errors

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -95,6 +95,7 @@ export class {{classname}} {
     }
 {{/hasSomeFormParams}}
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         {{#isQueryParamObjectFormatJson}}
         httpParams = this.addToHttpParamsRecursive(httpParams, value, key);

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/api/default.service.ts
@@ -51,6 +51,7 @@ export class DefaultService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/pet.service.ts
@@ -66,6 +66,7 @@ export class PetService {
         return false;
     }
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/store.service.ts
@@ -51,6 +51,7 @@ export class StoreService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/user.service.ts
@@ -51,6 +51,7 @@ export class UserService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
@@ -66,6 +66,7 @@ export class PetService {
         return false;
     }
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
@@ -51,6 +51,7 @@ export class StoreService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
@@ -51,6 +51,7 @@ export class UserService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -66,6 +66,7 @@ export class PetService {
         return false;
     }
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
@@ -51,6 +51,7 @@ export class StoreService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
@@ -51,6 +51,7 @@ export class UserService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/api/default.service.ts
@@ -51,6 +51,7 @@ export class DefaultService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/pet.service.ts
@@ -66,6 +66,7 @@ export class PetService {
         return false;
     }
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/store.service.ts
@@ -51,6 +51,7 @@ export class StoreService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/user.service.ts
@@ -51,6 +51,7 @@ export class UserService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
@@ -66,6 +66,7 @@ export class PetService {
         return false;
     }
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
@@ -51,6 +51,7 @@ export class StoreService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
@@ -51,6 +51,7 @@ export class UserService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -66,6 +66,7 @@ export class PetService {
         return false;
     }
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
@@ -51,6 +51,7 @@ export class StoreService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
@@ -51,6 +51,7 @@ export class UserService {
     }
 
 
+    // @ts-ignore
     private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
         if (typeof value === "object" && value instanceof Date === false) {
             httpParams = this.addToHttpParamsRecursive(httpParams, value);


### PR DESCRIPTION
The unused method doesn't pass stricter TS compiler settings (`noUnusedLocals`).

![image](https://user-images.githubusercontent.com/55280588/173530253-a09c83b9-58ba-4b4c-aeca-c2e59f1de443.png)

Tested by using the modified template as an override in project.

A similar change was made in #10713

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
