### PR TITLE
[csharp-netcore] Form data serialize non-primitive objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
@@ -117,6 +117,16 @@ namespace {{packageName}}.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -371,7 +371,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/isArray}}
             {{/isFile}}
             {{^isFile}}
-            localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
+            localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.{{#isPrimitiveType}}ParameterToString{{/isPrimitiveType}}{{^isPrimitiveType}}Serialize{{/isPrimitiveType}}({{paramName}})); // form parameter
             {{/isFile}}
             {{/required}}
             {{^required}}

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Api/MultipartApi.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Api/MultipartApi.cs
@@ -502,7 +502,7 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
-            localVarRequestOptions.FormParameters.Add("status", Org.OpenAPITools.Client.ClientUtils.ParameterToString(status)); // form parameter
+            localVarRequestOptions.FormParameters.Add("status", Org.OpenAPITools.Client.ClientUtils.Serialize(status)); // form parameter
             if (marker != null)
             {
                 localVarRequestOptions.FormParameters.Add("marker", Org.OpenAPITools.Client.ClientUtils.ParameterToString(marker)); // form parameter

--- a/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/others/csharp-netcore-complex-files/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -121,6 +121,16 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
+        /// Serializes the given object when not null. Otherwise return null.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize(object obj)
+        {
+            return obj != null ? Newtonsoft.Json.JsonConvert.SerializeObject(obj) : null;
+        }
+
+        /// <summary>
         /// Encode string in base64 format.
         /// </summary>
         /// <param name="text">string to be encoded.</param>


### PR DESCRIPTION
In the current csharp-netcore generator objects passed as multipart form-data are treated as primitive type and converted to string. With this changes it will also be possible to pass non-primitive objects that will be serialized as JSON, similar to how it is done in the `csharp` generator: https://github.com/OpenAPITools/openapi-generator/blob/eeb1711f9f073a90b62e4d0fa2ecf81b51a13281/modules/openapi-generator/src/main/resources/csharp/api.mustache#L272

Example specification supported now with the changes:

```yaml
...
paths:
  /upload:
    post:
      requestBody:
        content:
          multipart/form-data:
            schema:
              $ref: '#/components/schemas/UploadsRequest'

components:
  schemas:
    UploadsRequest:
      type: object
      properties:
        config:
          $ref: '#/components/schemas/UploadConfig'
        file:
          type: string
          format: binary

    UploadConfig:
      type: object
      properties:
        version:
          type: string
        timeout:
          type: integer
          format: int32
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05)