### PR TITLE
Issue 13043: [python-experimental] Fixed stackoverflow error in toExampleValueRecursive 

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonExperimentalClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonExperimentalClientTest.java
@@ -18,12 +18,15 @@ package org.openapitools.codegen.python;
 
 import com.google.common.io.Resources;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.*;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.PythonExperimentalClientCodegen;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @SuppressWarnings("static-method")
@@ -69,6 +72,30 @@ public class PythonExperimentalClientTest {
         Assert.assertEquals(openAPI.getOpenapi() , "3.0.0");
         Assert.assertFalse(openAPI.getExtensions().isEmpty());
         Assert.assertFalse(openAPI.getExtensions().containsValue("x-original-swagger-version"));
+    }
+
+    @Test(description = "tests GeoJson Examples")
+    public void testRecursiveGeoJsonExample() throws IOException {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_13043_recursive_model.yaml");
+        final PythonExperimentalClientCodegen codegen = new PythonExperimentalClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final Operation operation = openAPI.getPaths().get("/geojson").getPost();
+        Schema schema = ModelUtils.getSchemaFromRequestBody(operation.getRequestBody());
+        String exampleValue = codegen.toExampleValue(schema, null);
+
+       // uncomment if you need to regenerate the expected value
+       //        PrintWriter printWriter = new PrintWriter("src/test/resources/3_0/issue_8052_recursive_model_expected_value.txt");
+       //        printWriter.write(exampleValue);
+       //        printWriter.close();
+       //        org.junit.Assert.assertTrue(false);
+
+        String expectedValue = Resources.toString(
+                Resources.getResource("3_0/issue_13043_recursive_model_expected_value.txt"),
+                StandardCharsets.UTF_8);
+        expectedValue = expectedValue.replaceAll("\\r\\n", "\n");
+        Assert.assertEquals(exampleValue.trim(), expectedValue.trim());
+
     }
 
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_13043_recursive_model.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_13043_recursive_model.yaml
@@ -1,0 +1,83 @@
+openapi: 3.0.0
+info:
+  version: 01.01.00
+  title: APITest API documentation.
+  termsOfService: http://api.apitest.com/party/tos/
+servers:
+  - url: https://api.apitest.com/v1
+paths:
+  /geojson:
+    post:
+      summary: Add a GeoJson Object
+      operationId: post-geojson
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string
+                description: GeoJson ID
+        '400':
+          description: Bad Request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GeoJsonGeometry'
+      parameters: []
+components:
+  schemas:
+    GeoJsonGeometry:
+      title: GeoJsonGeometry
+      description: GeoJSON geometry
+      oneOf:
+        - $ref: '#/components/schemas/Point'
+        - $ref: '#/components/schemas/GeometryCollection'
+      discriminator:
+        propertyName: type
+        mapping:
+          Point: '#/components/schemas/Point'
+          GeometryCollection: '#/components/schemas/GeometryCollection'
+      externalDocs:
+        url: http://geojson.org/geojson-spec.html#geometry-objects
+    Point:
+      title: Point
+      type: object
+      description: GeoJSON geometry
+      externalDocs:
+        url: http://geojson.org/geojson-spec.html#id2
+      properties:
+        coordinates:
+          title: Point3D
+          type: array
+          description: Point in 3D space
+          externalDocs:
+            url: http://geojson.org/geojson-spec.html#id2
+          minItems: 2
+          maxItems: 3
+          items:
+            type: number
+            format: double
+        type:
+          type: string
+          default: Point
+      required:
+        - type
+    GeometryCollection:
+      title: GeometryCollection
+      type: object
+      description: GeoJSon geometry collection
+      required:
+        - type
+        - geometries
+      externalDocs:
+        url: http://geojson.org/geojson-spec.html#geometrycollection
+      properties:
+        type:
+          type: string
+          default: GeometryCollection
+        geometries:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeoJsonGeometry'

--- a/modules/openapi-generator/src/test/resources/3_0/issue_13043_recursive_model_expected_value.txt
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_13043_recursive_model_expected_value.txt
@@ -1,0 +1,4 @@
+GeoJsonGeometry(
+        type="GeometryCollection",
+        geometries=[],
+    )


### PR DESCRIPTION
In PythonExperimentalClientCodegen:
* Added a function to isolate the addition of schemas to the included schema list.  This function will throw an exception if a schema is added twice (an error condition).
* add composed schemas to the included shemas list (thanks @spacether)
* terminate recursion for anyType if a cycle is found (thanks @spacether )
* moved a call to addSchemasToIncludedSchemaList outside of the for loop in 'exampleForObjectModel'
* added unit test with spec to reproduce this bug

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
