### PR TITLE
[PHP] Allow strings with only whitespaces in enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -664,6 +664,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             return "EMPTY";
         }
 
+        if(name.trim().length() == 0) {
+            return "SPACE_" + name.length();
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
             return (getSymbolName(name)).toUpperCase(Locale.ROOT);
@@ -736,6 +740,11 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     @Override
     public String escapeText(String input) {
         if (input == null) {
+            return input;
+        }
+
+        // If the string contains only "trim-able" characters, don't trim it
+        if(input.trim().length() == 0) {
             return input;
         }
 


### PR DESCRIPTION
The current implementation of the PHP client doesn't allow strings containing only white spaces (like `' '`) as values for enum, despite they being valid in OpenAPI specification (or, at least not forbidden). This is a fragment of Microsoft Business Central API for reading/posting a Journal Entry (I'm only showing the relevant field):
```
components:
  schemas:
    JournalEntry:
      - type: object
        properties:
          'Document_Type':
            type: string
            enum:
              - ' '
              - 'Payment'
              - 'Invoice'
              - 'Credit Memo'
              - 'Finance Charge Memo'
              - 'Reminder'
              - 'Refund'
            default: ' '
```
Microsoft Business Central API **demands** the default value to be a string with exactly one space character inside it, otherwise it fails.
The current PHP generator sanitizes the enum options, removing all white spaces - even if the option contain only white spaces.
This PR changes the generator, so that it accepts whitespace-only strings as valid enum options and name them as `SPACE_X`, where `X` is the number of spaces inside that string. The change does NOT affect the trimming of enum options containing characters other than spaces - which means, this should not be a BC: it only affect a currently unsupported scenario.  

We already use this change in our own branch of openapi-generator - I'm creating some PRs upstream, so that we can share the small bugs we have fixed, and this is one of them! :smile:

The immediate benefit of this PR is to allow the OpenAPIGenerator PHP client to work with Microsoft Business Central, but it will surely benefit other APIs using space-only strings as enum values. :wink:

Cheers!

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee]
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon
