### PR TITLE
[java][okhttp-gson] Add streaming support in group parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -472,10 +472,17 @@ public class {{classname}} {
         {{#isDeprecated}}
         @Deprecated
         {{/isDeprecated}}
+        {{^vendorExtensions.x-streaming}}
         public {{{returnType}}}{{^returnType}}void{{/returnType}} execute() throws ApiException {
             {{#returnType}}ApiResponse<{{{.}}}> localVarResp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{#returnType}}
             return localVarResp.getData();{{/returnType}}
         }
+        {{/vendorExtensions.x-streaming}}
+        {{#vendorExtensions.x-streaming}}
+        public InputStream execute() throws ApiException {
+            return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+        }
+        {{/vendorExtensions.x-streaming}}
 
         /**
          * Execute {{operationId}} request with HTTP info returned
@@ -497,9 +504,16 @@ public class {{classname}} {
         {{#isDeprecated}}
         @Deprecated
         {{/isDeprecated}}
+        {{^vendorExtensions.x-streaming}}
         public ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> executeWithHttpInfo() throws ApiException {
             return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
         }
+        {{/vendorExtensions.x-streaming}}
+        {{#vendorExtensions.x-streaming}}
+        public InputStream executeWithHttpInfo() throws ApiException {
+            return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+        }
+        {{/vendorExtensions.x-streaming}}
 
         /**
          * Execute {{operationId}} request (asynchronously)

--- a/modules/openapi-generator/src/test/resources/3_0/streaming.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/streaming.yaml
@@ -23,6 +23,39 @@ paths:
             'application/json':
                schema:
                  $ref: "#/components/schemas/SomeObj"
+    get:
+      x-streaming: true
+      x-group-parameters: true
+      operationId: getPing
+      tags:
+      - ping
+      parameters:
+        - name: petId
+          in: query
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+               schema:
+                 $ref: "#/components/schemas/SomeObj"
 components:
   schemas:
     SomeObj:

--- a/samples/client/others/java/okhttp-gson-streaming/README.md
+++ b/samples/client/others/java/okhttp-gson-streaming/README.md
@@ -91,12 +91,17 @@ public class Example {
     defaultClient.setBasePath("http://localhost:8082");
 
     PingApi apiInstance = new PingApi(defaultClient);
-    SomeObj someObj = new SomeObj(); // SomeObj | 
+    Long petId = 56L; // Long | ID of pet that needs to be updated
+    String name = "name_example"; // String | Updated name of the pet
+    String status = "status_example"; // String | Updated status of the pet
     try {
-      SomeObj result = apiInstance.postPing(someObj);
+      SomeObj result = apiInstance.getPing(petId)
+            .name(name)
+            .status(status)
+            .execute();
       System.out.println(result);
     } catch (ApiException e) {
-      System.err.println("Exception when calling PingApi#postPing");
+      System.err.println("Exception when calling PingApi#getPing");
       System.err.println("Status code: " + e.getCode());
       System.err.println("Reason: " + e.getResponseBody());
       System.err.println("Response headers: " + e.getResponseHeaders());
@@ -113,6 +118,7 @@ All URIs are relative to *http://localhost:8082*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*PingApi* | [**getPing**](docs/PingApi.md#getPing) | **GET** /ping | 
 *PingApi* | [**postPing**](docs/PingApi.md#postPing) | **POST** /ping | 
 
 

--- a/samples/client/others/java/okhttp-gson-streaming/api/openapi.yaml
+++ b/samples/client/others/java/okhttp-gson-streaming/api/openapi.yaml
@@ -6,6 +6,36 @@ servers:
 - url: http://localhost:8082/
 paths:
   /ping:
+    get:
+      operationId: getPing
+      parameters:
+      - description: ID of pet that needs to be updated
+        explode: true
+        in: query
+        name: petId
+        required: true
+        schema:
+          format: int64
+          type: integer
+        style: form
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/getPing_request'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SomeObj'
+          description: OK
+      tags:
+      - ping
+      x-streaming: true
+      x-group-parameters: true
+      x-content-type: application/x-www-form-urlencoded
+      x-accepts: application/json
     post:
       operationId: postPing
       requestBody:
@@ -48,6 +78,15 @@ components:
         active:
           type: boolean
         type:
+          type: string
+      type: object
+    getPing_request:
+      properties:
+        name:
+          description: Updated name of the pet
+          type: string
+        status:
+          description: Updated status of the pet
           type: string
       type: object
 

--- a/samples/client/others/java/okhttp-gson-streaming/docs/PingApi.md
+++ b/samples/client/others/java/okhttp-gson-streaming/docs/PingApi.md
@@ -4,8 +4,76 @@ All URIs are relative to *http://localhost:8082*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**getPing**](PingApi.md#getPing) | **GET** /ping |  |
 | [**postPing**](PingApi.md#postPing) | **POST** /ping |  |
 
+
+<a name="getPing"></a>
+# **getPing**
+> SomeObj getPing(petId).name(name).status(status).execute();
+
+
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PingApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost:8082");
+
+    PingApi apiInstance = new PingApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet that needs to be updated
+    String name = "name_example"; // String | Updated name of the pet
+    String status = "status_example"; // String | Updated status of the pet
+    try {
+      SomeObj result = apiInstance.getPing(petId)
+            .name(name)
+            .status(status)
+            .execute();
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PingApi#getPing");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **petId** | **Long**| ID of pet that needs to be updated | |
+| **name** | **String**| Updated name of the pet | [optional] |
+| **status** | **String**| Updated status of the pet | [optional] |
+
+### Return type
+
+[**SomeObj**](SomeObj.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | OK |  -  |
 
 <a name="postPing"></a>
 # **postPing**

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/api/PingApi.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/api/PingApi.java
@@ -74,6 +74,194 @@ public class PingApi {
         this.localCustomBaseUrl = customBaseUrl;
     }
 
+    private okhttp3.Call getPingCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/ping";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (name != null) {
+            localVarFormParams.put("name", name);
+        }
+
+        if (status != null) {
+            localVarFormParams.put("status", status);
+        }
+
+        if (petId != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("petId", petId));
+        }
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            "application/x-www-form-urlencoded"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call getPingValidateBeforeCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+        
+        // verify the required parameter 'petId' is set
+        if (petId == null) {
+            throw new ApiException("Missing the required parameter 'petId' when calling getPing(Async)");
+        }
+        
+
+        okhttp3.Call localVarCall = getPingCall(petId, name, status, _callback);
+        return localVarCall;
+
+    }
+
+
+    private InputStream getPingWithHttpInfo(Long petId, String name, String status) throws ApiException {
+        okhttp3.Call localVarCall = getPingValidateBeforeCall(petId, name, status, null);
+        Type localVarReturnType = new TypeToken<SomeObj>(){}.getType();
+        return localVarApiClient.executeStream(localVarCall, localVarReturnType);
+    }
+    
+    private okhttp3.Call getPingAsync(Long petId, String name, String status, final ApiCallback<SomeObj> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = getPingValidateBeforeCall(petId, name, status, _callback);
+        Type localVarReturnType = new TypeToken<SomeObj>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+
+    public class APIgetPingRequest {
+        private final Long petId;
+        private String name;
+        private String status;
+
+        private APIgetPingRequest(Long petId) {
+            this.petId = petId;
+        }
+
+        /**
+         * Set name
+         * @param name Updated name of the pet (optional)
+         * @return APIgetPingRequest
+         */
+        public APIgetPingRequest name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Set status
+         * @param status Updated status of the pet (optional)
+         * @return APIgetPingRequest
+         */
+        public APIgetPingRequest status(String status) {
+            this.status = status;
+            return this;
+        }
+
+        /**
+         * Build call for getPing
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return getPingCall(petId, name, status, _callback);
+        }
+
+        /**
+         * Execute getPing request
+         * @return SomeObj
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+         </table>
+         */
+        public InputStream execute() throws ApiException {
+            return getPingWithHttpInfo(petId, name, status);
+        }
+
+        /**
+         * Execute getPing request with HTTP info returned
+         * @return ApiResponse&lt;SomeObj&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+         </table>
+         */
+        public InputStream executeWithHttpInfo() throws ApiException {
+            return getPingWithHttpInfo(petId, name, status);
+        }
+
+        /**
+         * Execute getPing request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call executeAsync(final ApiCallback<SomeObj> _callback) throws ApiException {
+            return getPingAsync(petId, name, status, _callback);
+        }
+    }
+
+    /**
+     * 
+     * 
+     * @param petId ID of pet that needs to be updated (required)
+     * @return APIgetPingRequest
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
+     </table>
+     */
+    public APIgetPingRequest getPing(Long petId) {
+        return new APIgetPingRequest(petId);
+    }
     /**
      * Build call for postPing
      * @param someObj  (optional)


### PR DESCRIPTION
Add streaming support in group parameters (useSingleRequestParameter=true to enable `x-group-parameters` in the operations)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
