### PR TITLE
fix typescript node default enum

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -345,4 +345,10 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
         }
         return def;
     }
+
+    @Override
+    public String toEnumDefaultValue(String value, String datatype) {
+        return datatype + "." + value;
+    }
+
 }

--- a/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
@@ -19,7 +19,7 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     * {{{.}}}
     */
 {{/description}}
-    '{{name}}'{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+    '{{name}}'{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{#defaultValue}} = {{#isEnum}}{{classname}}.{{/isEnum}}{{{.}}}{{/defaultValue}};
 {{/vars}}
 
     {{#discriminator}}


### PR DESCRIPTION
- Default enum value and type are seperated by .
- classname is added to enum default property

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This is a fix for the bug mentioned here #12634.
I changed the default enum value to be <datatype>.<value>, and edited model.mustache template accordingly.
For testing I used the following yaml schema and generation command. I made sure that before the fix the client wasn't generated correctly and that the problem was solved after the fix.

Fixes #12634

Opeanapi schema:
```yaml
openapi: "3.0.0"
info:
  version: "1.0.0"
  title: "Test default enum value"
paths:
  /eat:
    post:
      requestBody:
        content:
          application/json:
            schema:
              $ref: "#/components/schemas/Fruit"
      responses:
        200:
          description: "Yummy"

components:
  schemas:
    Fruit:
      type: "object"
      properties:
        fruit:
          type: "string"
          enum: [
              "melon",
              "apple"
            ]
          default: "apple"
```
Generation command:
```
openapi-generator-cli generate -g typescript-node -i openapi.yml --additional-properties=npmName=example
```
Committee mentions: @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka 
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


