### PR TITLE
[rust] fix incorrect Cargo.toml generated when supportAsync & withAWSV4Signature are both enabled.

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -18,6 +18,11 @@ serde_yaml = "0.7"
 base64 = "~0.7.0"
 futures = "^0.3"
 {{/hyper}}
+{{#withAWSV4Signature}}
+aws-sigv4 = "0.3.0"
+http = "0.2.5"
+secrecy = "0.8.0"
+{{/withAWSV4Signature}}
 {{#reqwest}}
 {{^supportAsync}}
 reqwest = "~0.9"
@@ -28,11 +33,6 @@ version = "^0.11"
 features = ["json", "multipart"]
 {{/supportAsync}}
 {{/reqwest}}
-{{#withAWSV4Signature}}
-aws-sigv4 = "0.3.0"
-http = "0.2.5"
-secrecy = "0.8.0"
-{{/withAWSV4Signature}}
 
 [dev-dependencies]
 {{#hyper}}

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
@@ -10,9 +10,9 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde"] }
-reqwest = "~0.9"
 aws-sigv4 = "0.3.0"
 http = "0.2.5"
 secrecy = "0.8.0"
+reqwest = "~0.9"
 
 [dev-dependencies]


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When supportAsync and withAWSV4Signature are both enabled, the generate `Cargo.toml` will contain the following code:

```
[dependencies]
serde = "^1.0"
serde_derive = "^1.0"
serde_json = "^1.0"
url = "^2.2"
uuid = { version = "^1.0", features = ["serde"] }
[dependencies.reqwest]
version = "^0.11"
features = ["json", "multipart"]
aws-sigv4 = "0.3.0"
http = "0.2.5"
secrecy = "0.8.0"
```

The last 3 lines become children of `[dependencies.reqwest]` which can cause compile errors.



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @farcaller
