### PR TITLE
Fix npe when unwrapping optional in swift 5 client, if web server returns no data and client should return nil

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -353,8 +353,8 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
         default:
 
             guard let data = data, !data.isEmpty else {
-                if T.self is ExpressibleByNilLiteral.Type {
-                    completion(.success(Response(response: httpResponse, body: Optional<T>.none as! T)))
+                if let E = T.self as? ExpressibleByNilLiteral.Type {
+                    completion(.success(Response(response: httpResponse, body: E.init(nilLiteral: ()) as! T)))
                 } else {
                     completion(.failure(ErrorResponse.error(httpResponse.statusCode, nil, response, DecodableRequestBuilderError.emptyDataResponse)))
                 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When calling an api that returns an optional result, the generated swift 5 client with url session implementation tries to unwrap nil and crashes, in cases where the called endpoint actually returns no data. I think that this is due to the fact that it is never possible to cast Optional < T >.none to T. The solution implemented here is stolen from https://stackoverflow.com/questions/41492153/how-to-produce-a-nil-of-a-generic-type and it works for me.

You can reproduce this, for example, using the MoWeSta Api (https://www.mowesta.com/api/mowesta.json) using the api call that returns the nearest weather station for a city (/cities/{id}/station). If you call this with a city id that does not lie near Germany (e.g. Essen in Belgium, id: 81211), the api responds with 201 (success, no data) and no data (i.e. no weather station). As a result, the client will try to return a nil value which will cause the process to crash. 

With the change applied, the client works as expected.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @d-date (2018/03)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
