### PR TITLE
Fix regression of nullability on allOf with $ref

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3419,7 +3419,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (Boolean.FALSE.equals(p.getNullable())) {
             LOGGER.warn("Schema '{}' is any type, which includes the 'null' value. 'nullable' cannot be set to 'false'", p.getName());
         }
-        property.isNullable = true;
+        property.isNullable = ModelUtils.isNullable(p);
         if (languageSpecificPrimitives.contains(property.dataType)) {
             property.isPrimitiveType = true;
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
-        [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
+        [DataMember(Name = "anytype_1", EmitDefaultValue = false)]
         public Object Anytype1
         {
             get{ return _Anytype1;}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/User.cs
@@ -359,7 +359,7 @@ namespace Org.OpenAPITools.Model
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
-        [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
+        [DataMember(Name = "anyTypeProp", EmitDefaultValue = false)]
         public Object AnyTypeProp
         {
             get{ return _AnyTypeProp;}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
-        [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
+        [DataMember(Name = "anytype_1", EmitDefaultValue = false)]
         public Object Anytype1 { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/User.cs
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
-        [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
+        [DataMember(Name = "anyTypeProp", EmitDefaultValue = false)]
         public Object AnyTypeProp { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
-        [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
+        [DataMember(Name = "anytype_1", EmitDefaultValue = false)]
         public Object Anytype1 { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/User.cs
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
-        [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
+        [DataMember(Name = "anyTypeProp", EmitDefaultValue = false)]
         public Object AnyTypeProp { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
-        [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
+        [DataMember(Name = "anytype_1", EmitDefaultValue = false)]
         public Object Anytype1 { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/User.cs
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
-        [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
+        [DataMember(Name = "anyTypeProp", EmitDefaultValue = false)]
         public Object AnyTypeProp { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
-        [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
+        [DataMember(Name = "anytype_1", EmitDefaultValue = false)]
         public Object Anytype1 { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
@@ -131,7 +131,7 @@ namespace Org.OpenAPITools.Model
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
-        [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
+        [DataMember(Name = "anyTypeProp", EmitDefaultValue = false)]
         public Object AnyTypeProp { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
-        [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
+        [DataMember(Name = "anytype_1", EmitDefaultValue = false)]
         public Object Anytype1 { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/User.cs
@@ -130,7 +130,7 @@ namespace Org.OpenAPITools.Model
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
-        [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
+        [DataMember(Name = "anyTypeProp", EmitDefaultValue = false)]
         public Object AnyTypeProp { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/AllOfWithSingleRef.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/AllOfWithSingleRef.cs
@@ -33,7 +33,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets SingleRefType
         /// </summary>
-        [DataMember(Name="SingleRefType", EmitDefaultValue=true)]
+        [DataMember(Name="SingleRefType", EmitDefaultValue=false)]
         public SingleRefType? SingleRefType { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="AllOfWithSingleRef" /> class.
@@ -42,7 +42,6 @@ namespace Org.OpenAPITools.Model
         /// <param name="singleRefType">singleRefType.</param>
         public AllOfWithSingleRef(string username = default(string), SingleRefType? singleRefType = default(SingleRefType?))
         {
-            this.SingleRefType = singleRefType;
             this.Username = username;
             this.SingleRefType = singleRefType;
         }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
@@ -23,10 +23,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.client.model.SingleRefType;
-import org.openapitools.jackson.nullable.JsonNullable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.openapitools.jackson.nullable.JsonNullable;
-import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -43,7 +39,7 @@ public class AllOfWithSingleRef {
   private String username;
 
   public static final String JSON_PROPERTY_SINGLE_REF_TYPE = "SingleRefType";
-  private JsonNullable<SingleRefType> singleRefType = JsonNullable.<SingleRefType>undefined();
+  private SingleRefType singleRefType;
 
   public AllOfWithSingleRef() { 
   }
@@ -76,8 +72,8 @@ public class AllOfWithSingleRef {
 
 
   public AllOfWithSingleRef singleRefType(SingleRefType singleRefType) {
-    this.singleRefType = JsonNullable.<SingleRefType>of(singleRefType);
     
+    this.singleRefType = singleRefType;
     return this;
   }
 
@@ -87,26 +83,18 @@ public class AllOfWithSingleRef {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonIgnore
-
-  public SingleRefType getSingleRefType() {
-        return singleRefType.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_SINGLE_REF_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<SingleRefType> getSingleRefType_JsonNullable() {
+  public SingleRefType getSingleRefType() {
     return singleRefType;
   }
-  
-  @JsonProperty(JSON_PROPERTY_SINGLE_REF_TYPE)
-  public void setSingleRefType_JsonNullable(JsonNullable<SingleRefType> singleRefType) {
-    this.singleRefType = singleRefType;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_SINGLE_REF_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSingleRefType(SingleRefType singleRefType) {
-    this.singleRefType = JsonNullable.<SingleRefType>of(singleRefType);
+    this.singleRefType = singleRefType;
   }
 
 
@@ -120,23 +108,12 @@ public class AllOfWithSingleRef {
     }
     AllOfWithSingleRef allOfWithSingleRef = (AllOfWithSingleRef) o;
     return Objects.equals(this.username, allOfWithSingleRef.username) &&
-        equalsNullable(this.singleRefType, allOfWithSingleRef.singleRefType);
-  }
-
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+        Objects.equals(this.singleRefType, allOfWithSingleRef.singleRefType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(username, hashCodeNullable(singleRefType));
-  }
-
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
-      return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+    return Objects.hash(username, singleRefType);
   }
 
   @Override

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -27,10 +27,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.openapitools.jackson.nullable.JsonNullable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.openapitools.jackson.nullable.JsonNullable;
-import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.openapitools.client.JSON;
 
@@ -57,7 +53,7 @@ public class AdditionalPropertiesClass {
   private Map<String, Map<String, String>> mapOfMapProperty = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  private JsonNullable<Object> anytype1 = JsonNullable.<Object>of(null);
+  private Object anytype1 = null;
 
   public static final String JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE1 = "map_with_undeclared_properties_anytype_1";
   private Object mapWithUndeclaredPropertiesAnytype1;
@@ -146,7 +142,7 @@ public class AdditionalPropertiesClass {
 
 
   public AdditionalPropertiesClass anytype1(Object anytype1) {
-    this.anytype1 = JsonNullable.<Object>of(anytype1);
+    this.anytype1 = anytype1;
     return this;
   }
 
@@ -156,26 +152,18 @@ public class AdditionalPropertiesClass {
   **/
   @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonIgnore
-
-  public Object getAnytype1() {
-        return anytype1.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<Object> getAnytype1_JsonNullable() {
+  public Object getAnytype1() {
     return anytype1;
   }
-  
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  public void setAnytype1_JsonNullable(JsonNullable<Object> anytype1) {
-    this.anytype1 = anytype1;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
-    this.anytype1 = JsonNullable.<Object>of(anytype1);
+    this.anytype1 = anytype1;
   }
 
 
@@ -251,7 +239,7 @@ public class AdditionalPropertiesClass {
   @jakarta.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE3)
-  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Map<String, Object> getMapWithUndeclaredPropertiesAnytype3() {
     return mapWithUndeclaredPropertiesAnytype3;
@@ -259,7 +247,7 @@ public class AdditionalPropertiesClass {
 
 
   @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE3)
-  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype3(Map<String, Object> mapWithUndeclaredPropertiesAnytype3) {
     this.mapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
   }
@@ -339,7 +327,7 @@ public class AdditionalPropertiesClass {
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
     return Objects.equals(this.mapProperty, additionalPropertiesClass.mapProperty) &&
         Objects.equals(this.mapOfMapProperty, additionalPropertiesClass.mapOfMapProperty) &&
-        equalsNullable(this.anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
         Objects.equals(this.mapWithUndeclaredPropertiesAnytype1, additionalPropertiesClass.mapWithUndeclaredPropertiesAnytype1) &&
         Objects.equals(this.mapWithUndeclaredPropertiesAnytype2, additionalPropertiesClass.mapWithUndeclaredPropertiesAnytype2) &&
         Objects.equals(this.mapWithUndeclaredPropertiesAnytype3, additionalPropertiesClass.mapWithUndeclaredPropertiesAnytype3) &&
@@ -347,20 +335,9 @@ public class AdditionalPropertiesClass {
         Objects.equals(this.mapWithUndeclaredPropertiesString, additionalPropertiesClass.mapWithUndeclaredPropertiesString);
   }
 
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
-  }
-
   @Override
   public int hashCode() {
-    return Objects.hash(mapProperty, mapOfMapProperty, hashCodeNullable(anytype1), mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, emptyMap, mapWithUndeclaredPropertiesString);
-  }
-
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
-      return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+    return Objects.hash(mapProperty, mapOfMapProperty, anytype1, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, emptyMap, mapWithUndeclaredPropertiesString);
   }
 
   @Override

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/User.java
@@ -82,7 +82,7 @@ public class User {
   private JsonNullable<Object> objectWithNoDeclaredPropsNullable = JsonNullable.<Object>undefined();
 
   public static final String JSON_PROPERTY_ANY_TYPE_PROP = "anyTypeProp";
-  private JsonNullable<Object> anyTypeProp = JsonNullable.<Object>of(null);
+  private Object anyTypeProp = null;
 
   public static final String JSON_PROPERTY_ANY_TYPE_PROP_NULLABLE = "anyTypePropNullable";
   private JsonNullable<Object> anyTypePropNullable = JsonNullable.<Object>of(null);
@@ -359,7 +359,7 @@ public class User {
 
 
   public User anyTypeProp(Object anyTypeProp) {
-    this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
+    this.anyTypeProp = anyTypeProp;
     return this;
   }
 
@@ -369,26 +369,18 @@ public class User {
   **/
   @jakarta.annotation.Nullable
   @ApiModelProperty(value = "test code generation for any type Here the 'type' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389")
-  @JsonIgnore
-
-  public Object getAnyTypeProp() {
-        return anyTypeProp.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<Object> getAnyTypeProp_JsonNullable() {
+  public Object getAnyTypeProp() {
     return anyTypeProp;
   }
-  
-  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
-  public void setAnyTypeProp_JsonNullable(JsonNullable<Object> anyTypeProp) {
-    this.anyTypeProp = anyTypeProp;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypeProp(Object anyTypeProp) {
-    this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
+    this.anyTypeProp = anyTypeProp;
   }
 
 
@@ -448,7 +440,7 @@ public class User {
         Objects.equals(this.userStatus, user.userStatus) &&
         Objects.equals(this.objectWithNoDeclaredProps, user.objectWithNoDeclaredProps) &&
         equalsNullable(this.objectWithNoDeclaredPropsNullable, user.objectWithNoDeclaredPropsNullable) &&
-        equalsNullable(this.anyTypeProp, user.anyTypeProp) &&
+        Objects.equals(this.anyTypeProp, user.anyTypeProp) &&
         equalsNullable(this.anyTypePropNullable, user.anyTypePropNullable);
   }
 
@@ -458,7 +450,7 @@ public class User {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, username, firstName, lastName, email, password, phone, userStatus, objectWithNoDeclaredProps, hashCodeNullable(objectWithNoDeclaredPropsNullable), hashCodeNullable(anyTypeProp), hashCodeNullable(anyTypePropNullable));
+    return Objects.hash(id, username, firstName, lastName, email, password, phone, userStatus, objectWithNoDeclaredProps, hashCodeNullable(objectWithNoDeclaredPropsNullable), anyTypeProp, hashCodeNullable(anyTypePropNullable));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -360,20 +359,9 @@ public class AdditionalPropertiesClass {
         Objects.equals(this.additionalProperties, additionalPropertiesClass.additionalProperties);
   }
 
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
-  }
-
   @Override
   public int hashCode() {
     return Objects.hash(mapProperty, mapOfMapProperty, anytype1, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, emptyMap, mapWithUndeclaredPropertiesString, additionalProperties);
-  }
-
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
-      return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AllOfWithSingleRef.java
@@ -23,10 +23,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.client.model.SingleRefType;
-import org.openapitools.jackson.nullable.JsonNullable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.openapitools.jackson.nullable.JsonNullable;
-import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -43,7 +39,7 @@ public class AllOfWithSingleRef {
   private String username;
 
   public static final String JSON_PROPERTY_SINGLE_REF_TYPE = "SingleRefType";
-  private JsonNullable<SingleRefType> singleRefType = JsonNullable.<SingleRefType>undefined();
+  private SingleRefType singleRefType;
 
   public AllOfWithSingleRef() { 
   }
@@ -76,8 +72,8 @@ public class AllOfWithSingleRef {
 
 
   public AllOfWithSingleRef singleRefType(SingleRefType singleRefType) {
-    this.singleRefType = JsonNullable.<SingleRefType>of(singleRefType);
     
+    this.singleRefType = singleRefType;
     return this;
   }
 
@@ -87,26 +83,18 @@ public class AllOfWithSingleRef {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonIgnore
-
-  public SingleRefType getSingleRefType() {
-        return singleRefType.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_SINGLE_REF_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<SingleRefType> getSingleRefType_JsonNullable() {
+  public SingleRefType getSingleRefType() {
     return singleRefType;
   }
-  
-  @JsonProperty(JSON_PROPERTY_SINGLE_REF_TYPE)
-  public void setSingleRefType_JsonNullable(JsonNullable<SingleRefType> singleRefType) {
-    this.singleRefType = singleRefType;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_SINGLE_REF_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSingleRefType(SingleRefType singleRefType) {
-    this.singleRefType = JsonNullable.<SingleRefType>of(singleRefType);
+    this.singleRefType = singleRefType;
   }
 
 
@@ -120,23 +108,12 @@ public class AllOfWithSingleRef {
     }
     AllOfWithSingleRef allOfWithSingleRef = (AllOfWithSingleRef) o;
     return Objects.equals(this.username, allOfWithSingleRef.username) &&
-        equalsNullable(this.singleRefType, allOfWithSingleRef.singleRefType);
-  }
-
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+        Objects.equals(this.singleRefType, allOfWithSingleRef.singleRefType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(username, hashCodeNullable(singleRefType));
-  }
-
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
-      return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+    return Objects.hash(username, singleRefType);
   }
 
   @Override

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/all_of_with_single_ref.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/all_of_with_single_ref.rb
@@ -43,7 +43,6 @@ module Petstore
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
-        :'single_ref_type'
       ])
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/all_of_with_single_ref.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/all_of_with_single_ref.rb
@@ -43,7 +43,6 @@ module Petstore
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
-        :'single_ref_type'
       ])
     end
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -37,7 +37,7 @@ export interface AllOfWithSingleRef {
      * @type {SingleRefType}
      * @memberof AllOfWithSingleRef
      */
-    singleRefType?: SingleRefType | null;
+    singleRefType?: SingleRefType;
 }
 
 /**

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/src/model/all_of_with_single_ref.dart
@@ -55,7 +55,7 @@ class AllOfWithSingleRef {
   @override
   int get hashCode =>
     username.hashCode +
-    (singleRefType == null ? 0 : singleRefType.hashCode);
+    singleRefType.hashCode;
 
   factory AllOfWithSingleRef.fromJson(Map<String, dynamic> json) => _$AllOfWithSingleRefFromJson(json);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/src/model/all_of_with_single_ref.dart
@@ -52,7 +52,7 @@ class _$AllOfWithSingleRefSerializer implements StructuredSerializer<AllOfWithSi
             result
                 ..add(r'SingleRefType')
                 ..add(serializers.serialize(object.singleRefType,
-                    specifiedType: const FullType.nullable(SingleRefType)));
+                    specifiedType: const FullType(SingleRefType)));
         }
         return result;
     }
@@ -76,8 +76,7 @@ class _$AllOfWithSingleRefSerializer implements StructuredSerializer<AllOfWithSi
                     break;
                 case r'SingleRefType':
                     final valueDes = serializers.deserialize(value,
-                        specifiedType: const FullType.nullable(SingleRefType)) as SingleRefType?;
-                    if (valueDes == null) continue;
+                        specifiedType: const FullType(SingleRefType)) as SingleRefType;
                     result.singleRefType = valueDes;
                     break;
             }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/User.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/User.md
@@ -321,16 +321,6 @@ SetArbitraryTypeValue sets ArbitraryTypeValue field to given value.
 
 HasArbitraryTypeValue returns a boolean if a field has been set.
 
-### SetArbitraryTypeValueNil
-
-`func (o *User) SetArbitraryTypeValueNil(b bool)`
-
- SetArbitraryTypeValueNil sets the value for ArbitraryTypeValue to be an explicit nil
-
-### UnsetArbitraryTypeValue
-`func (o *User) UnsetArbitraryTypeValue()`
-
-UnsetArbitraryTypeValue ensures that no value is present for ArbitraryTypeValue, not even an explicit nil
 ### GetArbitraryNullableTypeValue
 
 `func (o *User) GetArbitraryNullableTypeValue() interface{}`

--- a/samples/openapi3/client/petstore/go/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_user.go
@@ -30,7 +30,7 @@ type User struct {
 	// test code generation for nullable objects. Value must be a map of strings to values or the 'null' value.
 	ArbitraryNullableObject map[string]interface{} `json:"arbitraryNullableObject,omitempty"`
 	// test code generation for any type Value can be any type - string, number, boolean, array or object.
-	ArbitraryTypeValue interface{} `json:"arbitraryTypeValue,omitempty"`
+	ArbitraryTypeValue *interface{} `json:"arbitraryTypeValue,omitempty"`
 	// test code generation for any type Value can be any type - string, number, boolean, array, object or the 'null' value.
 	ArbitraryNullableTypeValue interface{} `json:"arbitraryNullableTypeValue,omitempty"`
 	AdditionalProperties map[string]interface{}
@@ -376,23 +376,22 @@ func (o *User) SetArbitraryNullableObject(v map[string]interface{}) {
 	o.ArbitraryNullableObject = v
 }
 
-// GetArbitraryTypeValue returns the ArbitraryTypeValue field value if set, zero value otherwise (both if not set or set to explicit null).
+// GetArbitraryTypeValue returns the ArbitraryTypeValue field value if set, zero value otherwise.
 func (o *User) GetArbitraryTypeValue() interface{} {
-	if o == nil {
+	if o == nil || o.ArbitraryTypeValue == nil {
 		var ret interface{}
 		return ret
 	}
-	return o.ArbitraryTypeValue
+	return *o.ArbitraryTypeValue
 }
 
 // GetArbitraryTypeValueOk returns a tuple with the ArbitraryTypeValue field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *User) GetArbitraryTypeValueOk() (*interface{}, bool) {
 	if o == nil || o.ArbitraryTypeValue == nil {
 		return nil, false
 	}
-	return &o.ArbitraryTypeValue, true
+	return o.ArbitraryTypeValue, true
 }
 
 // HasArbitraryTypeValue returns a boolean if a field has been set.
@@ -406,7 +405,7 @@ func (o *User) HasArbitraryTypeValue() bool {
 
 // SetArbitraryTypeValue gets a reference to the given interface{} and assigns it to the ArbitraryTypeValue field.
 func (o *User) SetArbitraryTypeValue(v interface{}) {
-	o.ArbitraryTypeValue = v
+	o.ArbitraryTypeValue = &v
 }
 
 // GetArbitraryNullableTypeValue returns the ArbitraryNullableTypeValue field value if set, zero value otherwise (both if not set or set to explicit null).

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -27,10 +27,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.openapitools.jackson.nullable.JsonNullable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.openapitools.jackson.nullable.JsonNullable;
-import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.openapitools.client.JSON;
 
@@ -57,7 +53,7 @@ public class AdditionalPropertiesClass {
   private Map<String, Map<String, String>> mapOfMapProperty = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  private JsonNullable<Object> anytype1 = JsonNullable.<Object>of(null);
+  private Object anytype1 = null;
 
   public static final String JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE1 = "map_with_undeclared_properties_anytype_1";
   private Object mapWithUndeclaredPropertiesAnytype1;
@@ -146,7 +142,7 @@ public class AdditionalPropertiesClass {
 
 
   public AdditionalPropertiesClass anytype1(Object anytype1) {
-    this.anytype1 = JsonNullable.<Object>of(anytype1);
+    this.anytype1 = anytype1;
     return this;
   }
 
@@ -156,26 +152,18 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonIgnore
-
-  public Object getAnytype1() {
-        return anytype1.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<Object> getAnytype1_JsonNullable() {
+  public Object getAnytype1() {
     return anytype1;
   }
-  
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  public void setAnytype1_JsonNullable(JsonNullable<Object> anytype1) {
-    this.anytype1 = anytype1;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
-    this.anytype1 = JsonNullable.<Object>of(anytype1);
+    this.anytype1 = anytype1;
   }
 
 
@@ -251,7 +239,7 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE3)
-  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Map<String, Object> getMapWithUndeclaredPropertiesAnytype3() {
     return mapWithUndeclaredPropertiesAnytype3;
@@ -259,7 +247,7 @@ public class AdditionalPropertiesClass {
 
 
   @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE3)
-  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype3(Map<String, Object> mapWithUndeclaredPropertiesAnytype3) {
     this.mapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
   }
@@ -339,7 +327,7 @@ public class AdditionalPropertiesClass {
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
     return Objects.equals(this.mapProperty, additionalPropertiesClass.mapProperty) &&
         Objects.equals(this.mapOfMapProperty, additionalPropertiesClass.mapOfMapProperty) &&
-        equalsNullable(this.anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
         Objects.equals(this.mapWithUndeclaredPropertiesAnytype1, additionalPropertiesClass.mapWithUndeclaredPropertiesAnytype1) &&
         Objects.equals(this.mapWithUndeclaredPropertiesAnytype2, additionalPropertiesClass.mapWithUndeclaredPropertiesAnytype2) &&
         Objects.equals(this.mapWithUndeclaredPropertiesAnytype3, additionalPropertiesClass.mapWithUndeclaredPropertiesAnytype3) &&
@@ -347,20 +335,9 @@ public class AdditionalPropertiesClass {
         Objects.equals(this.mapWithUndeclaredPropertiesString, additionalPropertiesClass.mapWithUndeclaredPropertiesString);
   }
 
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
-  }
-
   @Override
   public int hashCode() {
-    return Objects.hash(mapProperty, mapOfMapProperty, hashCodeNullable(anytype1), mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, emptyMap, mapWithUndeclaredPropertiesString);
-  }
-
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
-      return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+    return Objects.hash(mapProperty, mapOfMapProperty, anytype1, mapWithUndeclaredPropertiesAnytype1, mapWithUndeclaredPropertiesAnytype2, mapWithUndeclaredPropertiesAnytype3, emptyMap, mapWithUndeclaredPropertiesString);
   }
 
   @Override

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -82,7 +82,7 @@ public class User {
   private JsonNullable<Object> objectWithNoDeclaredPropsNullable = JsonNullable.<Object>undefined();
 
   public static final String JSON_PROPERTY_ANY_TYPE_PROP = "anyTypeProp";
-  private JsonNullable<Object> anyTypeProp = JsonNullable.<Object>of(null);
+  private Object anyTypeProp = null;
 
   public static final String JSON_PROPERTY_ANY_TYPE_PROP_NULLABLE = "anyTypePropNullable";
   private JsonNullable<Object> anyTypePropNullable = JsonNullable.<Object>of(null);
@@ -359,7 +359,7 @@ public class User {
 
 
   public User anyTypeProp(Object anyTypeProp) {
-    this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
+    this.anyTypeProp = anyTypeProp;
     return this;
   }
 
@@ -369,26 +369,18 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "test code generation for any type Here the 'type' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389")
-  @JsonIgnore
-
-  public Object getAnyTypeProp() {
-        return anyTypeProp.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<Object> getAnyTypeProp_JsonNullable() {
+  public Object getAnyTypeProp() {
     return anyTypeProp;
   }
-  
-  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
-  public void setAnyTypeProp_JsonNullable(JsonNullable<Object> anyTypeProp) {
-    this.anyTypeProp = anyTypeProp;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypeProp(Object anyTypeProp) {
-    this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
+    this.anyTypeProp = anyTypeProp;
   }
 
 
@@ -448,7 +440,7 @@ public class User {
         Objects.equals(this.userStatus, user.userStatus) &&
         Objects.equals(this.objectWithNoDeclaredProps, user.objectWithNoDeclaredProps) &&
         equalsNullable(this.objectWithNoDeclaredPropsNullable, user.objectWithNoDeclaredPropsNullable) &&
-        equalsNullable(this.anyTypeProp, user.anyTypeProp) &&
+        Objects.equals(this.anyTypeProp, user.anyTypeProp) &&
         equalsNullable(this.anyTypePropNullable, user.anyTypePropNullable);
   }
 
@@ -458,7 +450,7 @@ public class User {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, username, firstName, lastName, email, password, phone, userStatus, objectWithNoDeclaredProps, hashCodeNullable(objectWithNoDeclaredPropsNullable), hashCodeNullable(anyTypeProp), hashCodeNullable(anyTypePropNullable));
+    return Objects.hash(id, username, firstName, lastName, email, password, phone, userStatus, objectWithNoDeclaredProps, hashCodeNullable(objectWithNoDeclaredPropsNullable), anyTypeProp, hashCodeNullable(anyTypePropNullable));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/all_of_with_single_ref.py
@@ -57,7 +57,8 @@ class AllOfWithSingleRef(object):
 
         if username is not None:
             self.username = username
-        self.single_ref_type = single_ref_type
+        if single_ref_type is not None:
+            self.single_ref_type = single_ref_type
 
     @property
     def username(self):

--- a/samples/server/petstore/php-laravel/lib/app/Models/AllOfWithSingleRef.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/AllOfWithSingleRef.php
@@ -12,7 +12,7 @@ class AllOfWithSingleRef {
     /** @var string $username */
     public $username = "";
 
-    /** @var SingleRefType|null $singleRefType */
-    public $singleRefType = null;
+    /** @var SingleRefType $singleRefType */
+    public $singleRefType;
 
 }


### PR DESCRIPTION
I believe this fixes #10780, though there's some differences in our examples, so I can't be entirely sure.
I can reproduce this regression between 5.2.1 and 5.3.0, so it probably is.

There's possibly a deeper problem here, as I'm not sure if these composed types are supposed to be handled by updatePropertyForAnyType(). But since they currently are, I kept my changes to a minimum.
I found that ModelUtils.isNullable() returns the correct value here, as it recognises that composed types are only nullable in some cases and not all cases, as updatePropertyForAnyType() otherwise suggests.

An object with the definition below would currently be generated with a nullable `value3` property. I believe that's a bug, as that is not the default behaviour with either `value1` or `value2` in my example.

```YAML
---
openapi: 3.0.3
info:
  title: Foo
  version: v1
servers:
- url: /
  description: Foo
paths:
  /foo:
    get:
      responses:
        "200":
          description: OK
components:
  schemas:
    Bar:
      required:
        - value1
        - value2
        - value3
      type: object
      properties:
        value1:
          type: string
        value2:
          allOf:
            - type: string
        value3:
          allOf:
            - $ref: '#/components/schemas/Foo'
    Foo:
      type: string
```

(Swift is my language of choice for the example, but this change is not specific to any language, as the change is in DefaultCodegen.java)

Before my change:
```Swift
[...]
public struct Bar: Codable, JSONEncodable, Hashable {

    public var value1: String
    public var value2: String
    public var value3: String?
[...]
```

After my change:
```Swift
[...]
public struct Bar: Codable, JSONEncodable, Hashable {

    public var value1: String
    public var value2: String
    public var value3: String
[...]
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Since this is not targeting a particular language, I hope it's okay I ping the core team instead.
cc @wing328 @jimschubert @cbornet @jmini @etherealjoy @spacether
