### PR TITLE
[R] fix deserialization for models with special item names

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
@@ -158,17 +158,17 @@
     fromJSON = function({{classname}}Json) {
       {{classname}}Object <- jsonlite::fromJSON({{classname}}Json)
       {{#vars}}
-      if (!is.null({{classname}}Object$`{{name}}`)) {
+      if (!is.null({{classname}}Object$`{{baseName}}`)) {
         {{#isContainer}}
-        self$`{{name}}` <- ApiClient$new()$deserializeObj({{classname}}Object$`{{name}}`, "{{dataType}}", loadNamespace("{{packageName}}"))
+        self$`{{name}}` <- ApiClient$new()$deserializeObj({{classname}}Object$`{{baseName}}`, "{{dataType}}", loadNamespace("{{packageName}}"))
         {{/isContainer}}
         {{^isContainer}}
         {{#isPrimitiveType}}
-        self$`{{name}}` <- {{classname}}Object$`{{name}}`
+        self$`{{name}}` <- {{classname}}Object$`{{baseName}}`
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{name}}Object <- {{dataType}}$new()
-        {{name}}Object$fromJSON(jsonlite::toJSON({{classname}}Object${{name}}, auto_unbox = TRUE, digits = NA))
+        {{name}}Object$fromJSON(jsonlite::toJSON({{classname}}Object${{baseName}}, auto_unbox = TRUE, digits = NA))
         self$`{{name}}` <- {{name}}Object
         {{/isPrimitiveType}}
         {{/isContainer}}

--- a/samples/client/petstore/R/R/special.R
+++ b/samples/client/petstore/R/R/special.R
@@ -63,14 +63,14 @@ Special <- R6::R6Class(
     },
     fromJSON = function(SpecialJson) {
       SpecialObject <- jsonlite::fromJSON(SpecialJson)
-      if (!is.null(SpecialObject$`item_self`)) {
-        self$`item_self` <- SpecialObject$`item_self`
+      if (!is.null(SpecialObject$`self`)) {
+        self$`item_self` <- SpecialObject$`self`
       }
-      if (!is.null(SpecialObject$`item_private`)) {
-        self$`item_private` <- SpecialObject$`item_private`
+      if (!is.null(SpecialObject$`private`)) {
+        self$`item_private` <- SpecialObject$`private`
       }
-      if (!is.null(SpecialObject$`item_super`)) {
-        self$`item_super` <- SpecialObject$`item_super`
+      if (!is.null(SpecialObject$`super`)) {
+        self$`item_super` <- SpecialObject$`super`
       }
       self
     },

--- a/samples/client/petstore/R/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R/tests/testthat/test_petstore.R
@@ -139,6 +139,29 @@ test_that("Tests validateJSON", {
   
 })
 
+# test object with special item names: self, private, super
+test_that("Tests oneOf", {
+  special_json <-
+  '{"self": 123, "private": "red", "super": "something"}'
+
+  # test fromJSON
+  special <- Special$new()$fromJSON(special_json)
+  expect_equal(special$item_self, 123)
+  expect_equal(special$item_private, "red")
+  expect_equal(special$item_super, "something")
+
+  # test toJSONString 
+  expect_true(grepl('"private"', special$toJSONString()))
+  expect_true(grepl('"self"', special$toJSONString()))
+  expect_true(grepl('"super"', special$toJSONString()))
+
+  # round trip test
+  s1 <- Special$new()$fromJSONString(special_json)
+  s2 <- Special$new()$fromJSONString(s1$toJSONString())
+  expect_equal(s1, s2)
+
+})
+
 test_that("Tests oneOf", {
   basque_pig_json <-
   '{"className": "BasquePig", "color": "red"}'
@@ -153,8 +176,8 @@ test_that("Tests oneOf", {
     {"Name" : "Ada", "Occupation" : "Engineer"}
   ]'
 
-  original_danish_pig = DanishPig$new()$fromJSON(danish_pig_json)
-  original_basque_pig = BasquePig$new()$fromJSON(basque_pig_json)
+  original_danish_pig <- DanishPig$new()$fromJSON(danish_pig_json)
+  original_basque_pig <- BasquePig$new()$fromJSON(basque_pig_json)
 
   # test fromJSON, actual_tpye, actual_instance
   pig <- Pig$new()
@@ -208,8 +231,8 @@ test_that("Tests anyOf", {
     {"Name" : "Ada", "Occupation" : "Engineer"}
   ]'
 
-  original_danish_pig = DanishPig$new()$fromJSON(danish_pig_json)
-  original_basque_pig = BasquePig$new()$fromJSON(basque_pig_json)
+  original_danish_pig <- DanishPig$new()$fromJSON(danish_pig_json)
+  original_basque_pig <- BasquePig$new()$fromJSON(basque_pig_json)
 
   # test fromJSON, actual_tpye, actual_instance
   pig <- AnyOfPig$new()


### PR DESCRIPTION
- fix deserialization for models with special item names: private, self, super


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
