### PR TITLE
Better validation for R client parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -253,6 +253,100 @@
       }
 
       {{/requiredParams}}
+      {{#allParams}}
+      {{#maxLength}}
+      if (nchar(`{{paramName}}`) > {{maxLength}}) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, must be smaller than or equal to {{maxLength}}.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, must be smaller than or equal to {{maxLength}}.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid length for ${{paramName}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}."))
+        {{/useRlangExceptionHandling}}
+      }
+      {{/maxLength}}
+      {{#minLength}}
+      if (nchar(`{{paramName}}`) < {{minLength}}) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, must be bigger than or equal to {{minLength}}.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, must be bigger than or equal to {{minLength}}.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, must be bigger than or equal to {{minLength}}."))
+        {{/useRlangExceptionHandling}}
+      }
+      {{/minLength}}
+      {{#maximum}}
+      if (`{{paramName}}` >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}."))
+        {{/useRlangExceptionHandling}}
+      }
+      {{/maximum}}
+      {{#minimum}}
+      if (`{{paramName}}` <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}."))
+        {{/useRlangExceptionHandling}}
+      }
+      {{/minimum}}
+      {{#pattern}}
+      if (!str_detect(`{{paramName}}`, "{{{pattern}}}")) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must conform to the pattern {{{pattern}}}.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must conform to the pattern {{{pattern}}}.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}, must conform to the pattern {{{pattern}}}."))
+        {{/useRlangExceptionHandling}}
+      }
+      {{/pattern}}
+      {{#maxItems}}
+      if (length(`{{paramName}}`) > {{maxItems}}) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, number of items must be less than or equal to {{maxItems}}.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, number of items must be less than or equal to {{maxItems}}.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, number of items must be less than or equal to {{maxItems}}."))
+        {{/useRlangExceptionHandling}}
+      }
+      {{/maxItems}}
+      {{#minItems}}
+      if (length(`{{paramName}}`) < {{minItems}}) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, number of items must be greater than or equal to {{minItems}}.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, number of items must be greater than or equal to {{minItems}}.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid length for `{{paramName}}` when calling {{classname}}${{operationId}}, number of items must be greater than or equal to {{minItems}}."))
+        {{/useRlangExceptionHandling}}
+      }
+      {{/minItems}}
+
+      {{/allParams}}
       {{#headerParams}}
       header_params["{{baseName}}"] <- `{{paramName}}`
 

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -136,6 +136,8 @@ FakeApi <- R6::R6Class(
                                                      reason = "Missing required parameter `dummy`."))
       }
 
+
+
       header_params["dummy"] <- `dummy`
 
       header_params["data_file"] <- `var_data_file`

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -640,6 +640,7 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet`."))
       }
 
+
       if (!missing(`pet`)) {
         local_var_body <- `pet`$toJSONString()
       } else {
@@ -762,6 +763,8 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
+
+
       header_params["api_key"] <- `api_key`
 
       local_var_url_path <- "/pet/{petId}"
@@ -866,6 +869,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `status`."))
       }
+
 
       query_params["status"] <- `status`
 
@@ -981,6 +985,7 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `tags`."))
       }
 
+
       query_params["tags"] <- `tags`
 
       local_var_url_path <- "/pet/findByTags"
@@ -1094,6 +1099,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet_id`."))
       }
+
 
       local_var_url_path <- "/pet/{petId}"
       if (!missing(`pet_id`)) {
@@ -1216,6 +1222,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet_id`."))
       }
+
 
       local_var_url_path <- "/pet/{petId}?streaming"
       if (!missing(`pet_id`)) {
@@ -1344,6 +1351,7 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `header_test_int`."))
       }
 
+
       header_params["header_test_int"] <- `header_test_int`
 
       local_var_url_path <- "/pet_header_test"
@@ -1462,6 +1470,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet`."))
       }
+
 
       if (!missing(`pet`)) {
         local_var_body <- `pet`$toJSONString()
@@ -1583,6 +1592,9 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
+
+
+
       form_params["name"] <- `name`
       form_params["status"] <- `status`
       local_var_url_path <- "/pet/{petId}"
@@ -1691,6 +1703,9 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet_id`."))
       }
+
+
+
 
       form_params["additionalMetadata"] <- `additional_metadata`
       file_params["file"] <- curl::form_file(`file`)

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -284,6 +284,7 @@ StoreApi <- R6::R6Class(
                                                      reason = "Missing required parameter `order_id`."))
       }
 
+
       local_var_url_path <- "/store/order/{orderId}"
       if (!missing(`order_id`)) {
         local_var_url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), local_var_url_path)
@@ -486,6 +487,19 @@ StoreApi <- R6::R6Class(
                                                      reason = "Missing required parameter `order_id`."))
       }
 
+      if (`order_id` > 5) {
+        rlang::abort(message = "Invalid value for `order_id` when calling StoreApi$get_order_by_id, must be smaller than or equal to 5.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `order_id` when calling StoreApi$get_order_by_id, must be smaller than or equal to 5."))
+      }
+      if (`order_id` < 1) {
+        rlang::abort(message = "Invalid value for `order_id` when calling StoreApi$get_order_by_id, must be bigger than or equal to 1.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `order_id` when calling StoreApi$get_order_by_id, must be bigger than or equal to 1."))
+      }
+
       local_var_url_path <- "/store/order/{orderId}"
       if (!missing(`order_id`)) {
         local_var_url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), local_var_url_path)
@@ -597,6 +611,7 @@ StoreApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `order`."))
       }
+
 
       if (!missing(`order`)) {
         local_var_body <- `order`$toJSONString()

--- a/samples/client/petstore/R-httr2/R/user_api.R
+++ b/samples/client/petstore/R-httr2/R/user_api.R
@@ -470,6 +470,7 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `user`."))
       }
 
+
       if (!missing(`user`)) {
         local_var_body <- `user`$toJSONString()
       } else {
@@ -572,6 +573,7 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `user`."))
       }
+
 
       if (!missing(`user`)) {
         body.items <- paste(unlist(lapply(`user`, function(param) {
@@ -679,6 +681,7 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `user`."))
       }
 
+
       if (!missing(`user`)) {
         body.items <- paste(unlist(lapply(`user`, function(param) {
                                                              param$toJSONString()
@@ -785,6 +788,7 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `username`."))
       }
 
+
       local_var_url_path <- "/user/{username}"
       if (!missing(`username`)) {
         local_var_url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), local_var_url_path)
@@ -887,6 +891,7 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `username`."))
       }
+
 
       local_var_url_path <- "/user/{username}"
       if (!missing(`username`)) {
@@ -1008,6 +1013,14 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `password`."))
       }
+
+      if (!str_detect(`username`, "/^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$/")) {
+        rlang::abort(message = "Invalid value for `username` when calling UserApi$login_user, must conform to the pattern /^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$/.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `username` when calling UserApi$login_user, must conform to the pattern /^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$/."))
+      }
+
 
       query_params["username"] <- `username`
 
@@ -1215,6 +1228,8 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `user`."))
       }
+
+
 
       if (!missing(`user`)) {
         local_var_body <- `user`$toJSONString()

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -136,6 +136,8 @@ FakeApi <- R6::R6Class(
                                                      reason = "Missing required parameter `dummy`."))
       }
 
+
+
       header_params["dummy"] <- `dummy`
 
       header_params["data_file"] <- `var_data_file`

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -640,6 +640,7 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet`."))
       }
 
+
       if (!missing(`pet`)) {
         local_var_body <- `pet`$toJSONString()
       } else {
@@ -762,6 +763,8 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
+
+
       header_params["api_key"] <- `api_key`
 
       local_var_url_path <- "/pet/{petId}"
@@ -866,6 +869,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `status`."))
       }
+
 
       query_params["status"] <- `status`
 
@@ -981,6 +985,7 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `tags`."))
       }
 
+
       query_params["tags"] <- `tags`
 
       local_var_url_path <- "/pet/findByTags"
@@ -1094,6 +1099,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet_id`."))
       }
+
 
       local_var_url_path <- "/pet/{petId}"
       if (!missing(`pet_id`)) {
@@ -1216,6 +1222,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet_id`."))
       }
+
 
       local_var_url_path <- "/pet/{petId}?streaming"
       if (!missing(`pet_id`)) {
@@ -1344,6 +1351,7 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `header_test_int`."))
       }
 
+
       header_params["header_test_int"] <- `header_test_int`
 
       local_var_url_path <- "/pet_header_test"
@@ -1462,6 +1470,7 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet`."))
       }
+
 
       if (!missing(`pet`)) {
         local_var_body <- `pet`$toJSONString()
@@ -1583,6 +1592,9 @@ PetApi <- R6::R6Class(
                                                      reason = "Missing required parameter `pet_id`."))
       }
 
+
+
+
       form_params["name"] <- `name`
       form_params["status"] <- `status`
       local_var_url_path <- "/pet/{petId}"
@@ -1691,6 +1703,9 @@ PetApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `pet_id`."))
       }
+
+
+
 
       form_params["additionalMetadata"] <- `additional_metadata`
       file_params["file"] <- httr::upload_file(`file`)

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -284,6 +284,7 @@ StoreApi <- R6::R6Class(
                                                      reason = "Missing required parameter `order_id`."))
       }
 
+
       local_var_url_path <- "/store/order/{orderId}"
       if (!missing(`order_id`)) {
         local_var_url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), local_var_url_path)
@@ -486,6 +487,19 @@ StoreApi <- R6::R6Class(
                                                      reason = "Missing required parameter `order_id`."))
       }
 
+      if (`order_id` > 5) {
+        rlang::abort(message = "Invalid value for `order_id` when calling StoreApi$GetOrderById, must be smaller than or equal to 5.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `order_id` when calling StoreApi$GetOrderById, must be smaller than or equal to 5."))
+      }
+      if (`order_id` < 1) {
+        rlang::abort(message = "Invalid value for `order_id` when calling StoreApi$GetOrderById, must be bigger than or equal to 1.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `order_id` when calling StoreApi$GetOrderById, must be bigger than or equal to 1."))
+      }
+
       local_var_url_path <- "/store/order/{orderId}"
       if (!missing(`order_id`)) {
         local_var_url_path <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order_id`), reserved = TRUE), local_var_url_path)
@@ -597,6 +611,7 @@ StoreApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `order`."))
       }
+
 
       if (!missing(`order`)) {
         local_var_body <- `order`$toJSONString()

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -470,6 +470,7 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `user`."))
       }
 
+
       if (!missing(`user`)) {
         local_var_body <- `user`$toJSONString()
       } else {
@@ -572,6 +573,7 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `user`."))
       }
+
 
       if (!missing(`user`)) {
         body.items <- paste(unlist(lapply(`user`, function(param) {
@@ -679,6 +681,7 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `user`."))
       }
 
+
       if (!missing(`user`)) {
         body.items <- paste(unlist(lapply(`user`, function(param) {
                                                              param$toJSONString()
@@ -785,6 +788,7 @@ UserApi <- R6::R6Class(
                                                      reason = "Missing required parameter `username`."))
       }
 
+
       local_var_url_path <- "/user/{username}"
       if (!missing(`username`)) {
         local_var_url_path <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), local_var_url_path)
@@ -887,6 +891,7 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `username`."))
       }
+
 
       local_var_url_path <- "/user/{username}"
       if (!missing(`username`)) {
@@ -1008,6 +1013,14 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `password`."))
       }
+
+      if (!str_detect(`username`, "/^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$/")) {
+        rlang::abort(message = "Invalid value for `username` when calling UserApi$LoginUser, must conform to the pattern /^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$/.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `username` when calling UserApi$LoginUser, must conform to the pattern /^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$/."))
+      }
+
 
       query_params["username"] <- `username`
 
@@ -1215,6 +1228,8 @@ UserApi <- R6::R6Class(
                      ApiException = ApiException$new(status = 0,
                                                      reason = "Missing required parameter `user`."))
       }
+
+
 
       if (!missing(`user`)) {
         local_var_body <- `user`$toJSONString()


### PR DESCRIPTION
- Better validation for R client parameters


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @Ramanth (2019/07) @saigiridhar21 (2019/07)
