### PR TITLE
[R] Prefix local variables in API functions to avoid naming collisions

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -201,14 +201,14 @@
       }
 
       {{/vendorExtensions.x-streaming}}
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -260,7 +260,7 @@
 
       {{/query_params}}
       {{#hasFormParams}}
-      body <- list(
+      local_var_body <- list(
         {{#formParams}}
         {{^isFile}}
         "{{baseName}}" = {{paramName}}{{^-last}},{{/-last}}
@@ -279,10 +279,10 @@
         body.items <- paste(unlist(lapply({{paramName}}, function(param) {
                                                              param$toJSONString()
                                                          })), collapse = ",")
-        body <- paste0("[", body.items, "]")
+        local_var_body <- paste0("[", body.items, "]")
         {{/isArray}}
         {{^isArray}}
-        body <- `{{paramName}}`$toJSONString()
+        local_var_body <- `{{paramName}}`$toJSONString()
         {{/isArray}}
       } else {
         body <- NULL
@@ -292,14 +292,14 @@
       {{/hasBodyParam}}
       {{^hasBodyParam}}
       {{^hasFormParams}}
-      body <- NULL
+      local_var_body <- NULL
       {{/hasFormParams}}
       {{/hasBodyParam}}
-      url_path <- "{{path}}"
+      local_var_url_path <- "{{path}}"
       {{#hasPathParams}}
       {{#pathParams}}
       if (!missing(`{{paramName}}`)) {
-        url_path <- gsub(paste0("\\{", "{{baseName}}", "\\}"), URLencode(as.character(`{{paramName}}`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "{{baseName}}", "\\}"), URLencode(as.character(`{{paramName}}`), reserved = TRUE), local_var_url_path)
       }
 
       {{/pathParams}}
@@ -334,18 +334,18 @@
       {{/authMethods}}
 
       # The Accept request HTTP header
-      accepts = list({{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}})
+      local_var_accepts = list({{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}})
 
       # The Content-Type representation header
-      content_types = list({{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}})
+      local_var_content_types = list({{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}})
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "{{httpMethod}}",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  {{#vendorExtensions.x-streaming}}
                                  stream_callback = stream_callback,
                                  {{/vendorExtensions.x-streaming}}
@@ -357,15 +357,15 @@
       }
 
       {{/vendorExtensions.x-streaming}}
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         {{#returnType}}
         {{#isPrimitiveType}}
-        content <- httr::content(
-            resp, "text", encoding = "UTF-8", simplifyVector = FALSE
+        local_var_content <- httr::content(
+            local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE
         )
         # save response in a file
         if (!is.null(data_file)) {
-            write(content, data_file)
+            write(local_var_content, data_file)
         }
 
         ApiResponse$new(content,resp)
@@ -373,11 +373,11 @@
         {{^isPrimitiveType}}
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "{{returnType}}", loadNamespace("{{packageName}}")),
+          self$api_client$deserialize(local_var_resp, "{{returnType}}", loadNamespace("{{packageName}}")),
           error = function(e) {
            {{#useDefaultExceptionHandling}}
              stop("Failed to deserialize response")
@@ -385,70 +385,70 @@
            {{#useRlangExceptionHandling}}
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
            {{/useRlangExceptionHandling}}
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
         {{/isPrimitiveType}}
         {{/returnType}}
         {{^returnType}}
         {{! Returning the ApiResponse object with NULL object when the endpoint doesn't return anything}}
-        ApiResponse$new(NULL, resp)
+        ApiResponse$new(NULL, local_var_resp)
         {{/returnType}}
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
       {{#returnExceptionOnFailure}}
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
         }
         {{#useDefaultExceptionHandling}}
-        stop(error_msg)
+        stop(local_var_error_msg)
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+        {{/useRlangExceptionHandling}}
+      {{/returnExceptionOnFailure}}
+      {{^returnExceptionOnFailure}}
+        ApiResponse$new(paste("Server returned ", httr::status_code(local_var_resp), " response status code."), local_var_resp)
+      {{/returnExceptionOnFailure}}
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+      {{#returnExceptionOnFailure}}
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        {{#useDefaultExceptionHandling}}
+        stop(local_var_error_msg)
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+        {{/useRlangExceptionHandling}}
+      {{/returnExceptionOnFailure}}
+      {{^returnExceptionOnFailure}}
+        ApiResponse$new("API client error", local_var_resp)
+      {{/returnExceptionOnFailure}}
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+      {{#returnExceptionOnFailure}}
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
+        }
+        {{#useDefaultExceptionHandling}}
+        stop(local_var_error_msg)
         {{/useDefaultExceptionHandling}}
         {{#useRlangExceptionHandling}}
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
         {{/useRlangExceptionHandling}}
       {{/returnExceptionOnFailure}}
       {{^returnExceptionOnFailure}}
-        ApiResponse$new(paste("Server returned ", httr::status_code(resp), " response status code."), resp)
-      {{/returnExceptionOnFailure}}
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-      {{#returnExceptionOnFailure}}
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        {{#useDefaultExceptionHandling}}
-        stop(error_msg)
-        {{/useDefaultExceptionHandling}}
-        {{#useRlangExceptionHandling}}
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-        {{/useRlangExceptionHandling}}
-      {{/returnExceptionOnFailure}}
-      {{^returnExceptionOnFailure}}
-        ApiResponse$new("API client error", resp)
-      {{/returnExceptionOnFailure}}
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-      {{#returnExceptionOnFailure}}
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        {{#useDefaultExceptionHandling}}
-        stop(error_msg)
-        {{/useDefaultExceptionHandling}}
-        {{#useRlangExceptionHandling}}
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-        {{/useRlangExceptionHandling}}
-      {{/returnExceptionOnFailure}}
-      {{^returnExceptionOnFailure}}
-        ApiResponse$new("API server error", resp)
+        ApiResponse$new("API server error", local_var_resp)
       {{/returnExceptionOnFailure}}
       }
     }{{^-last}},{{/-last}}

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -100,14 +100,14 @@ FakeApi <- R6::R6Class(
     #' @export
     FakeDataFile = function(dummy, var_data_file = NULL, data_file = NULL, ...) {
       api_response <- self$FakeDataFileWithHttpInfo(dummy, var_data_file, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -134,63 +134,63 @@ FakeApi <- R6::R6Class(
                                                      reason = "Missing required parameter `dummy`."))
       }
 
-      body <- NULL
-      url_path <- "/fake/data_file"
+      local_var_body <- NULL
+      local_var_url_path <- "/fake/data_file"
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "User", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     }
   )

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -545,14 +545,14 @@ PetApi <- R6::R6Class(
     #' @export
     AddPet = function(pet, data_file = NULL, ...) {
       api_response <- self$AddPetWithHttpInfo(pet, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -579,69 +579,69 @@ PetApi <- R6::R6Class(
       }
 
       if (!missing(`pet`)) {
-        body <- `pet`$toJSONString()
+        local_var_body <- `pet`$toJSONString()
       } else {
         body <- NULL
       }
 
-      url_path <- "/pet"
+      local_var_url_path <- "/pet"
       # HTTP basic auth
       header_params["Authorization"] <- paste("Basic", base64enc::base64encode(charToRaw(paste(self$api_client$username, self$api_client$password, sep = ":"))))
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list("application/json", "application/xml", "multipart/related")
+      local_var_content_types = list("application/json", "application/xml", "multipart/related")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "POST",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "Pet", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Deletes a pet
@@ -656,14 +656,14 @@ PetApi <- R6::R6Class(
     #' @export
     DeletePet = function(pet_id, api_key = NULL, ...) {
       api_response <- self$DeletePetWithHttpInfo(pet_id, api_key, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -689,56 +689,56 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
-      body <- NULL
-      url_path <- "/pet/{petId}?streaming"
+      local_var_body <- NULL
+      local_var_url_path <- "/pet/{petId}?streaming"
       if (!missing(`pet_id`)) {
-        url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)
       }
 
       # OAuth token
       header_params["Authorization"] <- paste("Bearer", self$api_client$access_token, sep = " ")
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "DELETE",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Finds Pets by status
@@ -753,14 +753,14 @@ PetApi <- R6::R6Class(
     #' @export
     FindPetsByStatus = function(status, data_file = NULL, ...) {
       api_response <- self$FindPetsByStatusWithHttpInfo(status, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -786,65 +786,65 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `status`."))
       }
 
-      body <- NULL
-      url_path <- "/pet/findByStatus"
+      local_var_body <- NULL
+      local_var_url_path <- "/pet/findByStatus"
       # OAuth token
       header_params["Authorization"] <- paste("Bearer", self$api_client$access_token, sep = " ")
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Finds Pets by tags
@@ -859,14 +859,14 @@ PetApi <- R6::R6Class(
     #' @export
     FindPetsByTags = function(tags, data_file = NULL, ...) {
       api_response <- self$FindPetsByTagsWithHttpInfo(tags, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -892,65 +892,65 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `tags`."))
       }
 
-      body <- NULL
-      url_path <- "/pet/findByTags"
+      local_var_body <- NULL
+      local_var_url_path <- "/pet/findByTags"
       # OAuth token
       header_params["Authorization"] <- paste("Bearer", self$api_client$access_token, sep = " ")
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Find pet by ID
@@ -965,14 +965,14 @@ PetApi <- R6::R6Class(
     #' @export
     GetPetById = function(pet_id, data_file = NULL, ...) {
       api_response <- self$GetPetByIdWithHttpInfo(pet_id, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -998,68 +998,68 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
-      body <- NULL
-      url_path <- "/pet/{petId}"
+      local_var_body <- NULL
+      local_var_url_path <- "/pet/{petId}"
       if (!missing(`pet_id`)) {
-        url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)
       }
 
       header_params["Authorization"] <- paste("Bearer", self$api_client$bearer_token, sep = " ")
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "Pet", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Find pet by ID (streaming)
@@ -1079,14 +1079,14 @@ PetApi <- R6::R6Class(
         return(invisible(NULL))
       }
 
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -1113,10 +1113,10 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
-      body <- NULL
-      url_path <- "/pet/{petId}?streaming"
+      local_var_body <- NULL
+      local_var_url_path <- "/pet/{petId}?streaming"
       if (!missing(`pet_id`)) {
-        url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)
       }
 
       # API key authentication
@@ -1125,18 +1125,18 @@ PetApi <- R6::R6Class(
       }
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  stream_callback = stream_callback,
                                  ...)
 
@@ -1144,45 +1144,45 @@ PetApi <- R6::R6Class(
         return(invisible(NULL))
       }
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "Pet", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Update an existing pet
@@ -1197,14 +1197,14 @@ PetApi <- R6::R6Class(
     #' @export
     UpdatePet = function(pet, data_file = NULL, ...) {
       api_response <- self$UpdatePetWithHttpInfo(pet, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -1231,69 +1231,69 @@ PetApi <- R6::R6Class(
       }
 
       if (!missing(`pet`)) {
-        body <- `pet`$toJSONString()
+        local_var_body <- `pet`$toJSONString()
       } else {
         body <- NULL
       }
 
-      url_path <- "/pet"
+      local_var_url_path <- "/pet"
       # OAuth token
       header_params["Authorization"] <- paste("Bearer", self$api_client$access_token, sep = " ")
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list("application/json", "application/xml", "multipart/related")
+      local_var_content_types = list("application/json", "application/xml", "multipart/related")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "PUT",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "Pet", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Updates a pet in the store with form data
@@ -1309,14 +1309,14 @@ PetApi <- R6::R6Class(
     #' @export
     UpdatePetWithForm = function(pet_id, name = NULL, status = NULL, ...) {
       api_response <- self$UpdatePetWithFormWithHttpInfo(pet_id, name, status, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -1343,60 +1343,60 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
-      body <- list(
+      local_var_body <- list(
         "name" = name,
         "status" = status
       )
 
-      url_path <- "/pet/{petId}?streaming"
+      local_var_url_path <- "/pet/{petId}?streaming"
       if (!missing(`pet_id`)) {
-        url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)
       }
 
       # OAuth token
       header_params["Authorization"] <- paste("Bearer", self$api_client$access_token, sep = " ")
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list("application/x-www-form-urlencoded")
+      local_var_content_types = list("application/x-www-form-urlencoded")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "POST",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' uploads an image
@@ -1413,14 +1413,14 @@ PetApi <- R6::R6Class(
     #' @export
     UploadFile = function(pet_id, additional_metadata = NULL, file = NULL, data_file = NULL, ...) {
       api_response <- self$UploadFileWithHttpInfo(pet_id, additional_metadata, file, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -1448,73 +1448,73 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
-      body <- list(
+      local_var_body <- list(
         "additionalMetadata" = additional_metadata,
         "file" = httr::upload_file(file)
       )
 
-      url_path <- "/pet/{petId}/uploadImage"
+      local_var_url_path <- "/pet/{petId}/uploadImage"
       if (!missing(`pet_id`)) {
-        url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)
       }
 
       # OAuth token
       header_params["Authorization"] <- paste("Bearer", self$api_client$access_token, sep = " ")
 
       # The Accept request HTTP header
-      accepts = list("application/json")
+      local_var_accepts = list("application/json")
 
       # The Content-Type representation header
-      content_types = list("multipart/form-data")
+      local_var_content_types = list("multipart/form-data")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "POST",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "ModelApiResponse", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "ModelApiResponse", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     }
   )

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -250,14 +250,14 @@ StoreApi <- R6::R6Class(
     #' @export
     DeleteOrder = function(order_id, ...) {
       api_response <- self$DeleteOrderWithHttpInfo(order_id, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -282,54 +282,54 @@ StoreApi <- R6::R6Class(
                                                      reason = "Missing required parameter `order_id`."))
       }
 
-      body <- NULL
-      url_path <- "/store/order/{orderId}"
+      local_var_body <- NULL
+      local_var_url_path <- "/store/order/{orderId}"
       if (!missing(`order_id`)) {
-        url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), local_var_url_path)
       }
 
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "DELETE",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Returns pet inventories by status
@@ -343,14 +343,14 @@ StoreApi <- R6::R6Class(
     #' @export
     GetInventory = function(data_file = NULL, ...) {
       api_response <- self$GetInventoryWithHttpInfo(data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -368,67 +368,67 @@ StoreApi <- R6::R6Class(
       query_params <- list()
       header_params <- c()
 
-      body <- NULL
-      url_path <- "/store/inventory"
+      local_var_body <- NULL
+      local_var_url_path <- "/store/inventory"
       # API key authentication
       if ("api_key" %in% names(self$api_client$api_keys) && nchar(self$api_client$api_keys["api_key"]) > 0) {
         header_params["api_key"] <- paste(unlist(self$api_client$api_keys["api_key"]), collapse = "")
       }
 
       # The Accept request HTTP header
-      accepts = list("application/json")
+      local_var_accepts = list("application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "map(integer)", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "map(integer)", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Find purchase order by ID
@@ -443,14 +443,14 @@ StoreApi <- R6::R6Class(
     #' @export
     GetOrderById = function(order_id, data_file = NULL, ...) {
       api_response <- self$GetOrderByIdWithHttpInfo(order_id, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -476,67 +476,67 @@ StoreApi <- R6::R6Class(
                                                      reason = "Missing required parameter `order_id`."))
       }
 
-      body <- NULL
-      url_path <- "/store/order/{orderId}"
+      local_var_body <- NULL
+      local_var_url_path <- "/store/order/{orderId}"
       if (!missing(`order_id`)) {
-        url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), local_var_url_path)
       }
 
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "Order", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Place an order for a pet
@@ -551,14 +551,14 @@ StoreApi <- R6::R6Class(
     #' @export
     PlaceOrder = function(order, data_file = NULL, ...) {
       api_response <- self$PlaceOrderWithHttpInfo(order, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -585,67 +585,67 @@ StoreApi <- R6::R6Class(
       }
 
       if (!missing(`order`)) {
-        body <- `order`$toJSONString()
+        local_var_body <- `order`$toJSONString()
       } else {
         body <- NULL
       }
 
-      url_path <- "/store/order"
+      local_var_url_path <- "/store/order"
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list("application/json")
+      local_var_content_types = list("application/json")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "POST",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "Order", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     }
   )

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -436,14 +436,14 @@ UserApi <- R6::R6Class(
     #' @export
     CreateUser = function(user, ...) {
       api_response <- self$CreateUserWithHttpInfo(user, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -469,58 +469,58 @@ UserApi <- R6::R6Class(
       }
 
       if (!missing(`user`)) {
-        body <- `user`$toJSONString()
+        local_var_body <- `user`$toJSONString()
       } else {
         body <- NULL
       }
 
-      url_path <- "/user"
+      local_var_url_path <- "/user"
       # API key authentication
       if ("api_key" %in% names(self$api_client$api_keys) && nchar(self$api_client$api_keys["api_key"]) > 0) {
         header_params["api_key"] <- paste(unlist(self$api_client$api_keys["api_key"]), collapse = "")
       }
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list("application/json")
+      local_var_content_types = list("application/json")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "POST",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Creates list of users with given input array
@@ -534,14 +534,14 @@ UserApi <- R6::R6Class(
     #' @export
     CreateUsersWithArrayInput = function(user, ...) {
       api_response <- self$CreateUsersWithArrayInputWithHttpInfo(user, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -570,58 +570,58 @@ UserApi <- R6::R6Class(
         body.items <- paste(unlist(lapply(user, function(param) {
                                                              param$toJSONString()
                                                          })), collapse = ",")
-        body <- paste0("[", body.items, "]")
+        local_var_body <- paste0("[", body.items, "]")
       } else {
         body <- NULL
       }
 
-      url_path <- "/user/createWithArray"
+      local_var_url_path <- "/user/createWithArray"
       # API key authentication
       if ("api_key" %in% names(self$api_client$api_keys) && nchar(self$api_client$api_keys["api_key"]) > 0) {
         header_params["api_key"] <- paste(unlist(self$api_client$api_keys["api_key"]), collapse = "")
       }
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list("application/json")
+      local_var_content_types = list("application/json")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "POST",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Creates list of users with given input array
@@ -635,14 +635,14 @@ UserApi <- R6::R6Class(
     #' @export
     CreateUsersWithListInput = function(user, ...) {
       api_response <- self$CreateUsersWithListInputWithHttpInfo(user, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -671,58 +671,58 @@ UserApi <- R6::R6Class(
         body.items <- paste(unlist(lapply(user, function(param) {
                                                              param$toJSONString()
                                                          })), collapse = ",")
-        body <- paste0("[", body.items, "]")
+        local_var_body <- paste0("[", body.items, "]")
       } else {
         body <- NULL
       }
 
-      url_path <- "/user/createWithList"
+      local_var_url_path <- "/user/createWithList"
       # API key authentication
       if ("api_key" %in% names(self$api_client$api_keys) && nchar(self$api_client$api_keys["api_key"]) > 0) {
         header_params["api_key"] <- paste(unlist(self$api_client$api_keys["api_key"]), collapse = "")
       }
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list("application/json")
+      local_var_content_types = list("application/json")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "POST",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Delete user
@@ -736,14 +736,14 @@ UserApi <- R6::R6Class(
     #' @export
     DeleteUser = function(username, ...) {
       api_response <- self$DeleteUserWithHttpInfo(username, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -768,10 +768,10 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `username`."))
       }
 
-      body <- NULL
-      url_path <- "/user/{username}"
+      local_var_body <- NULL
+      local_var_url_path <- "/user/{username}"
       if (!missing(`username`)) {
-        url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), local_var_url_path)
       }
 
       # API key authentication
@@ -780,46 +780,46 @@ UserApi <- R6::R6Class(
       }
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "DELETE",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Get user by user name
@@ -834,14 +834,14 @@ UserApi <- R6::R6Class(
     #' @export
     GetUserByName = function(username, data_file = NULL, ...) {
       api_response <- self$GetUserByNameWithHttpInfo(username, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -867,67 +867,67 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `username`."))
       }
 
-      body <- NULL
-      url_path <- "/user/{username}"
+      local_var_body <- NULL
+      local_var_url_path <- "/user/{username}"
       if (!missing(`username`)) {
-        url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), local_var_url_path)
       }
 
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "User", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Logs user into the system
@@ -943,14 +943,14 @@ UserApi <- R6::R6Class(
     #' @export
     LoginUser = function(username, password, data_file = NULL, ...) {
       api_response <- self$LoginUserWithHttpInfo(username, password, data_file = data_file, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -984,63 +984,63 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `password`."))
       }
 
-      body <- NULL
-      url_path <- "/user/login"
+      local_var_body <- NULL
+      local_var_url_path <- "/user/login"
 
       # The Accept request HTTP header
-      accepts = list("application/xml", "application/json")
+      local_var_accepts = list("application/xml", "application/json")
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
         # save response in a file
         if (!is.null(data_file)) {
-            write(httr::content(resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
+            write(httr::content(local_var_resp, "text", encoding = "UTF-8", simplifyVector = FALSE), data_file)
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(resp, "character", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp, "character", loadNamespace("petstore")),
           error = function(e) {
              rlang::abort(message = "Failed to deserialize response",
                           .subclass = "ApiException",
-                          ApiException = ApiException$new(http_response = resp))
+                          ApiException = ApiException$new(http_response = local_var_resp))
           }
         )
-        ApiResponse$new(deserialized_resp_obj, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+        ApiResponse$new(deserialized_resp_obj, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Logs out current logged in user session
@@ -1053,14 +1053,14 @@ UserApi <- R6::R6Class(
     #' @export
     LogoutUser = function(...) {
       api_response <- self$LogoutUserWithHttpInfo(...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -1077,54 +1077,54 @@ UserApi <- R6::R6Class(
       query_params <- list()
       header_params <- c()
 
-      body <- NULL
-      url_path <- "/user/logout"
+      local_var_body <- NULL
+      local_var_url_path <- "/user/logout"
       # API key authentication
       if ("api_key" %in% names(self$api_client$api_keys) && nchar(self$api_client$api_keys["api_key"]) > 0) {
         header_params["api_key"] <- paste(unlist(self$api_client$api_keys["api_key"]), collapse = "")
       }
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list()
+      local_var_content_types = list()
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "GET",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     },
     #' Updated user
@@ -1139,14 +1139,14 @@ UserApi <- R6::R6Class(
     #' @export
     UpdateUser = function(username, user, ...) {
       api_response <- self$UpdateUserWithHttpInfo(username, user, ...)
-      resp <- api_response$response
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
+      local_var_response <- api_response$response
+      if (httr::status_code(local_var_response) >= 200 && httr::status_code(local_var_response) <= 299) {
         api_response$content
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
+      } else if (httr::status_code(local_var_response) >= 300 && httr::status_code(local_var_response) <= 399) {
         api_response
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
+      } else if (httr::status_code(local_var_response) >= 400 && httr::status_code(local_var_response) <= 499) {
         api_response
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
+      } else if (httr::status_code(local_var_response) >= 500 && httr::status_code(local_var_response) <= 599) {
         api_response
       }
     },
@@ -1180,14 +1180,14 @@ UserApi <- R6::R6Class(
       }
 
       if (!missing(`user`)) {
-        body <- `user`$toJSONString()
+        local_var_body <- `user`$toJSONString()
       } else {
         body <- NULL
       }
 
-      url_path <- "/user/{username}"
+      local_var_url_path <- "/user/{username}"
       if (!missing(`username`)) {
-        url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), url_path)
+        local_var_url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), local_var_url_path)
       }
 
       # API key authentication
@@ -1196,46 +1196,46 @@ UserApi <- R6::R6Class(
       }
 
       # The Accept request HTTP header
-      accepts = list()
+      local_var_accepts = list()
 
       # The Content-Type representation header
-      content_types = list("application/json")
+      local_var_content_types = list("application/json")
 
-      resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, url_path),
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
                                  method = "PUT",
                                  query_params = query_params,
                                  header_params = header_params,
-                                 accepts = accepts,
-                                 content_types = content_types,
-                                 body = body,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
                                  ...)
 
-      if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
-        ApiResponse$new(NULL, resp)
-      } else if (httr::status_code(resp) >= 300 && httr::status_code(resp) <= 399) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- paste("Server returned ", httr::status_code(resp), " response status code.")
+      if (httr::status_code(local_var_resp) >= 200 && httr::status_code(local_var_resp) <= 299) {
+        ApiResponse$new(NULL, local_var_resp)
+      } else if (httr::status_code(local_var_resp) >= 300 && httr::status_code(local_var_resp) <= 399) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", httr::status_code(local_var_resp), " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 400 && httr::status_code(local_var_resp) <= 499) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (httr::status_code(local_var_resp) >= 500 && httr::status_code(local_var_resp) <= 599) {
+        local_var_error_msg <- toString(content(local_var_resp))
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
         }
         rlang::abort(message = error_msg,
                      .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 400 && httr::status_code(resp) <= 499) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api client exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
-      } else if (httr::status_code(resp) >= 500 && httr::status_code(resp) <= 599) {
-        error_msg <- toString(content(resp))
-        if (error_msg == "") {
-          error_msg <- "Api server exception encountered."
-        }
-        rlang::abort(message = error_msg,
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(http_response = resp))
+                     ApiException = ApiException$new(http_response = local_var_resp))
       }
     }
   )


### PR DESCRIPTION
Prefix local variables in API functions to avoid naming collisions with function parameters.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

