### PR TITLE
Update php-symfony/model_variables.mustache to fix template bug (#13060)

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/model_variables.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_variables.mustache
@@ -77,10 +77,10 @@
     {{/minimum}}
     {{#maximum}}
     {{#exclusiveMaximum}}
-     * @Assert\LessThan({{minimum}})
+     * @Assert\LessThan({{maximum}})
     {{/exclusiveMaximum}}
     {{^exclusiveMaximum}}
-     * @Assert\LessThanOrEqual({{minimum}})
+     * @Assert\LessThanOrEqual({{maximum}})
     {{/exclusiveMaximum}}
     {{/maximum}}
     {{#pattern}}


### PR DESCRIPTION
Small fix to `modules/openapi-generator/src/main/resources/php-symfony/model_variables.mustache` (PHP Symfony generator) to fix variable typo in validation annotations