### PR TITLE
[PHP] double curly braces bugfix

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -233,7 +233,7 @@ use {{invokerPackage}}\ObjectSerializer;
                         $content = $response->getBody(); //stream goes to serializer
                     } else {
                         $content = (string) $response->getBody();
-                        if ('{{dataType}}' !== 'string') {
+                        if ('{{{dataType}}}' !== 'string') {
                             $content = json_decode($content);
                         }
                     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -412,7 +412,7 @@ class StoreApi
                         $content = $response->getBody(); //stream goes to serializer
                     } else {
                         $content = (string) $response->getBody();
-                        if ('array&lt;string,int&gt;' !== 'string') {
+                        if ('array<string,int>' !== 'string') {
                             $content = json_decode($content);
                         }
                     }


### PR DESCRIPTION
This PR fixes a small bug on api.mustache, where a recent change used double curly braces instead of triple ones. As one can see in the only affected generated sample, the content of  'dataType' should never be HTML-escaped... :wink:

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon