### PR TITLE
[R] Add toString method to oneOf/anyOf objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
@@ -69,11 +69,11 @@
     #' @description
     #' Serialize {{{classname}}} to JSON string.
     #'
-    #' @return JSON string reprenation of the {{{classname}}}.
+    #' @return JSON string representation of the {{{classname}}}.
     #' @export
     toJSONString = function() {
       if (!is.null(self$actual_instance)) {
-        self$actual_instance$toJSONString()
+        as.character(jsonlite::minify((self$actual_instance$toJSONString())))
       } else {
         NULL
       }
@@ -83,7 +83,7 @@
     #' @description
     #' Serialize {{{classname}}} to JSON.
     #'
-    #' @return JSON reprenation of the {{{classname}}}.
+    #' @return JSON representation of the {{{classname}}}.
     #' @export
     toJSON = function() {
       if (!is.null(self$actual_instance)) {
@@ -111,6 +111,22 @@
       # no error thrown, restore old values
       self$actual_instance <- actual_instance_bak
       self$actual_type <- actual_type_bak
-    }
+    },
+    #' Returns the string representation of the instance.
+    #'
+    #' @description
+    #' Returns the string representation of the instance.
+    #'
+    #' @return The string representation of the instance.
+    #' @export
+    toString = function() {
+      jsoncontent <- c(
+        sprintf('"actual_instance": %s', if (is.null(self$actual_instance)) {NULL} else {self$actual_instance$toJSONString()}),
+        sprintf('"actual_type": "%s"', self$actual_type),
+        sprintf('"any_of": "%s"',  paste( unlist(self$any_of), collapse=', '))
+      )
+      jsoncontent <- paste(jsoncontent, collapse = ",")
+      as.character(jsonlite::prettify(paste('{', jsoncontent, '}', sep = "")))
+     }
   )
 )

--- a/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
@@ -84,11 +84,11 @@
     #' @description
     #' Serialize {{{classname}}} to JSON string.
     #'
-    #' @return JSON string reprenation of the {{{classname}}}.
+    #' @return JSON string representation of the {{{classname}}}.
     #' @export
     toJSONString = function() {
       if (!is.null(self$actual_instance)) {
-        self$actual_instance$toJSONString()
+        as.character(jsonlite::minify(self$actual_instance$toJSONString()))
       } else {
         NULL
       }
@@ -98,7 +98,7 @@
     #' @description
     #' Serialize {{{classname}}} to JSON.
     #'
-    #' @return JSON reprenation of the {{{classname}}}.
+    #' @return JSON representation of the {{{classname}}}.
     #' @export
     toJSON = function() {
       if (!is.null(self$actual_instance)) {
@@ -126,6 +126,22 @@
       # no error thrown, restore old values
       self$actual_instance <- actual_instance_bak
       self$actual_type <- actual_type_bak
+    },
+    #' Returns the string representation of the instance.
+    #'
+    #' @description
+    #' Returns the string representation of the instance.
+    #'
+    #' @return The string representation of the instance.
+    #' @export
+    toString = function() {
+      jsoncontent <- c(
+        sprintf('"actual_instance": %s', if (is.null(self$actual_instance)) {NULL} else {self$actual_instance$toJSONString()}),
+        sprintf('"actual_type": "%s"', self$actual_type),
+        sprintf('"one_of": "%s"',  paste( unlist(self$one_of), collapse=', '))
+      )
+      jsoncontent <- paste(jsoncontent, collapse = ",")
+      as.character(jsonlite::prettify(paste('{', jsoncontent, '}', sep = "")))
     }
   )
 )

--- a/samples/client/petstore/R/R/any_of_pig.R
+++ b/samples/client/petstore/R/R/any_of_pig.R
@@ -92,11 +92,11 @@ AnyOfPig <- R6::R6Class(
     #' @description
     #' Serialize AnyOfPig to JSON string.
     #'
-    #' @return JSON string reprenation of the AnyOfPig.
+    #' @return JSON string representation of the AnyOfPig.
     #' @export
     toJSONString = function() {
       if (!is.null(self$actual_instance)) {
-        self$actual_instance$toJSONString()
+        as.character(jsonlite::minify((self$actual_instance$toJSONString())))
       } else {
         NULL
       }
@@ -106,7 +106,7 @@ AnyOfPig <- R6::R6Class(
     #' @description
     #' Serialize AnyOfPig to JSON.
     #'
-    #' @return JSON reprenation of the AnyOfPig.
+    #' @return JSON representation of the AnyOfPig.
     #' @export
     toJSON = function() {
       if (!is.null(self$actual_instance)) {
@@ -134,7 +134,23 @@ AnyOfPig <- R6::R6Class(
       # no error thrown, restore old values
       self$actual_instance <- actual_instance_bak
       self$actual_type <- actual_type_bak
-    }
+    },
+    #' Returns the string representation of the instance.
+    #'
+    #' @description
+    #' Returns the string representation of the instance.
+    #'
+    #' @return The string representation of the instance.
+    #' @export
+    toString = function() {
+      jsoncontent <- c(
+        sprintf('"actual_instance": %s', if (is.null(self$actual_instance)) {NULL} else {self$actual_instance$toJSONString()}),
+        sprintf('"actual_type": "%s"', self$actual_type),
+        sprintf('"any_of": "%s"',  paste( unlist(self$any_of), collapse=', '))
+      )
+      jsoncontent <- paste(jsoncontent, collapse = ",")
+      as.character(jsonlite::prettify(paste('{', jsoncontent, '}', sep = "")))
+     }
   )
 )
 

--- a/samples/client/petstore/R/R/pig.R
+++ b/samples/client/petstore/R/R/pig.R
@@ -108,11 +108,11 @@ Pig <- R6::R6Class(
     #' @description
     #' Serialize Pig to JSON string.
     #'
-    #' @return JSON string reprenation of the Pig.
+    #' @return JSON string representation of the Pig.
     #' @export
     toJSONString = function() {
       if (!is.null(self$actual_instance)) {
-        self$actual_instance$toJSONString()
+        as.character(jsonlite::minify(self$actual_instance$toJSONString()))
       } else {
         NULL
       }
@@ -122,7 +122,7 @@ Pig <- R6::R6Class(
     #' @description
     #' Serialize Pig to JSON.
     #'
-    #' @return JSON reprenation of the Pig.
+    #' @return JSON representation of the Pig.
     #' @export
     toJSON = function() {
       if (!is.null(self$actual_instance)) {
@@ -150,6 +150,22 @@ Pig <- R6::R6Class(
       # no error thrown, restore old values
       self$actual_instance <- actual_instance_bak
       self$actual_type <- actual_type_bak
+    },
+    #' Returns the string representation of the instance.
+    #'
+    #' @description
+    #' Returns the string representation of the instance.
+    #'
+    #' @return The string representation of the instance.
+    #' @export
+    toString = function() {
+      jsoncontent <- c(
+        sprintf('"actual_instance": %s', if (is.null(self$actual_instance)) {NULL} else {self$actual_instance$toJSONString()}),
+        sprintf('"actual_type": "%s"', self$actual_type),
+        sprintf('"one_of": "%s"',  paste( unlist(self$one_of), collapse=', '))
+      )
+      jsoncontent <- paste(jsoncontent, collapse = ",")
+      as.character(jsonlite::prettify(paste('{', jsoncontent, '}', sep = "")))
     }
   )
 )

--- a/samples/client/petstore/R/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R/tests/testthat/test_petstore.R
@@ -236,7 +236,10 @@ test_that("Tests oneOf", {
   nested_oneof$nested_pig <- pig
   nested_oneof$size <- 15
   expect_equal(nested_oneof$toJSONString(), '{"size":15,"nested_pig":{"className":"BasquePig","color":"red"}}')
-   
+
+  # test toString
+  expect_equal(as.character(jsonlite::minify(pig$toString())), "{\"actual_instance\":{\"className\":\"BasquePig\",\"color\":\"red\"},\"actual_type\":\"BasquePig\",\"one_of\":\"BasquePig, DanishPig\"}")
+  expect_equal(as.character(jsonlite::minify(Pig$new()$toString())), "{\"one_of\":\"BasquePig, DanishPig\"}")
 })
 
 test_that("Tests anyOf", {


### PR DESCRIPTION
- Add toString method to oneOf/anyOf objects for easier debugging.
- Fix toJSONString to return characters instead of json object

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
