### PR TITLE
PHP: fix ranged status codes

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -227,7 +227,7 @@ use {{invokerPackage}}\ObjectSerializer;
 
             switch($statusCode) {
             {{/-first}}
-            {{#dataType}}
+            {{#dataType}}{{^isRange}}
                 {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
                     if ('{{{dataType}}}' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -243,7 +243,7 @@ use {{invokerPackage}}\ObjectSerializer;
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            {{/dataType}}
+            {{/isRange}}{{/dataType}}
             {{#-last}}
             }
             {{/-last}}
@@ -273,7 +273,7 @@ use {{invokerPackage}}\ObjectSerializer;
         } catch (ApiException $e) {
             switch ($e->getCode()) {
         {{#responses}}
-            {{#dataType}}
+            {{#dataType}}{{^isRange}}
                 {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -282,7 +282,7 @@ use {{invokerPackage}}\ObjectSerializer;
                     );
                     $e->setResponseObject($data);
                     break;
-            {{/dataType}}
+            {{/isRange}}{{/dataType}}
         {{/responses}}
             }
             throw $e;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -183,6 +183,7 @@ class AnotherFakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Client' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -198,6 +199,7 @@ class AnotherFakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Client';
@@ -218,6 +220,7 @@ class AnotherFakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -226,6 +229,7 @@ class AnotherFakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -177,6 +177,7 @@ class DefaultApi
             }
 
             switch($statusCode) {
+            
                 default:
                     if ('\OpenAPI\Client\Model\FooGetDefaultResponse' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -192,6 +193,7 @@ class DefaultApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\FooGetDefaultResponse';
@@ -212,6 +214,7 @@ class DefaultApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 default:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -220,6 +223,7 @@ class DefaultApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -181,6 +181,7 @@ class FakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\HealthCheckResult' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -196,6 +197,7 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\HealthCheckResult';
@@ -216,6 +218,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -224,6 +227,7 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -450,6 +454,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -687,6 +692,7 @@ class FakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('bool' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -702,6 +708,7 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = 'bool';
@@ -722,6 +729,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -730,6 +738,7 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -951,6 +960,7 @@ class FakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\OuterComposite' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -966,6 +976,7 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\OuterComposite';
@@ -986,6 +997,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -994,6 +1006,7 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -1215,6 +1228,7 @@ class FakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('float' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1230,6 +1244,7 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = 'float';
@@ -1250,6 +1265,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1258,6 +1274,7 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -1479,6 +1496,7 @@ class FakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('string' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1494,6 +1512,7 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = 'string';
@@ -1514,6 +1533,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1522,6 +1542,7 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -1743,6 +1764,7 @@ class FakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\OuterObjectWithEnumProperty' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1758,6 +1780,7 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\OuterObjectWithEnumProperty';
@@ -1778,6 +1801,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1786,6 +1810,7 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -2015,6 +2040,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -2231,6 +2257,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -2449,6 +2476,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -2685,6 +2713,7 @@ class FakeApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Client' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -2700,6 +2729,7 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Client';
@@ -2720,6 +2750,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -2728,6 +2759,7 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -2991,6 +3023,8 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }
@@ -3397,6 +3431,8 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }
@@ -3711,6 +3747,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -4018,6 +4055,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -4244,6 +4282,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -4487,6 +4526,7 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -183,6 +183,7 @@ class FakeClassnameTags123Api
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Client' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -198,6 +199,7 @@ class FakeClassnameTags123Api
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Client';
@@ -218,6 +220,7 @@ class FakeClassnameTags123Api
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -226,6 +229,7 @@ class FakeClassnameTags123Api
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -193,6 +193,8 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }
@@ -441,6 +443,8 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }
@@ -676,6 +680,7 @@ class PetApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Pet[]' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -691,6 +696,8 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Pet[]';
@@ -711,6 +718,7 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -719,6 +727,8 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
+            
             }
             throw $e;
         }
@@ -963,6 +973,7 @@ class PetApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Pet[]' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -978,6 +989,8 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Pet[]';
@@ -998,6 +1011,7 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1006,6 +1020,8 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
+            
             }
             throw $e;
         }
@@ -1252,6 +1268,7 @@ class PetApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Pet' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1267,6 +1284,9 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
+            
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Pet';
@@ -1287,6 +1307,7 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1295,6 +1316,9 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
+            
+            
             }
             throw $e;
         }
@@ -1547,6 +1571,10 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
+            
+            
             }
             throw $e;
         }
@@ -1797,6 +1825,8 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }
@@ -2043,6 +2073,7 @@ class PetApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\ApiResponse' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -2058,6 +2089,7 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\ApiResponse';
@@ -2078,6 +2110,7 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -2086,6 +2119,7 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -2353,6 +2387,7 @@ class PetApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\ApiResponse' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -2368,6 +2403,7 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\ApiResponse';
@@ -2388,6 +2424,7 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -2396,6 +2433,7 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -185,6 +185,8 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }
@@ -407,6 +409,7 @@ class StoreApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('array<string,int>' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -422,6 +425,7 @@ class StoreApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
             }
 
             $returnType = 'array<string,int>';
@@ -442,6 +446,7 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -450,6 +455,7 @@ class StoreApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
             }
             throw $e;
         }
@@ -675,6 +681,7 @@ class StoreApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Order' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -690,6 +697,9 @@ class StoreApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
+            
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Order';
@@ -710,6 +720,7 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -718,6 +729,9 @@ class StoreApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
+            
+            
             }
             throw $e;
         }
@@ -962,6 +976,7 @@ class StoreApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\Order' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -977,6 +992,8 @@ class StoreApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\Order';
@@ -997,6 +1014,7 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1005,6 +1023,8 @@ class StoreApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
+            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -185,6 +185,7 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -409,6 +410,7 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -633,6 +635,7 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -857,6 +860,8 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }
@@ -1081,6 +1086,7 @@ class UserApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('\OpenAPI\Client\Model\User' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1096,6 +1102,9 @@ class UserApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
+            
+            
             }
 
             $returnType = '\OpenAPI\Client\Model\User';
@@ -1116,6 +1125,7 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1124,6 +1134,9 @@ class UserApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
+            
+            
             }
             throw $e;
         }
@@ -1363,6 +1376,7 @@ class UserApi
             }
 
             switch($statusCode) {
+            
                 case 200:
                     if ('string' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1378,6 +1392,8 @@ class UserApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
+            
+            
             }
 
             $returnType = 'string';
@@ -1398,6 +1414,7 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1406,6 +1423,8 @@ class UserApi
                     );
                     $e->setResponseObject($data);
                     break;
+            
+            
             }
             throw $e;
         }
@@ -1662,6 +1681,7 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
             }
             throw $e;
         }
@@ -1873,6 +1893,8 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
+            
+            
             }
             throw $e;
         }


### PR DESCRIPTION
The current version of the PHP generator does not support ranged status codes since they are treated as `int` in the switch case statements. Hence I did get some `PHP Parse error:  syntax error, unexpected 'XX' (T_STRING) in` errors. This PR removes ranged status codes from the switch-case statements

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)