### PR TITLE
[typescript-axios] avoid stringifying header string values

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -146,12 +146,16 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
             }
             {{/isArray}}
             {{^isArray}}
-            if ({{paramName}} !== undefined && {{paramName}} !== null) {
+            {{! `val == null` covers for both `null` and `undefined`}}
+            if ({{paramName}} != null) {
                 {{#isString}}
                 localVarHeaderParameter['{{baseName}}'] = String({{paramName}});
                 {{/isString}}
                 {{^isString}}
-                localVarHeaderParameter['{{baseName}}'] = String(JSON.stringify({{paramName}}));
+                {{! isString is falsy also for $ref that defines a string or enum type}}
+                localVarHeaderParameter['{{baseName}}'] = typeof {{paramName}} === 'string' 
+                    ? {{paramName}} 
+                    : JSON.stringify({{paramName}});
                 {{/isString}}
             }
             {{/isArray}}

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-complex-headers.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-complex-headers.yaml
@@ -43,6 +43,10 @@ paths:
             type: array
             items:
               $ref: '#/components/requestBodies/Pet'
+        - name: Accept
+          in: header
+          schema:
+            $ref: '#/components/schemas/MediaType'
       requestBody:
         $ref: '#/components/requestBodies/Pet'
     put:
@@ -578,6 +582,9 @@ components:
       name: api_key
       in: header
   schemas:
+    MediaType:
+        type: string
+        enum: ['application/json', 'application/xml']
     Order:
       title: Pet Order
       description: An order for a pets from the pet store

--- a/samples/client/petstore/typescript-axios/builds/default/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/api.ts
@@ -318,7 +318,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
@@ -318,7 +318,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -2408,7 +2408,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 localVarHeaderParameter['enum_header_string_array'] = mapped.join(COLLECTION_FORMATS["csv"]);
             }
 
-            if (enumHeaderString !== undefined && enumHeaderString !== null) {
+            if (enumHeaderString != null) {
                 localVarHeaderParameter['enum_header_string'] = String(enumHeaderString);
             }
 
@@ -2485,12 +2485,16 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 localVarQueryParameter['int64_group'] = int64Group;
             }
 
-            if (requiredBooleanGroup !== undefined && requiredBooleanGroup !== null) {
-                localVarHeaderParameter['required_boolean_group'] = String(JSON.stringify(requiredBooleanGroup));
+            if (requiredBooleanGroup != null) {
+                localVarHeaderParameter['required_boolean_group'] = typeof requiredBooleanGroup === 'string' 
+                    ? requiredBooleanGroup 
+                    : JSON.stringify(requiredBooleanGroup);
             }
 
-            if (booleanGroup !== undefined && booleanGroup !== null) {
-                localVarHeaderParameter['boolean_group'] = String(JSON.stringify(booleanGroup));
+            if (booleanGroup != null) {
+                localVarHeaderParameter['boolean_group'] = typeof booleanGroup === 'string' 
+                    ? booleanGroup 
+                    : JSON.stringify(booleanGroup);
             }
 
 
@@ -3431,7 +3435,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
@@ -66,6 +66,20 @@ export interface Category {
     'name'?: string;
 }
 /**
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export const MediaType = {
+    Json: 'application/json',
+    Xml: 'application/xml'
+} as const;
+
+export type MediaType = typeof MediaType[keyof typeof MediaType];
+
+
+/**
  * An order for a pets from the pet store
  * @export
  * @interface Order
@@ -256,10 +270,11 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
          * @param {Pet} pet Pet object that needs to be added to the store
          * @param {Pet} [header1] 
          * @param {Array<Pet>} [header2] 
+         * @param {MediaType} [accept] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet: async (pet: Pet, header1?: Pet, header2?: Array<Pet>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addPet: async (pet: Pet, header1?: Pet, header2?: Array<Pet>, accept?: MediaType, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pet' is not null or undefined
             assertParamExists('addPet', 'pet', pet)
             const localVarPath = `/pet`;
@@ -278,13 +293,21 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (header1 !== undefined && header1 !== null) {
-                localVarHeaderParameter['header1'] = String(JSON.stringify(header1));
+            if (header1 != null) {
+                localVarHeaderParameter['header1'] = typeof header1 === 'string' 
+                    ? header1 
+                    : JSON.stringify(header1);
             }
 
             if (header2) {
                 let mapped = header2.map(value => (<any>"Array<Pet>" !== "Array<string>") ? JSON.stringify(value) : (value || ""));
                 localVarHeaderParameter['header2'] = mapped.join(COLLECTION_FORMATS["csv"]);
+            }
+
+            if (accept != null) {
+                localVarHeaderParameter['Accept'] = typeof accept === 'string' 
+                    ? accept 
+                    : JSON.stringify(accept);
             }
 
 
@@ -329,7 +352,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 
@@ -624,11 +647,12 @@ export const PetApiFp = function(configuration?: Configuration) {
          * @param {Pet} pet Pet object that needs to be added to the store
          * @param {Pet} [header1] 
          * @param {Array<Pet>} [header2] 
+         * @param {MediaType} [accept] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, header1, header2, options);
+        async addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, accept?: MediaType, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addPet(pet, header1, header2, accept, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -730,11 +754,12 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {Pet} pet Pet object that needs to be added to the store
          * @param {Pet} [header1] 
          * @param {Array<Pet>} [header2] 
+         * @param {MediaType} [accept] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: any): AxiosPromise<void> {
-            return localVarFp.addPet(pet, header1, header2, options).then((request) => request(axios, basePath));
+        addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, accept?: MediaType, options?: any): AxiosPromise<void> {
+            return localVarFp.addPet(pet, header1, header2, accept, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -828,12 +853,13 @@ export class PetApi extends BaseAPI {
      * @param {Pet} pet Pet object that needs to be added to the store
      * @param {Pet} [header1] 
      * @param {Array<Pet>} [header2] 
+     * @param {MediaType} [accept] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PetApi
      */
-    public addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: AxiosRequestConfig) {
-        return PetApiFp(this.configuration).addPet(pet, header1, header2, options).then((request) => request(this.axios, this.basePath));
+    public addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, accept?: MediaType, options?: AxiosRequestConfig) {
+        return PetApiFp(this.configuration).addPet(pet, header1, header2, accept, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -2006,7 +2006,7 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 localVarHeaderParameter['enum_header_string_array'] = mapped.join(COLLECTION_FORMATS["csv"]);
             }
 
-            if (enumHeaderString !== undefined && enumHeaderString !== null) {
+            if (enumHeaderString != null) {
                 localVarHeaderParameter['enum_header_string'] = String(enumHeaderString);
             }
 
@@ -2083,12 +2083,16 @@ export const FakeApiAxiosParamCreator = function (configuration?: Configuration)
                 localVarQueryParameter['int64_group'] = int64Group;
             }
 
-            if (requiredBooleanGroup !== undefined && requiredBooleanGroup !== null) {
-                localVarHeaderParameter['required_boolean_group'] = String(JSON.stringify(requiredBooleanGroup));
+            if (requiredBooleanGroup != null) {
+                localVarHeaderParameter['required_boolean_group'] = typeof requiredBooleanGroup === 'string' 
+                    ? requiredBooleanGroup 
+                    : JSON.stringify(requiredBooleanGroup);
             }
 
-            if (booleanGroup !== undefined && booleanGroup !== null) {
-                localVarHeaderParameter['boolean_group'] = String(JSON.stringify(booleanGroup));
+            if (booleanGroup != null) {
+                localVarHeaderParameter['boolean_group'] = typeof booleanGroup === 'string' 
+                    ? booleanGroup 
+                    : JSON.stringify(booleanGroup);
             }
 
 
@@ -3076,7 +3080,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
@@ -318,7 +318,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/api.ts
@@ -322,7 +322,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
@@ -98,7 +98,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
@@ -318,7 +318,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/api.ts
@@ -318,7 +318,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/api.ts
@@ -322,7 +322,7 @@ export const PetApiAxiosParamCreator = function (configuration?: Configuration) 
             // oauth required
             await setOAuthToObject(localVarHeaderParameter, "petstore_auth", ["write:pets", "read:pets"], configuration)
 
-            if (apiKey !== undefined && apiKey !== null) {
+            if (apiKey != null) {
                 localVarHeaderParameter['api_key'] = String(apiKey);
             }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Serialization of complex headers was introduced in https://github.com/OpenAPITools/openapi-generator/pull/1874 .
However, a header value of type string/enum defined via `$ref` is serialized as well.
```js
JSON.stringify('foo') === '"foo"' // note the problematic extra quotes
```
The only (known to me) workaround is to use the last parameter of generated methods: `options: AxiosRequestConfig` where we can override all headers. A cumbersome solution.

This PR solves the problem of stringifying values that are already string.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/10840

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)
