### PR TITLE
fix: [JAVA/SPRING] [#12692] fixed optional config property legacyDisc…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -297,8 +297,8 @@ public class SpringCodegen extends AbstractJavaCodegen
             LOGGER.info("Set base package to invoker package ({})", basePackage);
         }
 
-		useOneOfInterfaces = true;
-		legacyDiscriminatorBehavior = false;
+        useOneOfInterfaces = true;
+        legacyDiscriminatorBehavior = false;
         super.processOpts();
 
         if (DocumentationProvider.SPRINGFOX.equals(getDocumentationProvider())) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -297,9 +297,9 @@ public class SpringCodegen extends AbstractJavaCodegen
             LOGGER.info("Set base package to invoker package ({})", basePackage);
         }
 
+		useOneOfInterfaces = true;
+		legacyDiscriminatorBehavior = false;
         super.processOpts();
-        useOneOfInterfaces = true;
-        legacyDiscriminatorBehavior = false;
 
         if (DocumentationProvider.SPRINGFOX.equals(getDocumentationProvider())) {
             LOGGER.warn("The springfox documentation provider is deprecated for removal. Use the springdoc provider instead.");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1432,4 +1432,30 @@ public class SpringCodegenTest {
                 "consumes", "{ \"application/octet-stream\", \"application/*\" }"
             ));
     }
+
+	@Test
+	public void shouldGenerateDiscriminatorFromAllOfWhenUsingLegacyDiscriminatorBehaviour_issue12692() throws IOException {
+		File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+		output.deleteOnExit();
+
+		OpenAPI openAPI = new OpenAPIParser()
+				.readLocation("src/test/resources/bugs/issue_12692.yml", null, new ParseOptions()).getOpenAPI();
+		SpringCodegen codegen = new SpringCodegen();
+		codegen.setLibrary(SPRING_BOOT);
+		codegen.setOutputDir(output.getAbsolutePath());
+		codegen.additionalProperties().put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true");
+
+		ClientOptInput input = new ClientOptInput()
+				.openAPI(openAPI)
+				.config(codegen);
+
+		DefaultGenerator generator = new DefaultGenerator();
+		generator.opts(input).generate();
+
+		String jsonTypeInfo = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"type\", visible = true)";
+		String jsonSubType = "@JsonSubTypes({\n" +
+							 "  @JsonSubTypes.Type(value = Cat.class, name = \"cat\")" +
+							 "})";
+		assertFileContains(Paths.get(output.getAbsolutePath() + "/src/main/java/org/openapitools/model/Pet.java"), jsonTypeInfo, jsonSubType);
+	}
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1433,29 +1433,29 @@ public class SpringCodegenTest {
             ));
     }
 
-	@Test
-	public void shouldGenerateDiscriminatorFromAllOfWhenUsingLegacyDiscriminatorBehaviour_issue12692() throws IOException {
-		File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
-		output.deleteOnExit();
+    @Test
+    public void shouldGenerateDiscriminatorFromAllOfWhenUsingLegacyDiscriminatorBehaviour_issue12692() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
 
-		OpenAPI openAPI = new OpenAPIParser()
-				.readLocation("src/test/resources/bugs/issue_12692.yml", null, new ParseOptions()).getOpenAPI();
-		SpringCodegen codegen = new SpringCodegen();
-		codegen.setLibrary(SPRING_BOOT);
-		codegen.setOutputDir(output.getAbsolutePath());
-		codegen.additionalProperties().put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true");
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/bugs/issue_12692.yml", null, new ParseOptions()).getOpenAPI();
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setLibrary(SPRING_BOOT);
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true");
 
-		ClientOptInput input = new ClientOptInput()
-				.openAPI(openAPI)
-				.config(codegen);
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
 
-		DefaultGenerator generator = new DefaultGenerator();
-		generator.opts(input).generate();
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(input).generate();
 
-		String jsonTypeInfo = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"type\", visible = true)";
-		String jsonSubType = "@JsonSubTypes({\n" +
-							 "  @JsonSubTypes.Type(value = Cat.class, name = \"cat\")" +
-							 "})";
-		assertFileContains(Paths.get(output.getAbsolutePath() + "/src/main/java/org/openapitools/model/Pet.java"), jsonTypeInfo, jsonSubType);
-	}
+        String jsonTypeInfo = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"type\", visible = true)";
+        String jsonSubType = "@JsonSubTypes({\n" +
+                             "  @JsonSubTypes.Type(value = Cat.class, name = \"cat\")" +
+                             "})";
+        assertFileContains(Paths.get(output.getAbsolutePath() + "/src/main/java/org/openapitools/model/Pet.java"), jsonTypeInfo, jsonSubType);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/bugs/issue_12692.yml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_12692.yml
@@ -1,0 +1,45 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+paths:
+  "/pets":
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: description
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          cat: "#/components/schemas/Cat"
+    Cat:
+      allOf:
+        - "$ref": "#/components/schemas/Pet"
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+          discriminator:
+            propertyName: type
+            mapping:
+              cat: "#/components/schemas/Cat"


### PR DESCRIPTION
…riminatorBehavior always being overwritten to false in spring codegen

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #12692
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlevente
