### PR TITLE
[R] add tests for nested oneOf's fromJSONString method

### DIFF
--- a/samples/client/petstore/R/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R/tests/testthat/test_petstore.R
@@ -15,7 +15,6 @@ result <- pet_api$AddPet(pet)
 
 test_that("AddPet", {
   expect_equal(pet_id, 123321)
-  #expect_equal(result, NULL)
   expect_equal(pet$toJSONString(), '{"id":123321,"category":{"id":450,"name":"test_cat"},"name":"name_test","photoUrls":["photo_test","second test"],"tags":[{"id":123,"name":"tag_test"},{"id":456,"name":"unknown"}],"status":"available"}')
 })
 
@@ -228,14 +227,19 @@ test_that("Tests oneOf", {
   expect_equal(pig2$actual_instance$color, "red")
   expect_equal(pig2$actual_instance$className, "BasquePig")
   expect_equal(pig2$toJSONString(), original_basque_pig$toJSONString())
-  
+
   expect_error(Pig$new(instance = basque_pig), 'Failed to initialize Pig with oneOf schemas BasquePig, DanishPig. Provided class name:  Pig')
 
-  # test nested oneOf
+  # test nested oneOf toJSONString
   nested_oneof <- NestedOneOf$new()
   nested_oneof$nested_pig <- pig
   nested_oneof$size <- 15
   expect_equal(nested_oneof$toJSONString(), '{"size":15,"nested_pig":{"className":"BasquePig","color":"red"}}')
+
+  # test fromJSONString with nested oneOf
+  nested_json_str <- '{"size":15,"nested_pig":{"className":"BasquePig","color":"red"}}'
+  nested_oneof2 <- NestedOneOf$new()$fromJSONString(nested_json_str)
+  expect_equal(nested_oneof2$toJSONString(), '{"size":15,"nested_pig":{"className":"BasquePig","color":"red"}}')
 
   # test toString
   expect_equal(as.character(jsonlite::minify(pig$toString())), "{\"actual_instance\":{\"className\":\"BasquePig\",\"color\":\"red\"},\"actual_type\":\"BasquePig\",\"one_of\":\"BasquePig, DanishPig\"}")
@@ -270,7 +274,7 @@ test_that("Tests anyOf", {
   expect_equal(pig$actual_instance$size, 7)
   expect_equal(pig$actual_instance$className, "DanishPig")
 
-  # test toJSON
+  # test toJSONString
   expect_equal(danish_pig$toJSONString(), original_danish_pig$toJSONString())
 
   basque_pig <- pig$fromJSON(basque_pig_json)


### PR DESCRIPTION
- add tests for nested oneOf's fromJSONString method

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
