### PR TITLE
Fixes fromProperty when property is required vs optional

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3526,6 +3526,19 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
+     * TODO remove this in 7.0.0 as a breaking change
+     * This method was kept when required was added to the fromProperty signature
+     * to ensure that the change was non-breaking
+     *
+     * @param name     name of the property
+     * @param p        OAS property schema
+     * @return Codegen Property object
+     */
+    public CodegenProperty fromProperty(String name, Schema p) {
+        return fromProperty(name, p, false);
+    }
+
+    /**
      * Convert OAS Property object to Codegen Property object.
      * <p>
      * The return value is cached. An internal cache is looked up to determine
@@ -3534,8 +3547,9 @@ public class DefaultCodegen implements CodegenConfig {
      * Any subsequent processing of the CodegenModel return value must be idempotent
      * for a given (String name, Schema schema).
      *
-     * @param name name of the property
-     * @param p    OAS property schema
+     * @param name     name of the property
+     * @param p        OAS property schema
+     * @param required true if the property is required in the next higher object schema, false otherwise
      * @return Codegen Property object
      */
     public CodegenProperty fromProperty(String name, Schema p, boolean required) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4864,7 +4864,9 @@ public class DefaultCodegen implements CodegenConfig {
             imports.add(codegenProperty.baseType);
         }
         codegenParameter.dataFormat = codegenProperty.dataFormat;
-        codegenParameter.required = parameter.getRequired().booleanValue();
+        if (parameter.getRequired() != null) {
+            codegenParameter.required = parameter.getRequired().booleanValue();
+        }
 
         if (codegenProperty.isEnum) {
             codegenParameter.datatypeWithEnum = codegenProperty.datatypeWithEnum;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2456,26 +2456,29 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     private static class NamedSchema {
-        private NamedSchema(String name, Schema s) {
+        private NamedSchema(String name, Schema s, boolean required) {
             this.name = name;
             this.schema = s;
+            this.required = required;
         }
 
         private String name;
         private Schema schema;
+        private boolean required;
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             NamedSchema that = (NamedSchema) o;
-            return Objects.equals(name, that.name) &&
+            return Objects.equals(required, that.required)  &&
+                    Objects.equals(name, that.name) &&
                     Objects.equals(schema, that.schema);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(name, schema);
+            return Objects.hash(name, schema, required);
         }
     }
 
@@ -2548,7 +2551,7 @@ public class DefaultCodegen implements CodegenConfig {
                 if (StringUtils.isBlank(interfaceSchema.get$ref())) {
                     // primitive type
                     String languageType = getTypeDeclaration(interfaceSchema);
-                    CodegenProperty interfaceProperty = fromProperty(languageType, interfaceSchema);
+                    CodegenProperty interfaceProperty = fromProperty(languageType, interfaceSchema, false);
                     if (ModelUtils.isArraySchema(interfaceSchema) || ModelUtils.isMapSchema(interfaceSchema)) {
                         while (interfaceProperty != null) {
                             addImport(m, interfaceProperty.complexType);
@@ -2584,7 +2587,7 @@ public class DefaultCodegen implements CodegenConfig {
                     refSchema = allDefinitions.get(ref);
                 }
                 final String modelName = toModelName(ref);
-                CodegenProperty interfaceProperty = fromProperty(modelName, interfaceSchema);
+                CodegenProperty interfaceProperty = fromProperty(modelName, interfaceSchema, false);
                 m.interfaces.add(modelName);
                 addImport(composed, refSchema, m, modelName);
 
@@ -2835,7 +2838,7 @@ public class DefaultCodegen implements CodegenConfig {
         m.setTypeProperties(schema);
         m.setComposedSchemas(getComposedSchemas(schema));
         if (ModelUtils.isArraySchema(schema)) {
-            CodegenProperty arrayProperty = fromProperty(name, schema);
+            CodegenProperty arrayProperty = fromProperty(name, schema, false);
             m.setItems(arrayProperty.items);
             m.arrayModelType = arrayProperty.complexType;
             addParentContainer(m, name, schema);
@@ -2955,17 +2958,17 @@ public class DefaultCodegen implements CodegenConfig {
         if (schema.getAdditionalProperties() == null) {
             if (!disallowAdditionalPropertiesIfNotPresent) {
                 isAdditionalPropertiesTrue = true;
-                addPropProp = fromProperty("", new Schema());
+                addPropProp = fromProperty("", new Schema(), false);
                 additionalPropertiesIsAnyType = true;
             }
         } else if (schema.getAdditionalProperties() instanceof Boolean) {
             if (Boolean.TRUE.equals(schema.getAdditionalProperties())) {
                 isAdditionalPropertiesTrue = true;
-                addPropProp = fromProperty("", new Schema());
+                addPropProp = fromProperty("", new Schema(), false);
                 additionalPropertiesIsAnyType = true;
             }
         } else {
-            addPropProp = fromProperty("", (Schema) schema.getAdditionalProperties());
+            addPropProp = fromProperty("", (Schema) schema.getAdditionalProperties(), false);
             if (ModelUtils.isAnyType((Schema) schema.getAdditionalProperties())) {
                 additionalPropertiesIsAnyType = true;
             }
@@ -3451,7 +3454,7 @@ public class DefaultCodegen implements CodegenConfig {
             innerSchema = new StringSchema().description("//TODO automatically added by openapi-generator due to undefined type");
             p.setAdditionalProperties(innerSchema);
         }
-        CodegenProperty cp = fromProperty("inner", innerSchema);
+        CodegenProperty cp = fromProperty("inner", innerSchema, false);
         updatePropertyForMap(property, cp);
     }
 
@@ -3535,22 +3538,23 @@ public class DefaultCodegen implements CodegenConfig {
      * @param p    OAS property schema
      * @return Codegen Property object
      */
-    public CodegenProperty fromProperty(String name, Schema p) {
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
         if (p == null) {
             LOGGER.error("Undefined property/schema for `{}`. Default to type:string.", name);
             return null;
         }
         LOGGER.debug("debugging fromProperty for {} : {}", name, p);
-        NamedSchema ns = new NamedSchema(name, p);
+        NamedSchema ns = new NamedSchema(name, p, required);
         CodegenProperty cpc = schemaCodegenPropertyCache.get(ns);
         if (cpc != null) {
-            LOGGER.debug("Cached fromProperty for {} : {}", name, p.getName());
+            LOGGER.debug("Cached fromProperty for {} : {} required={}", name, p.getName(), required);
             return cpc;
         }
         // unalias schema
         p = unaliasSchema(p, schemaMapping);
 
         CodegenProperty property = CodegenModelFactory.newInstance(CodegenModelType.PROPERTY);
+        property.required = required;
         ModelUtils.syncValidationProperties(p, property);
 
         property.name = toVarName(name);
@@ -3717,7 +3721,7 @@ public class DefaultCodegen implements CodegenConfig {
             }
             ArraySchema arraySchema = (ArraySchema) p;
             Schema innerSchema = unaliasSchema(getSchemaItems(arraySchema), schemaMapping);
-            CodegenProperty cp = fromProperty(itemName, innerSchema);
+            CodegenProperty cp = fromProperty(itemName, innerSchema, false);
             updatePropertyForArray(property, cp);
         } else if (ModelUtils.isTypeObjectSchema(p)) {
             updatePropertyForObject(property, p);
@@ -3965,14 +3969,14 @@ public class DefaultCodegen implements CodegenConfig {
         Schema responseSchema = unaliasSchema(ModelUtils.getSchemaFromResponse(methodResponse), schemaMapping);
 
         if (responseSchema != null) {
-            CodegenProperty cm = fromProperty("response", responseSchema);
+            CodegenProperty cm = fromProperty("response", responseSchema, false);
 
             if (ModelUtils.isArraySchema(responseSchema)) {
                 ArraySchema as = (ArraySchema) responseSchema;
-                CodegenProperty innerProperty = fromProperty("response", getSchemaItems(as));
+                CodegenProperty innerProperty = fromProperty("response", getSchemaItems(as), false);
                 op.returnBaseType = innerProperty.baseType;
             } else if (ModelUtils.isMapSchema(responseSchema)) {
-                CodegenProperty innerProperty = fromProperty("response", getAdditionalProperties(responseSchema));
+                CodegenProperty innerProperty = fromProperty("response", getAdditionalProperties(responseSchema), false);
                 op.returnBaseType = innerProperty.baseType;
             } else {
                 if (cm.complexType != null) {
@@ -4430,7 +4434,7 @@ public class DefaultCodegen implements CodegenConfig {
             r.setPattern(toRegularExpression(responseSchema.getPattern()));
         }
 
-        CodegenProperty cp = fromProperty("response", responseSchema);
+        CodegenProperty cp = fromProperty("response", responseSchema, false);
         r.dataType = getTypeDeclaration(responseSchema);
 
         if (!ModelUtils.isArraySchema(responseSchema)) {
@@ -4453,7 +4457,7 @@ public class DefaultCodegen implements CodegenConfig {
             r.isArray = true;
             r.containerType = cp.containerType;
             ArraySchema as = (ArraySchema) responseSchema;
-            CodegenProperty items = fromProperty("response", getSchemaItems(as));
+            CodegenProperty items = fromProperty("response", getSchemaItems(as), false);
             r.setItems(items);
             CodegenProperty innerCp = items;
 
@@ -4612,7 +4616,7 @@ public class DefaultCodegen implements CodegenConfig {
 
 
     private void updateParameterForMap(CodegenParameter codegenParameter, Schema parameterSchema, Set<String> imports) {
-        CodegenProperty codegenProperty = fromProperty("inner", getAdditionalProperties(parameterSchema));
+        CodegenProperty codegenProperty = fromProperty("inner", getAdditionalProperties(parameterSchema), false);
         codegenParameter.items = codegenProperty;
         codegenParameter.mostInnerItems = codegenProperty.mostInnerItems;
         codegenParameter.baseType = codegenProperty.dataType;
@@ -4700,11 +4704,11 @@ public class DefaultCodegen implements CodegenConfig {
             if (this instanceof RustServerCodegen) {
                 // for rust server, we need to do somethings special as it uses
                 // $ref (e.g. #components/schemas/Pet) to determine whether it's a model
-                prop = fromProperty(parameter.getName(), parameterSchema);
+                prop = fromProperty(parameter.getName(), parameterSchema, false);
             } else if (getUseInlineModelResolver()) {
-                prop = fromProperty(parameter.getName(), getReferencedSchemaWhenNotEnum(parameterSchema));
+                prop = fromProperty(parameter.getName(), getReferencedSchemaWhenNotEnum(parameterSchema), false);
             } else {
-                prop = fromProperty(parameter.getName(), parameterSchema);
+                prop = fromProperty(parameter.getName(), parameterSchema, false);
             }
             codegenParameter.setSchema(prop);
         } else if (parameter.getContent() != null) {
@@ -4827,7 +4831,7 @@ public class DefaultCodegen implements CodegenConfig {
             collectionFormat = getCollectionFormat(parameter);
             // default to csv:
             collectionFormat = StringUtils.isEmpty(collectionFormat) ? "csv" : collectionFormat;
-            CodegenProperty itemsProperty = fromProperty("inner", inner);
+            CodegenProperty itemsProperty = fromProperty("inner", inner, false);
             codegenParameter.items = itemsProperty;
             codegenParameter.mostInnerItems = itemsProperty.mostInnerItems;
             codegenParameter.baseType = itemsProperty.dataType;
@@ -4843,15 +4847,10 @@ public class DefaultCodegen implements CodegenConfig {
             ;
         }
 
-        CodegenProperty codegenProperty = fromProperty(parameter.getName(), parameterSchema);
+        CodegenProperty codegenProperty = fromProperty(parameter.getName(), parameterSchema, false);
         if (Boolean.TRUE.equals(codegenProperty.isModel)) {
             codegenParameter.isModel = true;
         }
-        // TODO revise below which seems not working
-        //if (parameterSchema.getRequired() != null && !parameterSchema.getRequired().isEmpty() && parameterSchema.getRequired().contains(codegenProperty.baseName)) {
-        codegenProperty.required = Boolean.TRUE.equals(parameter.getRequired()) ? true : false;
-        //}
-        //codegenProperty.required = true;
 
         if (parameterModelName != null) {
             codegenParameter.dataType = parameterModelName;
@@ -4865,7 +4864,7 @@ public class DefaultCodegen implements CodegenConfig {
             imports.add(codegenProperty.baseType);
         }
         codegenParameter.dataFormat = codegenProperty.dataFormat;
-        codegenParameter.required = codegenProperty.required;
+        codegenParameter.required = parameter.getRequired().booleanValue();
 
         if (codegenProperty.isEnum) {
             codegenParameter.datatypeWithEnum = codegenProperty.datatypeWithEnum;
@@ -4902,15 +4901,19 @@ public class DefaultCodegen implements CodegenConfig {
             if (schema.get$ref() != null) {
                 schema = ModelUtils.getReferencedSchema(openAPI, schema);
             }
-            codegenParameter.items = fromProperty(codegenParameter.paramName, schema);
+            codegenParameter.items = fromProperty(codegenParameter.paramName, schema, false);
             // https://swagger.io/docs/specification/serialization/
             if (schema != null) {
                 Map<String, Schema<?>> properties = schema.getProperties();
+                List<String> requiredVarNames = new ArrayList<>();
+                if (schema.getRequired() != null) {
+                    requiredVarNames.addAll(schema.getRequired());
+                }
                 if (properties != null) {
                     codegenParameter.items.vars =
                             properties.entrySet().stream()
                                     .map(entry -> {
-                                        CodegenProperty property = fromProperty(entry.getKey(), entry.getValue());
+                                        CodegenProperty property = fromProperty(entry.getKey(), entry.getValue(), requiredVarNames.contains(entry.getKey()));
                                         property.baseName = codegenParameter.baseName + "[" + entry.getKey() + "]";
                                         return property;
                                     }).collect(Collectors.toList());
@@ -5189,7 +5192,7 @@ public class DefaultCodegen implements CodegenConfig {
                 } else {
                     schema = header.getSchema();
                 }
-                CodegenProperty cp = fromProperty(headerEntry.getKey(), schema);
+                CodegenProperty cp = fromProperty(headerEntry.getKey(), schema, false);
                 cp.setDescription(escapeText(description));
                 cp.setUnescapedDescription(description);
                 if (header.getRequired() != null) {
@@ -5257,7 +5260,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param schema the input OAS schema.
      */
     protected void addParentContainer(CodegenModel model, String name, Schema schema) {
-        final CodegenProperty property = fromProperty(name, schema);
+        final CodegenProperty property = fromProperty(name, schema, false);
         addImport(model, property.complexType);
         model.parent = toInstantiationType(schema);
         final String containerType = property.containerType;
@@ -5423,8 +5426,7 @@ public class DefaultCodegen implements CodegenConfig {
             if (prop == null) {
                 LOGGER.warn("Please report the issue. There shouldn't be null property for {}", key);
             } else {
-                final CodegenProperty cp = fromProperty(key, prop);
-                cp.required = mandatory.contains(key);
+                final CodegenProperty cp = fromProperty(key, prop, mandatory.contains(key));
                 vars.add(cp);
                 if (cm == null) {
                     continue;
@@ -6467,7 +6469,7 @@ public class DefaultCodegen implements CodegenConfig {
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
 
         LOGGER.debug("Debugging fromFormProperty {}: {}", name, propertySchema);
-        CodegenProperty codegenProperty = fromProperty(name, propertySchema);
+        CodegenProperty codegenProperty = fromProperty(name, propertySchema, false);
 
         Schema ps = unaliasSchema(propertySchema, schemaMapping);
         ModelUtils.syncValidationProperties(ps, codegenParameter);
@@ -6553,7 +6555,7 @@ public class DefaultCodegen implements CodegenConfig {
             ;
         } else if (ModelUtils.isArraySchema(ps)) {
             Schema inner = getSchemaItems((ArraySchema) ps);
-            CodegenProperty arrayInnerProperty = fromProperty("inner", inner);
+            CodegenProperty arrayInnerProperty = fromProperty("inner", inner, false);
             codegenParameter.items = arrayInnerProperty;
             codegenParameter.mostInnerItems = arrayInnerProperty.mostInnerItems;
             codegenParameter.isPrimitiveType = false;
@@ -6648,7 +6650,7 @@ public class DefaultCodegen implements CodegenConfig {
             codegenParameter.isNullable = codegenModel.isNullable;
             imports.add(codegenParameter.baseType);
         } else {
-            CodegenProperty codegenProperty = fromProperty("property", schema);
+            CodegenProperty codegenProperty = fromProperty("property", schema, false);
 
             if (codegenProperty != null && codegenProperty.getComplexType() != null && codegenProperty.getComplexType().contains(" | ")) {
                 List<String> parts = Arrays.asList(codegenProperty.getComplexType().split(" \\| "));
@@ -6713,7 +6715,7 @@ public class DefaultCodegen implements CodegenConfig {
                 inner = new StringSchema().description("//TODO automatically added by openapi-generator");
                 schema.setAdditionalProperties(inner);
             }
-            CodegenProperty codegenProperty = fromProperty("property", schema);
+            CodegenProperty codegenProperty = fromProperty("property", schema, false);
 
             imports.add(codegenProperty.baseType);
 
@@ -6745,7 +6747,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     protected void updateRequestBodyForPrimitiveType(CodegenParameter codegenParameter, Schema schema, String bodyParameterName, Set<String> imports) {
-        CodegenProperty codegenProperty = fromProperty("PRIMITIVE_REQUEST_BODY", schema);
+        CodegenProperty codegenProperty = fromProperty("PRIMITIVE_REQUEST_BODY", schema, false);
         if (codegenProperty != null) {
             if (StringUtils.isEmpty(bodyParameterName)) {
                 codegenParameter.baseName = "body";  // default to body
@@ -6779,7 +6781,7 @@ public class DefaultCodegen implements CodegenConfig {
             codegenParameter.isFreeFormObject = true;
 
             // HTTP request body is free form object
-            CodegenProperty codegenProperty = fromProperty("FREE_FORM_REQUEST_BODY", schema);
+            CodegenProperty codegenProperty = fromProperty("FREE_FORM_REQUEST_BODY", schema, false);
             if (codegenProperty != null) {
                 if (StringUtils.isEmpty(bodyParameterName)) {
                     codegenParameter.baseName = "body";  // default to body
@@ -6808,7 +6810,7 @@ public class DefaultCodegen implements CodegenConfig {
         } else {
             final ArraySchema arraySchema = (ArraySchema) schema;
             Schema inner = getSchemaItems(arraySchema);
-            CodegenProperty codegenProperty = fromProperty("property", arraySchema);
+            CodegenProperty codegenProperty = fromProperty("property", arraySchema, false);
             imports.add(codegenProperty.baseType);
             CodegenProperty innerCp = codegenProperty;
             CodegenProperty mostInnerItem = innerCp;
@@ -6942,7 +6944,7 @@ public class DefaultCodegen implements CodegenConfig {
             String contentType = contentEntry.getKey();
             CodegenProperty schemaProp = null;
             if (mt.getSchema() != null) {
-                schemaProp = fromProperty(toMediaTypeSchemaName(contentType, mediaTypeSchemaSuffix), mt.getSchema());
+                schemaProp = fromProperty(toMediaTypeSchemaName(contentType, mediaTypeSchemaSuffix), mt.getSchema(), false);
             }
             CodegenMediaType codegenMt = new CodegenMediaType(schemaProp, ceMap);
             cmtContent.put(contentType, codegenMt);
@@ -7576,7 +7578,7 @@ public class DefaultCodegen implements CodegenConfig {
         Schema notSchema = schema.getNot();
         CodegenProperty notProperty = null;
         if (notSchema != null) {
-            notProperty = fromProperty("NotSchema", notSchema);
+            notProperty = fromProperty("NotSchema", notSchema, false);
         }
         List<CodegenProperty> allOf = new ArrayList<>();
         List<CodegenProperty> oneOf = new ArrayList<>();
@@ -7602,7 +7604,7 @@ public class DefaultCodegen implements CodegenConfig {
         List<CodegenProperty> xOf = new ArrayList<>();
         int i = 0;
         for (Schema xOfSchema : xOfCollection) {
-            CodegenProperty cp = fromProperty(collectionName + "_" + i, xOfSchema);
+            CodegenProperty cp = fromProperty(collectionName + "_" + i, xOfSchema, false);
             xOf.add(cp);
             i += 1;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -129,7 +129,7 @@ public interface IJsonSchemaValidationProperties {
 
     boolean getHasVars();
 
-    void setHasVars(boolean hasRequiredVars);
+    void setHasVars(boolean hasVars);
 
     boolean getHasRequired();
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
@@ -385,8 +385,8 @@ abstract public class AbstractAdaCodegen extends DefaultCodegen implements Codeg
     }
 
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty property = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty property = super.fromProperty(name, p, required);
         if (property != null) {
             String nameInCamelCase = property.nameInCamelCase;
             nameInCamelCase = sanitizeName(nameInCamelCase);
@@ -566,7 +566,7 @@ abstract public class AbstractAdaCodegen extends DefaultCodegen implements Codeg
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
             ApiResponse methodResponse = findMethodResponse(operation.getResponses());
             if (methodResponse != null && ModelUtils.getSchemaFromResponse(methodResponse) != null) {
-                CodegenProperty cm = fromProperty("response", ModelUtils.getSchemaFromResponse(methodResponse));
+                CodegenProperty cm = fromProperty("response", ModelUtils.getSchemaFromResponse(methodResponse), false);
                 op.vendorExtensions.put("x-codegen-response", cm);
                 op.vendorExtensions.put("x-is-model-type", isModelType(cm));
                 op.vendorExtensions.put("x-is-stream-type", isStreamType(cm));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -251,8 +251,8 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
 
     @SuppressWarnings("rawtypes")
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty property = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty property = super.fromProperty(name, p, required);
         String nameInCamelCase = property.nameInCamelCase;
         if (nameInCamelCase.length() > 1) {
             nameInCamelCase = sanitizeName(Character.toLowerCase(nameInCamelCase.charAt(0)) + nameInCamelCase.substring(1));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -551,8 +551,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     }
 
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        final CodegenProperty property = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        final CodegenProperty property = super.fromProperty(name, p, required);
 
         // Handle composed properties
         if (ModelUtils.isComposedSchema(p)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
@@ -461,8 +461,8 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
      * @return Codegen Property object
      */
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty prop = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty prop = super.fromProperty(name, p, required);
         if (ModelUtils.isArraySchema(p)) {
             ArraySchema as = (ArraySchema) p;
             if (ModelUtils.isSet(as)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -852,8 +852,8 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
     }
 
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty cm = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty cm = super.fromProperty(name, p, required);
         Schema ref = ModelUtils.getReferencedSchema(openAPI, p);
         if (ref != null) {
             if (ref.getEnum() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -242,7 +242,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
             if (apiResponse != null) {
                 Schema response = ModelUtils.getSchemaFromResponse(apiResponse);
                 if (response != null) {
-                    CodegenProperty cm = fromProperty("response", response);
+                    CodegenProperty cm = fromProperty("response", response, false);
                     op.vendorExtensions.put("x-codegen-response", cm);
                     if ("HttpContent".equals(cm.dataType)) {
                         op.vendorExtensions.put("x-codegen-response-ishttpcontent", true);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -297,7 +297,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
                 Schema response = ModelUtils.getSchemaFromResponse(methodResponse);
                 response = ModelUtils.unaliasSchema(this.openAPI, response, schemaMapping);
                 if (response != null) {
-                    CodegenProperty cm = fromProperty("response", response);
+                    CodegenProperty cm = fromProperty("response", response, false);
                     op.vendorExtensions.put("x-codegen-response", cm);
                     if ("std::shared_ptr<HttpContent>".equals(cm.dataType)) {
                         op.vendorExtensions.put("x-codegen-response-ishttpcontent", true);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -384,8 +384,8 @@ public class GoClientCodegen extends AbstractGoCodegen {
     }
 
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty prop = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty prop = super.fromProperty(name, p, required);
         String cc = camelize(prop.name, true);
         if (isReservedWord(cc)) {
             cc = escapeReservedWord(cc);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
@@ -323,7 +323,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
                 }
                 if (!hasPrimaryKey) {
                     final IntegerSchema schema = new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT);
-                    CodegenProperty cp = super.fromProperty(primaryKeyConvention, schema);
+                    CodegenProperty cp = super.fromProperty(primaryKeyConvention, schema, false);
                     cp.setRequired(true);
                     model.vars.add(0, cp);
                     model.allVars.add(0, cp);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
@@ -307,8 +307,8 @@ public class PhpLaravelServerCodegen extends AbstractPhpCodegen {
     }
 
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty property = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty property = super.fromProperty(name, p, required);
         Schema referencedSchema = ModelUtils.getReferencedSchema(this.openAPI, p);
 
         //Referenced enum case:

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -446,8 +446,8 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
      * @return Codegen Property object
      */
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty cp = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty cp = super.fromProperty(name, p, required);
         if (cp.isEnum) {
             updateCodegenPropertyEnum(cp);
         }
@@ -518,7 +518,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
             return cp;
         }
         Schema unaliasedSchema = unaliasSchema(schema, schemaMapping);
-        CodegenProperty unaliasedProp = fromProperty("body", unaliasedSchema);
+        CodegenProperty unaliasedProp = fromProperty("body", unaliasedSchema, false);
         Boolean dataTypeMismatch = !cp.dataType.equals(unaliasedProp.dataType);
         Boolean baseTypeMismatch = !cp.baseType.equals(unaliasedProp.complexType) && unaliasedProp.complexType != null;
         if (dataTypeMismatch || baseTypeMismatch) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
@@ -849,8 +849,8 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
      * @return Codegen Property object
      */
     @Override
-    public CodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty cp = super.fromProperty(name, p);
+    public CodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty cp = super.fromProperty(name, p, required);
         if (cp.isAnyType && cp.isNullable) {
             cp.isNullable = false;
         }
@@ -964,7 +964,7 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
             return cp;
         }
         Schema unaliasedSchema = unaliasSchema(schema, schemaMapping);
-        CodegenProperty unaliasedProp = fromProperty("body", unaliasedSchema);
+        CodegenProperty unaliasedProp = fromProperty("body", unaliasedSchema, false);
         Boolean dataTypeMismatch = !cp.dataType.equals(unaliasedProp.dataType);
         Boolean baseTypeMismatch = !cp.baseType.equals(unaliasedProp.complexType) && unaliasedProp.complexType != null;
         if (dataTypeMismatch || baseTypeMismatch) {
@@ -1022,7 +1022,7 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
             codegenParameter.isNullable = codegenModel.isNullable;
             imports.add(codegenParameter.baseType);
         } else {
-            CodegenProperty codegenProperty = fromProperty("property", schema);
+            CodegenProperty codegenProperty = fromProperty("property", schema, false);
 
             if (codegenProperty != null && codegenProperty.getComplexType() != null && codegenProperty.getComplexType().contains(" | ")) {
                 List<String> parts = Arrays.asList(codegenProperty.getComplexType().split(" \\| "));
@@ -2033,7 +2033,7 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
                 isAdditionalPropertiesTrue = true;
                 // pass in the hashCode as the name to ensure that the returned property is not from the cache
                 // if we need to set indent on every one, then they need to be different
-                addPropProp = fromProperty(String.valueOf(property.hashCode()),  new Schema());
+                addPropProp = fromProperty(String.valueOf(property.hashCode()),  new Schema(), false);
                 addPropProp.name = "";
                 addPropProp.baseName = "";
                 addPropProp.nameInSnakeCase = null;
@@ -2042,14 +2042,14 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
         } else if (schema.getAdditionalProperties() instanceof Boolean) {
             if (Boolean.TRUE.equals(schema.getAdditionalProperties())) {
                 isAdditionalPropertiesTrue = true;
-                addPropProp = fromProperty(String.valueOf(property.hashCode()),  new Schema());
+                addPropProp = fromProperty(String.valueOf(property.hashCode()),  new Schema(), false);
                 addPropProp.name = "";
                 addPropProp.baseName = "";
                 addPropProp.nameInSnakeCase = null;
                 additionalPropertiesIsAnyType = true;
             }
         } else {
-            addPropProp = fromProperty(String.valueOf(property.hashCode()), (Schema) schema.getAdditionalProperties());
+            addPropProp = fromProperty(String.valueOf(property.hashCode()), (Schema) schema.getAdditionalProperties(), false);
             addPropProp.name = "";
             addPropProp.baseName = "";
             addPropProp.nameInSnakeCase = null;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -443,8 +443,8 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     }
 
     @Override
-    public ExtendedCodegenProperty fromProperty(String name, Schema p) {
-        CodegenProperty cp = super.fromProperty(name, p);
+    public ExtendedCodegenProperty fromProperty(String name, Schema p, boolean required) {
+        CodegenProperty cp = super.fromProperty(name, p, required);
         return new ExtendedCodegenProperty(cp);
     }
 
@@ -515,7 +515,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
                     if (op.returnPassthrough instanceof String && cm != null) {
                         cp = (ExtendedCodegenProperty) this.processCodeGenModel(cm).vars.get(1);
                     } else if (responseSchema != null) {
-                        cp = fromProperty("response", responseSchema);
+                        cp = fromProperty("response", responseSchema, false);
                         this.processCodegenProperty(cp, "", null);
                     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4220,4 +4220,29 @@ public class DefaultCodegenTest {
         Assert.assertEquals(codegenParameter.defaultValue, "1971-12-19T03:39:57-08:00");
         Assert.assertEquals(codegenParameter.getSchema(), null);
     }
+
+    @Test
+    public void testFromPropertyRequiredAndOptional() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_12857.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.setDisallowAdditionalPropertiesIfNotPresent(false);
+
+        String modelName = "FooRequired";
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel fooRequired = codegen.fromModel(modelName, sc);
+        modelName = "FooOptional";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        CodegenModel fooOptional = codegen.fromModel(modelName, sc);
+        Assert.assertTrue(fooRequired.vars.get(0).required);
+        Assert.assertEquals(fooRequired.vars.get(0).name, "foo");
+
+        Assert.assertEquals(fooRequired.requiredVars.size(), 1);
+        Assert.assertEquals(fooRequired.requiredVars.get(0).name, "foo");
+        Assert.assertTrue(fooRequired.requiredVars.get(0).required);
+
+        Assert.assertFalse(fooOptional.vars.get(0).required);
+        Assert.assertEquals(fooOptional.vars.get(0).name, "foo");
+        Assert.assertEquals(fooOptional.requiredVars.size(), 0);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_12857.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_12857.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: openapi 3.0.3 sample spec
+  description: sample spec for testing openapi functionality, built from json schema
+    tests for draft6
+  version: 0.0.1
+paths: {}
+components:
+  schemas:
+    FooRequired:
+      properties:
+        foo: {}
+      required:
+        - foo
+    FooOptional:
+      properties:
+        foo: {}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/docs/ChildCat.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/docs/ChildCat.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
+**PetType** | **string** |  | [optional] [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -53,8 +53,8 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetType
         /// </summary>
 
-        [DataMember(Name = "pet_type", IsRequired = true, EmitDefaultValue = false)]
-        public PetTypeEnum PetType
+        [DataMember(Name = "pet_type", EmitDefaultValue = false)]
+        public PetTypeEnum? PetType
         {
             get{ return _PetType;}
             set
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
                 _flagPetType = true;
             }
         }
-        private PetTypeEnum _PetType;
+        private PetTypeEnum? _PetType;
         private bool _flagPetType;
 
         /// <summary>
@@ -86,10 +86,9 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
         {
-            this._PetType = petType;
             this._Name = name;
             if (this.Name != null)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/ChildCat.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/ChildCat.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
+**PetType** | **string** |  | [optional] [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -53,8 +53,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>
-        [DataMember(Name = "pet_type", IsRequired = true, EmitDefaultValue = false)]
-        public PetTypeEnum PetType { get; set; }
+        [DataMember(Name = "pet_type", EmitDefaultValue = false)]
+        public PetTypeEnum? PetType { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
@@ -67,11 +67,11 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
         {
-            this.PetType = petType;
             this.Name = name;
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/ChildCat.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/ChildCat.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
+**PetType** | **string** |  | [optional] [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -52,8 +52,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>
-        [DataMember(Name = "pet_type", IsRequired = true, EmitDefaultValue = false)]
-        public PetTypeEnum PetType { get; set; }
+        [DataMember(Name = "pet_type", EmitDefaultValue = false)]
+        public PetTypeEnum? PetType { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
@@ -66,11 +66,11 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
         {
-            this.PetType = petType;
             this.Name = name;
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/ChildCat.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/ChildCat.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
+**PetType** | **string** |  | [optional] [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -52,8 +52,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>
-        [DataMember(Name = "pet_type", IsRequired = true, EmitDefaultValue = false)]
-        public PetTypeEnum PetType { get; set; }
+        [DataMember(Name = "pet_type", EmitDefaultValue = false)]
+        public PetTypeEnum? PetType { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
@@ -66,11 +66,11 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
         {
-            this.PetType = petType;
             this.Name = name;
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/ChildCat.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/ChildCat.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
+**PetType** | **string** |  | [optional] [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -52,8 +52,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>
-        [DataMember(Name = "pet_type", IsRequired = true, EmitDefaultValue = false)]
-        public PetTypeEnum PetType { get; set; }
+        [DataMember(Name = "pet_type", EmitDefaultValue = false)]
+        public PetTypeEnum? PetType { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
@@ -66,11 +66,11 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
         {
-            this.PetType = petType;
             this.Name = name;
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/ChildCat.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/ChildCat.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | [optional] 
-**PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
+**PetType** | **string** |  | [optional] [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -52,8 +52,8 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>
-        [DataMember(Name = "pet_type", IsRequired = true, EmitDefaultValue = false)]
-        public PetTypeEnum PetType { get; set; }
+        [DataMember(Name = "pet_type", EmitDefaultValue = false)]
+        public PetTypeEnum? PetType { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
@@ -63,11 +63,11 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        /// <param name="petType">petType (default to PetTypeEnum.ChildCat).</param>
+        public ChildCat(string name = default(string), PetTypeEnum? petType = PetTypeEnum.ChildCat) : base()
         {
-            this.PetType = petType;
             this.Name = name;
+            this.PetType = petType;
         }
 
         /// <summary>

--- a/samples/client/petstore/java/jersey3/docs/ChildCat.md
+++ b/samples/client/petstore/java/jersey3/docs/ChildCat.md
@@ -8,7 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**name** | **String** |  |  [optional] |
-|**petType** | [**String**](#String) |  |  |
+|**petType** | [**String**](#String) |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -105,10 +105,10 @@ public class ChildCat extends ParentPet {
    * Get petType
    * @return petType
   **/
-  @jakarta.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @jakarta.annotation.Nullable
+  @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PET_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getPetType() {
     return petType;
@@ -116,7 +116,7 @@ public class ChildCat extends ParentPet {
 
 
   @JsonProperty(JSON_PROPERTY_PET_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetType(String petType) {
     if (!PET_TYPE_VALUES.contains(petType)) {
       throw new IllegalArgumentException(petType + " is invalid. Possible values for petType: " + String.join(", ", PET_TYPE_VALUES));

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -359,7 +359,7 @@ export interface ChildCat extends ParentPet {
      * @type {string}
      * @memberof ChildCat
      */
-    'pet_type': ChildCatPetTypeEnum;
+    'pet_type'?: ChildCatPetTypeEnum;
 }
 
 export const ChildCatPetTypeEnum = {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/ChildCat.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/ChildCat.md
@@ -8,7 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**name** | **String** |  |  [optional] |
-|**petType** | [**String**](#String) |  |  |
+|**petType** | [**String**](#String) |  |  [optional] |
 
 
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -105,10 +105,10 @@ public class ChildCat extends ParentPet {
    * Get petType
    * @return petType
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_PET_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getPetType() {
     return petType;
@@ -116,7 +116,7 @@ public class ChildCat extends ParentPet {
 
 
   @JsonProperty(JSON_PROPERTY_PET_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetType(String petType) {
     if (!PET_TYPE_VALUES.contains(petType)) {
       throw new IllegalArgumentException(petType + " is invalid. Possible values for petType: " + String.join(", ", PET_TYPE_VALUES));

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+6.1.0-SNAPSHOT

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-6.1.0-SNAPSHOT
+unset

--- a/samples/openapi3/client/petstore/python-experimental/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/python-experimental/docs/PetApi.md
@@ -1315,7 +1315,7 @@ skip_deserialization | bool | default is False | when True, headers and body wil
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **additionalMetadata** | **str** | Additional data to pass to server | [optional] 
-**file** | **file_type** | file to upload | 
+**file** | **file_type** | file to upload | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 ### path_params

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api/fake_api_endpoints/endpoint_parameters.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api/fake_api_endpoints/endpoint_parameters.py
@@ -73,6 +73,10 @@ class SchemaForRequestBodyApplicationXWwwFormUrlencoded(
     DictSchema
 ):
     _required_property_names = set((
+        'number',
+        'double',
+        'pattern_without_delimiter',
+        'byte',
     ))
     
     
@@ -171,6 +175,10 @@ class SchemaForRequestBodyApplicationXWwwFormUrlencoded(
     def __new__(
         cls,
         *args: typing.Union[dict, frozendict, ],
+        number: number,
+        double: double,
+        pattern_without_delimiter: pattern_without_delimiter,
+        byte: byte,
         integer: typing.Union[integer, Unset] = unset,
         int32: typing.Union[int32, Unset] = unset,
         int64: typing.Union[int64, Unset] = unset,
@@ -186,6 +194,10 @@ class SchemaForRequestBodyApplicationXWwwFormUrlencoded(
         return super().__new__(
             cls,
             *args,
+            number=number,
+            double=double,
+            pattern_without_delimiter=pattern_without_delimiter,
+            byte=byte,
             integer=integer,
             int32=int32,
             int64=int64,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api/fake_api_endpoints/json_form_data.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api/fake_api_endpoints/json_form_data.py
@@ -73,6 +73,8 @@ class SchemaForRequestBodyApplicationXWwwFormUrlencoded(
     DictSchema
 ):
     _required_property_names = set((
+        'param',
+        'param2',
     ))
     param = StrSchema
     param2 = StrSchema
@@ -81,12 +83,16 @@ class SchemaForRequestBodyApplicationXWwwFormUrlencoded(
     def __new__(
         cls,
         *args: typing.Union[dict, frozendict, ],
+        param: param,
+        param2: param2,
         _configuration: typing.Optional[Configuration] = None,
         **kwargs: typing.Type[Schema],
     ) -> 'SchemaForRequestBodyApplicationXWwwFormUrlencoded':
         return super().__new__(
             cls,
             *args,
+            param=param,
+            param2=param2,
             _configuration=_configuration,
             **kwargs,
         )

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api/fake_api_endpoints/upload_file.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api/fake_api_endpoints/upload_file.py
@@ -75,6 +75,7 @@ class SchemaForRequestBodyMultipartFormData(
     DictSchema
 ):
     _required_property_names = set((
+        'file',
     ))
     additionalMetadata = StrSchema
     file = BinarySchema
@@ -83,6 +84,7 @@ class SchemaForRequestBodyMultipartFormData(
     def __new__(
         cls,
         *args: typing.Union[dict, frozendict, ],
+        file: file,
         additionalMetadata: typing.Union[additionalMetadata, Unset] = unset,
         _configuration: typing.Optional[Configuration] = None,
         **kwargs: typing.Type[Schema],
@@ -90,6 +92,7 @@ class SchemaForRequestBodyMultipartFormData(
         return super().__new__(
             cls,
             *args,
+            file=file,
             additionalMetadata=additionalMetadata,
             _configuration=_configuration,
             **kwargs,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api/pet_api_endpoints/upload_file_with_required_file.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api/pet_api_endpoints/upload_file_with_required_file.py
@@ -101,6 +101,7 @@ class SchemaForRequestBodyMultipartFormData(
     DictSchema
 ):
     _required_property_names = set((
+        'requiredFile',
     ))
     additionalMetadata = StrSchema
     requiredFile = BinarySchema
@@ -109,6 +110,7 @@ class SchemaForRequestBodyMultipartFormData(
     def __new__(
         cls,
         *args: typing.Union[dict, frozendict, ],
+        requiredFile: requiredFile,
         additionalMetadata: typing.Union[additionalMetadata, Unset] = unset,
         _configuration: typing.Optional[Configuration] = None,
         **kwargs: typing.Type[Schema],
@@ -116,6 +118,7 @@ class SchemaForRequestBodyMultipartFormData(
         return super().__new__(
             cls,
             *args,
+            requiredFile=requiredFile,
             additionalMetadata=additionalMetadata,
             _configuration=_configuration,
             **kwargs,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api/pet_api_endpoints/upload_image.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api/pet_api_endpoints/upload_image.py
@@ -108,6 +108,7 @@ class SchemaForRequestBodyMultipartFormData(
         cls,
         *args: typing.Union[dict, frozendict, ],
         additionalMetadata: typing.Union[additionalMetadata, Unset] = unset,
+        file: typing.Union[file, Unset] = unset,
         _configuration: typing.Optional[Configuration] = None,
         **kwargs: typing.Type[Schema],
     ) -> 'SchemaForRequestBodyMultipartFormData':
@@ -115,6 +116,7 @@ class SchemaForRequestBodyMultipartFormData(
             cls,
             *args,
             additionalMetadata=additionalMetadata,
+            file=file,
             _configuration=_configuration,
             **kwargs,
         )


### PR DESCRIPTION
Fixes fromProperty when property is required vs optional
The current code will grab a cached CodegenProperty whether or not the property is required in the higher object schema.
This messes up code that depends on property.required to be correct.
I preserved the old fromProperty method to make this a non-breaking change.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
