### PR TITLE
Perl: Fix JSONization of ArrayObjects

### DIFF
--- a/modules/openapi-generator/src/main/resources/perl/BaseObject.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/BaseObject.mustache
@@ -111,6 +111,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AllOfWithSingleRef.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AllOfWithSingleRef.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Animal.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Animal.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ApiResponse.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ApiResponse.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfArrayOfNumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfArrayOfNumberOnly.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfNumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfNumberOnly.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayTest.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Capitalization.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Capitalization.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Cat.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Cat.pm
@@ -161,6 +161,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/CatAllOf.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/CatAllOf.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Category.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Category.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ClassModel.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ClassModel.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Client.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Client.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DeprecatedObject.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DeprecatedObject.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Dog.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Dog.pm
@@ -161,6 +161,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DogAllOf.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DogAllOf.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumArrays.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumArrays.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumClass.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
@@ -155,6 +155,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/File.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/File.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FileSchemaTestClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FileSchemaTestClass.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Foo.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Foo.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FooGetDefaultResponse.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FooGetDefaultResponse.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HasOnlyReadOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HasOnlyReadOnly.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HealthCheckResult.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HealthCheckResult.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/List.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/List.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MapTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MapTest.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MixedPropertiesAndAdditionalPropertiesClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MixedPropertiesAndAdditionalPropertiesClass.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Model200Response.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Model200Response.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ModelReturn.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ModelReturn.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Name.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Name.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NullableClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NullableClass.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NumberOnly.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ObjectWithDeprecatedFields.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ObjectWithDeprecatedFields.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Order.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Order.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterComposite.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterComposite.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnum.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnum.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumDefaultValue.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumDefaultValue.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumInteger.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumInteger.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumIntegerDefaultValue.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumIntegerDefaultValue.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterObjectWithEnumProperty.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterObjectWithEnumProperty.pm
@@ -152,6 +152,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Pet.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Pet.pm
@@ -153,6 +153,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ReadOnlyFirst.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ReadOnlyFirst.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SingleRefType.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SingleRefType.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SpecialModelName.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SpecialModelName.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Tag.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Tag.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/User.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/User.pm
@@ -151,6 +151,8 @@ sub _to_json_primitives {
             return $data->rfc3339;
         }
         return $data .q();
+    } else { # hash (model),  In this case, the TO_JSON of the $data object is executed
+        return $data;
     }
 }
 

--- a/samples/client/petstore/perl/tests/02_store_api.t
+++ b/samples/client/petstore/perl/tests/02_store_api.t
@@ -1,4 +1,4 @@
-use Test::More tests => 52;
+use Test::More tests => 56;
 use Test::Exception;
 
 use lib 'lib';
@@ -171,3 +171,17 @@ like $order_to_json, qr/2020-11-06T09:20:48Z/, '$order{shipDate} to date-time fo
 like $order_to_json, qr/"101112"/, '$order{status} is number. But json type is string';
 
 like $order_to_json, qr/false/, '$order{complete} is number. But json type is boolean';
+
+my $pet_object = WWW::OpenAPIClient::Object::Pet->new->from_hash({
+    tags => [ 
+        WWW::OpenAPIClient::Object::Tag->new->from_hash({id => 123, name => 1000}), 
+        WWW::OpenAPIClient::Object::Tag->new->from_hash({id => 456, name => 'test2'}),
+    ]
+});
+
+
+my $pet_object_to_json = JSON->new->convert_blessed->encode($pet_object);
+like $pet_object_to_json, qr/\"id\":123/, '$pet_object->tags->[0]->id';
+like $pet_object_to_json, qr/\"name\":\"1000\"/, '$pet_object->tags->[0]->name';
+like $pet_object_to_json, qr/\"id\":456/, '$pet_object->tags->[1]->id';
+like $pet_object_to_json, qr/\"name\":\"test2\"/, '$pet_object->tags->[1]->name';


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 @yue9944882

---

Sorry, 
I had created a bug in the <https://github.com/OpenAPITools/openapi-generator/pull/12891>  PR.
It fails when trying to convert an array of Objects to JSON.
```perl
my $object = WWW::OpenAPIClient::Object::Pet->new->from_hash(
  {
    tags => [ WWW::OpenAPIClient::Object::Tag->new->from_hash({id => 123, name => 'test' }), WWW::OpenAPIClient::Object::Tag->new->from_hash({ id => 321, name => 'foo'}) ],
  });

my $json = JSON->new->convert_blessed->encode($object);
say $json;
```

got json 
```json
"{\"tags\":[\"\",\"\"],\"photoUrls\":[]}"
```

The JSON I want is this.
```json
"{\"tags\":[{\"id\":123,\"name\":\"test\"},{\"id\":321,\"name\":\"foo\"}],\"photoUrls\":[]}"
```


The cause was that I forgot to return a value in primitive type that did not match any if statement.
I fixed it and added a test