### PR TITLE
Gradle Plugin: Clean up Kotlin code

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -37,27 +37,27 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
             val meta = extensions.create(
-                    "openApiMeta",
-                    OpenApiGeneratorMetaExtension::class.java,
-                    project
+                "openApiMeta",
+                OpenApiGeneratorMetaExtension::class.java,
+                project
             )
 
             val validate = extensions.create(
-                    "openApiValidate",
-                    OpenApiGeneratorValidateExtension::class.java,
-                    project
+                "openApiValidate",
+                OpenApiGeneratorValidateExtension::class.java,
+                project
             )
 
             val generate = extensions.create(
-                    "openApiGenerate",
-                    OpenApiGeneratorGenerateExtension::class.java,
-                    project
+                "openApiGenerate",
+                OpenApiGeneratorGenerateExtension::class.java,
+                project
             )
 
             val generators = extensions.create(
-                    "openApiGenerators",
-                    OpenApiGeneratorGeneratorsExtension::class.java,
-                    project
+                "openApiGenerators",
+                OpenApiGeneratorGeneratorsExtension::class.java,
+                project
             )
 
             generate.outputDir.set("$buildDir/generate-resources/main")
@@ -89,7 +89,8 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
 
                 register("openApiGenerate", GenerateTask::class.java).configure {
                     group = pluginGroup
-                    description = "Generate code via Open API Tools Generator for Open API 2.0 or 3.x specification documents."
+                    description =
+                        "Generate code via Open API Tools Generator for Open API 2.0 or 3.x specification documents."
 
                     verbose.set(generate.verbose)
                     validateSpec.set(generate.validateSpec)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -22,19 +22,18 @@ import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 
 /**
- * Gradle project level extension object definition for the generate task
+ * Gradle project level extension object definition for the `generate` task
  *
  * @author Jim Schubert
  */
 open class OpenApiGeneratorGenerateExtension(project: Project) {
-
     /**
      * The verbosity of generation
      */
     val verbose = project.objects.property<Boolean>()
 
     /**
-     * Whether or not an input specification should be validated upon generation.
+     * Whether an input specification should be validated upon generation.
      */
     val validateSpec = project.objects.property<Boolean>()
 
@@ -157,17 +156,17 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val invokerPackage = project.objects.property<String>()
 
     /**
-     * GroupId in generated pom.xml/build.gradle or other build script. Language-specific conversions occur in non-jvm generators.
+     * GroupId in generated pom.xml/build.gradle.kts or other build script. Language-specific conversions occur in non-jvm generators.
      */
     val groupId = project.objects.property<String>()
 
     /**
-     * ArtifactId in generated pom.xml/build.gradle or other build script. Language-specific conversions occur in non-jvm generators.
+     * ArtifactId in generated pom.xml/build.gradle.kts or other build script. Language-specific conversions occur in non-jvm generators.
      */
     val id = project.objects.property<String>()
 
     /**
-     * Artifact version in generated pom.xml/build.gradle or other build script. Language-specific conversions occur in non-jvm generators.
+     * Artifact version in generated pom.xml/build.gradle.kts or other build script. Language-specific conversions occur in non-jvm generators.
      */
     val version = project.objects.property<String>()
 
@@ -242,7 +241,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Defines which supporting files should be generated. This allows you to create a subset of generated files (or none at all).
      *
-     * Supporting files are those related to projects/frameworks which may be modified
+     * Supporting files are those related to `projects/frameworks` which may be modified
      * by consumers.
      *
      * NOTE: Configuring any one of [apiFilesConstrainedTo], [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results
@@ -252,7 +251,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val supportingFilesConstrainedTo = project.objects.listProperty<String>()
 
     /**
-     * Defines whether or not model-related _test_ files should be generated.
+     * Defines whether model-related _test_ files should be generated.
      *
      * This option enables/disables generation of ALL model-related _test_ files.
      *
@@ -262,7 +261,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val generateModelTests = project.objects.property<Boolean>()
 
     /**
-     * Defines whether or not model-related _documentation_ files should be generated.
+     * Defines whether model-related _documentation_ files should be generated.
      *
      * This option enables/disables generation of ALL model-related _documentation_ files.
      *
@@ -272,7 +271,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val generateModelDocumentation = project.objects.property<Boolean>()
 
     /**
-     * Defines whether or not api-related _test_ files should be generated.
+     * Defines whether api-related _test_ files should be generated.
      *
      * This option enables/disables generation of ALL api-related _test_ files.
      *
@@ -282,7 +281,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val generateApiTests = project.objects.property<Boolean>()
 
     /**
-     * Defines whether or not api-related _documentation_ files should be generated.
+     * Defines whether api-related _documentation_ files should be generated.
      *
      * This option enables/disables generation of ALL api-related _documentation_ files.
      *

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGeneratorsExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGeneratorsExtension.kt
@@ -17,7 +17,6 @@
 package org.openapitools.generator.gradle.plugin.extensions
 
 import org.gradle.api.Project
-import org.gradle.api.tasks.Internal
 import org.gradle.kotlin.dsl.listProperty
 import org.openapitools.codegen.meta.Stability
 
@@ -37,7 +36,6 @@ open class OpenApiGeneratorGeneratorsExtension(project: Project) {
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
-    fun applyDefaults(){
-        include.set(Stability.values().map { s -> s.value() }.filterNot { it == Stability.DEPRECATED.value() })
-    }
+    fun applyDefaults() =
+        include.set(Stability.values().map { it.value() }.filterNot { it == Stability.DEPRECATED.value() })
 }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
@@ -31,7 +31,7 @@ open class OpenApiGeneratorValidateExtension(project: Project) {
     val inputSpec = project.objects.property<String>()
 
     /**
-     * Whether or not to offer recommendations related to the validated specification document.
+     * Whether to offer recommendations related to the validated specification document.
      */
     val recommend = project.objects.property<Boolean?>()
 
@@ -40,7 +40,5 @@ open class OpenApiGeneratorValidateExtension(project: Project) {
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
-    fun applyDefaults(){
-        recommend.set(true)
-    }
+    fun applyDefaults() = recommend.set(true)
 }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -51,7 +51,6 @@ import org.openapitools.codegen.config.GlobalSettings
 @Suppress("UnstableApiUsage")
 @CacheableTask
 open class GenerateTask : DefaultTask() {
-
     /**
      * The verbosity of generation
      */
@@ -60,7 +59,7 @@ open class GenerateTask : DefaultTask() {
     val verbose = project.objects.property<Boolean>()
 
     /**
-     * Whether or not an input specification should be validated upon generation.
+     * Whether an input specification should be validated upon generation.
      */
     @Optional
     @Input
@@ -241,21 +240,21 @@ open class GenerateTask : DefaultTask() {
     val invokerPackage = project.objects.property<String>()
 
     /**
-     * GroupId in generated pom.xml/build.gradle or other build script. Language-specific conversions occur in non-jvm generators.
+     * GroupId in generated pom.xml/build.gradle.kts or other build script. Language-specific conversions occur in non-jvm generators.
      */
     @Optional
     @Input
     val groupId = project.objects.property<String>()
 
     /**
-     * ArtifactId in generated pom.xml/build.gradle or other build script. Language-specific conversions occur in non-jvm generators.
+     * ArtifactId in generated pom.xml/build.gradle.kts or other build script. Language-specific conversions occur in non-jvm generators.
      */
     @Optional
     @Input
     val id = project.objects.property<String>()
 
     /**
-     * Artifact version in generated pom.xml/build.gradle or other build script. Language-specific conversions occur in non-jvm generators.
+     * Artifact version in generated pom.xml/build.gradle.kts or other build script. Language-specific conversions occur in non-jvm generators.
      */
     @Optional
     @Input
@@ -358,7 +357,7 @@ open class GenerateTask : DefaultTask() {
     /**
      * Defines which supporting files should be generated. This allows you to create a subset of generated files (or none at all).
      *
-     * Supporting files are those related to projects/frameworks which may be modified
+     * Supporting files are those related to `projects/frameworks` which may be modified
      * by consumers.
      *
      * NOTE: Configuring any one of [apiFilesConstrainedTo], [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results
@@ -370,7 +369,7 @@ open class GenerateTask : DefaultTask() {
     val supportingFilesConstrainedTo = project.objects.listProperty<String>()
 
     /**
-     * Defines whether or not model-related _test_ files should be generated.
+     * Defines whether model-related _test_ files should be generated.
      *
      * This option enables/disables generation of ALL model-related _test_ files.
      *
@@ -382,7 +381,7 @@ open class GenerateTask : DefaultTask() {
     val generateModelTests = project.objects.property<Boolean>()
 
     /**
-     * Defines whether or not model-related _documentation_ files should be generated.
+     * Defines whether model-related _documentation_ files should be generated.
      *
      * This option enables/disables generation of ALL model-related _documentation_ files.
      *
@@ -394,7 +393,7 @@ open class GenerateTask : DefaultTask() {
     val generateModelDocumentation = project.objects.property<Boolean>()
 
     /**
-     * Defines whether or not api-related _test_ files should be generated.
+     * Defines whether api-related _test_ files should be generated.
      *
      * This option enables/disables generation of ALL api-related _test_ files.
      *
@@ -406,7 +405,7 @@ open class GenerateTask : DefaultTask() {
     val generateApiTests = project.objects.property<Boolean>()
 
     /**
-     * Defines whether or not api-related _documentation_ files should be generated.
+     * Defines whether api-related _documentation_ files should be generated.
      *
      * This option enables/disables generation of ALL api-related _documentation_ files.
      *
@@ -504,7 +503,10 @@ open class GenerateTask : DefaultTask() {
             }
 
             if (supportingFilesConstrainedTo.isPresent && supportingFilesConstrainedTo.get().isNotEmpty()) {
-                GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, supportingFilesConstrainedTo.get().joinToString(","))
+                GlobalSettings.setProperty(
+                    CodegenConstants.SUPPORTING_FILES,
+                    supportingFilesConstrainedTo.get().joinToString(",")
+                )
             } else {
                 GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES)
             }
@@ -735,11 +737,11 @@ open class GenerateTask : DefaultTask() {
             }
 
             val clientOptInput = configurator.toClientOptInput()
-            val codgenConfig = clientOptInput.config
+            val codegenConfig = clientOptInput.config
 
             if (configOptions.isPresent) {
                 val userSpecifiedConfigOptions = configOptions.get()
-                codgenConfig.cliOptions().forEach {
+                codegenConfig.cliOptions().forEach {
                     if (userSpecifiedConfigOptions.containsKey(it.opt)) {
                         clientOptInput.config.additionalProperties()[it.opt] = userSpecifiedConfigOptions[it.opt]
                     }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GeneratorsTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GeneratorsTask.kt
@@ -43,7 +43,6 @@ open class GeneratorsTask : DefaultTask() {
     @get:Internal
     val include = project.objects.listProperty<String>()
 
-    @Suppress("unused")
     @TaskAction
     fun doWork() {
         val generators = CodegenConfigLoader.getAll()

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/MetaTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/MetaTask.kt
@@ -44,7 +44,6 @@ import java.nio.charset.Charset
  */
 @CacheableTask
 open class MetaTask : DefaultTask() {
-
     @get:Input
     val generatorName = project.objects.property<String>()
 
@@ -54,10 +53,8 @@ open class MetaTask : DefaultTask() {
     @get:OutputDirectory
     val outputFolder = project.objects.property<String>()
 
-    @Suppress("unused")
     @TaskAction
     fun doWork() {
-
         val packageToPath = packageName.get().replace(".", File.separator)
         val dir = File(outputFolder.get())
         val klass = "${generatorName.get().titleCasedTextOnly()}Generator"
@@ -73,21 +70,28 @@ open class MetaTask : DefaultTask() {
         logger.debug("generator class: {}", klass)
 
         val supportingFiles = listOf(
-                SupportingFile("pom.mustache", "", "pom.xml"),
-                SupportingFile("generatorClass.mustache", dir("src", "main", "java", packageToPath), "$klass.java"),
-                SupportingFile("README.mustache", "", "README.md"),
-                SupportingFile("api.template", dir("src", "main", "resources", templateResourceDir), "api.mustache"),
-                SupportingFile("model.template", dir("src", "main", "resources", templateResourceDir), "model.mustache"),
-                SupportingFile("myFile.template", dir("src", "main", "resources", templateResourceDir), "myFile.mustache"),
-                SupportingFile("services.mustache", dir("src", "main", "resources", "META-INF", "services"), CodegenConfig::class.java.canonicalName))
+            SupportingFile("pom.mustache", "", "pom.xml"),
+            SupportingFile("generatorClass.mustache", dir("src", "main", "java", packageToPath), "$klass.java"),
+            SupportingFile("README.mustache", "", "README.md"),
+            SupportingFile("api.template", dir("src", "main", "resources", templateResourceDir), "api.mustache"),
+            SupportingFile("model.template", dir("src", "main", "resources", templateResourceDir), "model.mustache"),
+            SupportingFile("myFile.template", dir("src", "main", "resources", templateResourceDir), "myFile.mustache"),
+            SupportingFile(
+                "services.mustache",
+                dir("src", "main", "resources", "META-INF", "services"),
+                CodegenConfig::class.java.canonicalName
+            )
+        )
 
         val currentVersion = CodegenConstants::class.java.`package`.implementationVersion
 
-        val data = mapOf("generatorPackage" to packageToPath,
-                "generatorClass" to klass,
-                "name" to templateResourceDir,
-                "fullyQualifiedGeneratorClass" to "${packageName.get()}.$klass",
-                "openapiGeneratorVersion" to currentVersion)
+        val data = mapOf(
+            "generatorPackage" to packageToPath,
+            "generatorClass" to klass,
+            "name" to templateResourceDir,
+            "fullyQualifiedGeneratorClass" to "${packageName.get()}.$klass",
+            "openapiGeneratorVersion" to currentVersion
+        )
 
         supportingFiles.map {
             try {
@@ -96,9 +100,9 @@ open class MetaTask : DefaultTask() {
                 val outputFile = File(destinationFolder, it.destinationFilename)
 
                 val templateProcessor = TemplateManager(
-                        TemplateManagerOptions(false, false),
-                        MustacheEngineAdapter(),
-                        arrayOf(CommonTemplateContentLocator("codegen"))
+                    TemplateManagerOptions(false, false),
+                    MustacheEngineAdapter(),
+                    arrayOf(CommonTemplateContentLocator("codegen"))
                 )
 
                 val template = templateProcessor.getFullTemplateContents(it.templateFile)
@@ -110,9 +114,9 @@ open class MetaTask : DefaultTask() {
 
                 if (it.templateFile.endsWith(".mustache")) {
                     formatted = Mustache.compiler()
-                            .withLoader(loader)
-                            .defaultValue("")
-                            .compile(template).execute(data)
+                        .withLoader(loader)
+                        .defaultValue("")
+                        .compile(template).execute(data)
                 }
 
                 outputFile.writeText(formatted, Charset.forName("UTF8"))
@@ -131,11 +135,10 @@ open class MetaTask : DefaultTask() {
     }
 
     private fun String.titleCasedTextOnly(): String =
-            this.split(Regex("[^a-zA-Z0-9]")).joinToString(separator = "", transform = String::capitalize)
+        split(Regex("[^a-zA-Z0-9]")).joinToString(separator = "", transform = String::capitalize)
 
     private fun String.hyphenatedTextOnly(): String =
-            this.split(Regex("[^a-zA-Z0-9]")).joinToString(separator = "-", transform = String::toLowerCase)
+        split(Regex("[^a-zA-Z0-9]")).joinToString(separator = "-", transform = String::toLowerCase)
 
-    private fun dir(vararg parts: String): String =
-            parts.joinToString(separator = File.separator)
+    private fun dir(vararg parts: String): String = parts.joinToString(separator = File.separator)
 }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("UnstableApiUsage")
-
 package org.openapitools.generator.gradle.plugin.tasks
 
 import io.swagger.parser.OpenAPIParser
@@ -45,7 +43,7 @@ import org.openapitools.codegen.validations.oas.RuleConfiguration
  *
  *   ./gradlew openApiValidate --input=/path/to/file
  *
- * build.gradle:
+ * build.gradle.kts:
  *
  *   openApiMeta {
  *      inputSpec = "path/to/spec.yaml"
@@ -62,7 +60,6 @@ open class ValidateTask : DefaultTask() {
     @Input
     val recommend = project.objects.property<Boolean?>()
 
-    @Suppress("unused")
     @get:Internal
     @set:Option(option = "input", description = "The input specification.")
     var input: String? = null
@@ -70,7 +67,6 @@ open class ValidateTask : DefaultTask() {
             inputSpec.set(value)
         }
 
-    @Suppress("unused")
     @TaskAction
     fun doWork() {
         val logger = Logging.getLogger(javaClass)
@@ -105,7 +101,6 @@ open class ValidateTask : DefaultTask() {
         }
 
         if (messages.isNotEmpty() || validationResult.errors.isNotEmpty()) {
-
             out.withStyle(StyledTextOutput.Style.Error)
             out.println("\nSpec is invalid.\nIssues:\n")
 

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
@@ -4,12 +4,13 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.testng.annotations.Test
 import java.io.File
+import java.nio.file.Files.createTempDirectory
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class GenerateTaskDslTest : TestBase() {
-    override var temp: File = createTempDir(javaClass.simpleName)
+    override var temp: File = createTempDirectory(javaClass.simpleName).toFile()
 
     private val defaultBuildGradle = """
         plugins {
@@ -61,7 +62,7 @@ class GenerateTaskDslTest : TestBase() {
                 "build/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt"
         ).map {
             val f = File(temp, it)
-            assertTrue(f.exists() && f.isFile, "An expected file was not generated when invoking the generation.")
+            assertTrue(f.exists() && f.isFile, "An expected file was not generated when invoking the generation: $f")
         }
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":openApiGenerate")?.outcome,
@@ -110,7 +111,7 @@ class GenerateTaskDslTest : TestBase() {
                 "build/java/src/main/java/org/openapitools/example/api/PetsApiClassSuffix.java"
         ).map {
             val f = File(temp, it)
-            assertTrue(f.exists() && f.isFile, "An expected file was not generated when invoking the generation. - " + f)
+            assertTrue(f.exists() && f.isFile, "An expected file was not generated when invoking the generation. - $f")
         }
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":openApiGenerate")?.outcome,

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GeneratorsTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GeneratorsTaskDslTest.kt
@@ -27,7 +27,7 @@ class GeneratorsTaskDslTest : TestBase() {
                 .build()
 
         // Assert
-        assertTrue(result.output.contains("The following generators are available:"), "User friendly generator notice is missing.")
+        assertTrue(result.output.contains("The following generators are available:"), "User-friendly generator notice is missing.")
         assertTrue(result.output.contains("CLIENT generators:"), "Expected client generator header is missing.")
         assertTrue(result.output.contains("android"), "Spot-checking listed client generators is missing a client generator.")
         assertTrue(result.output.contains("SERVER generators:"), "Expected server generator header is missing.")

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/MetaTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/MetaTaskDslTest.kt
@@ -34,7 +34,7 @@ class MetaTaskDslTest : TestBase() {
                 .build()
 
         // Assert
-        assertTrue(result.output.contains("Wrote file to"), "User friendly write notice is missing.")
+        assertTrue(result.output.contains("Wrote file to"), "User-friendly write notice is missing.")
 
         // To avoid any OS-specific output causing issues with our stdout comparisons, only compare on expected filenames.
         listOf(

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/TestBase.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/TestBase.kt
@@ -4,27 +4,24 @@ import org.testng.annotations.AfterMethod
 import org.testng.annotations.BeforeMethod
 import java.io.File
 import java.io.InputStream
+import java.nio.file.Files.createTempDirectory
 
 abstract class TestBase {
     protected open lateinit var temp: File
 
     @BeforeMethod
     protected fun before() {
-        temp = createTempDir(javaClass.simpleName)
+        temp = createTempDirectory(javaClass.simpleName).toFile()
         temp.deleteOnExit()
     }
 
     @AfterMethod
-    protected fun after(){
+    protected fun after() {
         temp.deleteRecursively()
     }
 
-    protected fun withProject(
-            buildContents: String,
-            projectFiles: Map<String, InputStream> = mapOf()
-    ) {
-        val buildFile = File(temp,"build.gradle")
-        buildFile.writeText(buildContents)
+    protected fun withProject(buildContents: String, projectFiles: Map<String, InputStream> = mapOf()) {
+        File(temp, "build.gradle").writeText(buildContents)
 
         projectFiles.forEach { entry ->
             val target = File(temp, entry.key)

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
@@ -7,18 +7,20 @@ import org.gradle.util.GradleVersion
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 import java.io.File
+import java.nio.file.Files.createTempDirectory
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ValidateTaskDslTest : TestBase() {
-    override var temp: File = createTempDir(javaClass.simpleName)
+    override var temp: File = createTempDirectory(javaClass.simpleName).toFile()
 
     @DataProvider(name = "gradle_version_provider")
     fun gradleVersionProvider(): Array<Array<String?>> = arrayOf(
         arrayOf(null), // uses the version of Gradle used to build the plugin itself
         arrayOf("5.6.4"),
         arrayOf("6.9"),
-        arrayOf("7.0"))
+        arrayOf("7.0")
+    )
 
     private fun getGradleRunner(gradleVersion: String?): GradleRunner {
         val gradleRunner = GradleRunner.create()
@@ -33,7 +35,8 @@ class ValidateTaskDslTest : TestBase() {
     @Test(dataProvider = "gradle_version_provider")
     fun `openApiValidate should fail on non-file spec`(gradleVersion: String?) {
         // Arrange
-        withProject("""
+        withProject(
+            """
             | plugins {
             |   id 'org.openapi.generator'
             | }
@@ -41,14 +44,15 @@ class ValidateTaskDslTest : TestBase() {
             | openApiValidate {
             |   inputSpec = "some_location"
             | }
-        """.trimMargin())
+        """.trimMargin()
+        )
 
         // Act
         val result = getGradleRunner(gradleVersion)
-                .withProjectDir(temp)
-                .withArguments("openApiValidate")
-                .withPluginClasspath()
-                .buildAndFail()
+            .withProjectDir(temp)
+            .withArguments("openApiValidate")
+            .withPluginClasspath()
+            .buildAndFail()
 
         // Assert
         val gradleActualVersion = gradleVersion ?: GradleVersion.current().version
@@ -59,19 +63,25 @@ class ValidateTaskDslTest : TestBase() {
         } else {
             "An input file was expected to be present but it doesn't exist."
         }
-        assertTrue(result.output.contains(expectedMessage), "Unexpected/no message presented to the user for a spec pointing to an invalid URI.")
-        assertEquals(FAILED, result.task(":openApiValidate")?.outcome,
-                "Expected a failed run, but found ${result.task(":openApiValidate")?.outcome}")
+        assertTrue(
+            result.output.contains(expectedMessage),
+            "Unexpected/no message presented to the user for a spec pointing to an invalid URI."
+        )
+        assertEquals(
+            FAILED, result.task(":openApiValidate")?.outcome,
+            "Expected a failed run, but found ${result.task(":openApiValidate")?.outcome}"
+        )
     }
 
     @Test(dataProvider = "gradle_version_provider")
     fun `openApiValidate should succeed on valid spec`(gradleVersion: String?) {
         // Arrange
         val projectFiles = mapOf(
-                "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
+            "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
         )
 
-        withProject("""
+        withProject(
+            """
             | plugins {
             |   id 'org.openapi.generator'
             | }
@@ -79,28 +89,35 @@ class ValidateTaskDslTest : TestBase() {
             | openApiValidate {
             |   inputSpec = file("spec.yaml").absolutePath
             | }
-        """.trimMargin(), projectFiles)
+        """.trimMargin(), projectFiles
+        )
 
         // Act
         val result = getGradleRunner(gradleVersion)
-                .withProjectDir(temp)
-                .withArguments("openApiValidate")
-                .withPluginClasspath()
-                .build()
+            .withProjectDir(temp)
+            .withArguments("openApiValidate")
+            .withPluginClasspath()
+            .build()
 
         // Assert
-        assertTrue(result.output.contains("Spec is valid."), "Unexpected/no message presented to the user for a valid spec.")
-        assertEquals(SUCCESS, result.task(":openApiValidate")?.outcome,
-                "Expected a successful run, but found ${result.task(":openApiValidate")?.outcome}")
+        assertTrue(
+            result.output.contains("Spec is valid."),
+            "Unexpected/no message presented to the user for a valid spec."
+        )
+        assertEquals(
+            SUCCESS, result.task(":openApiValidate")?.outcome,
+            "Expected a successful run, but found ${result.task(":openApiValidate")?.outcome}"
+        )
     }
 
     @Test(dataProvider = "gradle_version_provider")
     fun `openApiValidate should fail on invalid spec`(gradleVersion: String?) {
         // Arrange
         val projectFiles = mapOf(
-                "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-invalid.yaml")
+            "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-invalid.yaml")
         )
-        withProject("""
+        withProject(
+            """
             | plugins {
             |   id 'org.openapi.generator'
             | }
@@ -108,19 +125,24 @@ class ValidateTaskDslTest : TestBase() {
             | openApiValidate {
             |   inputSpec = file('spec.yaml').absolutePath
             | }
-        """.trimMargin(), projectFiles)
+        """.trimMargin(), projectFiles
+        )
 
         // Act
         val result = getGradleRunner(gradleVersion)
-                .withProjectDir(temp)
-                .withArguments("openApiValidate")
-                .withPluginClasspath()
-                .buildAndFail()
+            .withProjectDir(temp)
+            .withArguments("openApiValidate")
+            .withPluginClasspath()
+            .buildAndFail()
 
         // Assert
-        assertTrue(result.output.contains("Spec is invalid."), "Unexpected/no message presented to the user for an invalid spec.")
-        assertEquals(FAILED, result.task(":openApiValidate")?.outcome,
-                "Expected a failed run, but found ${result.task(":openApiValidate")?.outcome}")
+        assertTrue(
+            result.output.contains("Spec is invalid."),
+            "Unexpected/no message presented to the user for an invalid spec."
+        )
+        assertEquals(
+            FAILED, result.task(":openApiValidate")?.outcome,
+            "Expected a failed run, but found ${result.task(":openApiValidate")?.outcome}"
+        )
     }
-
 }


### PR DESCRIPTION
Fix typos, unused imports and formatting issues. Remove @Supress
annotations that are no longer necessary

Related to https://github.com/OpenAPITools/openapi-generator/pull/12719

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
