### PR TITLE
[cpp-qt-client] Add support for AnyType objects

### DIFF
--- a/docs/generators/cpp-qt-client.md
+++ b/docs/generators/cpp-qt-client.md
@@ -38,6 +38,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Imports |
 | ---------- | ------- |
 |OAIHttpFileElement|#include &quot;OAIHttpFileElement.h&quot;|
+|QJsonValue|#include &lt;QJsonValue&gt;|
 
 
 ## INSTANTIATION TYPES

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQtClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQtClientCodegen.java
@@ -108,7 +108,9 @@ public class CppQtClientCodegen extends CppQtAbstractCodegen implements CodegenC
             supportingFiles.add(new SupportingFile("Project.mustache", sourceFolder, "client.pri"));
         }
         typeMapping.put("file", PREFIX + "HttpFileElement");
+        typeMapping.put("AnyType", "QJsonValue");
         importMapping.put(PREFIX + "HttpFileElement", "#include \"" + PREFIX + "HttpFileElement.h\"");
+        importMapping.put("QJsonValue", "#include <QJsonValue>");
     }
 
     @Override
@@ -140,7 +142,9 @@ public class CppQtClientCodegen extends CppQtAbstractCodegen implements CodegenC
 
 
             typeMapping.put("file", modelNamePrefix + "HttpFileElement");
+            typeMapping.put("AnyType", "QJsonValue");
             importMapping.put(modelNamePrefix + "HttpFileElement", "#include \"" + modelNamePrefix + "HttpFileElement.h\"");
+            importMapping.put("QJsonValue", "#include <QJsonValue>");
             if (optionalProjectFileFlag) {
                 supportingFiles.add(new SupportingFile("Project.mustache", sourceFolder, modelNamePrefix + "client.pri"));
             }

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/helpers-body.mustache
@@ -186,6 +186,10 @@ QJsonValue toJsonValue(const {{prefix}}HttpFileElement &value) {
     return value.asJsonValue();
 }
 
+QJsonValue toJsonValue(const QJsonValue &value) {
+    return value;
+}
+
 bool fromStringValue(const QString &inStr, QString &value) {
     value.clear();
     value.append(inStr);
@@ -413,6 +417,11 @@ bool fromJsonValue({{prefix}}Enum &value, const QJsonValue &jval) {
 
 bool fromJsonValue({{prefix}}HttpFileElement &value, const QJsonValue &jval) {
     return value.fromJsonValue(jval);
+}
+
+bool fromJsonValue(QJsonValue &value, const QJsonValue &jval) {
+    value = jval;
+    return true;
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/helpers-header.mustache
@@ -127,6 +127,7 @@ QJsonValue toJsonValue(const double &value);
 QJsonValue toJsonValue(const {{prefix}}Object &value);
 QJsonValue toJsonValue(const {{prefix}}Enum &value);
 QJsonValue toJsonValue(const {{prefix}}HttpFileElement &value);
+QJsonValue toJsonValue(const QJsonValue &value);
 
 template <typename T>
 QJsonValue toJsonValue(const QList<T> &val) {
@@ -213,6 +214,7 @@ bool fromJsonValue(double &value, const QJsonValue &jval);
 bool fromJsonValue({{prefix}}Object &value, const QJsonValue &jval);
 bool fromJsonValue({{prefix}}Enum &value, const QJsonValue &jval);
 bool fromJsonValue({{prefix}}HttpFileElement &value, const QJsonValue &jval);
+bool fromJsonValue(QJsonValue &value, const QJsonValue &jval);
 
 template <typename T>
 bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {

--- a/samples/client/petstore/cpp-qt/client/PFXHelpers.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXHelpers.cpp
@@ -194,6 +194,10 @@ QJsonValue toJsonValue(const PFXHttpFileElement &value) {
     return value.asJsonValue();
 }
 
+QJsonValue toJsonValue(const QJsonValue &value) {
+    return value;
+}
+
 bool fromStringValue(const QString &inStr, QString &value) {
     value.clear();
     value.append(inStr);
@@ -421,6 +425,11 @@ bool fromJsonValue(PFXEnum &value, const QJsonValue &jval) {
 
 bool fromJsonValue(PFXHttpFileElement &value, const QJsonValue &jval) {
     return value.fromJsonValue(jval);
+}
+
+bool fromJsonValue(QJsonValue &value, const QJsonValue &jval) {
+    value = jval;
+    return true;
 }
 
 } // namespace test_namespace

--- a/samples/client/petstore/cpp-qt/client/PFXHelpers.h
+++ b/samples/client/petstore/cpp-qt/client/PFXHelpers.h
@@ -135,6 +135,7 @@ QJsonValue toJsonValue(const double &value);
 QJsonValue toJsonValue(const PFXObject &value);
 QJsonValue toJsonValue(const PFXEnum &value);
 QJsonValue toJsonValue(const PFXHttpFileElement &value);
+QJsonValue toJsonValue(const QJsonValue &value);
 
 template <typename T>
 QJsonValue toJsonValue(const QList<T> &val) {
@@ -221,6 +222,7 @@ bool fromJsonValue(double &value, const QJsonValue &jval);
 bool fromJsonValue(PFXObject &value, const QJsonValue &jval);
 bool fromJsonValue(PFXEnum &value, const QJsonValue &jval);
 bool fromJsonValue(PFXHttpFileElement &value, const QJsonValue &jval);
+bool fromJsonValue(QJsonValue &value, const QJsonValue &jval);
 
 template <typename T>
 bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {


### PR DESCRIPTION
Fix #12641

@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd

The cpp-qt-client generator generates invalid code when the OpenAPI document contains AnyType objects (example: `type: {}`).
I have replaced `AnyType` with `QJsonValue`, so that the correct type can be manually unpacked later.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
