### PR TITLE
[PHP] Add support to nullable (based on #3493)

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ModelInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ModelInterface.mustache
@@ -83,4 +83,20 @@ interface ModelInterface
      * @return bool
      */
     public function valid();
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool;
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool;
 }

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -89,7 +89,7 @@ class ObjectSerializer
                             }
                         }
                     }
-                    if ($value !== null) {
+                    if (($data::isNullable($property) && $data->isNullableSetToNull($property)) || $value !== null) {
                         $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
                     }
                 }
@@ -460,7 +460,15 @@ class ObjectSerializer
             foreach ($instance::openAPITypes() as $property => $type) {
                 $propertySetter = $instance::setters()[$property];
 
-                if (!isset($propertySetter) || !isset($data->{$instance::attributeMap()[$property]})) {
+                if (!isset($propertySetter)) {
+                    continue;
+                }
+
+                if (!isset($data->{$instance::attributeMap()[$property]})) {
+                    if ($instance::isNullable($property)) {
+                        $instance->$propertySetter(null);
+                    }
+
                     continue;
                 }
 

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -32,6 +32,23 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        {{#vars}}'{{name}}' => {{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{^-last}},
+		{{/-last}}{{/vars}}
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -49,6 +66,48 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     public static function openAPIFormats()
     {
         return self::$openAPIFormats{{#parentSchema}} + parent::openAPIFormats(){{/parentSchema}};
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables{{#parentSchema}} + parent::openAPINullables(){{/parentSchema}};
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -172,13 +231,31 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
 
         {{/parentSchema}}
         {{#vars}}
-        $this->container['{{name}}'] = $data['{{name}}'] ?? {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}};
+        $this->setIfExists('{{name}}', $data ?? [], {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}});
         {{/vars}}
         {{#discriminator}}
 
         // Initialize discriminator property with the model name.
         $this->container['{{discriminatorName}}'] = static::$openAPIModelName;
         {{/discriminator}}
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -359,6 +436,25 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
         {{/minItems}}
         {{/hasValidation}}
+
+        {{#isNullable}}
+        if (is_null(${{name}})) {
+            array_push($this->openAPINullablesSetToNull, '{{name}}');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('{{name}}', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+        {{/isNullable}}
+        {{^isNullable}}
+        if (is_null(${{name}})) {
+            throw new \InvalidArgumentException('non-nullable {{name}} cannot be null');
+        }
+        {{/isNullable}}
+
         $this->container['{{name}}'] = ${{name}};
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -74,6 +74,23 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'map_property' => false,
+		'map_of_map_property' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,8 +240,26 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      */
     public function __construct(array $data = null)
     {
-        $this->container['map_property'] = $data['map_property'] ?? null;
-        $this->container['map_of_map_property'] = $data['map_of_map_property'] ?? null;
+        $this->setIfExists('map_property', $data ?? [], null);
+        $this->setIfExists('map_of_map_property', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -228,6 +305,11 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      */
     public function setMapProperty($map_property)
     {
+
+        if (is_null($map_property)) {
+            throw new \InvalidArgumentException('non-nullable map_property cannot be null');
+        }
+
         $this->container['map_property'] = $map_property;
 
         return $this;
@@ -252,6 +334,11 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      */
     public function setMapOfMapProperty($map_of_map_property)
     {
+
+        if (is_null($map_of_map_property)) {
+            throw new \InvalidArgumentException('non-nullable map_of_map_property cannot be null');
+        }
+
         $this->container['map_of_map_property'] = $map_of_map_property;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
@@ -74,6 +74,23 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'username' => false,
+		'single_ref_type' => true
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,8 +240,26 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     public function __construct(array $data = null)
     {
-        $this->container['username'] = $data['username'] ?? null;
-        $this->container['single_ref_type'] = $data['single_ref_type'] ?? null;
+        $this->setIfExists('username', $data ?? [], null);
+        $this->setIfExists('single_ref_type', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -228,6 +305,11 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     public function setUsername($username)
     {
+
+        if (is_null($username)) {
+            throw new \InvalidArgumentException('non-nullable username cannot be null');
+        }
+
         $this->container['username'] = $username;
 
         return $this;
@@ -252,6 +334,18 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     public function setSingleRefType($single_ref_type)
     {
+
+        if (is_null($single_ref_type)) {
+            array_push($this->openAPINullablesSetToNull, 'single_ref_type');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('single_ref_type', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['single_ref_type'] = $single_ref_type;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -74,6 +74,23 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'class_name' => false,
+		'color' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,11 +240,29 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['class_name'] = $data['class_name'] ?? null;
-        $this->container['color'] = $data['color'] ?? 'red';
+        $this->setIfExists('class_name', $data ?? [], null);
+        $this->setIfExists('color', $data ?? [], 'red');
 
         // Initialize discriminator property with the model name.
         $this->container['class_name'] = static::$openAPIModelName;
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -234,6 +311,11 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClassName($class_name)
     {
+
+        if (is_null($class_name)) {
+            throw new \InvalidArgumentException('non-nullable class_name cannot be null');
+        }
+
         $this->container['class_name'] = $class_name;
 
         return $this;
@@ -258,6 +340,11 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setColor($color)
     {
+
+        if (is_null($color)) {
+            throw new \InvalidArgumentException('non-nullable color cannot be null');
+        }
+
         $this->container['color'] = $color;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -76,6 +76,24 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'code' => false,
+		'type' => false,
+		'message' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -93,6 +111,48 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -186,9 +246,27 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['code'] = $data['code'] ?? null;
-        $this->container['type'] = $data['type'] ?? null;
-        $this->container['message'] = $data['message'] ?? null;
+        $this->setIfExists('code', $data ?? [], null);
+        $this->setIfExists('type', $data ?? [], null);
+        $this->setIfExists('message', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -234,6 +312,11 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCode($code)
     {
+
+        if (is_null($code)) {
+            throw new \InvalidArgumentException('non-nullable code cannot be null');
+        }
+
         $this->container['code'] = $code;
 
         return $this;
@@ -258,6 +341,11 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setType($type)
     {
+
+        if (is_null($type)) {
+            throw new \InvalidArgumentException('non-nullable type cannot be null');
+        }
+
         $this->container['type'] = $type;
 
         return $this;
@@ -282,6 +370,11 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMessage($message)
     {
+
+        if (is_null($message)) {
+            throw new \InvalidArgumentException('non-nullable message cannot be null');
+        }
+
         $this->container['message'] = $message;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -72,6 +72,22 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'array_array_number' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      */
     public function __construct(array $data = null)
     {
-        $this->container['array_array_number'] = $data['array_array_number'] ?? null;
+        $this->setIfExists('array_array_number', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      */
     public function setArrayArrayNumber($array_array_number)
     {
+
+        if (is_null($array_array_number)) {
+            throw new \InvalidArgumentException('non-nullable array_array_number cannot be null');
+        }
+
         $this->container['array_array_number'] = $array_array_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -72,6 +72,22 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'array_number' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      */
     public function __construct(array $data = null)
     {
-        $this->container['array_number'] = $data['array_number'] ?? null;
+        $this->setIfExists('array_number', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      */
     public function setArrayNumber($array_number)
     {
+
+        if (is_null($array_number)) {
+            throw new \InvalidArgumentException('non-nullable array_number cannot be null');
+        }
+
         $this->container['array_number'] = $array_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -76,6 +76,24 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'array_of_string' => false,
+		'array_array_of_integer' => false,
+		'array_array_of_model' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -93,6 +111,48 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -186,9 +246,27 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['array_of_string'] = $data['array_of_string'] ?? null;
-        $this->container['array_array_of_integer'] = $data['array_array_of_integer'] ?? null;
-        $this->container['array_array_of_model'] = $data['array_array_of_model'] ?? null;
+        $this->setIfExists('array_of_string', $data ?? [], null);
+        $this->setIfExists('array_array_of_integer', $data ?? [], null);
+        $this->setIfExists('array_array_of_model', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -249,6 +327,11 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($array_of_string) && (count($array_of_string) < 0)) {
             throw new \InvalidArgumentException('invalid length for $array_of_string when calling ArrayTest., number of items must be greater than or equal to 0.');
         }
+
+        if (is_null($array_of_string)) {
+            throw new \InvalidArgumentException('non-nullable array_of_string cannot be null');
+        }
+
         $this->container['array_of_string'] = $array_of_string;
 
         return $this;
@@ -273,6 +356,11 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayArrayOfInteger($array_array_of_integer)
     {
+
+        if (is_null($array_array_of_integer)) {
+            throw new \InvalidArgumentException('non-nullable array_array_of_integer cannot be null');
+        }
+
         $this->container['array_array_of_integer'] = $array_array_of_integer;
 
         return $this;
@@ -297,6 +385,11 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayArrayOfModel($array_array_of_model)
     {
+
+        if (is_null($array_array_of_model)) {
+            throw new \InvalidArgumentException('non-nullable array_array_of_model cannot be null');
+        }
+
         $this->container['array_array_of_model'] = $array_array_of_model;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -82,6 +82,27 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'small_camel' => false,
+		'capital_camel' => false,
+		'small_snake' => false,
+		'capital_snake' => false,
+		'sca_eth_flow_points' => false,
+		'att_name' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -99,6 +120,48 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -201,12 +264,30 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['small_camel'] = $data['small_camel'] ?? null;
-        $this->container['capital_camel'] = $data['capital_camel'] ?? null;
-        $this->container['small_snake'] = $data['small_snake'] ?? null;
-        $this->container['capital_snake'] = $data['capital_snake'] ?? null;
-        $this->container['sca_eth_flow_points'] = $data['sca_eth_flow_points'] ?? null;
-        $this->container['att_name'] = $data['att_name'] ?? null;
+        $this->setIfExists('small_camel', $data ?? [], null);
+        $this->setIfExists('capital_camel', $data ?? [], null);
+        $this->setIfExists('small_snake', $data ?? [], null);
+        $this->setIfExists('capital_snake', $data ?? [], null);
+        $this->setIfExists('sca_eth_flow_points', $data ?? [], null);
+        $this->setIfExists('att_name', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -252,6 +333,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSmallCamel($small_camel)
     {
+
+        if (is_null($small_camel)) {
+            throw new \InvalidArgumentException('non-nullable small_camel cannot be null');
+        }
+
         $this->container['small_camel'] = $small_camel;
 
         return $this;
@@ -276,6 +362,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCapitalCamel($capital_camel)
     {
+
+        if (is_null($capital_camel)) {
+            throw new \InvalidArgumentException('non-nullable capital_camel cannot be null');
+        }
+
         $this->container['capital_camel'] = $capital_camel;
 
         return $this;
@@ -300,6 +391,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSmallSnake($small_snake)
     {
+
+        if (is_null($small_snake)) {
+            throw new \InvalidArgumentException('non-nullable small_snake cannot be null');
+        }
+
         $this->container['small_snake'] = $small_snake;
 
         return $this;
@@ -324,6 +420,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCapitalSnake($capital_snake)
     {
+
+        if (is_null($capital_snake)) {
+            throw new \InvalidArgumentException('non-nullable capital_snake cannot be null');
+        }
+
         $this->container['capital_snake'] = $capital_snake;
 
         return $this;
@@ -348,6 +449,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setScaEthFlowPoints($sca_eth_flow_points)
     {
+
+        if (is_null($sca_eth_flow_points)) {
+            throw new \InvalidArgumentException('non-nullable sca_eth_flow_points cannot be null');
+        }
+
         $this->container['sca_eth_flow_points'] = $sca_eth_flow_points;
 
         return $this;
@@ -372,6 +478,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setAttName($att_name)
     {
+
+        if (is_null($att_name)) {
+            throw new \InvalidArgumentException('non-nullable att_name cannot be null');
+        }
+
         $this->container['att_name'] = $att_name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -70,6 +70,22 @@ class Cat extends Animal
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'declawed' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -87,6 +103,48 @@ class Cat extends Animal
     public static function openAPIFormats()
     {
         return self::$openAPIFormats + parent::openAPIFormats();
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables + parent::openAPINullables();
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -170,7 +228,25 @@ class Cat extends Animal
     {
         parent::__construct($data);
 
-        $this->container['declawed'] = $data['declawed'] ?? null;
+        $this->setIfExists('declawed', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -216,6 +292,11 @@ class Cat extends Animal
      */
     public function setDeclawed($declawed)
     {
+
+        if (is_null($declawed)) {
+            throw new \InvalidArgumentException('non-nullable declawed cannot be null');
+        }
+
         $this->container['declawed'] = $declawed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -72,6 +72,22 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'declawed' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['declawed'] = $data['declawed'] ?? null;
+        $this->setIfExists('declawed', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDeclawed($declawed)
     {
+
+        if (is_null($declawed)) {
+            throw new \InvalidArgumentException('non-nullable declawed cannot be null');
+        }
+
         $this->container['declawed'] = $declawed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -74,6 +74,23 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'id' => false,
+		'name' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,8 +240,26 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['id'] = $data['id'] ?? null;
-        $this->container['name'] = $data['name'] ?? 'default-name';
+        $this->setIfExists('id', $data ?? [], null);
+        $this->setIfExists('name', $data ?? [], 'default-name');
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -231,6 +308,11 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
+
+        if (is_null($id)) {
+            throw new \InvalidArgumentException('non-nullable id cannot be null');
+        }
+
         $this->container['id'] = $id;
 
         return $this;
@@ -255,6 +337,11 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
+
+        if (is_null($name)) {
+            throw new \InvalidArgumentException('non-nullable name cannot be null');
+        }
+
         $this->container['name'] = $name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -73,6 +73,22 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        '_class' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -90,6 +106,48 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -177,7 +235,25 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['_class'] = $data['_class'] ?? null;
+        $this->setIfExists('_class', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -223,6 +299,11 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClass($_class)
     {
+
+        if (is_null($_class)) {
+            throw new \InvalidArgumentException('non-nullable _class cannot be null');
+        }
+
         $this->container['_class'] = $_class;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -72,6 +72,22 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'client' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['client'] = $data['client'] ?? null;
+        $this->setIfExists('client', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClient($client)
     {
+
+        if (is_null($client)) {
+            throw new \InvalidArgumentException('non-nullable client cannot be null');
+        }
+
         $this->container['client'] = $client;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
@@ -72,6 +72,22 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'name' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = $data['name'] ?? null;
+        $this->setIfExists('name', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
+
+        if (is_null($name)) {
+            throw new \InvalidArgumentException('non-nullable name cannot be null');
+        }
+
         $this->container['name'] = $name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -70,6 +70,22 @@ class Dog extends Animal
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'breed' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -87,6 +103,48 @@ class Dog extends Animal
     public static function openAPIFormats()
     {
         return self::$openAPIFormats + parent::openAPIFormats();
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables + parent::openAPINullables();
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -170,7 +228,25 @@ class Dog extends Animal
     {
         parent::__construct($data);
 
-        $this->container['breed'] = $data['breed'] ?? null;
+        $this->setIfExists('breed', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -216,6 +292,11 @@ class Dog extends Animal
      */
     public function setBreed($breed)
     {
+
+        if (is_null($breed)) {
+            throw new \InvalidArgumentException('non-nullable breed cannot be null');
+        }
+
         $this->container['breed'] = $breed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -72,6 +72,22 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'breed' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['breed'] = $data['breed'] ?? null;
+        $this->setIfExists('breed', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBreed($breed)
     {
+
+        if (is_null($breed)) {
+            throw new \InvalidArgumentException('non-nullable breed cannot be null');
+        }
+
         $this->container['breed'] = $breed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -74,6 +74,23 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'just_symbol' => false,
+		'array_enum' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -211,8 +270,26 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['just_symbol'] = $data['just_symbol'] ?? null;
-        $this->container['array_enum'] = $data['array_enum'] ?? null;
+        $this->setIfExists('just_symbol', $data ?? [], null);
+        $this->setIfExists('array_enum', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -277,6 +354,11 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($just_symbol)) {
+            throw new \InvalidArgumentException('non-nullable just_symbol cannot be null');
+        }
+
         $this->container['just_symbol'] = $just_symbol;
 
         return $this;
@@ -310,6 +392,11 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($array_enum)) {
+            throw new \InvalidArgumentException('non-nullable array_enum cannot be null');
+        }
+
         $this->container['array_enum'] = $array_enum;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -86,6 +86,29 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'enum_string' => false,
+		'enum_string_required' => false,
+		'enum_integer' => false,
+		'enum_number' => false,
+		'outer_enum' => true,
+		'outer_enum_integer' => false,
+		'outer_enum_default_value' => false,
+		'outer_enum_integer_default_value' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -103,6 +126,48 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -275,14 +340,32 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['enum_string'] = $data['enum_string'] ?? null;
-        $this->container['enum_string_required'] = $data['enum_string_required'] ?? null;
-        $this->container['enum_integer'] = $data['enum_integer'] ?? null;
-        $this->container['enum_number'] = $data['enum_number'] ?? null;
-        $this->container['outer_enum'] = $data['outer_enum'] ?? null;
-        $this->container['outer_enum_integer'] = $data['outer_enum_integer'] ?? null;
-        $this->container['outer_enum_default_value'] = $data['outer_enum_default_value'] ?? null;
-        $this->container['outer_enum_integer_default_value'] = $data['outer_enum_integer_default_value'] ?? null;
+        $this->setIfExists('enum_string', $data ?? [], null);
+        $this->setIfExists('enum_string_required', $data ?? [], null);
+        $this->setIfExists('enum_integer', $data ?? [], null);
+        $this->setIfExists('enum_number', $data ?? [], null);
+        $this->setIfExists('outer_enum', $data ?? [], null);
+        $this->setIfExists('outer_enum_integer', $data ?? [], null);
+        $this->setIfExists('outer_enum_default_value', $data ?? [], null);
+        $this->setIfExists('outer_enum_integer_default_value', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -377,6 +460,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($enum_string)) {
+            throw new \InvalidArgumentException('non-nullable enum_string cannot be null');
+        }
+
         $this->container['enum_string'] = $enum_string;
 
         return $this;
@@ -411,6 +499,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($enum_string_required)) {
+            throw new \InvalidArgumentException('non-nullable enum_string_required cannot be null');
+        }
+
         $this->container['enum_string_required'] = $enum_string_required;
 
         return $this;
@@ -445,6 +538,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($enum_integer)) {
+            throw new \InvalidArgumentException('non-nullable enum_integer cannot be null');
+        }
+
         $this->container['enum_integer'] = $enum_integer;
 
         return $this;
@@ -479,6 +577,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($enum_number)) {
+            throw new \InvalidArgumentException('non-nullable enum_number cannot be null');
+        }
+
         $this->container['enum_number'] = $enum_number;
 
         return $this;
@@ -503,6 +606,18 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnum($outer_enum)
     {
+
+        if (is_null($outer_enum)) {
+            array_push($this->openAPINullablesSetToNull, 'outer_enum');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('outer_enum', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['outer_enum'] = $outer_enum;
 
         return $this;
@@ -527,6 +642,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnumInteger($outer_enum_integer)
     {
+
+        if (is_null($outer_enum_integer)) {
+            throw new \InvalidArgumentException('non-nullable outer_enum_integer cannot be null');
+        }
+
         $this->container['outer_enum_integer'] = $outer_enum_integer;
 
         return $this;
@@ -551,6 +671,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnumDefaultValue($outer_enum_default_value)
     {
+
+        if (is_null($outer_enum_default_value)) {
+            throw new \InvalidArgumentException('non-nullable outer_enum_default_value cannot be null');
+        }
+
         $this->container['outer_enum_default_value'] = $outer_enum_default_value;
 
         return $this;
@@ -575,6 +700,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnumIntegerDefaultValue($outer_enum_integer_default_value)
     {
+
+        if (is_null($outer_enum_integer_default_value)) {
+            throw new \InvalidArgumentException('non-nullable outer_enum_integer_default_value cannot be null');
+        }
+
         $this->container['outer_enum_integer_default_value'] = $outer_enum_integer_default_value;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -73,6 +73,22 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'source_uri' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -90,6 +106,48 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -177,7 +235,25 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['source_uri'] = $data['source_uri'] ?? null;
+        $this->setIfExists('source_uri', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -223,6 +299,11 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSourceUri($source_uri)
     {
+
+        if (is_null($source_uri)) {
+            throw new \InvalidArgumentException('non-nullable source_uri cannot be null');
+        }
+
         $this->container['source_uri'] = $source_uri;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -74,6 +74,23 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'file' => false,
+		'files' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,8 +240,26 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      */
     public function __construct(array $data = null)
     {
-        $this->container['file'] = $data['file'] ?? null;
-        $this->container['files'] = $data['files'] ?? null;
+        $this->setIfExists('file', $data ?? [], null);
+        $this->setIfExists('files', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -228,6 +305,11 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      */
     public function setFile($file)
     {
+
+        if (is_null($file)) {
+            throw new \InvalidArgumentException('non-nullable file cannot be null');
+        }
+
         $this->container['file'] = $file;
 
         return $this;
@@ -252,6 +334,11 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      */
     public function setFiles($files)
     {
+
+        if (is_null($files)) {
+            throw new \InvalidArgumentException('non-nullable files cannot be null');
+        }
+
         $this->container['files'] = $files;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -72,6 +72,22 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'bar' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['bar'] = $data['bar'] ?? 'bar';
+        $this->setIfExists('bar', $data ?? [], 'bar');
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBar($bar)
     {
+
+        if (is_null($bar)) {
+            throw new \InvalidArgumentException('non-nullable bar cannot be null');
+        }
+
         $this->container['bar'] = $bar;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
@@ -72,6 +72,22 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'string' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      */
     public function __construct(array $data = null)
     {
-        $this->container['string'] = $data['string'] ?? null;
+        $this->setIfExists('string', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      */
     public function setString($string)
     {
+
+        if (is_null($string)) {
+            throw new \InvalidArgumentException('non-nullable string cannot be null');
+        }
+
         $this->container['string'] = $string;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -102,6 +102,37 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'integer' => false,
+		'int32' => false,
+		'int64' => false,
+		'number' => false,
+		'float' => false,
+		'double' => false,
+		'decimal' => false,
+		'string' => false,
+		'byte' => false,
+		'binary' => false,
+		'date' => false,
+		'date_time' => false,
+		'uuid' => false,
+		'password' => false,
+		'pattern_with_digits' => false,
+		'pattern_with_digits_and_delimiter' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -119,6 +150,48 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -251,22 +324,40 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['integer'] = $data['integer'] ?? null;
-        $this->container['int32'] = $data['int32'] ?? null;
-        $this->container['int64'] = $data['int64'] ?? null;
-        $this->container['number'] = $data['number'] ?? null;
-        $this->container['float'] = $data['float'] ?? null;
-        $this->container['double'] = $data['double'] ?? null;
-        $this->container['decimal'] = $data['decimal'] ?? null;
-        $this->container['string'] = $data['string'] ?? null;
-        $this->container['byte'] = $data['byte'] ?? null;
-        $this->container['binary'] = $data['binary'] ?? null;
-        $this->container['date'] = $data['date'] ?? null;
-        $this->container['date_time'] = $data['date_time'] ?? null;
-        $this->container['uuid'] = $data['uuid'] ?? null;
-        $this->container['password'] = $data['password'] ?? null;
-        $this->container['pattern_with_digits'] = $data['pattern_with_digits'] ?? null;
-        $this->container['pattern_with_digits_and_delimiter'] = $data['pattern_with_digits_and_delimiter'] ?? null;
+        $this->setIfExists('integer', $data ?? [], null);
+        $this->setIfExists('int32', $data ?? [], null);
+        $this->setIfExists('int64', $data ?? [], null);
+        $this->setIfExists('number', $data ?? [], null);
+        $this->setIfExists('float', $data ?? [], null);
+        $this->setIfExists('double', $data ?? [], null);
+        $this->setIfExists('decimal', $data ?? [], null);
+        $this->setIfExists('string', $data ?? [], null);
+        $this->setIfExists('byte', $data ?? [], null);
+        $this->setIfExists('binary', $data ?? [], null);
+        $this->setIfExists('date', $data ?? [], null);
+        $this->setIfExists('date_time', $data ?? [], null);
+        $this->setIfExists('uuid', $data ?? [], null);
+        $this->setIfExists('password', $data ?? [], null);
+        $this->setIfExists('pattern_with_digits', $data ?? [], null);
+        $this->setIfExists('pattern_with_digits_and_delimiter', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -392,6 +483,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be bigger than or equal to 10.');
         }
 
+
+        if (is_null($integer)) {
+            throw new \InvalidArgumentException('non-nullable integer cannot be null');
+        }
+
         $this->container['integer'] = $integer;
 
         return $this;
@@ -424,6 +520,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be bigger than or equal to 20.');
         }
 
+
+        if (is_null($int32)) {
+            throw new \InvalidArgumentException('non-nullable int32 cannot be null');
+        }
+
         $this->container['int32'] = $int32;
 
         return $this;
@@ -448,6 +549,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setInt64($int64)
     {
+
+        if (is_null($int64)) {
+            throw new \InvalidArgumentException('non-nullable int64 cannot be null');
+        }
+
         $this->container['int64'] = $int64;
 
         return $this;
@@ -478,6 +584,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         }
         if (($number < 32.1)) {
             throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be bigger than or equal to 32.1.');
+        }
+
+
+        if (is_null($number)) {
+            throw new \InvalidArgumentException('non-nullable number cannot be null');
         }
 
         $this->container['number'] = $number;
@@ -512,6 +623,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be bigger than or equal to 54.3.');
         }
 
+
+        if (is_null($float)) {
+            throw new \InvalidArgumentException('non-nullable float cannot be null');
+        }
+
         $this->container['float'] = $float;
 
         return $this;
@@ -544,6 +660,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be bigger than or equal to 67.8.');
         }
 
+
+        if (is_null($double)) {
+            throw new \InvalidArgumentException('non-nullable double cannot be null');
+        }
+
         $this->container['double'] = $double;
 
         return $this;
@@ -568,6 +689,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDecimal($decimal)
     {
+
+        if (is_null($decimal)) {
+            throw new \InvalidArgumentException('non-nullable decimal cannot be null');
+        }
+
         $this->container['decimal'] = $decimal;
 
         return $this;
@@ -597,6 +723,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
         }
 
+
+        if (is_null($string)) {
+            throw new \InvalidArgumentException('non-nullable string cannot be null');
+        }
+
         $this->container['string'] = $string;
 
         return $this;
@@ -621,6 +752,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setByte($byte)
     {
+
+        if (is_null($byte)) {
+            throw new \InvalidArgumentException('non-nullable byte cannot be null');
+        }
+
         $this->container['byte'] = $byte;
 
         return $this;
@@ -645,6 +781,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBinary($binary)
     {
+
+        if (is_null($binary)) {
+            throw new \InvalidArgumentException('non-nullable binary cannot be null');
+        }
+
         $this->container['binary'] = $binary;
 
         return $this;
@@ -669,6 +810,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDate($date)
     {
+
+        if (is_null($date)) {
+            throw new \InvalidArgumentException('non-nullable date cannot be null');
+        }
+
         $this->container['date'] = $date;
 
         return $this;
@@ -693,6 +839,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDateTime($date_time)
     {
+
+        if (is_null($date_time)) {
+            throw new \InvalidArgumentException('non-nullable date_time cannot be null');
+        }
+
         $this->container['date_time'] = $date_time;
 
         return $this;
@@ -717,6 +868,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setUuid($uuid)
     {
+
+        if (is_null($uuid)) {
+            throw new \InvalidArgumentException('non-nullable uuid cannot be null');
+        }
+
         $this->container['uuid'] = $uuid;
 
         return $this;
@@ -748,6 +904,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('invalid length for $password when calling FormatTest., must be bigger than or equal to 10.');
         }
 
+
+        if (is_null($password)) {
+            throw new \InvalidArgumentException('non-nullable password cannot be null');
+        }
+
         $this->container['password'] = $password;
 
         return $this;
@@ -777,6 +938,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
         }
 
+
+        if (is_null($pattern_with_digits)) {
+            throw new \InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
+        }
+
         $this->container['pattern_with_digits'] = $pattern_with_digits;
 
         return $this;
@@ -804,6 +970,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
 
         if (!is_null($pattern_with_digits_and_delimiter) && (!preg_match("/^image_\\d{1,3}$/i", $pattern_with_digits_and_delimiter))) {
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
+        }
+
+
+        if (is_null($pattern_with_digits_and_delimiter)) {
+            throw new \InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
         }
 
         $this->container['pattern_with_digits_and_delimiter'] = $pattern_with_digits_and_delimiter;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -74,6 +74,23 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'bar' => false,
+		'foo' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,8 +240,26 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['bar'] = $data['bar'] ?? null;
-        $this->container['foo'] = $data['foo'] ?? null;
+        $this->setIfExists('bar', $data ?? [], null);
+        $this->setIfExists('foo', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -228,6 +305,11 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBar($bar)
     {
+
+        if (is_null($bar)) {
+            throw new \InvalidArgumentException('non-nullable bar cannot be null');
+        }
+
         $this->container['bar'] = $bar;
 
         return $this;
@@ -252,6 +334,11 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setFoo($foo)
     {
+
+        if (is_null($foo)) {
+            throw new \InvalidArgumentException('non-nullable foo cannot be null');
+        }
+
         $this->container['foo'] = $foo;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -73,6 +73,22 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'nullable_message' => true
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -90,6 +106,48 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -177,7 +235,25 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      */
     public function __construct(array $data = null)
     {
-        $this->container['nullable_message'] = $data['nullable_message'] ?? null;
+        $this->setIfExists('nullable_message', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -223,6 +299,18 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      */
     public function setNullableMessage($nullable_message)
     {
+
+        if (is_null($nullable_message)) {
+            array_push($this->openAPINullablesSetToNull, 'nullable_message');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('nullable_message', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['nullable_message'] = $nullable_message;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -78,6 +78,25 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'map_map_of_string' => false,
+		'map_of_enum_string' => false,
+		'direct_map' => false,
+		'indirect_map' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -95,6 +114,48 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -206,10 +267,28 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['map_map_of_string'] = $data['map_map_of_string'] ?? null;
-        $this->container['map_of_enum_string'] = $data['map_of_enum_string'] ?? null;
-        $this->container['direct_map'] = $data['direct_map'] ?? null;
-        $this->container['indirect_map'] = $data['indirect_map'] ?? null;
+        $this->setIfExists('map_map_of_string', $data ?? [], null);
+        $this->setIfExists('map_of_enum_string', $data ?? [], null);
+        $this->setIfExists('direct_map', $data ?? [], null);
+        $this->setIfExists('indirect_map', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -255,6 +334,11 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMapMapOfString($map_map_of_string)
     {
+
+        if (is_null($map_map_of_string)) {
+            throw new \InvalidArgumentException('non-nullable map_map_of_string cannot be null');
+        }
+
         $this->container['map_map_of_string'] = $map_map_of_string;
 
         return $this;
@@ -288,6 +372,11 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($map_of_enum_string)) {
+            throw new \InvalidArgumentException('non-nullable map_of_enum_string cannot be null');
+        }
+
         $this->container['map_of_enum_string'] = $map_of_enum_string;
 
         return $this;
@@ -312,6 +401,11 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDirectMap($direct_map)
     {
+
+        if (is_null($direct_map)) {
+            throw new \InvalidArgumentException('non-nullable direct_map cannot be null');
+        }
+
         $this->container['direct_map'] = $direct_map;
 
         return $this;
@@ -336,6 +430,11 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setIndirectMap($indirect_map)
     {
+
+        if (is_null($indirect_map)) {
+            throw new \InvalidArgumentException('non-nullable indirect_map cannot be null');
+        }
+
         $this->container['indirect_map'] = $indirect_map;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -76,6 +76,24 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'uuid' => false,
+		'date_time' => false,
+		'map' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -93,6 +111,48 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -186,9 +246,27 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      */
     public function __construct(array $data = null)
     {
-        $this->container['uuid'] = $data['uuid'] ?? null;
-        $this->container['date_time'] = $data['date_time'] ?? null;
-        $this->container['map'] = $data['map'] ?? null;
+        $this->setIfExists('uuid', $data ?? [], null);
+        $this->setIfExists('date_time', $data ?? [], null);
+        $this->setIfExists('map', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -234,6 +312,11 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      */
     public function setUuid($uuid)
     {
+
+        if (is_null($uuid)) {
+            throw new \InvalidArgumentException('non-nullable uuid cannot be null');
+        }
+
         $this->container['uuid'] = $uuid;
 
         return $this;
@@ -258,6 +341,11 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      */
     public function setDateTime($date_time)
     {
+
+        if (is_null($date_time)) {
+            throw new \InvalidArgumentException('non-nullable date_time cannot be null');
+        }
+
         $this->container['date_time'] = $date_time;
 
         return $this;
@@ -282,6 +370,11 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      */
     public function setMap($map)
     {
+
+        if (is_null($map)) {
+            throw new \InvalidArgumentException('non-nullable map cannot be null');
+        }
+
         $this->container['map'] = $map;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -75,6 +75,23 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'name' => false,
+		'class' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -92,6 +109,48 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -182,8 +241,26 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = $data['name'] ?? null;
-        $this->container['class'] = $data['class'] ?? null;
+        $this->setIfExists('name', $data ?? [], null);
+        $this->setIfExists('class', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -229,6 +306,11 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
+
+        if (is_null($name)) {
+            throw new \InvalidArgumentException('non-nullable name cannot be null');
+        }
+
         $this->container['name'] = $name;
 
         return $this;
@@ -253,6 +335,11 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClass($class)
     {
+
+        if (is_null($class)) {
+            throw new \InvalidArgumentException('non-nullable class cannot be null');
+        }
+
         $this->container['class'] = $class;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelInterface.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelInterface.php
@@ -92,4 +92,20 @@ interface ModelInterface
      * @return bool
      */
     public function valid();
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool;
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool;
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -72,6 +72,22 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        '_123_list' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['_123_list'] = $data['_123_list'] ?? null;
+        $this->setIfExists('_123_list', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function set123List($_123_list)
     {
+
+        if (is_null($_123_list)) {
+            throw new \InvalidArgumentException('non-nullable _123_list cannot be null');
+        }
+
         $this->container['_123_list'] = $_123_list;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -73,6 +73,22 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'return' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -90,6 +106,48 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -177,7 +235,25 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['return'] = $data['return'] ?? null;
+        $this->setIfExists('return', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -223,6 +299,11 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setReturn($return)
     {
+
+        if (is_null($return)) {
+            throw new \InvalidArgumentException('non-nullable return cannot be null');
+        }
+
         $this->container['return'] = $return;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -79,6 +79,25 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'name' => false,
+		'snake_case' => false,
+		'property' => false,
+		'_123_number' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -96,6 +115,48 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -192,10 +253,28 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['name'] = $data['name'] ?? null;
-        $this->container['snake_case'] = $data['snake_case'] ?? null;
-        $this->container['property'] = $data['property'] ?? null;
-        $this->container['_123_number'] = $data['_123_number'] ?? null;
+        $this->setIfExists('name', $data ?? [], null);
+        $this->setIfExists('snake_case', $data ?? [], null);
+        $this->setIfExists('property', $data ?? [], null);
+        $this->setIfExists('_123_number', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -244,6 +323,11 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
+
+        if (is_null($name)) {
+            throw new \InvalidArgumentException('non-nullable name cannot be null');
+        }
+
         $this->container['name'] = $name;
 
         return $this;
@@ -268,6 +352,11 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSnakeCase($snake_case)
     {
+
+        if (is_null($snake_case)) {
+            throw new \InvalidArgumentException('non-nullable snake_case cannot be null');
+        }
+
         $this->container['snake_case'] = $snake_case;
 
         return $this;
@@ -292,6 +381,11 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setProperty($property)
     {
+
+        if (is_null($property)) {
+            throw new \InvalidArgumentException('non-nullable property cannot be null');
+        }
+
         $this->container['property'] = $property;
 
         return $this;
@@ -316,6 +410,11 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function set123Number($_123_number)
     {
+
+        if (is_null($_123_number)) {
+            throw new \InvalidArgumentException('non-nullable _123_number cannot be null');
+        }
+
         $this->container['_123_number'] = $_123_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -94,6 +94,33 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'integer_prop' => true,
+		'number_prop' => true,
+		'boolean_prop' => true,
+		'string_prop' => true,
+		'date_prop' => true,
+		'datetime_prop' => true,
+		'array_nullable_prop' => true,
+		'array_and_items_nullable_prop' => true,
+		'array_items_nullable' => false,
+		'object_nullable_prop' => true,
+		'object_and_items_nullable_prop' => true,
+		'object_items_nullable' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -111,6 +138,48 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -231,18 +300,36 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['integer_prop'] = $data['integer_prop'] ?? null;
-        $this->container['number_prop'] = $data['number_prop'] ?? null;
-        $this->container['boolean_prop'] = $data['boolean_prop'] ?? null;
-        $this->container['string_prop'] = $data['string_prop'] ?? null;
-        $this->container['date_prop'] = $data['date_prop'] ?? null;
-        $this->container['datetime_prop'] = $data['datetime_prop'] ?? null;
-        $this->container['array_nullable_prop'] = $data['array_nullable_prop'] ?? null;
-        $this->container['array_and_items_nullable_prop'] = $data['array_and_items_nullable_prop'] ?? null;
-        $this->container['array_items_nullable'] = $data['array_items_nullable'] ?? null;
-        $this->container['object_nullable_prop'] = $data['object_nullable_prop'] ?? null;
-        $this->container['object_and_items_nullable_prop'] = $data['object_and_items_nullable_prop'] ?? null;
-        $this->container['object_items_nullable'] = $data['object_items_nullable'] ?? null;
+        $this->setIfExists('integer_prop', $data ?? [], null);
+        $this->setIfExists('number_prop', $data ?? [], null);
+        $this->setIfExists('boolean_prop', $data ?? [], null);
+        $this->setIfExists('string_prop', $data ?? [], null);
+        $this->setIfExists('date_prop', $data ?? [], null);
+        $this->setIfExists('datetime_prop', $data ?? [], null);
+        $this->setIfExists('array_nullable_prop', $data ?? [], null);
+        $this->setIfExists('array_and_items_nullable_prop', $data ?? [], null);
+        $this->setIfExists('array_items_nullable', $data ?? [], null);
+        $this->setIfExists('object_nullable_prop', $data ?? [], null);
+        $this->setIfExists('object_and_items_nullable_prop', $data ?? [], null);
+        $this->setIfExists('object_items_nullable', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -288,6 +375,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setIntegerProp($integer_prop)
     {
+
+        if (is_null($integer_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'integer_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('integer_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['integer_prop'] = $integer_prop;
 
         return $this;
@@ -312,6 +411,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setNumberProp($number_prop)
     {
+
+        if (is_null($number_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'number_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('number_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['number_prop'] = $number_prop;
 
         return $this;
@@ -336,6 +447,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBooleanProp($boolean_prop)
     {
+
+        if (is_null($boolean_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'boolean_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('boolean_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['boolean_prop'] = $boolean_prop;
 
         return $this;
@@ -360,6 +483,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setStringProp($string_prop)
     {
+
+        if (is_null($string_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'string_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('string_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['string_prop'] = $string_prop;
 
         return $this;
@@ -384,6 +519,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDateProp($date_prop)
     {
+
+        if (is_null($date_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'date_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('date_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['date_prop'] = $date_prop;
 
         return $this;
@@ -408,6 +555,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDatetimeProp($datetime_prop)
     {
+
+        if (is_null($datetime_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'datetime_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('datetime_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['datetime_prop'] = $datetime_prop;
 
         return $this;
@@ -432,6 +591,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayNullableProp($array_nullable_prop)
     {
+
+        if (is_null($array_nullable_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'array_nullable_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('array_nullable_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['array_nullable_prop'] = $array_nullable_prop;
 
         return $this;
@@ -456,6 +627,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayAndItemsNullableProp($array_and_items_nullable_prop)
     {
+
+        if (is_null($array_and_items_nullable_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'array_and_items_nullable_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('array_and_items_nullable_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['array_and_items_nullable_prop'] = $array_and_items_nullable_prop;
 
         return $this;
@@ -480,6 +663,11 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayItemsNullable($array_items_nullable)
     {
+
+        if (is_null($array_items_nullable)) {
+            throw new \InvalidArgumentException('non-nullable array_items_nullable cannot be null');
+        }
+
         $this->container['array_items_nullable'] = $array_items_nullable;
 
         return $this;
@@ -504,6 +692,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setObjectNullableProp($object_nullable_prop)
     {
+
+        if (is_null($object_nullable_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'object_nullable_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('object_nullable_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['object_nullable_prop'] = $object_nullable_prop;
 
         return $this;
@@ -528,6 +728,18 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setObjectAndItemsNullableProp($object_and_items_nullable_prop)
     {
+
+        if (is_null($object_and_items_nullable_prop)) {
+            array_push($this->openAPINullablesSetToNull, 'object_and_items_nullable_prop');
+        } else {
+            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
+            $index = array_search('object_and_items_nullable_prop', $nullablesSetToNull);
+            if ($index !== FALSE) {
+                unset($nullablesSetToNull[$index]);
+                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
+            }
+        }
+
         $this->container['object_and_items_nullable_prop'] = $object_and_items_nullable_prop;
 
         return $this;
@@ -552,6 +764,11 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setObjectItemsNullable($object_items_nullable)
     {
+
+        if (is_null($object_items_nullable)) {
+            throw new \InvalidArgumentException('non-nullable object_items_nullable cannot be null');
+        }
+
         $this->container['object_items_nullable'] = $object_items_nullable;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -72,6 +72,22 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'just_number' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['just_number'] = $data['just_number'] ?? null;
+        $this->setIfExists('just_number', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setJustNumber($just_number)
     {
+
+        if (is_null($just_number)) {
+            throw new \InvalidArgumentException('non-nullable just_number cannot be null');
+        }
+
         $this->container['just_number'] = $just_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -78,6 +78,25 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'uuid' => false,
+		'id' => false,
+		'deprecated_ref' => false,
+		'bars' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -95,6 +114,48 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -191,10 +252,28 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function __construct(array $data = null)
     {
-        $this->container['uuid'] = $data['uuid'] ?? null;
-        $this->container['id'] = $data['id'] ?? null;
-        $this->container['deprecated_ref'] = $data['deprecated_ref'] ?? null;
-        $this->container['bars'] = $data['bars'] ?? null;
+        $this->setIfExists('uuid', $data ?? [], null);
+        $this->setIfExists('id', $data ?? [], null);
+        $this->setIfExists('deprecated_ref', $data ?? [], null);
+        $this->setIfExists('bars', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -240,6 +319,11 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setUuid($uuid)
     {
+
+        if (is_null($uuid)) {
+            throw new \InvalidArgumentException('non-nullable uuid cannot be null');
+        }
+
         $this->container['uuid'] = $uuid;
 
         return $this;
@@ -266,6 +350,11 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setId($id)
     {
+
+        if (is_null($id)) {
+            throw new \InvalidArgumentException('non-nullable id cannot be null');
+        }
+
         $this->container['id'] = $id;
 
         return $this;
@@ -292,6 +381,11 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setDeprecatedRef($deprecated_ref)
     {
+
+        if (is_null($deprecated_ref)) {
+            throw new \InvalidArgumentException('non-nullable deprecated_ref cannot be null');
+        }
+
         $this->container['deprecated_ref'] = $deprecated_ref;
 
         return $this;
@@ -318,6 +412,11 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setBars($bars)
     {
+
+        if (is_null($bars)) {
+            throw new \InvalidArgumentException('non-nullable bars cannot be null');
+        }
+
         $this->container['bars'] = $bars;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -82,6 +82,27 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'id' => false,
+		'pet_id' => false,
+		'quantity' => false,
+		'ship_date' => false,
+		'status' => false,
+		'complete' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -99,6 +120,48 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -218,12 +281,30 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['id'] = $data['id'] ?? null;
-        $this->container['pet_id'] = $data['pet_id'] ?? null;
-        $this->container['quantity'] = $data['quantity'] ?? null;
-        $this->container['ship_date'] = $data['ship_date'] ?? null;
-        $this->container['status'] = $data['status'] ?? null;
-        $this->container['complete'] = $data['complete'] ?? false;
+        $this->setIfExists('id', $data ?? [], null);
+        $this->setIfExists('pet_id', $data ?? [], null);
+        $this->setIfExists('quantity', $data ?? [], null);
+        $this->setIfExists('ship_date', $data ?? [], null);
+        $this->setIfExists('status', $data ?? [], null);
+        $this->setIfExists('complete', $data ?? [], false);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -278,6 +359,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
+
+        if (is_null($id)) {
+            throw new \InvalidArgumentException('non-nullable id cannot be null');
+        }
+
         $this->container['id'] = $id;
 
         return $this;
@@ -302,6 +388,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPetId($pet_id)
     {
+
+        if (is_null($pet_id)) {
+            throw new \InvalidArgumentException('non-nullable pet_id cannot be null');
+        }
+
         $this->container['pet_id'] = $pet_id;
 
         return $this;
@@ -326,6 +417,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setQuantity($quantity)
     {
+
+        if (is_null($quantity)) {
+            throw new \InvalidArgumentException('non-nullable quantity cannot be null');
+        }
+
         $this->container['quantity'] = $quantity;
 
         return $this;
@@ -350,6 +446,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setShipDate($ship_date)
     {
+
+        if (is_null($ship_date)) {
+            throw new \InvalidArgumentException('non-nullable ship_date cannot be null');
+        }
+
         $this->container['ship_date'] = $ship_date;
 
         return $this;
@@ -384,6 +485,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($status)) {
+            throw new \InvalidArgumentException('non-nullable status cannot be null');
+        }
+
         $this->container['status'] = $status;
 
         return $this;
@@ -408,6 +514,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setComplete($complete)
     {
+
+        if (is_null($complete)) {
+            throw new \InvalidArgumentException('non-nullable complete cannot be null');
+        }
+
         $this->container['complete'] = $complete;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -76,6 +76,24 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'my_number' => false,
+		'my_string' => false,
+		'my_boolean' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -93,6 +111,48 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -186,9 +246,27 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['my_number'] = $data['my_number'] ?? null;
-        $this->container['my_string'] = $data['my_string'] ?? null;
-        $this->container['my_boolean'] = $data['my_boolean'] ?? null;
+        $this->setIfExists('my_number', $data ?? [], null);
+        $this->setIfExists('my_string', $data ?? [], null);
+        $this->setIfExists('my_boolean', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -234,6 +312,11 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMyNumber($my_number)
     {
+
+        if (is_null($my_number)) {
+            throw new \InvalidArgumentException('non-nullable my_number cannot be null');
+        }
+
         $this->container['my_number'] = $my_number;
 
         return $this;
@@ -258,6 +341,11 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMyString($my_string)
     {
+
+        if (is_null($my_string)) {
+            throw new \InvalidArgumentException('non-nullable my_string cannot be null');
+        }
+
         $this->container['my_string'] = $my_string;
 
         return $this;
@@ -282,6 +370,11 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMyBoolean($my_boolean)
     {
+
+        if (is_null($my_boolean)) {
+            throw new \InvalidArgumentException('non-nullable my_boolean cannot be null');
+        }
+
         $this->container['my_boolean'] = $my_boolean;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
@@ -72,6 +72,22 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'value' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      */
     public function __construct(array $data = null)
     {
-        $this->container['value'] = $data['value'] ?? null;
+        $this->setIfExists('value', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -225,6 +301,11 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      */
     public function setValue($value)
     {
+
+        if (is_null($value)) {
+            throw new \InvalidArgumentException('non-nullable value cannot be null');
+        }
+
         $this->container['value'] = $value;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -82,6 +82,27 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'id' => false,
+		'category' => false,
+		'name' => false,
+		'photo_urls' => false,
+		'tags' => false,
+		'status' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -99,6 +120,48 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -218,12 +281,30 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['id'] = $data['id'] ?? null;
-        $this->container['category'] = $data['category'] ?? null;
-        $this->container['name'] = $data['name'] ?? null;
-        $this->container['photo_urls'] = $data['photo_urls'] ?? null;
-        $this->container['tags'] = $data['tags'] ?? null;
-        $this->container['status'] = $data['status'] ?? null;
+        $this->setIfExists('id', $data ?? [], null);
+        $this->setIfExists('category', $data ?? [], null);
+        $this->setIfExists('name', $data ?? [], null);
+        $this->setIfExists('photo_urls', $data ?? [], null);
+        $this->setIfExists('tags', $data ?? [], null);
+        $this->setIfExists('status', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -284,6 +365,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
+
+        if (is_null($id)) {
+            throw new \InvalidArgumentException('non-nullable id cannot be null');
+        }
+
         $this->container['id'] = $id;
 
         return $this;
@@ -308,6 +394,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCategory($category)
     {
+
+        if (is_null($category)) {
+            throw new \InvalidArgumentException('non-nullable category cannot be null');
+        }
+
         $this->container['category'] = $category;
 
         return $this;
@@ -332,6 +423,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
+
+        if (is_null($name)) {
+            throw new \InvalidArgumentException('non-nullable name cannot be null');
+        }
+
         $this->container['name'] = $name;
 
         return $this;
@@ -358,6 +454,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     {
 
 
+
+        if (is_null($photo_urls)) {
+            throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
+        }
+
         $this->container['photo_urls'] = $photo_urls;
 
         return $this;
@@ -382,6 +483,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setTags($tags)
     {
+
+        if (is_null($tags)) {
+            throw new \InvalidArgumentException('non-nullable tags cannot be null');
+        }
+
         $this->container['tags'] = $tags;
 
         return $this;
@@ -416,6 +522,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
+
+        if (is_null($status)) {
+            throw new \InvalidArgumentException('non-nullable status cannot be null');
+        }
+
         $this->container['status'] = $status;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -74,6 +74,23 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'bar' => false,
+		'baz' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,8 +240,26 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['bar'] = $data['bar'] ?? null;
-        $this->container['baz'] = $data['baz'] ?? null;
+        $this->setIfExists('bar', $data ?? [], null);
+        $this->setIfExists('baz', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -228,6 +305,11 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBar($bar)
     {
+
+        if (is_null($bar)) {
+            throw new \InvalidArgumentException('non-nullable bar cannot be null');
+        }
+
         $this->container['bar'] = $bar;
 
         return $this;
@@ -252,6 +334,11 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBaz($baz)
     {
+
+        if (is_null($baz)) {
+            throw new \InvalidArgumentException('non-nullable baz cannot be null');
+        }
+
         $this->container['baz'] = $baz;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -72,6 +72,22 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'special_property_name' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -89,6 +105,48 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -176,7 +234,25 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['special_property_name'] = $data['special_property_name'] ?? null;
+        $this->setIfExists('special_property_name', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -222,6 +298,11 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSpecialPropertyName($special_property_name)
     {
+
+        if (is_null($special_property_name)) {
+            throw new \InvalidArgumentException('non-nullable special_property_name cannot be null');
+        }
+
         $this->container['special_property_name'] = $special_property_name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -74,6 +74,23 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'id' => false,
+		'name' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -91,6 +108,48 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -181,8 +240,26 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['id'] = $data['id'] ?? null;
-        $this->container['name'] = $data['name'] ?? null;
+        $this->setIfExists('id', $data ?? [], null);
+        $this->setIfExists('name', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -228,6 +305,11 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
+
+        if (is_null($id)) {
+            throw new \InvalidArgumentException('non-nullable id cannot be null');
+        }
+
         $this->container['id'] = $id;
 
         return $this;
@@ -252,6 +334,11 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
+
+        if (is_null($name)) {
+            throw new \InvalidArgumentException('non-nullable name cannot be null');
+        }
+
         $this->container['name'] = $name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -86,6 +86,29 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     ];
 
     /**
+      * Array of nullable properties. Used for (de)serialization
+      *
+      * @var boolean[]
+      */
+    protected static array $openAPINullables = [
+        'id' => false,
+		'username' => false,
+		'first_name' => false,
+		'last_name' => false,
+		'email' => false,
+		'password' => false,
+		'phone' => false,
+		'user_status' => false
+    ];
+
+    /**
+      * If a nullable field gets set to null, insert it here
+      *
+      * @var boolean[]
+      */
+    protected array $openAPINullablesSetToNull = [];
+
+    /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
@@ -103,6 +126,48 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
+    }
+
+    /**
+     * Array of nullable properties
+     *
+     * @return array
+     */
+    protected static function openAPINullables(): array
+    {
+        return self::$openAPINullables;
+    }
+
+    /**
+     * Array of nullable field names deliberately set to null
+     *
+     * @return boolean[]
+     */
+    private function getOpenAPINullablesSetToNull(): array
+    {
+        return $this->openAPINullablesSetToNull;
+    }
+
+    /**
+     * Checks if a property is nullable
+     *
+     * @param string $property
+     * @return bool
+     */
+    public static function isNullable(string $property): bool
+    {
+        return self::openAPINullables()[$property] ?? false;
+    }
+
+    /**
+     * Checks if a nullable property is set to null.
+     *
+     * @param string $property
+     * @return bool
+     */
+    public function isNullableSetToNull(string $property): bool
+    {
+        return in_array($property, $this->getOpenAPINullablesSetToNull(), true);
     }
 
     /**
@@ -211,14 +276,32 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function __construct(array $data = null)
     {
-        $this->container['id'] = $data['id'] ?? null;
-        $this->container['username'] = $data['username'] ?? null;
-        $this->container['first_name'] = $data['first_name'] ?? null;
-        $this->container['last_name'] = $data['last_name'] ?? null;
-        $this->container['email'] = $data['email'] ?? null;
-        $this->container['password'] = $data['password'] ?? null;
-        $this->container['phone'] = $data['phone'] ?? null;
-        $this->container['user_status'] = $data['user_status'] ?? null;
+        $this->setIfExists('id', $data ?? [], null);
+        $this->setIfExists('username', $data ?? [], null);
+        $this->setIfExists('first_name', $data ?? [], null);
+        $this->setIfExists('last_name', $data ?? [], null);
+        $this->setIfExists('email', $data ?? [], null);
+        $this->setIfExists('password', $data ?? [], null);
+        $this->setIfExists('phone', $data ?? [], null);
+        $this->setIfExists('user_status', $data ?? [], null);
+    }
+
+    /**
+    * Sets $this->container[$variableName] to the given data or to the given default Value; if $variableName
+    * is nullable and its value is set to null in the $fields array, then mark it as "set to null" in the
+    * $this->openAPINullablesSetToNull array
+    *
+    * @param string $variableName
+    * @param array  $fields
+    * @param mixed  $defaultValue
+    */
+    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    {
+        if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
+            $this->openAPINullablesSetToNull[] = $variableName;
+        }
+
+        $this->container[$variableName] = $fields[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -264,6 +347,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
+
+        if (is_null($id)) {
+            throw new \InvalidArgumentException('non-nullable id cannot be null');
+        }
+
         $this->container['id'] = $id;
 
         return $this;
@@ -288,6 +376,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setUsername($username)
     {
+
+        if (is_null($username)) {
+            throw new \InvalidArgumentException('non-nullable username cannot be null');
+        }
+
         $this->container['username'] = $username;
 
         return $this;
@@ -312,6 +405,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setFirstName($first_name)
     {
+
+        if (is_null($first_name)) {
+            throw new \InvalidArgumentException('non-nullable first_name cannot be null');
+        }
+
         $this->container['first_name'] = $first_name;
 
         return $this;
@@ -336,6 +434,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setLastName($last_name)
     {
+
+        if (is_null($last_name)) {
+            throw new \InvalidArgumentException('non-nullable last_name cannot be null');
+        }
+
         $this->container['last_name'] = $last_name;
 
         return $this;
@@ -360,6 +463,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setEmail($email)
     {
+
+        if (is_null($email)) {
+            throw new \InvalidArgumentException('non-nullable email cannot be null');
+        }
+
         $this->container['email'] = $email;
 
         return $this;
@@ -384,6 +492,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPassword($password)
     {
+
+        if (is_null($password)) {
+            throw new \InvalidArgumentException('non-nullable password cannot be null');
+        }
+
         $this->container['password'] = $password;
 
         return $this;
@@ -408,6 +521,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPhone($phone)
     {
+
+        if (is_null($phone)) {
+            throw new \InvalidArgumentException('non-nullable phone cannot be null');
+        }
+
         $this->container['phone'] = $phone;
 
         return $this;
@@ -432,6 +550,11 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setUserStatus($user_status)
     {
+
+        if (is_null($user_status)) {
+            throw new \InvalidArgumentException('non-nullable user_status cannot be null');
+        }
+
         $this->container['user_status'] = $user_status;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -98,7 +98,7 @@ class ObjectSerializer
                             }
                         }
                     }
-                    if ($value !== null) {
+                    if (($data::isNullable($property) && $data->isNullableSetToNull($property)) || $value !== null) {
                         $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
                     }
                 }
@@ -469,7 +469,15 @@ class ObjectSerializer
             foreach ($instance::openAPITypes() as $property => $type) {
                 $propertySetter = $instance::setters()[$property];
 
-                if (!isset($propertySetter) || !isset($data->{$instance::attributeMap()[$property]})) {
+                if (!isset($propertySetter)) {
+                    continue;
+                }
+
+                if (!isset($data->{$instance::attributeMap()[$property]})) {
+                    if ($instance::isNullable($property)) {
+                        $instance->$propertySetter(null);
+                    }
+
                     continue;
                 }
 


### PR DESCRIPTION
This is basically PR #3493, rebased, adjusted to the latest code and with some bug fixes and code modernization. @githubERIK, the author of the original PR, said he doesn't plan to continue with that (https://github.com/OpenAPITools/openapi-generator/pull/3493#issuecomment-812058825), but we have been using his code in our fork for more than 2 years, with no issues! :smile: 

His biggest concert was support for openapi 2.0. But this is not a problem at all: OpenAPIGenerator is setting `isNullable` to true if `'x-nullable' ` is defined in the swagger file, which means, this code works OOTB with openapi 2.0, provided that `x-nullable` is properly set.

The most important changes to the original code are:
- model_generic.mustache, method `isNullable()`: changed to use `self::openAPINullables()` method instead of the property itself. This is a bugfix: if we don't do this, parent properties will not be checked.
- model_generic.mustache, methods `getOpenAPINullablesSetToNull()` and `setIfExists()`: changed to private, since they are internal to the model class.
- model_generic.mustache, method `openAPINullables()`: changed to protected, since it is only used within class and parent scope.
- model_generic.mustache, method `setIfExists()`: changed to return void, as it is used only internally and its return is never used.
- included `isNullable()` and `isNullableSetToNull()` to ModelInterface.mustache, which didn't exist when the original PR was presented
- modernized PR code (null coalesce operator, return types, missing types for properties)

If the original author prefers, I can present these changes as a patch to his own PR, or he can add me to his branch so that I can merge them myself. The only important thing for me is to see the feature in OpenAPIGenerator base code, as a) it works very well! :smile: and b) this would help us moving away from using a fork :wink:

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee]
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon