### PR TITLE
[typescript-axios] discriminator type in template

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelOneOf.mustache
@@ -3,4 +3,13 @@
  * {{{.}}}{{/description}}
  * @export
  */
-export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
+export type {{classname}} = {{#discriminator}}{{!
+
+discriminator with mapped models - TypeScript discriminating union
+}}{{#mappedModels}}{ {{discriminator.propertyName}}: '{{mappingName}}' } & {{modelName}}{{^-last}} | {{/-last}}{{/mappedModels}}{{!
+
+discriminator only - fallback to not use the discriminator. Default model names are available but possibility of having null/nullable values could introduce more edge cases
+}}{{^mappedModels}}{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}{{/mappedModels}}{{/discriminator}}{{!
+
+plain oneOf
+}}{{^discriminator}}{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}{{/discriminator}};

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -700,7 +700,7 @@ export interface List {
  * @type Mammal
  * @export
  */
-export type Mammal = Whale | Zebra;
+export type Mammal = { className: 'whale' } & Whale | { className: 'zebra' } & Zebra;
 
 /**
  * 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
**typescript-axios** generator does not handle the [discriminator](https://swagger.io/specification/#discriminator-object) in any way. This change was inspired by existing functionality of [typescript-fetch](https://github.com/OpenAPITools/openapi-generator/blob/36aba267a077ea9a64242d4c6bbeb8837b5eb8e4/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOfInterfaces.mustache) generator - with an additional edge case  handled (not handled in typescript-fetch) - having a discriminator without explicit mapping. Thanks for the bunch of specs & tests/samples btw. 👍 

Food for thought:
I'm totally ok with fixing the implementation in **typescript-fetch** or possibly adding it in all other `typescript-*` like generators where missing. Just wasn't sure if it's ok having it all in a single PR. Let me know 😉 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)


