### PR TITLE
[PHP] ObjectSerializer::deserialize() associative arrays bugfix

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -446,6 +446,11 @@ class ObjectSerializer
             return $data;
         } else {
             $data = is_string($data) ? json_decode($data) : $data;
+
+            if (is_array($data)) {
+                $data = (object)$data;
+            }
+
             // If a discriminator is defined and points to a valid subclass, use it.
             $discriminator = $class::DISCRIMINATOR;
             if (!empty($discriminator) && isset($data->{$discriminator}) && is_string($data->{$discriminator})) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -455,6 +455,11 @@ class ObjectSerializer
             return $data;
         } else {
             $data = is_string($data) ? json_decode($data) : $data;
+
+            if (is_array($data)) {
+                $data = (object)$data;
+            }
+
             // If a discriminator is defined and points to a valid subclass, use it.
             $discriminator = $class::DISCRIMINATOR;
             if (!empty($discriminator) && isset($data->{$discriminator}) && is_string($data->{$discriminator})) {


### PR DESCRIPTION
This comes from a bug we found while dealing with the Tripletex API.

ObjectSerializer::deserialize()'s last `else` block instantiates an object of type `$class` and tries to populate it with the contents of `$data`. From this point on, `$data` is always handled as an object, as we check for its properties (`$data->{$discriminator}` or $data->{$instance::attributeMap()[$property]}.

But while working with Tripletex (and after a lot of debugging), we figured out that in some very specific cases the received `$data` parameter was an associative array, which then caused all properties from the instance to become empty.

This PR casts `$data` to object, in case it is an array. It is absolutely harmless, since it happens in the last `else` block (where we only care for an object anyway). It's only purpose is to make sure that the data in a received associative array will be properly handled as an object.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee]
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon