### PR TITLE
[R] Throw exception if username, password is not set in HTTP auth

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -308,6 +308,17 @@
       {{#isBasic}}
       {{#isBasicBasic}}
       # HTTP basic auth
+      if (is.null(self$api_client$username) || is.null(self$api_client$password)) {
+        {{#useDefaultExceptionHandling}}
+        stop("username, password in `api_client` must be set for authentication in the endpoint `{{{operationId}}}`.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "username, password in `api_client` must be set for authentication in the endpoint `{{{operationId}}}`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "username, password in `api_client` must be set for authentication in the endpoint `{{{operationId}}}`."))
+        {{/useRlangExceptionHandling}}
+      }
       header_params["Authorization"] <- paste("Basic", base64enc::base64encode(charToRaw(paste(self$api_client$username, self$api_client$password, sep = ":"))))
       {{/isBasicBasic}}
       {{#isBasicBearer}}

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -586,6 +586,12 @@ PetApi <- R6::R6Class(
 
       local_var_url_path <- "/pet"
       # HTTP basic auth
+      if (is.null(self$api_client$username) || is.null(self$api_client$password)) {
+        rlang::abort(message = "username, password in `api_client` must be set for authentication in the endpoint `AddPet`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "username, password in `api_client` must be set for authentication in the endpoint `AddPet`."))
+      }
       header_params["Authorization"] <- paste("Basic", base64enc::base64encode(charToRaw(paste(self$api_client$username, self$api_client$password, sep = ":"))))
 
       # The Accept request HTTP header

--- a/samples/client/petstore/R/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R/tests/testthat/test_petstore.R
@@ -11,8 +11,9 @@ pet <- Pet$new("name_test",
   ),
   status = "available"
 )
-pet_api$api_client$username <- "username123"
-pet_api$api_client$password <- "password123"
+
+pet_api$api_client$username <- ""
+pet_api$api_client$password <- ""
 result <- pet_api$AddPet(pet)
 
 test_that("Test toJSONString", {


### PR DESCRIPTION
Throw exception if username, password is not set in endpoints that require HTTP auth


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

