### PR TITLE
Add decimal mapping in Perl client generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PerlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PerlClientCodegen.java
@@ -127,6 +127,7 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("float", "double");
         typeMapping.put("double", "double");
         typeMapping.put("number", "double");
+        typeMapping.put("decimal", "double");
         typeMapping.put("boolean", "boolean");
         typeMapping.put("string", "string");
         typeMapping.put("date", "DATE");

--- a/samples/client/petstore/perl/docs/FormatTest.md
+++ b/samples/client/petstore/perl/docs/FormatTest.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **number** | **double** |  | 
 **float** | **double** |  | [optional] 
 **double** | **double** |  | [optional] 
-**decimal** | [**Decimal**](Decimal.md) |  | [optional] 
+**decimal** | **double** |  | [optional] 
 **string** | **string** |  | [optional] 
 **byte** | **string** |  | 
 **binary** | **string** |  | [optional] 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
@@ -30,7 +30,6 @@ use Log::Any qw($log);
 use Date::Parse;
 use DateTime;
 
-use WWW::OpenAPIClient::Object::Decimal;
 
 use base ("Class::Accessor", "Class::Data::Inheritable");
 
@@ -257,7 +256,7 @@ __PACKAGE__->method_documentation({
         read_only => '',
             },
     'decimal' => {
-        datatype => 'Decimal',
+        datatype => 'double',
         base_name => 'decimal',
         description => '',
         format => '',
@@ -335,7 +334,7 @@ __PACKAGE__->openapi_types( {
     'number' => 'double',
     'float' => 'double',
     'double' => 'double',
-    'decimal' => 'Decimal',
+    'decimal' => 'double',
     'string' => 'string',
     'byte' => 'string',
     'binary' => 'string',


### PR DESCRIPTION
- Add decimal mapping in Perl client generator.

all tests passed locally:
```
ok 32 - accept_tokens() correctly set api_key
ok 33 - accept_tokens() correctly set api_key_prefix
ok 34 - accept_tokens() correctly set api_key_in
ok 35 - clear_tokens() returns the correct data structure
ok 36 - bad token causes exception
ok 37 - no (unexpected) warnings (via END block)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.460 s
[INFO] Finished at: 2022-07-17T13:01:51+08:00
[INFO] ------------------------------------------------------------------------
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

