### PR TITLE
Issue 13043: Improved handling of recursive schemas

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonExperimentalClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonExperimentalClientTest.java
@@ -20,6 +20,7 @@ import com.google.common.io.Resources;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.*;
+import java.io.PrintWriter;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.PythonExperimentalClientCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -28,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.testng.reporters.jq.Model;
 
 @SuppressWarnings("static-method")
 public class PythonExperimentalClientTest {
@@ -74,24 +76,42 @@ public class PythonExperimentalClientTest {
         Assert.assertFalse(openAPI.getExtensions().containsValue("x-original-swagger-version"));
     }
 
-    @Test(description = "tests GeoJson Examples")
-    public void testRecursiveGeoJsonExample() throws IOException {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_13043_recursive_model.yaml");
+    @Test(description = "tests GeoJson Example for GeoJsonGeometry")
+    public void testRecursiveGeoJsonExampleWhenTypeIsGeoJsonGeometry() throws IOException {
+
+        testEndpointExampleValue("/geojson",
+                                 "src/test/resources/3_0/issue_13043_recursive_model.yaml",
+                                 "3_0/issue_13043_recursive_model_expected_value.txt");
+
+
+    }
+
+    @Test(description = "tests GeoJson Example for GeometryCollection")
+    public void testRecursiveGeoJsonExampleWhenTypeIsGeometryCollection() throws IOException {
+
+        testEndpointExampleValue("/geojson_geometry_collection",
+                                 "src/test/resources/3_0/issue_13043_recursive_model.yaml",
+                                 "3_0/issue_13043_geometry_collection_expected_value.txt");
+
+    }
+
+    private void testEndpointExampleValue(String endpoint, String specFilePath, String expectedAnswerPath) throws IOException {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec(specFilePath);
         final PythonExperimentalClientCodegen codegen = new PythonExperimentalClientCodegen();
         codegen.setOpenAPI(openAPI);
 
-        final Operation operation = openAPI.getPaths().get("/geojson").getPost();
+        final Operation operation = openAPI.getPaths().get(endpoint).getPost();
         Schema schema = ModelUtils.getSchemaFromRequestBody(operation.getRequestBody());
         String exampleValue = codegen.toExampleValue(schema, null);
 
-       // uncomment if you need to regenerate the expected value
-       //        PrintWriter printWriter = new PrintWriter("src/test/resources/3_0/issue_8052_recursive_model_expected_value.txt");
-       //        printWriter.write(exampleValue);
-       //        printWriter.close();
-       //        org.junit.Assert.assertTrue(false);
+        // uncomment if you need to regenerate the expected value
+        //        PrintWriter printWriter = new PrintWriter("src/test/resources/" + expectedAnswerPath);
+        //        printWriter.write(exampleValue);
+        //        printWriter.close();
+        //        org.junit.Assert.assertTrue(false);
 
         String expectedValue = Resources.toString(
-                Resources.getResource("3_0/issue_13043_recursive_model_expected_value.txt"),
+                Resources.getResource(expectedAnswerPath),
                 StandardCharsets.UTF_8);
         expectedValue = expectedValue.replaceAll("\\r\\n", "\n");
         Assert.assertEquals(exampleValue.trim(), expectedValue.trim());

--- a/modules/openapi-generator/src/test/resources/3_0/issue_13043_geometry_collection_expected_value.txt
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_13043_geometry_collection_expected_value.txt
@@ -1,0 +1,4 @@
+GeometryCollection(
+        type="GeometryCollection",
+        geometries=[],
+    )

--- a/modules/openapi-generator/src/test/resources/3_0/issue_13043_recursive_model.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_13043_recursive_model.yaml
@@ -26,6 +26,26 @@ paths:
             schema:
               $ref: '#/components/schemas/GeoJsonGeometry'
       parameters: []
+  /geojson_geometry_collection:
+    post:
+      summary: Add a GeoJson GeometryCollection Object
+      operationId: post-geojson-geometry-collection
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string
+                description: GeoJson ID
+        '400':
+          description: Bad Request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GeometryCollection'
+      parameters: []
 components:
   schemas:
     GeoJsonGeometry:


### PR DESCRIPTION
Converted Exception to a warning when a Schema is doubly added to the includedSchemas list
Broke recursion in a more reasonable place when generating example values

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
- [ ] @spacether 
