### PR TITLE
[typescript-fetch] Fixing error handler in middleware

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -181,7 +181,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -192,7 +192,7 @@ export class BaseAPI {
                     }) || response;
                 }
             }
-            if (response !== undefined) {
+            if (response === undefined) {
                 throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
             }
         }


### PR DESCRIPTION
We made a mistake in #12716 when implementing error handling interceptors - we fail in case of an error if interceptor returned an alternative response, although should have failed in the opposite case, when none of the interceptors could process the error.

This PR fixes the bug.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.0.1) (patch release), `6.1.x` (breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
