### PR TITLE
Feat: Add freezed serialization to dart-dio generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -57,6 +57,8 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
 
     public static final String SERIALIZATION_LIBRARY_BUILT_VALUE = "built_value";
     public static final String SERIALIZATION_LIBRARY_JSON_SERIALIZABLE = "json_serializable";
+
+    public static final String SERIALIZATION_LIBRARY_FREEZED = "freezed";
     public static final String SERIALIZATION_LIBRARY_DEFAULT = SERIALIZATION_LIBRARY_BUILT_VALUE;
 
     private static final String DIO_IMPORT = "package:dio/dio.dart";
@@ -90,6 +92,8 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
 
         supportedLibraries.put(SERIALIZATION_LIBRARY_BUILT_VALUE, "[DEFAULT] built_value");
         supportedLibraries.put(SERIALIZATION_LIBRARY_JSON_SERIALIZABLE, "[BETA] json_serializable");
+        supportedLibraries.put(SERIALIZATION_LIBRARY_FREEZED, "[BETA] freezed");
+
         final CliOption serializationLibrary = CliOption.newString(CodegenConstants.SERIALIZATION_LIBRARY, "Specify serialization library");
         serializationLibrary.setEnum(supportedLibraries);
         serializationLibrary.setDefault(SERIALIZATION_LIBRARY_DEFAULT);
@@ -199,6 +203,10 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
                 additionalProperties.put("useJsonSerializable", "true");
                 configureSerializationLibraryJsonSerializable(srcFolder);
                 break;
+            case SERIALIZATION_LIBRARY_FREEZED:
+                additionalProperties.put("useFreezed", "true");
+                configureSerializationLibraryFreezed(srcFolder);
+                break;
             default:
             case SERIALIZATION_LIBRARY_BUILT_VALUE:
                 additionalProperties.put("useBuiltValue", "true");
@@ -255,6 +263,16 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
         supportingFiles.add(new SupportingFile("serialization/json_serializable/build.yaml.mustache", "" /* main project dir */, "build.yaml"));
         supportingFiles.add(new SupportingFile("serialization/json_serializable/deserialize.mustache", srcFolder,
                 "deserialize.dart"));
+
+        // most of these are defined in AbstractDartCodegen, we are overriding
+        // just the binary / file handling
+        languageSpecificPrimitives.add("Object");
+        imports.put("Uint8List", "dart:typed_data");
+        imports.put("MultipartFile", DIO_IMPORT);
+    }
+
+    private void configureSerializationLibraryFreezed(String srcFolder) {
+        supportingFiles.add(new SupportingFile("serialization/freezed/build.yaml.mustache", "" /* main project dir */, "build.yaml"));
 
         // most of these are defined in AbstractDartCodegen, we are overriding
         // just the binary / file handling

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
@@ -20,6 +20,10 @@ dependencies:
 {{#useJsonSerializable}}
   json_annotation: '^4.4.0'
 {{/useJsonSerializable}}
+{{#useFreezed}}
+  freezed_annotation: '^2.0.3'
+  json_annotation: '^4.4.0'
+{{/useFreezed}}
 {{#useDateLibTimeMachine}}
   time_machine: ^0.9.16
 {{/useDateLibTimeMachine}}
@@ -33,4 +37,9 @@ dev_dependencies:
   build_runner: any
   json_serializable: '^6.1.5'
 {{/useJsonSerializable}}
+{{#useFreezed}}
+  freezed: '^2.0.3'
+  json_serializable: '^6.1.4'
+  build_runner: any
+{{/useFreezed}}
   test: ^1.16.0

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/constructor.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/constructor.mustache
@@ -1,0 +1,1 @@
+  const {{classname}}(this._dio);

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/deserialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/deserialize.mustache
@@ -1,0 +1,28 @@
+{{#isResponseFile}}
+    _responseData = _response.data as {{{returnType}}};
+{{/isResponseFile}}
+{{^isResponseFile}}
+    {{#returnSimpleType}}
+        {{#returnTypeIsPrimitive}}
+            _responseData = _response.data as {{{returnType}}};
+        {{/returnTypeIsPrimitive}}
+        {{^returnTypeIsPrimitive}}
+            _responseData = {{{returnType}}}.fromJson(_response.data as Map<String,dynamic>);
+        {{/returnTypeIsPrimitive}}
+    {{/returnSimpleType}}
+    {{^returnSimpleType}}
+        {{#isArray}}
+            {{#uniqueItems}}
+                final _responseDataAsSet = _response.data as List<dynamic>;
+                    _responseData = _responseDataAsSet.map<{{{returnBaseType}}}>((dynamic e)=> {{{returnBaseType}}}.fromJson(e as Map<String, dynamic>)).toSet();
+            {{/uniqueItems}}
+            {{^uniqueItems}}
+                    final _responseDataAsList = _response.data as List<dynamic>;
+                    _responseData = _responseDataAsList.map<{{{returnBaseType}}}>((dynamic e)=> {{{returnBaseType}}}.fromJson(e as Map<String, dynamic>)).toList();
+            {{/uniqueItems}}
+        {{/isArray}}
+        {{#isMap}}
+                _responseData = _response.data as Map<String, {{{returnBaseType}}}>;
+        {{/isMap}}
+    {{/returnSimpleType}}
+{{/isResponseFile}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/imports.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/imports.mustache
@@ -1,0 +1,2 @@
+// ignore: unused_import
+import 'dart:convert';

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/query_param.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/query_param.mustache
@@ -1,0 +1,1 @@
+{{{paramName}}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/serialize.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/api/serialize.mustache
@@ -1,0 +1,1 @@
+{{#bodyParam}}_bodyData=jsonEncode({{{paramName}}});{{/bodyParam}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/build.yaml.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/build.yaml.mustache
@@ -1,0 +1,11 @@
+targets:
+  $default:
+    builders:
+      freezed|freezed:
+        # This restricts freezed build runner to look
+        # files only inside models folder.
+        # If you prefer the build runner to scan the whole
+        # project for files then simply remove this build.yaml file
+        generate_for:
+          include:
+            - "lib/src/model/**.dart"

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/class.mustache
@@ -1,0 +1,51 @@
+//ignore_for_file: invalid_annotation_target
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part '{{classFilename}}.g.dart';
+part '{{classFilename}}.freezed.dart';
+
+/// {{{description}}}{{^description}}{{classname}}{{/description}}
+{{#hasVars}}
+    ///
+    /// Properties:
+    {{#allVars}}
+        /// * [{{{name}}}] {{#description}}- {{{.}}}{{/description}}
+    {{/allVars}}
+{{/hasVars}}
+
+@freezed
+class {{classname}} with _${{classname}} {
+const {{classname}}._();
+
+const factory {{classname}}({
+{{#vars}}
+    {{#description}}
+        /// {{{.}}}
+    {{/description}}
+    @JsonKey(name: r'{{baseName}}') {{>serialization/freezed/variable_type}} {{name}},
+{{/vars}}
+}) = _{{classname}};
+
+factory {{classname}}.fromJson(Map<String, dynamic> json) => _${{classname}}FromJson(json);
+}
+
+{{!
+    Generate an enum for any variables that are declared as inline enums
+    isEnum is only true for inline variables that are enums.
+    If an enum is declared as a definition, isEnum is false and the enum is generated from the
+    enum.mustache template.
+}}
+{{#vars}}
+    {{#isEnum}}
+        {{^isContainer}}
+
+            {{>serialization/freezed/enum_inline}}
+        {{/isContainer}}
+        {{#isContainer}}
+            {{#mostInnerItems}}
+
+                {{>serialization/freezed/enum_inline}}
+            {{/mostInnerItems}}
+        {{/isContainer}}
+    {{/isEnum}}
+{{/vars}}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/enum.mustache
@@ -1,0 +1,12 @@
+//ignore_for_file: invalid_annotation_target
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+{{#description}}/// {{{description}}}{{/description}}
+enum {{classname}} {
+{{#allowableValues}}
+    {{#enumVars}}
+        @JsonValue({{#isString}}r{{/isString}}{{{value}}})
+        {{{name}}},
+    {{/enumVars}}
+{{/allowableValues}}
+}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/enum_inline.mustache
@@ -1,0 +1,8 @@
+{{#description}}/// {{{description}}}{{/description}}
+enum {{{enumName}}} {
+{{#allowableValues}}
+    {{#enumVars}}
+        @JsonValue(r{{{value}}}) {{{name}}},
+    {{/enumVars}}
+{{/allowableValues}}
+}

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/test_instance.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/test_instance.mustache
@@ -1,0 +1,2 @@
+  final {{{classname}}}? instance = /* {{{classname}}}(...) */ null;
+  // TODO add properties to the entity

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/variable_type.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/freezed/variable_type.mustache
@@ -1,0 +1,14 @@
+{{!
+Required   Nullable  Result
+true	   true	     required Type?
+true	   false	 required Type
+false	   true	     Type?
+false	   false	 Type?
+}}
+
+{{#required}}
+    {{#required}}required {{/required}}{{#isContainer}}{{baseType}}<{{#isMap}}String, {{/isMap}}{{#items}}{{>serialization/built_value/variable_type}}{{/items}}>{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{#isNullable}}?{{/isNullable}}
+{{/required}}
+{{^required}}
+    {{#isContainer}}{{baseType}}<{{#isMap}}String, {{/isMap}}{{#items}}{{>serialization/built_value/variable_type}}{{/items}}>{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}?
+{{/required}}


### PR DESCRIPTION
This PR is aimed at adding the freezed serialization to the dart-dio generator. The changes were actually copied from changes made on old branch which was tested quite a lot. Since the branches diverged I have migrated the changes to the freshly cloned branch.

The new changes could be tested by simply changing the serialization library to freezed.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)