### PR TITLE
[Ruby] Remove configuring verbose option from Faraday template

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -67,7 +67,6 @@
       # Overload default options only if provided
       request.options.params_encoder = config.params_encoder if config.params_encoder
       request.options.timeout        = config.timeout        if config.timeout
-      request.options.verbose        = config.debugging      if config.debugging
 
       request.url url
       request.params = query_params

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -112,7 +112,6 @@ module Petstore
       # Overload default options only if provided
       request.options.params_encoder = config.params_encoder if config.params_encoder
       request.options.timeout        = config.timeout        if config.timeout
-      request.options.verbose        = config.debugging      if config.debugging
 
       request.url url
       request.params = query_params


### PR DESCRIPTION
We've run into this issue when setting `config.debugging = true`:
```rb
require 'petstore'
api_instance = Petstore::FakeApi.new

Petstore.configure do |config|
  config.debugging = true
end

result = api_instance.fake_health_get
```

> D, [2022-07-28T13:52:50.321834 #25054] DEBUG -- : Calling API: FakeApi.fake_health_get ...
> openapi-generator/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb:115:in `build_request': undefined method `verbose=' for #<Faraday::RequestOptions timeout=60> (NoMethodError)
> 
>       request.options.verbose        = config.debugging      if config.debugging
>                      ^^^^^^^^^^^^^^^^^


Looks like the `verbose` option [comes from typhoeus](https://github.com/OpenAPITools/openapi-generator/blob/79c5091de49a387a65bc87088b45e2be8aa8e484/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache#L71) but there is no support in Faraday:
https://github.com/lostisland/faraday/blob/v1.8.0/lib/faraday/options/request_options.rb#L5-L8


It had not been an issue but in [this PR](https://github.com/OpenAPITools/openapi-generator/pull/11692/files#diff-b83ea5b3cde19c1bb0527b22a0888c23e0ed6d91e1e623ea7af6118ed71749f0R89), the way to configure options was changed so the problem has surfaced: 
```diff
-      request.options = OpenStruct.new(req_opts)
          :
+      request.options.verbose         = @config.debugging       if @config.debugging
```


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
