### PR TITLE
[typescript] Don't throw exception when `additionalProperties` is set to `true`

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -887,7 +887,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
             inner = ((ArraySchema) p).getItems();
             return this.getSchemaType(p) + "<" + this.getTypeDeclaration(unaliasSchema(inner)) + ">";
         } else if (ModelUtils.isMapSchema(p)) {
-            inner = (Schema) p.getAdditionalProperties();
+            inner = getSchemaAdditionalProperties(p);
             return "{ [key: string]: " + this.getTypeDeclaration(unaliasSchema(inner)) + "; }";
         } else if (ModelUtils.isFileSchema(p)) {
             return "HttpFile";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -79,4 +79,23 @@ public class TypeScriptClientCodegenTest {
         Assert.assertFalse(codegenModel.imports.contains("Set"));
     }
 
+    @Test
+    public void testWithAdditionalProperties() {
+        final Schema inner = new ObjectSchema();
+        inner.setAdditionalProperties(true);
+
+        final Schema root = new ObjectSchema()
+            .addProperties("inner", inner);
+
+        final DefaultCodegen codegen = new TypeScriptClientCodegen();
+        final OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", root);
+        codegen.setOpenAPI(openAPI);
+
+        try {
+            // TypeScriptClientCodegen can generate codes without any exception.
+            codegen.fromModel("sample", root);
+        } catch (Exception e) {
+            Assert.fail("Exception was thrown.");
+        }
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -92,7 +92,7 @@ public class TypeScriptClientCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         try {
-            // TypeScriptClientCodegen can generate codes without any exception.
+            // TypeScriptClientCodegen can generate codes without throwing exception.
             codegen.fromModel("sample", root);
         } catch (Exception e) {
             Assert.fail("Exception was thrown.");


### PR DESCRIPTION
resolves #12973

This PR enables `typescript generator` to generate code without throwing any exceptions when `additionalProperty` is explicitly set to `true`, as in the following example.

```yaml
openapi: 3.0.3
components:
  schemas:
    foo:
      properties:
        bar:
          additionalProperties: true
          description: baz
          type: object
      type: object
info:
  title: Repro
  version: 1.0.0
paths:
  "/":
    get:
      description: Foo
      operationId: getFoo
      responses:
        '200':
          content:
            application/json:
              schema:
                properties:
                  foo:
                    description: Foo.
                    type: string
                required:
                - foo
                type: object
          description: Foo
      summary: Foo
      tags:
      - metadata
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
