### PR TITLE
[BUG] [typescript-axios] Generated project does not compile with the supportsES6 option

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
@@ -6,6 +6,9 @@
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",
+    {{#supportsES6}}
+    "moduleResolution": "node",
+    {{/supportsES6}}
     {{^supportsES6}}
     "lib": [
       "es6",


### PR DESCRIPTION
Fix #12728

typescript-axios generated project does not compile with the supportsES6 option unless "moduleResolution": "node" is added in tsconfig.json

This simple patch add the missing line to tsconfig.json only when supportsES6 is true

@nicokoenig you are listed as the technical committee member for typescript-axios so I'm mentioning you to review this patch as suggested by the guidelines.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
