### PR TITLE
Issue 13043: converted an exception to a warning

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonExperimentalClientCodegen.java
@@ -1687,13 +1687,12 @@ public class PythonExperimentalClientCodegen extends AbstractPythonCodegen {
      */
     private void addSchemaToIncludedSchemaList(List<Schema> includedSchemas, Schema schema) {
 
-        // if the schema is in the list, then throw an exception.
-        // this should never happen
+        // if the schema is in the list, issue a warning
         if(includedSchemas.contains(schema)) {
-            throw new RuntimeException("Attempted to add a schema to the includedSchemas list twice");
+            LOGGER.warn("Attempted to add a schema to the includedSchemas list twice");
+        } else {
+            includedSchemas.add(schema);
         }
-
-        includedSchemas.add(schema);
     }
 
     /***


### PR DESCRIPTION
Converted an exception to a warning when doubly adding schemas to the includedSchemas list.  Rather than crashing, the code will issue a warning and proceed.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@spacether 
