### PR TITLE
[java][apache-httpclient] Fix issue content-type default charset

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -707,18 +707,14 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Parse content type object from header value
    */
-  private ContentType getContentType(String headerValue) throws ApiException {
-    try {
-      return ContentType.parse(headerValue);
-    } catch (ParseException e) {
-      throw new ApiException("Could not parse content type " + headerValue);
-    }
+  private ContentType getContentType(String headerValue) {
+    return ContentType.getByMimeType(headerValue);
   }
 
   /**
    * Get content type of a response or null if one was not provided
    */
-  private String getResponseMimeType(HttpResponse response) throws ApiException {
+  private String getResponseMimeType(HttpResponse response) {
     Header contentTypeHeader = response.getFirstHeader("Content-Type");
     if (contentTypeHeader != null) {
       return getContentType(contentTypeHeader.getValue()).getMimeType();

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -662,18 +662,14 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Parse content type object from header value
    */
-  private ContentType getContentType(String headerValue) throws ApiException {
-    try {
-      return ContentType.parse(headerValue);
-    } catch (ParseException e) {
-      throw new ApiException("Could not parse content type " + headerValue);
-    }
+  private ContentType getContentType(String headerValue) {
+    return ContentType.getByMimeType(headerValue);
   }
 
   /**
    * Get content type of a response or null if one was not provided
    */
-  private String getResponseMimeType(HttpResponse response) throws ApiException {
+  private String getResponseMimeType(HttpResponse response) {
     Header contentTypeHeader = response.getFirstHeader("Content-Type");
     if (contentTypeHeader != null) {
       return getContentType(contentTypeHeader.getValue()).getMimeType();


### PR DESCRIPTION
Change ContentType parsing. 

Existing parsing use ISO-8859-1 that does nos support accent or characters from unicode standard. 
The new mediatype parsing use UTF-8 to support all unicode characters to comply with [RFC4627](https://www.ietf.org/rfc/rfc4627.txt).

Opened issue : [12797](https://github.com/OpenAPITools/openapi-generator/issues/12797)

Java technical-committee members:
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608