### PR TITLE
[Java] fix JsonCreator with JsonNullable

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2054,6 +2054,22 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     /**
+     * Search for property by {@link CodegenProperty#name}
+     * @param name - name to search for
+     * @param properties - list of properties
+     * @return either found property or {@link Optional#empty()} if nothing has been found
+     */
+    protected Optional<CodegenProperty> findByName(String name, List<CodegenProperty> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return properties.stream()
+            .filter(p -> p.name.equals(name))
+            .findFirst();
+    }
+
+    /**
      * This method removes all implicit header parameters from the list of parameters
      *
      * @param operation - operation to be processed

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFClientCodegen.java
@@ -159,6 +159,8 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
             if (openApiNullable) {
                 if (Boolean.FALSE.equals(property.required) && Boolean.TRUE.equals(property.isNullable)) {
                     property.getVendorExtensions().put("x-is-jackson-optional-nullable", true);
+                    findByName(property.name, model.readOnlyVars)
+                        .ifPresent(p -> p.getVendorExtensions().put("x-is-jackson-optional-nullable", true));
                     model.imports.add("JsonNullable");
                     model.imports.add("JsonIgnore");
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -926,6 +926,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                         // only add JsonNullable and related imports to optional and nullable values
                         addImports |= isOptionalNullable;
                         var.getVendorExtensions().put("x-is-jackson-optional-nullable", isOptionalNullable);
+                        findByName(var.name, cm.readOnlyVars)
+                            .ifPresent(p -> p.getVendorExtensions().put("x-is-jackson-optional-nullable", isOptionalNullable));
                     }
 
                     if (Boolean.TRUE.equals(var.getVendorExtensions().get("x-enum-as-string"))) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -100,7 +100,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   ) {
     this();
   {{#readOnlyVars}}
-    this.{{name}} = {{name}};
+    this.{{name}} = {{#vendorExtensions.x-is-jackson-optional-nullable}}{{name}} == null ? JsonNullable.<{{{datatypeWithEnum}}}>undefined() : JsonNullable.of({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{name}}{{/vendorExtensions.x-is-jackson-optional-nullable}};
   {{/readOnlyVars}}
   }{{/jackson}}{{/withXml}}{{/vendorExtensions.x-has-readonly-properties}}
   {{#vars}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -100,7 +100,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   ) {
   this();
   {{#readOnlyVars}}
-    this.{{name}} = {{name}};
+    this.{{name}} = {{#vendorExtensions.x-is-jackson-optional-nullable}}{{name}} == null ? JsonNullable.<{{{datatypeWithEnum}}}>undefined() : JsonNullable.of({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{name}}{{/vendorExtensions.x-is-jackson-optional-nullable}};
   {{/readOnlyVars}}
   }{{/withXml}}{{/vendorExtensions.x-has-readonly-properties}}
   {{#vars}}

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -93,12 +93,12 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{#jsonb}}@JsonbCreator{{/jsonb}}{{#jackson}}@JsonCreator{{/jackson}}
   public {{classname}}(
   {{#readOnlyVars}}
-    {{#jsonb}}@JsonbProperty("{{baseName}}"){{/jsonb}}{{#jackson}}@JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}}){{/jackson}} {{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}
+    {{#jsonb}}@JsonbProperty(value = "{{baseName}}"{{^required}}, nillable = true{{/required}}){{/jsonb}}{{#jackson}}@JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}}){{/jackson}} {{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}
   {{/readOnlyVars}}
   ) {
     this();
   {{#readOnlyVars}}
-    this.{{name}} = {{name}};
+    this.{{name}} = {{#vendorExtensions.x-is-jackson-optional-nullable}}{{name}} == null ? JsonNullable.<{{{datatypeWithEnum}}}>undefined() : JsonNullable.of({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{name}}{{/vendorExtensions.x-is-jackson-optional-nullable}};
   {{/readOnlyVars}}
   }{{/withXml}}{{/vendorExtensions.x-has-readonly-properties}}
   {{#vars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ConstructorAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ConstructorAssert.java
@@ -1,0 +1,97 @@
+package org.openapitools.codegen.java.assertions;
+
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.nodeTypes.NodeWithName;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.util.CanIgnoreReturnValue;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@CanIgnoreReturnValue
+public class ConstructorAssert extends AbstractAssert<ConstructorAssert, ConstructorDeclaration> {
+
+    private final JavaFileAssert fileAssert;
+    private final String signature;
+
+    ConstructorAssert(final JavaFileAssert fileAssert, final ConstructorDeclaration constructorDeclaration) {
+        super(constructorDeclaration, ConstructorAssert.class);
+        this.fileAssert = fileAssert;
+        this.signature = constructorDeclaration.getDeclarationAsString();
+    }
+
+    public JavaFileAssert toFileAssert() {
+        return fileAssert;
+    }
+
+    public MethodAnnotationAssert assertConstructorAnnotations() {
+        return new MethodAnnotationAssert(this, actual.getAnnotations());
+    }
+
+    public ParameterAssert hasParameter(final String paramName) {
+        final Optional<Parameter> parameter = actual.getParameterByName(paramName);
+        Assertions.assertThat(parameter)
+            .withFailMessage("Constructor %s should have parameter %s, but it doesn't", signature, paramName)
+            .isPresent();
+        return new ParameterAssert(this, parameter.get());
+    }
+
+    public ConstructorAssert doesNotHaveParameter(final String paramName) {
+        Assertions.assertThat(actual.getParameterByName(paramName))
+            .withFailMessage("Constructor %s shouldn't have parameter %s, but it does", signature, paramName)
+            .isEmpty();
+        return this;
+    }
+
+    public ConstructorAssert bodyContainsLines(final String... lines) {
+        final String actualBody = actual.getTokenRange()
+            .orElseThrow(() -> new IllegalStateException("Can't get constructor body"))
+            .toString();
+        Assertions.assertThat(actualBody)
+            .withFailMessage(
+                "Constructor's %s body should contains lines\n====\n%s\n====\nbut actually was\n====\n%s\n====",
+                signature, Arrays.stream(lines).collect(Collectors.joining(System.lineSeparator())), actualBody
+            )
+            .contains(lines);
+
+        return this;
+    }
+
+    public ConstructorAssert doesNotHaveComment() {
+        Assertions.assertThat(actual.getJavadocComment())
+            .withFailMessage("Constructor %s shouldn't contains comment, but it does", signature)
+            .isEmpty();
+        return this;
+    }
+
+    public ConstructorAssert commentContainsLines(final String... lines) {
+        Assertions.assertThat(actual.getJavadocComment())
+            .withFailMessage("Constructor %s should contains comment, but it doesn't", signature)
+            .isPresent();
+        final String actualComment = actual.getJavadocComment().get().getContent();
+        Assertions.assertThat(actualComment)
+            .withFailMessage(
+                "Constructor's %s comment should contains lines\n====\n%s\n====\nbut actually was\n====%s\n====",
+                signature, Arrays.stream(lines).collect(Collectors.joining(System.lineSeparator())), actualComment
+            )
+            .contains(lines);
+
+        return this;
+    }
+
+    public ConstructorAssert noneOfParameterHasAnnotation(final String annotationName) {
+        actual.getParameters()
+            .forEach(
+                param -> Assertions.assertThat(param.getAnnotations())
+                    .withFailMessage("Parameter %s contains annotation %s while it shouldn't", param.getNameAsString(), annotationName)
+                    .extracting(NodeWithName::getNameAsString)
+                    .doesNotContain(annotationName)
+            );
+
+        return this;
+    }
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/JavaFileAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/JavaFileAssert.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.CanIgnoreReturnValue;
@@ -57,6 +58,15 @@ public class JavaFileAssert extends AbstractAssert<JavaFileAssert, CompilationUn
             .hasSize(1);
 
         return new MethodAssert(this, methods.get(0));
+    }
+
+    public ConstructorAssert assertConstructor(final String... paramTypes) {
+        Optional<ConstructorDeclaration> constructorDeclaration = actual.getType(0).getConstructorByParameterTypes(paramTypes);
+        Assertions.assertThat(constructorDeclaration)
+            .withFailMessage("No constructor with parameter(s) %s", Arrays.toString(paramTypes))
+            .isPresent();
+
+        return new ConstructorAssert(this, constructorDeclaration.get());
     }
 
     public PropertyAssert hasProperty(final String propertyName) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/MethodAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/MethodAnnotationAssert.java
@@ -10,13 +10,32 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 public class MethodAnnotationAssert extends AbstractAnnotationAssert<MethodAnnotationAssert> {
 
     private final MethodAssert methodAssert;
+    private final ConstructorAssert constructorAssert;
 
     protected MethodAnnotationAssert(final MethodAssert methodAssert, final List<AnnotationExpr> annotationExpr) {
         super(annotationExpr);
         this.methodAssert = methodAssert;
+        this.constructorAssert = null;
+    }
+
+    protected MethodAnnotationAssert(final ConstructorAssert constructorAssert, final List<AnnotationExpr> annotationExpr) {
+        super(annotationExpr);
+        this.constructorAssert = constructorAssert;
+        this.methodAssert = null;
     }
 
     public MethodAssert toMethod() {
+        if (methodAssert == null) {
+            throw new IllegalArgumentException("No method assert for constructor's annotations");
+        }
         return methodAssert;
     }
+
+    public ConstructorAssert toConstructor() {
+        if (constructorAssert == null) {
+            throw new IllegalArgumentException("No constructor assert for method's annotations");
+        }
+        return constructorAssert;
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ParameterAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/ParameterAssert.java
@@ -10,14 +10,32 @@ import com.github.javaparser.ast.body.Parameter;
 public class ParameterAssert extends ObjectAssert<Parameter> {
 
     private final MethodAssert methodAssert;
+    private final ConstructorAssert constructorAssert;
 
     protected ParameterAssert(final MethodAssert methodAssert, final Parameter parameter) {
         super(parameter);
         this.methodAssert = methodAssert;
+        this.constructorAssert = null;
+    }
+
+    protected ParameterAssert(final ConstructorAssert constructorAssert, final Parameter parameter) {
+        super(parameter);
+        this.constructorAssert = constructorAssert;
+        this.methodAssert = null;
     }
 
     public MethodAssert toMethod() {
+        if (methodAssert == null) {
+            throw new IllegalArgumentException("No method assert for constructor's parameter");
+        }
         return methodAssert;
+    }
+
+    public ConstructorAssert toConstructor() {
+        if (constructorAssert == null) {
+            throw new IllegalArgumentException("No constructor assert for method's parameter");
+        }
+        return constructorAssert;
     }
 
     public ParameterAssert withType(final String expectedType) {

--- a/modules/openapi-generator/src/test/resources/bugs/issue_12790.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_12790.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Title
+  version: "1"
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestObject'
+components:
+  schemas:
+    TestObject:
+      type: object
+      properties:
+        nullableProperty:
+          type: string
+          nullable: true
+          readOnly: true
+        notNullableProperty:
+          type: string
+          readOnly: true
+        notNullablePropertyNotRO:
+          type: integer


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix for https://github.com/OpenAPITools/openapi-generator/issues/12790
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02)
