### PR TITLE
[PHP] ObjectSerializerTest: add tests for ObjectSerializer::deserialize() associative arrays bugfix

### DIFF
--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -4,6 +4,8 @@ namespace OpenAPI\Client;
 
 use DateTime;
 use GuzzleHttp\Psr7\Utils;
+use OpenAPI\Client\Model\Pet;
+use OpenAPI\Client\Model\Tag;
 use PHPUnit\Framework\TestCase;
 use SplFileObject;
 
@@ -467,5 +469,34 @@ class ObjectSerializerTest extends TestCase
                 true, 'skipValidation', 'boolean', 'form', true, false, 'skipValidation=true',
             ],
         ];
+    }
+
+    /**
+     * Test array to class deserialization.
+     *
+     * @covers ObjectSerializer::deserialize
+     *
+     * @see https://github.com/OpenAPITools/openapi-generator/pull/12849#issuecomment-1186130098
+     */
+    public function testArrayGivenAsObjectForDeserialize(): void
+    {
+        $data = [
+            'name' => 'Pet Name',
+            'status' => Pet::STATUS_AVAILABLE,
+            'tags' => [
+                ['name' => 'Tag Name'],
+            ]
+        ];
+
+        /** @var Pet $pet */
+        $pet = ObjectSerializer::deserialize($data, Pet::class);
+        $this->assertEquals('Pet Name', $pet->getName());
+        $this->assertEquals(Pet::STATUS_AVAILABLE, $pet->getStatus());
+
+        $tags = $pet->getTags();
+        $this->assertIsArray($tags);
+
+        $tag = $tags[0];
+        $this->assertInstanceOf(Tag::class, $tag);
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -2,44 +2,51 @@
 
 namespace OpenAPI\Client;
 
+use DateTime;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
+use SplFileObject;
 
-// test object serializer
+/**
+ * class ObjectSerializerTest
+ *
+ * @package OpenAPI\Client
+ */
 class ObjectSerializerTest extends TestCase
 {
-    // test sanitizeFilename
-    public function testSanitizeFilename()
+    /**
+     * Test sanitizeFilename
+     *
+     * @covers ObjectSerializer::sanitizeFilename
+     */
+    public function testSanitizeFilename(): void
     {
-        // initialize the API client
-        $s = new ObjectSerializer();
-
-        $this->assertSame("sun.gif", $s->sanitizeFilename("sun.gif"));
-        $this->assertSame("sun.gif", $s->sanitizeFilename("../sun.gif"));
-        $this->assertSame("sun.gif", $s->sanitizeFilename("/var/tmp/sun.gif"));
-        $this->assertSame("sun.gif", $s->sanitizeFilename("./sun.gif"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("sun.gif"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("../sun.gif"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("/var/tmp/sun.gif"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("./sun.gif"));
         
-        $this->assertSame("sun", $s->sanitizeFilename("sun"));
-        $this->assertSame("sun.gif", $s->sanitizeFilename("..\sun.gif"));
-        $this->assertSame("sun.gif", $s->sanitizeFilename("\var\tmp\sun.gif"));
-        $this->assertSame("sun.gif", $s->sanitizeFilename("c:\var\tmp\sun.gif"));
-        $this->assertSame("sun.gif", $s->sanitizeFilename(".\sun.gif"));
+        $this->assertSame("sun", ObjectSerializer::sanitizeFilename("sun"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("..\sun.gif"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("\var\tmp\sun.gif"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename("c:\var\tmp\sun.gif"));
+        $this->assertSame("sun.gif", ObjectSerializer::sanitizeFilename(".\sun.gif"));
     }
 
     /**
      * Test SplFileObject class deserialization.
      *
      * @see https://github.com/OpenAPITools/openapi-generator/pull/11184
-     * @covers ObjectSerializer::serialize
+     * @covers ObjectSerializer::deserialize
      * @dataProvider provideFileStreams
      */
     public function testDeserializeFile($stream, ?array $httpHeaders = null, ?string $expectedFilename = null): void
     {
         $s = new ObjectSerializer();
 
-        /** @var \SplFileObject */
-        $file = $s->deserialize($stream, '\SplFileObject', $httpHeaders);
-        $this->assertInstanceOf(\SplFileObject::class, $file);
+        /** @var SplFileObject $file */
+        $file = ObjectSerializer::deserialize($stream, '\SplFileObject', $httpHeaders);
+        $this->assertInstanceOf(SplFileObject::class, $file);
 
         if (is_string($expectedFilename)) {
             $this->assertEquals($expectedFilename, $file->getFilename());
@@ -48,7 +55,11 @@ class ObjectSerializerTest extends TestCase
         }
     }
 
-    public function provideFileStreams()
+    /**
+     * File Streams Provider
+     * @return array[]
+     */
+    public function provideFileStreams(): array
     {
         return [
             'File stream without headers' => [
@@ -90,9 +101,14 @@ class ObjectSerializerTest extends TestCase
     public function testDateTimeParseSecondAccuracy(string $timestamp, string $expected): void
     {
         $dateTime = ObjectSerializer::deserialize($timestamp, '\DateTime');
-        $this->assertEquals(new \DateTime($expected), $dateTime);
+        $this->assertEquals(new DateTime($expected), $dateTime);
     }
 
+    /**
+     * Timestamps provider
+     *
+     * @return string[][]
+     */
     public function provideTimestamps(): array
     {
         return [
@@ -149,6 +165,11 @@ class ObjectSerializerTest extends TestCase
         $this->assertEquals($expected, $query);
     }
 
+    /**
+     * Query params provider
+     *
+     * @return array[]
+     */
     public function provideQueryParams(): array
     {
         $array = ['blue', 'black', 'brown'];
@@ -321,6 +342,11 @@ class ObjectSerializerTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * Deep Objects provider
+     *
+     * @return array
+     */
     public function provideDeepObjects(): array
     {
         return [
@@ -360,6 +386,11 @@ class ObjectSerializerTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * toString() input provider
+     *
+     * @return array
+     */
     public function provideToStringInput(): array
     {
         return [
@@ -384,11 +415,12 @@ class ObjectSerializerTest extends TestCase
                 'expected' => 'some string',
             ],
             'a date' => [
-                'input' => new \DateTime('14-04-2022'),
+                'input' => new DateTime('14-04-2022'),
                 'expected' => '2022-04-14T00:00:00+00:00',
             ],
         ];
     }
+
     /**
      * @covers ObjectSerializer::toQueryValue
      * @dataProvider provideQueryParamsWithStringBooleanFormatForQueryString
@@ -412,6 +444,11 @@ class ObjectSerializerTest extends TestCase
         $this->assertEquals($expected, $query);
     }
 
+    /**
+     * Query Params with string boolean format provider
+     *
+     * @return array[]
+     */
     public function provideQueryParamsWithStringBooleanFormatForQueryString(): array
     {
         return [


### PR DESCRIPTION
PR #12849 fixed a small bug in ObjectSerializer::deserialize(). As requested [here](https://github.com/OpenAPITools/openapi-generator/pull/12849#issuecomment-1186130098) by @wing328, this PR adds tests for it.

There are two commits here: the first one does some code cleanup to the test class, while the second one adds the new tests.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon