### PR TITLE
[C][Client] Set the default value for the null json

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
@@ -28,7 +28,7 @@ cJSON *object_convertToJSON(object_t *object) {
     }
 
     if (!object->temporary) {
-        return cJSON_Parse("{}");
+        return cJSON_Parse("null");
     }
 
     return cJSON_Parse(object->temporary);

--- a/samples/client/petstore/c/model/object.c
+++ b/samples/client/petstore/c/model/object.c
@@ -28,7 +28,7 @@ cJSON *object_convertToJSON(object_t *object) {
     }
 
     if (!object->temporary) {
-        return cJSON_Parse("{}");
+        return cJSON_Parse("null");
     }
 
     return cJSON_Parse(object->temporary);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
@wing328 @zhemant @michelealbano

The PR https://github.com/OpenAPITools/openapi-generator/pull/12557 adds the support for the free-form object. When it is merged to the downstream project https://github.com/kubernetes-client/c, I received a comment https://github.com/kubernetes-client/c/pull/128#discussion_r898144002 that the default value for the null json should be `"null"` other than `"{}"`

cc  @harlequin-tech

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
