### PR TITLE
[Ruby] Enhance Faraday middleware support

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -111,9 +111,7 @@ module {{moduleName}}
       @ssl_ca_file = nil
       @ssl_client_cert = nil
       @ssl_client_key = nil
-      @middlewares = []
-      @request_middlewares = []
-      @response_middlewares = []
+      @middlewares = Hash.new { |h, k| h[k] = [] }
       @timeout = 60
       # return data as binary instead of file
       @return_binary_data = false
@@ -350,31 +348,56 @@ module {{moduleName}}
     {{#isFaraday}}
     # Adds middleware to the stack
     def use(*middleware)
-      @middlewares << middleware
+      set_faraday_middleware(:use, *middleware)
     end
 
     # Adds request middleware to the stack
     def request(*middleware)
-      @request_middlewares << middleware
+      set_faraday_middleware(:request, *middleware)
     end
 
     # Adds response middleware to the stack
     def response(*middleware)
-      @response_middlewares << middleware
+      set_faraday_middleware(:response, *middleware)
     end
+
+    # Adds Faraday middleware setting information to the stack
+    #
+    # @example Use the `set_faraday_middleware` method to set middleware information
+    #   config.set_faraday_middleware(:request, :retry, max: 3, methods: [:get, :post], retry_statuses: [503])
+    #   config.set_faraday_middleware(:response, :logger, nil, { bodies: true, log_level: :debug })
+    #   config.set_faraday_middleware(:use, Faraday::HttpCache, store: Rails.cache, shared_cache: false)
+    #   config.set_faraday_middleware(:insert, 0, FaradayMiddleware::FollowRedirects, { standards_compliant: true, limit: 1 })
+    #   config.set_faraday_middleware(:swap, 0, Faraday::Response::Logger)
+    #   config.set_faraday_middleware(:delete, Faraday::Multipart::Middleware)
+    #
+    # @see https://github.com/lostisland/faraday/blob/v2.3.0/lib/faraday/rack_builder.rb#L92-L143
+    def set_faraday_middleware(operation, key, *args, &block)
+      unless [:request, :response, :use, :insert, :insert_before, :insert_after, :swap, :delete].include?(operation)
+        fail ArgumentError, "Invalid faraday middleware operation #{operation}. Must be" \
+                            " :request, :response, :use, :insert, :insert_before, :insert_after, :swap or :delete."
+      end
+
+      @middlewares[operation] << [key, args, block]
+    end
+    ruby2_keywords(:set_faraday_middleware) if respond_to?(:ruby2_keywords, true)
 
     # Set up middleware on the connection
     def configure_middleware(connection)
-      @middlewares.each do |middleware|
-        connection.use(*middleware)
+      return if @middlewares.empty?
+
+      [:request, :response, :use, :insert, :insert_before, :insert_after, :swap].each do |operation|
+        next unless @middlewares.key?(operation)
+
+        @middlewares[operation].each do |key, args, block|
+          connection.builder.send(operation, key, *args, &block)
+        end
       end
 
-      @request_middlewares.each do |middleware|
-        connection.request(*middleware)
-      end
-
-      @response_middlewares.each do |middleware|
-        connection.response(*middleware)
+      if @middlewares.key?(:delete)
+        @middlewares[:delete].each do |key, _args, _block|
+          connection.builder.delete(key)
+        end
       end
     end
     {{/isFaraday}}

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -153,9 +153,7 @@ module Petstore
       @ssl_ca_file = nil
       @ssl_client_cert = nil
       @ssl_client_key = nil
-      @middlewares = []
-      @request_middlewares = []
-      @response_middlewares = []
+      @middlewares = Hash.new { |h, k| h[k] = [] }
       @timeout = 60
       # return data as binary instead of file
       @return_binary_data = false
@@ -368,31 +366,56 @@ module Petstore
 
     # Adds middleware to the stack
     def use(*middleware)
-      @middlewares << middleware
+      set_faraday_middleware(:use, *middleware)
     end
 
     # Adds request middleware to the stack
     def request(*middleware)
-      @request_middlewares << middleware
+      set_faraday_middleware(:request, *middleware)
     end
 
     # Adds response middleware to the stack
     def response(*middleware)
-      @response_middlewares << middleware
+      set_faraday_middleware(:response, *middleware)
     end
+
+    # Adds Faraday middleware setting information to the stack
+    #
+    # @example Use the `set_faraday_middleware` method to set middleware information
+    #   config.set_faraday_middleware(:request, :retry, max: 3, methods: [:get, :post], retry_statuses: [503])
+    #   config.set_faraday_middleware(:response, :logger, nil, { bodies: true, log_level: :debug })
+    #   config.set_faraday_middleware(:use, Faraday::HttpCache, store: Rails.cache, shared_cache: false)
+    #   config.set_faraday_middleware(:insert, 0, FaradayMiddleware::FollowRedirects, { standards_compliant: true, limit: 1 })
+    #   config.set_faraday_middleware(:swap, 0, Faraday::Response::Logger)
+    #   config.set_faraday_middleware(:delete, Faraday::Multipart::Middleware)
+    #
+    # @see https://github.com/lostisland/faraday/blob/v2.3.0/lib/faraday/rack_builder.rb#L92-L143
+    def set_faraday_middleware(operation, key, *args, &block)
+      unless [:request, :response, :use, :insert, :insert_before, :insert_after, :swap, :delete].include?(operation)
+        fail ArgumentError, "Invalid faraday middleware operation #{operation}. Must be" \
+                            " :request, :response, :use, :insert, :insert_before, :insert_after, :swap or :delete."
+      end
+
+      @middlewares[operation] << [key, args, block]
+    end
+    ruby2_keywords(:set_faraday_middleware) if respond_to?(:ruby2_keywords, true)
 
     # Set up middleware on the connection
     def configure_middleware(connection)
-      @middlewares.each do |middleware|
-        connection.use(*middleware)
+      return if @middlewares.empty?
+
+      [:request, :response, :use, :insert, :insert_before, :insert_after, :swap].each do |operation|
+        next unless @middlewares.key?(operation)
+
+        @middlewares[operation].each do |key, args, block|
+          connection.builder.send(operation, key, *args, &block)
+        end
       end
 
-      @request_middlewares.each do |middleware|
-        connection.request(*middleware)
-      end
-
-      @response_middlewares.each do |middleware|
-        connection.response(*middleware)
+      if @middlewares.key?(:delete)
+        @middlewares[:delete].each do |key, _args, _block|
+          connection.builder.delete(key)
+        end
       end
     end
   end


### PR DESCRIPTION
Thanks to @johngallagher Faraday middlewares are configurable now:
- #10495

In this PR, I'd like to enhance the Faraday middleware support to be able to call the [methods to push onto the various positions in the stack](https://github.com/lostisland/faraday/blob/v2.3.0/lib/faraday/rack_builder.rb#L117-L143) (`insert`, `insert_before`, `insert_after`, `swap`, and `delete`) and also to be able to pass a block to the methods.

### Usage
```ruby
PetstoreAPI.configure do |config|
  config.set_faraday_middleware(:request, :retry, max: 3, methods: [:get, :post], retry_statuses: [503])
  config.set_faraday_middleware(:response, :logger, nil, { bodies: true, log_level: :debug })
  config.set_faraday_middleware(:use, Faraday::HttpCache, store: Rails.cache, shared_cache: false)
  config.set_faraday_middleware(:insert, 0, FaradayMiddleware::FollowRedirects, { standards_compliant: true, limit: 1 })
  config.set_faraday_middleware(:swap, 0, Faraday::Response::Logger) })
  config.set_faraday_middleware(:delete, Faraday::Multipart::Middleware)
  :
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 