### PR TITLE
Remove unused import in R package

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/description.mustache
+++ b/modules/openapi-generator/src/main/resources/r/description.mustache
@@ -11,5 +11,5 @@ Encoding: UTF-8
 License: {{#lambdaLicense}}{{licenseInfo}}{{/lambdaLicense}}{{^licenseInfo}}Unlicense{{/licenseInfo}}
 LazyData: true
 Suggests: testthat
-Imports: jsonlite, httr, R6, base64enc{{#useRlangExceptionHandling}}, rlang{{/useRlangExceptionHandling}}
+Imports: jsonlite, httr, R6, base64enc
 RoxygenNote: 7.2.0

--- a/samples/client/petstore/R/DESCRIPTION
+++ b/samples/client/petstore/R/DESCRIPTION
@@ -11,5 +11,5 @@ Encoding: UTF-8
 License: Apache License 2.0
 LazyData: true
 Suggests: testthat
-Imports: jsonlite, httr, R6, base64enc, rlang
+Imports: jsonlite, httr, R6, base64enc
 RoxygenNote: 7.2.0


### PR DESCRIPTION
Remove unused import in R package
```
Namespace in Imports field not imported from: ‘rlang’
  All declared Imports should be used.
```
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
