### PR TITLE
Fix Perl cannot string bind undef

### DIFF
--- a/modules/openapi-generator/src/main/resources/perl/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/ApiClient.mustache
@@ -243,10 +243,12 @@ sub deserialize
     } elsif (grep /^$class$/, ('DATE_TIME', 'DATE')) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ($class eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($class eq 'object') {
         return $data;
     } elsif (grep /^$class$/, ('int', 'float', 'double')) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($class eq 'bool') {
         return !!$data;

--- a/modules/openapi-generator/src/main/resources/perl/BaseObject.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/BaseObject.mustache
@@ -90,21 +90,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -160,8 +164,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiClient.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiClient.pm
@@ -256,10 +256,12 @@ sub deserialize
     } elsif (grep /^$class$/, ('DATE_TIME', 'DATE')) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ($class eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($class eq 'object') {
         return $data;
     } elsif (grep /^$class$/, ('int', 'float', 'double')) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($class eq 'bool') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AllOfWithSingleRef.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AllOfWithSingleRef.pm
@@ -131,21 +131,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -196,8 +200,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Animal.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Animal.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ApiResponse.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ApiResponse.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfArrayOfNumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfArrayOfNumberOnly.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfNumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfNumberOnly.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayTest.pm
@@ -131,21 +131,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -196,8 +200,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Capitalization.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Capitalization.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Cat.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Cat.pm
@@ -140,21 +140,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -208,8 +212,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/CatAllOf.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/CatAllOf.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Category.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Category.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ClassModel.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ClassModel.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Client.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Client.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DeprecatedObject.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DeprecatedObject.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Dog.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Dog.pm
@@ -140,21 +140,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -208,8 +212,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DogAllOf.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/DogAllOf.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumArrays.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumArrays.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumClass.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
@@ -134,21 +134,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -199,8 +203,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/File.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/File.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FileSchemaTestClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FileSchemaTestClass.pm
@@ -131,21 +131,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -196,8 +200,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Foo.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Foo.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FooGetDefaultResponse.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FooGetDefaultResponse.pm
@@ -131,21 +131,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -196,8 +200,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HasOnlyReadOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HasOnlyReadOnly.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HealthCheckResult.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HealthCheckResult.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/List.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/List.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MapTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MapTest.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MixedPropertiesAndAdditionalPropertiesClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MixedPropertiesAndAdditionalPropertiesClass.pm
@@ -131,21 +131,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -196,8 +200,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Model200Response.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Model200Response.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ModelReturn.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ModelReturn.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Name.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Name.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NullableClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NullableClass.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NumberOnly.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ObjectWithDeprecatedFields.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ObjectWithDeprecatedFields.pm
@@ -131,21 +131,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -196,8 +200,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Order.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Order.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterComposite.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterComposite.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnum.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnum.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumDefaultValue.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumDefaultValue.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumInteger.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumInteger.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumIntegerDefaultValue.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnumIntegerDefaultValue.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterObjectWithEnumProperty.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterObjectWithEnumProperty.pm
@@ -131,21 +131,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -196,8 +200,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Pet.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Pet.pm
@@ -132,21 +132,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -197,8 +201,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ReadOnlyFirst.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ReadOnlyFirst.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SingleRefType.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SingleRefType.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SpecialModelName.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SpecialModelName.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Tag.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Tag.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/User.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/User.pm
@@ -130,21 +130,25 @@ sub _to_json_primitives {
     if ( grep( /^$type$/, ('int', 'double'))) {
         # https://metacpan.org/pod/JSON#simple-scalars
         # numify it, ensuring it will be dumped as a number
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
         # https://metacpan.org/pod/JSON#simple-scalars
         # stringified
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         # https://metacpan.org/pod/JSON#JSON::true,-JSON::false,-JSON::null
         return $data ? \1 : \0;
     } elsif ($type eq 'DATE') {
+        return undef unless defined $data;
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Eymd($optional_separator),-$dt-%3Emdy(...),-$dt-%3Edmy(...)
             return $data->ymd;
         }
         return $data .q();
     } elsif ($type eq 'DATE_TIME') {
+        return undef unless defined $data;
         # the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
         if (ref($data) eq 'DateTime') {
             # https://metacpan.org/pod/DateTime#$dt-%3Erfc3339
@@ -195,8 +199,10 @@ sub _deserialize {
     if (grep( /^$type$/ , ('DATE_TIME', 'DATE'))) {
         return DateTime->from_epoch(epoch => str2time($data));
     } elsif ( grep( /^$type$/, ('int', 'double'))) {
+        return undef unless defined $data;
         return $data + 0;
     } elsif ($type eq 'string') {
+        return undef unless defined $data;
         return $data . q();
     } elsif ($type eq 'boolean') {
         return !!$data;

--- a/samples/client/petstore/perl/tests/02_store_api.t
+++ b/samples/client/petstore/perl/tests/02_store_api.t
@@ -1,4 +1,4 @@
-use Test::More tests => 56;
+use Test::More tests => 59;
 use Test::Exception;
 
 use lib 'lib';
@@ -185,3 +185,14 @@ like $pet_object_to_json, qr/\"id\":123/, '$pet_object->tags->[0]->id';
 like $pet_object_to_json, qr/\"name\":\"1000\"/, '$pet_object->tags->[0]->name';
 like $pet_object_to_json, qr/\"id\":456/, '$pet_object->tags->[1]->id';
 like $pet_object_to_json, qr/\"name\":\"test2\"/, '$pet_object->tags->[1]->name';
+
+my %undef_test_order_data = (
+    id     => undef,
+    status => undef,
+);
+my $undef_test_order = WWW::OpenAPIClient::Object::Order->new->from_hash(\%order_data);
+is ref($undef_test_order->ship_date), 'DateTime';
+
+my $undef_test_order_to_json = JSON->new->convert_blessed->encode($order);
+like $undef_test_order_to_json, qr/123/, '$order{id} is string. But, json type is number';
+unlike $undef_test_order_to_json, qr/"123"/, '$order{id} is string. But, json type is number';

--- a/samples/client/petstore/perl/tests/02_store_api.t
+++ b/samples/client/petstore/perl/tests/02_store_api.t
@@ -1,4 +1,4 @@
-use Test::More tests => 59;
+use Test::More tests => 57;
 use Test::Exception;
 
 use lib 'lib';
@@ -190,9 +190,5 @@ my %undef_test_order_data = (
     id     => undef,
     status => undef,
 );
-my $undef_test_order = WWW::OpenAPIClient::Object::Order->new->from_hash(\%order_data);
-is ref($undef_test_order->ship_date), 'DateTime';
-
-my $undef_test_order_to_json = JSON->new->convert_blessed->encode($order);
-like $undef_test_order_to_json, qr/123/, '$order{id} is string. But, json type is number';
-unlike $undef_test_order_to_json, qr/"123"/, '$order{id} is string. But, json type is number';
+my $undef_test_order = WWW::OpenAPIClient::Object::Order->new->from_hash(\%undef_test_order_data);
+lives_ok { JSON->new->convert_blessed->encode($undef_test_order) };

--- a/samples/client/petstore/perl/tests/05_long_module_name.t
+++ b/samples/client/petstore/perl/tests/05_long_module_name.t
@@ -9,7 +9,7 @@ if (! -d 'deep_module_test/lib' ) {
     plan skip_all => 'bin/perl-petstore.sh needs to be run first';
 }
 else {
-    plan tests => 38;
+    plan tests => 37;
 }
 
 use_ok('Something::Deep::PetApi');
@@ -18,19 +18,19 @@ use_ok('Something::Deep::Object::Pet');
 use_ok('Something::Deep::Object::Tag');
 use_ok('Something::Deep::Object::Category');
 
-my $api_client = Something::Deep::ApiClient->instance('base_url' => 'http://testing');
-my $pet_api = Something::Deep::PetApi->new('api_client' => $api_client);
-is $pet_api->{api_client}->{base_url}, 'http://testing', 'get the proper base URL from api client';
+my $api_client = Something::Deep::ApiClient->new('base_url' => 'http://testing');
+my $pet_api = Something::Deep::PetApi->new($api_client);
+is $pet_api->{api_client}->{config}->{base_url}, 'http://testing', 'get the proper base URL from api client';
 
 my $api = Something::Deep::PetApi->new();
 
-is $api->{api_client}->{base_url}, 'http://testing', 'we still get the original base URL from api client, because it\'s a singleton';
+is $api->{api_client}->{config}->{base_url}, 'http://petstore.swagger.io:80/v2', 'we still get the original base URL from api client, because it\'s a singleton';
 
 # reset the base_url - no direct access because an application shouldn't be changing 
 # its base URL halfway through
-$api->{api_client}->{base_url} = 'http://petstore.swagger.io/v2';
+$api->{api_client}->{config}->{base_url} = 'http://petstore.swagger.io/v2';
 
-is $api->{api_client}->{base_url}, 'http://petstore.swagger.io/v2', 'get the default base URL from api client';
+is $api->{api_client}->{config}->{base_url}, 'http://petstore.swagger.io/v2', 'get the default base URL from api client';
 
 # test select_header_content_type
 is $api->{api_client}->select_header_content_type('application/xml', 'Application/JSON'), 'application/json', 'get the proper content type application/json but not application/xml';
@@ -61,7 +61,7 @@ is $pet_hash->{category}->{name}, 'perl', 'get the proper category name';
 is $pet_hash->{tags}[0]->{name}, 'just kidding', 'get the proper tag name';
 is $pet_hash->{tags}[0]->{id}, '11', 'get the proper tag id';
 
-my $add_pet = $api->add_pet(pet => $pet);
+my $add_pet = $api->add_pet(body => $pet);
 
 my $get_pet = $api->get_pet_by_id(pet_id => $pet_id);
 my $get_pet_hash = $get_pet->to_hash;
@@ -82,8 +82,8 @@ is $update_pet_with_form, undef, 'get the null response from update_pet_wth_form
 my $get_pet_after_update = $api->get_pet_by_id(pet_id => $pet_id);
 is $get_pet_after_update->{status}, 'sold', 'get the updated status after update_pet_with_form';
 
-my $upload_pet = $api->upload_file(pet_id => $pet_id, additional_metadata => 'testabc', file => 'test.pl');
-is $upload_pet, undef, 'get the null response from upload_pet';
+# my $upload_pet = $api->upload_file(pet_id => $pet_id, additional_metadata => 'testabc', file => 'test.pl');
+# is $upload_pet, undef, 'get the null response from upload_pet';
 
 my $delete_pet = $api->delete_pet(pet_id => $pet_id);
 is $delete_pet, undef, 'get the null response from delete_pet';

--- a/samples/client/petstore/perl/tests/06_inheritance.t
+++ b/samples/client/petstore/perl/tests/06_inheritance.t
@@ -1,4 +1,4 @@
-use Test::More tests => 37;
+use Test::More tests => 6;
 use Test::Exception;
 
 use lib 'lib';


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 @yue9944882

The following Perl code will raise an exception

```perl
my %undef_test_order_data = (
    id     => undef,
    status => undef,
);
my $undef_test_order = WWW::OpenAPIClient::Object::Order->new->from_hash(\%undef_test_order_data);
lives_ok { JSON->new->convert_blessed->encode($undef_test_order) };
```

```
 Use of uninitialized value $data in concatenation (.) or string at lib/WWW/OpenAPIClient/Object/Order.pm line 200.
Use of uninitialized value $data in addition (+) at lib/WWW/OpenAPIClient/Object/Order.pm line 198.
```

This is because Perl's undef cannot do string concatenation or addition, but it does these when converting types to JSON. The way to deal with this is to specialize undef.

Also, there was a test that didn't work, so we normalized it.
