### PR TITLE
Java: Add `toString` method to ApiException

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/apiException.mustache
@@ -77,4 +77,13 @@ public class ApiException extends{{#useRuntimeException}} RuntimeException {{/us
     public String getResponseBody() {
         return responseBody;
     }
+
+    @Override
+    public String toString() {
+        return "ApiException{" +
+                "code=" + code +
+                ", responseHeaders=" + responseHeaders +
+                ", responseBody='" + responseBody + '\'' +
+                '}';
+    }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/ApiException.mustache
@@ -5,7 +5,6 @@ package {{apiPackage}};
  */
 {{>generatedAnnotation}}
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/ApiException.mustache
@@ -5,7 +5,6 @@ package {{apiPackage}};
  */
 {{>generatedAnnotation}}
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiException.mustache
@@ -12,7 +12,6 @@ import javax.annotation.Generated;
  */
 {{>generatedAnnotation}}
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -36,4 +35,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/modules/openapi-generator/src/main/resources/android/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/android/apiException.mustache
@@ -27,4 +27,12 @@ public class ApiException extends Exception {
   public void setMessage(String message) {
     this.message = message;
   }
+
+  @Override
+  public String toString() {
+    return "ApiException{" +
+           "code=" + code +
+           ", message=" + message +
+           '}';
+  }
 }

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/apiException.mustache
@@ -47,4 +47,12 @@ public class ApiException extends Exception {
   public void setMessage(String message) {
     this.message = message;
   }
+
+  @Override
+  public String toString() {
+    return "ApiException{" +
+           "code=" + code +
+           ", message=" + message +
+           '}';
+  }
 }

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/ApiException.mustache
@@ -5,7 +5,6 @@ package {{apiPackage}};
  */
 {{>generatedAnnotation}}
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
@@ -88,4 +88,13 @@ public class ApiException extends Exception {
     public String getResponseBody() {
         return responseBody;
     }
+
+    @Override
+    public String toString() {
+        return "ApiException{" +
+                "code=" + code +
+                ", responseHeaders=" + responseHeaders +
+                ", responseBody='" + responseBody + '\'' +
+                '}';
+    }
 }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ApiException.java
@@ -88,4 +88,13 @@ public class ApiException extends Exception {
     public String getResponseBody() {
         return responseBody;
     }
+
+    @Override
+    public String toString() {
+        return "ApiException{" +
+                "code=" + code +
+                ", responseHeaders=" + responseHeaders +
+                ", responseBody='" + responseBody + '\'' +
+                '}';
+    }
 }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
@@ -88,4 +88,13 @@ public class ApiException extends Exception {
     public String getResponseBody() {
         return responseBody;
     }
+
+    @Override
+    public String toString() {
+        return "ApiException{" +
+                "code=" + code +
+                ", responseHeaders=" + responseHeaders +
+                ", responseBody='" + responseBody + '\'' +
+                '}';
+    }
 }

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaMSF4JServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-resteasy/java8/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaResteasyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/ApiException.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/ApiException.java
@@ -5,7 +5,6 @@ package org.openapitools.api;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class ApiException extends Exception {
-
     /** The HTTP status code. */
     private int code;
 
@@ -29,4 +28,10 @@ public class ApiException extends Exception {
         return code;
     }
 
+    @Override
+    public String toString() {
+        return "ApiException{" +
+               "code=" + code +
+               '}';
+    }
 }


### PR DESCRIPTION
Previously, only the class name appeared in stacktrace whereas now
relevant details are added. This applies to most Java-related
generators.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
