### PR TITLE
[Java][WebClient] return ResponseSpec to manually control response handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
@@ -152,9 +152,38 @@ public class {{classname}} {
         {{^returnType}}{{^vendorExtensions.x-webclient-blocking}}return {{/vendorExtensions.x-webclient-blocking}}{{/returnType}}{{#returnType}}return {{/returnType}}{{operationId}}RequestCreation({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}).{{#isArray}}bodyToFlux{{/isArray}}{{^isArray}}bodyToMono{{/isArray}}(localVarReturnType){{#vendorExtensions.x-webclient-blocking}}{{#isArray}}{{#uniqueItems}}.collect(Collectors.toSet()){{/uniqueItems}}{{^uniqueItems}}.collectList(){{/uniqueItems}}{{/isArray}}.block(){{/vendorExtensions.x-webclient-blocking}};
     }
 
+    /**
+     * {{summary}}
+     * {{notes}}
+{{#responses}}     * <p><b>{{code}}</b>{{#message}} - {{.}}{{/message}}
+{{/responses}}{{#allParams}}     * @param {{paramName}} {{description}}{{^description}}The {{paramName}} parameter{{/description}}
+{{/allParams}}{{#returnType}}     * @return ResponseEntity&lt;{{.}}&gt;
+{{/returnType}}     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+{{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+{{/externalDocs}}
+     */
     public {{#vendorExtensions.x-webclient-blocking}}{{#returnType}}{{#isArray}}ResponseEntity<List<{{{returnBaseType}}}>>{{/isArray}}{{^isArray}}ResponseEntity<{{{returnType}}}>{{/isArray}}{{/returnType}}{{^returnType}}ResponseEntity<Void>{{/returnType}} {{/vendorExtensions.x-webclient-blocking}}{{^vendorExtensions.x-webclient-blocking}}{{#returnType}}{{#isArray}}Mono<ResponseEntity<List<{{{returnBaseType}}}>>>{{/isArray}}{{^isArray}}Mono<ResponseEntity<{{{returnType}}}>>{{/isArray}}{{/returnType}}{{^returnType}}Mono<ResponseEntity<Void>>{{/returnType}} {{/vendorExtensions.x-webclient-blocking}}{{operationId}}WithHttpInfo({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.AbstractResource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.AbstractResource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws WebClientResponseException {
         {{#returnType}}ParameterizedTypeReference<{{#isArray}}{{{returnBaseType}}}{{/isArray}}{{^isArray}}{{{returnType}}}{{/isArray}}> localVarReturnType = new ParameterizedTypeReference<{{#isArray}}{{{returnBaseType}}}{{/isArray}}{{^isArray}}{{{returnType}}}{{/isArray}}>() {};{{/returnType}}{{^returnType}}ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};{{/returnType}}
         return {{operationId}}RequestCreation({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}).{{#isArray}}toEntityList{{/isArray}}{{^isArray}}toEntity{{/isArray}}(localVarReturnType){{#vendorExtensions.x-webclient-blocking}}.block(){{/vendorExtensions.x-webclient-blocking}};
+    }
+
+    /**
+     * {{summary}}
+     * {{notes}}
+{{#responses}}     * <p><b>{{code}}</b>{{#message}} - {{.}}{{/message}}
+{{/responses}}{{#allParams}}     * @param {{paramName}} {{description}}{{^description}}The {{paramName}} parameter{{/description}}
+{{/allParams}}
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+{{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+{{/externalDocs}}
+     */
+    public ResponseSpec {{operationId}}WithResponseSpec({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.AbstractResource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.AbstractResource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws WebClientResponseException {
+        return {{operationId}}RequestCreation({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
     }
     {{/operation}}
 }

--- a/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -88,8 +88,26 @@ public class DefaultApi {
         return nullableArrayTestGetRequestCreation().bodyToFlux(localVarReturnType);
     }
 
+    /**
+     * 
+     * 
+     * <p><b>200</b> - 
+     * @return ResponseEntity&lt;List&lt;ByteArrayObject&gt;&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<List<ByteArrayObject>>> nullableArrayTestGetWithHttpInfo() throws WebClientResponseException {
         ParameterizedTypeReference<ByteArrayObject> localVarReturnType = new ParameterizedTypeReference<ByteArrayObject>() {};
         return nullableArrayTestGetRequestCreation().toEntityList(localVarReturnType);
+    }
+
+    /**
+     * 
+     * 
+     * <p><b>200</b> - 
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec nullableArrayTestGetWithResponseSpec() throws WebClientResponseException {
+        return nullableArrayTestGetRequestCreation();
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -96,8 +96,28 @@ public class AnotherFakeApi {
         return call123testSpecialTagsRequestCreation(client).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * To test special tags
+     * To test special tags and operation ID starting with number
+     * <p><b>200</b> - successful operation
+     * @param client client model
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Client>> call123testSpecialTagsWithHttpInfo(Client client) throws WebClientResponseException {
         ParameterizedTypeReference<Client> localVarReturnType = new ParameterizedTypeReference<Client>() {};
         return call123testSpecialTagsRequestCreation(client).toEntity(localVarReturnType);
+    }
+
+    /**
+     * To test special tags
+     * To test special tags and operation ID starting with number
+     * <p><b>200</b> - successful operation
+     * @param client client model
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec call123testSpecialTagsWithResponseSpec(Client client) throws WebClientResponseException {
+        return call123testSpecialTagsRequestCreation(client);
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -88,8 +88,26 @@ public class DefaultApi {
         return fooGetRequestCreation().bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * 
+     * <p><b>0</b> - response
+     * @return ResponseEntity&lt;FooGetDefaultResponse&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<FooGetDefaultResponse>> fooGetWithHttpInfo() throws WebClientResponseException {
         ParameterizedTypeReference<FooGetDefaultResponse> localVarReturnType = new ParameterizedTypeReference<FooGetDefaultResponse>() {};
         return fooGetRequestCreation().toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * 
+     * <p><b>0</b> - response
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fooGetWithResponseSpec() throws WebClientResponseException {
+        return fooGetRequestCreation();
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -99,9 +99,27 @@ public class FakeApi {
         return fakeHealthGetRequestCreation().bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Health check endpoint
+     * 
+     * <p><b>200</b> - The instance started successfully
+     * @return ResponseEntity&lt;HealthCheckResult&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<HealthCheckResult>> fakeHealthGetWithHttpInfo() throws WebClientResponseException {
         ParameterizedTypeReference<HealthCheckResult> localVarReturnType = new ParameterizedTypeReference<HealthCheckResult>() {};
         return fakeHealthGetRequestCreation().toEntity(localVarReturnType);
+    }
+
+    /**
+     * Health check endpoint
+     * 
+     * <p><b>200</b> - The instance started successfully
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fakeHealthGetWithResponseSpec() throws WebClientResponseException {
+        return fakeHealthGetRequestCreation();
     }
     /**
      * test http signature authentication
@@ -157,9 +175,32 @@ public class FakeApi {
         return fakeHttpSignatureTestRequestCreation(pet, query1, header1).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * test http signature authentication
+     * 
+     * <p><b>200</b> - The instance started successfully
+     * @param pet Pet object that needs to be added to the store
+     * @param query1 query parameter
+     * @param header1 header parameter
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> fakeHttpSignatureTestWithHttpInfo(Pet pet, String query1, String header1) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return fakeHttpSignatureTestRequestCreation(pet, query1, header1).toEntity(localVarReturnType);
+    }
+
+    /**
+     * test http signature authentication
+     * 
+     * <p><b>200</b> - The instance started successfully
+     * @param pet Pet object that needs to be added to the store
+     * @param query1 query parameter
+     * @param header1 header parameter
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fakeHttpSignatureTestWithResponseSpec(Pet pet, String query1, String header1) throws WebClientResponseException {
+        return fakeHttpSignatureTestRequestCreation(pet, query1, header1);
     }
     /**
      * 
@@ -207,9 +248,29 @@ public class FakeApi {
         return fakeOuterBooleanSerializeRequestCreation(body).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * Test serialization of outer boolean types
+     * <p><b>200</b> - Output boolean
+     * @param body Input boolean as post body
+     * @return ResponseEntity&lt;Boolean&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Boolean>> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws WebClientResponseException {
         ParameterizedTypeReference<Boolean> localVarReturnType = new ParameterizedTypeReference<Boolean>() {};
         return fakeOuterBooleanSerializeRequestCreation(body).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * Test serialization of outer boolean types
+     * <p><b>200</b> - Output boolean
+     * @param body Input boolean as post body
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fakeOuterBooleanSerializeWithResponseSpec(Boolean body) throws WebClientResponseException {
+        return fakeOuterBooleanSerializeRequestCreation(body);
     }
     /**
      * 
@@ -257,9 +318,29 @@ public class FakeApi {
         return fakeOuterCompositeSerializeRequestCreation(outerComposite).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * Test serialization of object with outer number type
+     * <p><b>200</b> - Output composite
+     * @param outerComposite Input composite as post body
+     * @return ResponseEntity&lt;OuterComposite&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<OuterComposite>> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite) throws WebClientResponseException {
         ParameterizedTypeReference<OuterComposite> localVarReturnType = new ParameterizedTypeReference<OuterComposite>() {};
         return fakeOuterCompositeSerializeRequestCreation(outerComposite).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * Test serialization of object with outer number type
+     * <p><b>200</b> - Output composite
+     * @param outerComposite Input composite as post body
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fakeOuterCompositeSerializeWithResponseSpec(OuterComposite outerComposite) throws WebClientResponseException {
+        return fakeOuterCompositeSerializeRequestCreation(outerComposite);
     }
     /**
      * 
@@ -307,9 +388,29 @@ public class FakeApi {
         return fakeOuterNumberSerializeRequestCreation(body).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * Test serialization of outer number types
+     * <p><b>200</b> - Output number
+     * @param body Input number as post body
+     * @return ResponseEntity&lt;BigDecimal&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<BigDecimal>> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws WebClientResponseException {
         ParameterizedTypeReference<BigDecimal> localVarReturnType = new ParameterizedTypeReference<BigDecimal>() {};
         return fakeOuterNumberSerializeRequestCreation(body).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * Test serialization of outer number types
+     * <p><b>200</b> - Output number
+     * @param body Input number as post body
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fakeOuterNumberSerializeWithResponseSpec(BigDecimal body) throws WebClientResponseException {
+        return fakeOuterNumberSerializeRequestCreation(body);
     }
     /**
      * 
@@ -357,9 +458,29 @@ public class FakeApi {
         return fakeOuterStringSerializeRequestCreation(body).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * Test serialization of outer string types
+     * <p><b>200</b> - Output string
+     * @param body Input string as post body
+     * @return ResponseEntity&lt;String&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<String>> fakeOuterStringSerializeWithHttpInfo(String body) throws WebClientResponseException {
         ParameterizedTypeReference<String> localVarReturnType = new ParameterizedTypeReference<String>() {};
         return fakeOuterStringSerializeRequestCreation(body).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * Test serialization of outer string types
+     * <p><b>200</b> - Output string
+     * @param body Input string as post body
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fakeOuterStringSerializeWithResponseSpec(String body) throws WebClientResponseException {
+        return fakeOuterStringSerializeRequestCreation(body);
     }
     /**
      * 
@@ -411,9 +532,29 @@ public class FakeApi {
         return fakePropertyEnumIntegerSerializeRequestCreation(outerObjectWithEnumProperty).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * Test serialization of enum (int) properties with examples
+     * <p><b>200</b> - Output enum (int)
+     * @param outerObjectWithEnumProperty Input enum (int) as post body
+     * @return ResponseEntity&lt;OuterObjectWithEnumProperty&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<OuterObjectWithEnumProperty>> fakePropertyEnumIntegerSerializeWithHttpInfo(OuterObjectWithEnumProperty outerObjectWithEnumProperty) throws WebClientResponseException {
         ParameterizedTypeReference<OuterObjectWithEnumProperty> localVarReturnType = new ParameterizedTypeReference<OuterObjectWithEnumProperty>() {};
         return fakePropertyEnumIntegerSerializeRequestCreation(outerObjectWithEnumProperty).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * Test serialization of enum (int) properties with examples
+     * <p><b>200</b> - Output enum (int)
+     * @param outerObjectWithEnumProperty Input enum (int) as post body
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec fakePropertyEnumIntegerSerializeWithResponseSpec(OuterObjectWithEnumProperty outerObjectWithEnumProperty) throws WebClientResponseException {
+        return fakePropertyEnumIntegerSerializeRequestCreation(outerObjectWithEnumProperty);
     }
     /**
      * 
@@ -461,9 +602,28 @@ public class FakeApi {
         return testBodyWithBinaryRequestCreation(body).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * For this test, the body has to be a binary file.
+     * <p><b>200</b> - Success
+     * @param body image to upload
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testBodyWithBinaryWithHttpInfo(File body) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testBodyWithBinaryRequestCreation(body).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * For this test, the body has to be a binary file.
+     * <p><b>200</b> - Success
+     * @param body image to upload
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testBodyWithBinaryWithResponseSpec(File body) throws WebClientResponseException {
+        return testBodyWithBinaryRequestCreation(body);
     }
     /**
      * 
@@ -511,9 +671,28 @@ public class FakeApi {
         return testBodyWithFileSchemaRequestCreation(fileSchemaTestClass).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * For this test, the body for this request must reference a schema named &#x60;File&#x60;.
+     * <p><b>200</b> - Success
+     * @param fileSchemaTestClass The fileSchemaTestClass parameter
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testBodyWithFileSchemaRequestCreation(fileSchemaTestClass).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * For this test, the body for this request must reference a schema named &#x60;File&#x60;.
+     * <p><b>200</b> - Success
+     * @param fileSchemaTestClass The fileSchemaTestClass parameter
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testBodyWithFileSchemaWithResponseSpec(FileSchemaTestClass fileSchemaTestClass) throws WebClientResponseException {
+        return testBodyWithFileSchemaRequestCreation(fileSchemaTestClass);
     }
     /**
      * 
@@ -569,9 +748,30 @@ public class FakeApi {
         return testBodyWithQueryParamsRequestCreation(query, user).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * 
+     * <p><b>200</b> - Success
+     * @param query The query parameter
+     * @param user The user parameter
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testBodyWithQueryParamsWithHttpInfo(String query, User user) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testBodyWithQueryParamsRequestCreation(query, user).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * 
+     * <p><b>200</b> - Success
+     * @param query The query parameter
+     * @param user The user parameter
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testBodyWithQueryParamsWithResponseSpec(String query, User user) throws WebClientResponseException {
+        return testBodyWithQueryParamsRequestCreation(query, user);
     }
     /**
      * To test \&quot;client\&quot; model
@@ -623,9 +823,29 @@ public class FakeApi {
         return testClientModelRequestCreation(client).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * To test \&quot;client\&quot; model
+     * To test \&quot;client\&quot; model
+     * <p><b>200</b> - successful operation
+     * @param client client model
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Client>> testClientModelWithHttpInfo(Client client) throws WebClientResponseException {
         ParameterizedTypeReference<Client> localVarReturnType = new ParameterizedTypeReference<Client>() {};
         return testClientModelRequestCreation(client).toEntity(localVarReturnType);
+    }
+
+    /**
+     * To test \&quot;client\&quot; model
+     * To test \&quot;client\&quot; model
+     * <p><b>200</b> - successful operation
+     * @param client client model
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testClientModelWithResponseSpec(Client client) throws WebClientResponseException {
+        return testClientModelRequestCreation(client);
     }
     /**
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -742,9 +962,56 @@ public class FakeApi {
         return testEndpointParametersRequestCreation(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param number None
+     * @param _double None
+     * @param patternWithoutDelimiter None
+     * @param _byte None
+     * @param integer None
+     * @param int32 None
+     * @param int64 None
+     * @param _float None
+     * @param string None
+     * @param binary None
+     * @param date None
+     * @param dateTime None
+     * @param password None
+     * @param paramCallback None
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testEndpointParametersRequestCreation(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param number None
+     * @param _double None
+     * @param patternWithoutDelimiter None
+     * @param _byte None
+     * @param integer None
+     * @param int32 None
+     * @param int64 None
+     * @param _float None
+     * @param string None
+     * @param binary None
+     * @param date None
+     * @param dateTime None
+     * @param password None
+     * @param paramCallback None
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testEndpointParametersWithResponseSpec(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws WebClientResponseException {
+        return testEndpointParametersRequestCreation(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
     }
     /**
      * To test enum parameters
@@ -821,9 +1088,46 @@ public class FakeApi {
         return testEnumParametersRequestCreation(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * To test enum parameters
+     * To test enum parameters
+     * <p><b>400</b> - Invalid request
+     * <p><b>404</b> - Not found
+     * @param enumHeaderStringArray Header parameter enum test (string array)
+     * @param enumHeaderString Header parameter enum test (string)
+     * @param enumQueryStringArray Query parameter enum test (string array)
+     * @param enumQueryString Query parameter enum test (string)
+     * @param enumQueryInteger Query parameter enum test (double)
+     * @param enumQueryDouble Query parameter enum test (double)
+     * @param enumQueryModelArray The enumQueryModelArray parameter
+     * @param enumFormStringArray Form parameter enum test (string array)
+     * @param enumFormString Form parameter enum test (string)
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<EnumClass> enumQueryModelArray, List<String> enumFormStringArray, String enumFormString) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testEnumParametersRequestCreation(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString).toEntity(localVarReturnType);
+    }
+
+    /**
+     * To test enum parameters
+     * To test enum parameters
+     * <p><b>400</b> - Invalid request
+     * <p><b>404</b> - Not found
+     * @param enumHeaderStringArray Header parameter enum test (string array)
+     * @param enumHeaderString Header parameter enum test (string)
+     * @param enumQueryStringArray Query parameter enum test (string array)
+     * @param enumQueryString Query parameter enum test (string)
+     * @param enumQueryInteger Query parameter enum test (double)
+     * @param enumQueryDouble Query parameter enum test (double)
+     * @param enumQueryModelArray The enumQueryModelArray parameter
+     * @param enumFormStringArray Form parameter enum test (string array)
+     * @param enumFormString Form parameter enum test (string)
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testEnumParametersWithResponseSpec(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<EnumClass> enumQueryModelArray, List<String> enumFormStringArray, String enumFormString) throws WebClientResponseException {
+        return testEnumParametersRequestCreation(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumQueryModelArray, enumFormStringArray, enumFormString);
     }
     /**
      * Fake endpoint to test group parameters (optional)
@@ -896,9 +1200,38 @@ public class FakeApi {
         return testGroupParametersRequestCreation(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Fake endpoint to test group parameters (optional)
+     * Fake endpoint to test group parameters (optional)
+     * <p><b>400</b> - Someting wrong
+     * @param requiredStringGroup Required String in group parameters
+     * @param requiredBooleanGroup Required Boolean in group parameters
+     * @param requiredInt64Group Required Integer in group parameters
+     * @param stringGroup String in group parameters
+     * @param booleanGroup Boolean in group parameters
+     * @param int64Group Integer in group parameters
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testGroupParametersRequestCreation(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Fake endpoint to test group parameters (optional)
+     * Fake endpoint to test group parameters (optional)
+     * <p><b>400</b> - Someting wrong
+     * @param requiredStringGroup Required String in group parameters
+     * @param requiredBooleanGroup Required Boolean in group parameters
+     * @param requiredInt64Group Required Integer in group parameters
+     * @param stringGroup String in group parameters
+     * @param booleanGroup Boolean in group parameters
+     * @param int64Group Integer in group parameters
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testGroupParametersWithResponseSpec(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws WebClientResponseException {
+        return testGroupParametersRequestCreation(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
     }
     /**
      * test inline additionalProperties
@@ -946,9 +1279,28 @@ public class FakeApi {
         return testInlineAdditionalPropertiesRequestCreation(requestBody).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * test inline additionalProperties
+     * 
+     * <p><b>200</b> - successful operation
+     * @param requestBody request body
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testInlineAdditionalPropertiesRequestCreation(requestBody).toEntity(localVarReturnType);
+    }
+
+    /**
+     * test inline additionalProperties
+     * 
+     * <p><b>200</b> - successful operation
+     * @param requestBody request body
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testInlineAdditionalPropertiesWithResponseSpec(Map<String, String> requestBody) throws WebClientResponseException {
+        return testInlineAdditionalPropertiesRequestCreation(requestBody);
     }
     /**
      * test json serialization of form data
@@ -1007,9 +1359,30 @@ public class FakeApi {
         return testJsonFormDataRequestCreation(param, param2).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * test json serialization of form data
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param field1
+     * @param param2 field2
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testJsonFormDataWithHttpInfo(String param, String param2) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testJsonFormDataRequestCreation(param, param2).toEntity(localVarReturnType);
+    }
+
+    /**
+     * test json serialization of form data
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param field1
+     * @param param2 field2
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testJsonFormDataWithResponseSpec(String param, String param2) throws WebClientResponseException {
+        return testJsonFormDataRequestCreation(param, param2);
     }
     /**
      * 
@@ -1095,8 +1468,39 @@ public class FakeApi {
         return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, allowEmpty, language).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * 
+     * To test the collection format in query parameters
+     * <p><b>200</b> - Success
+     * @param pipe The pipe parameter
+     * @param ioutil The ioutil parameter
+     * @param http The http parameter
+     * @param url The url parameter
+     * @param context The context parameter
+     * @param allowEmpty The allowEmpty parameter
+     * @param language The language parameter
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, Map<String, String> language) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, allowEmpty, language).toEntity(localVarReturnType);
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * <p><b>200</b> - Success
+     * @param pipe The pipe parameter
+     * @param ioutil The ioutil parameter
+     * @param http The http parameter
+     * @param url The url parameter
+     * @param context The context parameter
+     * @param allowEmpty The allowEmpty parameter
+     * @param language The language parameter
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testQueryParameterCollectionFormatWithResponseSpec(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, Map<String, String> language) throws WebClientResponseException {
+        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, allowEmpty, language);
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -96,8 +96,28 @@ public class FakeClassnameTags123Api {
         return testClassnameRequestCreation(client).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * To test class name in snake case
+     * To test class name in snake case
+     * <p><b>200</b> - successful operation
+     * @param client client model
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Client>> testClassnameWithHttpInfo(Client client) throws WebClientResponseException {
         ParameterizedTypeReference<Client> localVarReturnType = new ParameterizedTypeReference<Client>() {};
         return testClassnameRequestCreation(client).toEntity(localVarReturnType);
+    }
+
+    /**
+     * To test class name in snake case
+     * To test class name in snake case
+     * <p><b>200</b> - successful operation
+     * @param client client model
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testClassnameWithResponseSpec(Client client) throws WebClientResponseException {
+        return testClassnameRequestCreation(client);
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -97,9 +97,30 @@ public class PetApi {
         return addPetRequestCreation(pet).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Add a new pet to the store
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>405</b> - Invalid input
+     * @param pet Pet object that needs to be added to the store
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> addPetWithHttpInfo(Pet pet) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return addPetRequestCreation(pet).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Add a new pet to the store
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>405</b> - Invalid input
+     * @param pet Pet object that needs to be added to the store
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec addPetWithResponseSpec(Pet pet) throws WebClientResponseException {
+        return addPetRequestCreation(pet);
     }
     /**
      * Deletes a pet
@@ -153,9 +174,32 @@ public class PetApi {
         return deletePetRequestCreation(petId, apiKey).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Deletes a pet
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>400</b> - Invalid pet value
+     * @param petId Pet id to delete
+     * @param apiKey The apiKey parameter
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> deletePetWithHttpInfo(Long petId, String apiKey) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return deletePetRequestCreation(petId, apiKey).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Deletes a pet
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>400</b> - Invalid pet value
+     * @param petId Pet id to delete
+     * @param apiKey The apiKey parameter
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec deletePetWithResponseSpec(Long petId, String apiKey) throws WebClientResponseException {
+        return deletePetRequestCreation(petId, apiKey);
     }
     /**
      * Finds Pets by status
@@ -209,9 +253,31 @@ public class PetApi {
         return findPetsByStatusRequestCreation(status).bodyToFlux(localVarReturnType).collectList().block();
     }
 
+    /**
+     * Finds Pets by status
+     * Multiple status values can be provided with comma separated strings
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid status value
+     * @param status Status values that need to be considered for filter
+     * @return ResponseEntity&lt;List&lt;Pet&gt;&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public ResponseEntity<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws WebClientResponseException {
         ParameterizedTypeReference<Pet> localVarReturnType = new ParameterizedTypeReference<Pet>() {};
         return findPetsByStatusRequestCreation(status).toEntityList(localVarReturnType).block();
+    }
+
+    /**
+     * Finds Pets by status
+     * Multiple status values can be provided with comma separated strings
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid status value
+     * @param status Status values that need to be considered for filter
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec findPetsByStatusWithResponseSpec(List<String> status) throws WebClientResponseException {
+        return findPetsByStatusRequestCreation(status);
     }
     /**
      * Finds Pets by tags
@@ -267,9 +333,31 @@ public class PetApi {
         return findPetsByTagsRequestCreation(tags).bodyToFlux(localVarReturnType).collect(Collectors.toSet()).block();
     }
 
+    /**
+     * Finds Pets by tags
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid tag value
+     * @param tags Tags to filter by
+     * @return ResponseEntity&lt;Set&lt;Pet&gt;&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public ResponseEntity<List<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws WebClientResponseException {
         ParameterizedTypeReference<Pet> localVarReturnType = new ParameterizedTypeReference<Pet>() {};
         return findPetsByTagsRequestCreation(tags).toEntityList(localVarReturnType).block();
+    }
+
+    /**
+     * Finds Pets by tags
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid tag value
+     * @param tags Tags to filter by
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec findPetsByTagsWithResponseSpec(Set<String> tags) throws WebClientResponseException {
+        return findPetsByTagsRequestCreation(tags);
     }
     /**
      * Find pet by ID
@@ -325,9 +413,33 @@ public class PetApi {
         return getPetByIdRequestCreation(petId).bodyToMono(localVarReturnType).block();
     }
 
+    /**
+     * Find pet by ID
+     * Returns a single pet
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * @param petId ID of pet to return
+     * @return ResponseEntity&lt;Pet&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public ResponseEntity<Pet> getPetByIdWithHttpInfo(Long petId) throws WebClientResponseException {
         ParameterizedTypeReference<Pet> localVarReturnType = new ParameterizedTypeReference<Pet>() {};
         return getPetByIdRequestCreation(petId).toEntity(localVarReturnType).block();
+    }
+
+    /**
+     * Find pet by ID
+     * Returns a single pet
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * @param petId ID of pet to return
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec getPetByIdWithResponseSpec(Long petId) throws WebClientResponseException {
+        return getPetByIdRequestCreation(petId);
     }
     /**
      * Update an existing pet
@@ -381,9 +493,34 @@ public class PetApi {
         updatePetRequestCreation(pet).bodyToMono(localVarReturnType).block();
     }
 
+    /**
+     * Update an existing pet
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * <p><b>405</b> - Validation exception
+     * @param pet Pet object that needs to be added to the store
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public ResponseEntity<Void> updatePetWithHttpInfo(Pet pet) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return updatePetRequestCreation(pet).toEntity(localVarReturnType).block();
+    }
+
+    /**
+     * Update an existing pet
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * <p><b>405</b> - Validation exception
+     * @param pet Pet object that needs to be added to the store
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec updatePetWithResponseSpec(Pet pet) throws WebClientResponseException {
+        return updatePetRequestCreation(pet);
     }
     /**
      * Updates a pet in the store with form data
@@ -444,9 +581,34 @@ public class PetApi {
         return updatePetWithFormRequestCreation(petId, name, status).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Updates a pet in the store with form data
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>405</b> - Invalid input
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return updatePetWithFormRequestCreation(petId, name, status).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Updates a pet in the store with form data
+     * 
+     * <p><b>200</b> - Successful operation
+     * <p><b>405</b> - Invalid input
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec updatePetWithFormWithResponseSpec(Long petId, String name, String status) throws WebClientResponseException {
+        return updatePetWithFormRequestCreation(petId, name, status);
     }
     /**
      * uploads an image
@@ -509,9 +671,33 @@ public class PetApi {
         return uploadFileRequestCreation(petId, additionalMetadata, _file).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * uploads an image
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param _file file to upload
+     * @return ResponseEntity&lt;ModelApiResponse&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<ModelApiResponse>> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File _file) throws WebClientResponseException {
         ParameterizedTypeReference<ModelApiResponse> localVarReturnType = new ParameterizedTypeReference<ModelApiResponse>() {};
         return uploadFileRequestCreation(petId, additionalMetadata, _file).toEntity(localVarReturnType);
+    }
+
+    /**
+     * uploads an image
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param _file file to upload
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec uploadFileWithResponseSpec(Long petId, String additionalMetadata, File _file) throws WebClientResponseException {
+        return uploadFileRequestCreation(petId, additionalMetadata, _file);
     }
     /**
      * uploads an image (required)
@@ -578,8 +764,32 @@ public class PetApi {
         return uploadFileWithRequiredFileRequestCreation(petId, requiredFile, additionalMetadata).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * uploads an image (required)
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update
+     * @param requiredFile file to upload
+     * @param additionalMetadata Additional data to pass to server
+     * @return ResponseEntity&lt;ModelApiResponse&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<ModelApiResponse>> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws WebClientResponseException {
         ParameterizedTypeReference<ModelApiResponse> localVarReturnType = new ParameterizedTypeReference<ModelApiResponse>() {};
         return uploadFileWithRequiredFileRequestCreation(petId, requiredFile, additionalMetadata).toEntity(localVarReturnType);
+    }
+
+    /**
+     * uploads an image (required)
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update
+     * @param requiredFile file to upload
+     * @param additionalMetadata Additional data to pass to server
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec uploadFileWithRequiredFileWithResponseSpec(Long petId, File requiredFile, String additionalMetadata) throws WebClientResponseException {
+        return uploadFileWithRequiredFileRequestCreation(petId, requiredFile, additionalMetadata);
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -94,9 +94,30 @@ public class StoreApi {
         return deleteOrderRequestCreation(orderId).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Delete purchase order by ID
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of the order that needs to be deleted
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> deleteOrderWithHttpInfo(String orderId) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return deleteOrderRequestCreation(orderId).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Delete purchase order by ID
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of the order that needs to be deleted
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec deleteOrderWithResponseSpec(String orderId) throws WebClientResponseException {
+        return deleteOrderRequestCreation(orderId);
     }
     /**
      * Returns pet inventories by status
@@ -140,9 +161,27 @@ public class StoreApi {
         return getInventoryRequestCreation().bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Returns pet inventories by status
+     * Returns a map of status codes to quantities
+     * <p><b>200</b> - successful operation
+     * @return ResponseEntity&lt;Map&lt;String, Integer&gt;&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Map<String, Integer>>> getInventoryWithHttpInfo() throws WebClientResponseException {
         ParameterizedTypeReference<Map<String, Integer>> localVarReturnType = new ParameterizedTypeReference<Map<String, Integer>>() {};
         return getInventoryRequestCreation().toEntity(localVarReturnType);
+    }
+
+    /**
+     * Returns pet inventories by status
+     * Returns a map of status codes to quantities
+     * <p><b>200</b> - successful operation
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec getInventoryWithResponseSpec() throws WebClientResponseException {
+        return getInventoryRequestCreation();
     }
     /**
      * Find purchase order by ID
@@ -198,9 +237,33 @@ public class StoreApi {
         return getOrderByIdRequestCreation(orderId).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Find purchase order by ID
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of pet that needs to be fetched
+     * @return ResponseEntity&lt;Order&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Order>> getOrderByIdWithHttpInfo(Long orderId) throws WebClientResponseException {
         ParameterizedTypeReference<Order> localVarReturnType = new ParameterizedTypeReference<Order>() {};
         return getOrderByIdRequestCreation(orderId).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Find purchase order by ID
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of pet that needs to be fetched
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec getOrderByIdWithResponseSpec(Long orderId) throws WebClientResponseException {
+        return getOrderByIdRequestCreation(orderId);
     }
     /**
      * Place an order for a pet
@@ -254,8 +317,30 @@ public class StoreApi {
         return placeOrderRequestCreation(order).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Place an order for a pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid Order
+     * @param order order placed for purchasing the pet
+     * @return ResponseEntity&lt;Order&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Order>> placeOrderWithHttpInfo(Order order) throws WebClientResponseException {
         ParameterizedTypeReference<Order> localVarReturnType = new ParameterizedTypeReference<Order>() {};
         return placeOrderRequestCreation(order).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Place an order for a pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid Order
+     * @param order order placed for purchasing the pet
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec placeOrderWithResponseSpec(Order order) throws WebClientResponseException {
+        return placeOrderRequestCreation(order);
     }
 }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -93,9 +93,28 @@ public class UserApi {
         return createUserRequestCreation(user).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Create user
+     * This can only be done by the logged in user.
+     * <p><b>0</b> - successful operation
+     * @param user Created user object
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> createUserWithHttpInfo(User user) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return createUserRequestCreation(user).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Create user
+     * This can only be done by the logged in user.
+     * <p><b>0</b> - successful operation
+     * @param user Created user object
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec createUserWithResponseSpec(User user) throws WebClientResponseException {
+        return createUserRequestCreation(user);
     }
     /**
      * Creates list of users with given input array
@@ -143,9 +162,28 @@ public class UserApi {
         return createUsersWithArrayInputRequestCreation(user).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param user List of user object
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> createUsersWithArrayInputWithHttpInfo(List<User> user) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return createUsersWithArrayInputRequestCreation(user).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param user List of user object
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec createUsersWithArrayInputWithResponseSpec(List<User> user) throws WebClientResponseException {
+        return createUsersWithArrayInputRequestCreation(user);
     }
     /**
      * Creates list of users with given input array
@@ -193,9 +231,28 @@ public class UserApi {
         return createUsersWithListInputRequestCreation(user).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param user List of user object
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> createUsersWithListInputWithHttpInfo(List<User> user) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return createUsersWithListInputRequestCreation(user).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param user List of user object
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec createUsersWithListInputWithResponseSpec(List<User> user) throws WebClientResponseException {
+        return createUsersWithListInputRequestCreation(user);
     }
     /**
      * Delete user
@@ -245,9 +302,30 @@ public class UserApi {
         return deleteUserRequestCreation(username).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Delete user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be deleted
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> deleteUserWithHttpInfo(String username) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return deleteUserRequestCreation(username).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Delete user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be deleted
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec deleteUserWithResponseSpec(String username) throws WebClientResponseException {
+        return deleteUserRequestCreation(username);
     }
     /**
      * Get user by user name
@@ -303,9 +381,33 @@ public class UserApi {
         return getUserByNameRequestCreation(username).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Get user by user name
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @return ResponseEntity&lt;User&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<User>> getUserByNameWithHttpInfo(String username) throws WebClientResponseException {
         ParameterizedTypeReference<User> localVarReturnType = new ParameterizedTypeReference<User>() {};
         return getUserByNameRequestCreation(username).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Get user by user name
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec getUserByNameWithResponseSpec(String username) throws WebClientResponseException {
+        return getUserByNameRequestCreation(username);
     }
     /**
      * Logs user into the system
@@ -366,9 +468,33 @@ public class UserApi {
         return loginUserRequestCreation(username, password).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Logs user into the system
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username/password supplied
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     * @return ResponseEntity&lt;String&gt;
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<String>> loginUserWithHttpInfo(String username, String password) throws WebClientResponseException {
         ParameterizedTypeReference<String> localVarReturnType = new ParameterizedTypeReference<String>() {};
         return loginUserRequestCreation(username, password).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Logs user into the system
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username/password supplied
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec loginUserWithResponseSpec(String username, String password) throws WebClientResponseException {
+        return loginUserRequestCreation(username, password);
     }
     /**
      * Logs out current logged in user session
@@ -408,9 +534,26 @@ public class UserApi {
         return logoutUserRequestCreation().bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Logs out current logged in user session
+     * 
+     * <p><b>0</b> - successful operation
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> logoutUserWithHttpInfo() throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return logoutUserRequestCreation().toEntity(localVarReturnType);
+    }
+
+    /**
+     * Logs out current logged in user session
+     * 
+     * <p><b>0</b> - successful operation
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec logoutUserWithResponseSpec() throws WebClientResponseException {
+        return logoutUserRequestCreation();
     }
     /**
      * Updated user
@@ -468,8 +611,31 @@ public class UserApi {
         return updateUserRequestCreation(username, user).bodyToMono(localVarReturnType);
     }
 
+    /**
+     * Updated user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid user supplied
+     * <p><b>404</b> - User not found
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
     public Mono<ResponseEntity<Void>> updateUserWithHttpInfo(String username, User user) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
         return updateUserRequestCreation(username, user).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Updated user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid user supplied
+     * <p><b>404</b> - User not found
+     * @param username name that need to be deleted
+     * @param user Updated user object
+     * @return ResponseSpec
+     * @throws WebClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec updateUserWithResponseSpec(String username, User user) throws WebClientResponseException {
+        return updateUserRequestCreation(username, user);
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix for https://github.com/OpenAPITools/openapi-generator/issues/12809

This PR gives ability to manually control handling of response. Additional method with `WithResponseSpec` suffix is introduced. This method gives ability to control how different HTTP status is handled. Examples can be checked here - https://github.com/spring-projects/spring-framework/issues/20280

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
