### PR TITLE
Use jacksons objectmapper to deserialize enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
@@ -38,7 +38,9 @@
       return String.valueOf(value);
     }
 
+    {{^jackson}}
     @JsonCreator
+    {{/jackson}}
     public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
       for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
         if (b.value.equals(value)) {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
@@ -39,7 +39,9 @@ public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatyp
     return String.valueOf(value);
   }
 
+  {{^jackson}}
   @JsonCreator
+  {{/jackson}}
   public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
     for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
       if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
@@ -65,7 +65,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -71,7 +71,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Order.java
@@ -65,7 +65,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/model/Pet.java
@@ -71,7 +71,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
@@ -65,7 +65,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
@@ -71,7 +71,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -65,7 +65,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -71,7 +71,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
@@ -65,7 +65,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -71,7 +71,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumClass.java
@@ -45,7 +45,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/OuterEnum.java
@@ -45,7 +45,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
@@ -54,7 +54,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -51,7 +51,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
@@ -47,7 +47,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -85,7 +84,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
@@ -50,7 +50,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -90,7 +89,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -128,7 +126,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -166,7 +163,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
@@ -51,7 +51,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
@@ -62,7 +62,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -71,7 +71,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
@@ -45,7 +45,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
@@ -45,7 +45,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
@@ -45,7 +45,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
@@ -45,7 +45,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
@@ -45,7 +45,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
@@ -45,7 +45,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Order.java
@@ -62,7 +62,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/model/Pet.java
@@ -68,7 +68,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
@@ -45,7 +45,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
@@ -45,7 +45,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Order.java
@@ -76,7 +76,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/java-camel/src/main/java/org/openapitools/model/Pet.java
@@ -83,7 +83,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumClass.java
@@ -45,7 +45,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/OuterEnum.java
@@ -45,7 +45,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumClass.java
@@ -43,7 +43,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/OuterEnum.java
@@ -43,7 +43,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCat.java
@@ -56,7 +56,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -53,7 +53,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/BigCat.java
@@ -56,7 +56,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -53,7 +53,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCat.java
@@ -56,7 +56,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -53,7 +53,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Order.java
@@ -62,7 +62,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/model/Pet.java
@@ -68,7 +68,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCat.java
@@ -56,7 +56,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -53,7 +53,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCat.java
@@ -56,7 +56,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -53,7 +53,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/Pet.java
@@ -70,7 +70,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCat.java
@@ -56,7 +56,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -53,7 +53,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCat.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCat.java
@@ -55,7 +55,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/BigCatAllOf.java
@@ -52,7 +52,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
@@ -48,7 +48,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -86,7 +85,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumClass.java
@@ -45,7 +45,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
@@ -51,7 +51,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -91,7 +90,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -129,7 +127,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -167,7 +164,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
@@ -52,7 +52,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
@@ -63,7 +63,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterEnum.java
@@ -45,7 +45,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -72,7 +72,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/BigCat.java
@@ -56,7 +56,6 @@ public class BigCat extends Cat {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/BigCatAllOf.java
@@ -53,7 +53,6 @@ public class BigCatAllOf {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static KindEnum fromValue(String value) {
       for (KindEnum b : KindEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArrays.java
@@ -49,7 +49,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
         if (b.value.equals(value)) {
@@ -87,7 +86,6 @@ public class EnumArrays {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumClass.java
@@ -44,7 +44,6 @@ public enum EnumClass {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static EnumClass fromValue(String value) {
     for (EnumClass b : EnumClass.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTest.java
@@ -52,7 +52,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringEnum fromValue(String value) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
         if (b.value.equals(value)) {
@@ -92,7 +91,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
       for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
         if (b.value.equals(value)) {
@@ -130,7 +128,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
         if (b.value.equals(value)) {
@@ -168,7 +165,6 @@ public class EnumTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTest.java
@@ -53,7 +53,6 @@ public class MapTest {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static InnerEnum fromValue(String value) {
       for (InnerEnum b : InnerEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
@@ -64,7 +64,6 @@ public class Order {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterEnum.java
@@ -44,7 +44,6 @@ public enum OuterEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static OuterEnum fromValue(String value) {
     for (OuterEnum b : OuterEnum.values()) {
       if (b.value.equals(value)) {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -73,7 +73,6 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    @JsonCreator
     public static StatusEnum fromValue(String value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The use of @JsonCreator overrides any configuration made in the projects' objectmapper. Removing the annotation is done in other generators

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608