### PR TITLE
[R] Skip client id, secret validation to allow multiple auth schemas

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -438,17 +438,6 @@
       {{/isApiKey}}
       {{#isOAuth}}
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        {{#useDefaultExceptionHandling}}
-        stop("oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `{{{operationId}}}`.")
-        {{/useDefaultExceptionHandling}}
-        {{#useRlangExceptionHandling}}
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `{{{operationId}}}`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `{{{operationId}}}`."))
-        {{/useRlangExceptionHandling}}
-      }
       is_oauth <- TRUE
       oauth_scopes <- "{{#scopes}}{{scope}}{{^-last}} {{/-last}}{{/scopes}}"
       {{/isOAuth}}

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -276,7 +276,7 @@ ApiClient  <- R6::R6Class(
 
       {{#hasOAuthMethods}}
       # use oauth authentication if the endpoint requires it
-      if (is_oauth) {
+      if (is_oauth && !is.null(self$oauth_client_id) && !is.null(self$oauth_secret)) {
         client <- oauth_client(
           id = self$oauth_client_id,
           secret = obfuscated(self$oauth_secret),

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -267,7 +267,7 @@ ApiClient  <- R6::R6Class(
       req <- req %>% req_method(method)
 
       # use oauth authentication if the endpoint requires it
-      if (is_oauth) {
+      if (is_oauth && !is.null(self$oauth_client_id) && !is.null(self$oauth_secret)) {
         client <- oauth_client(
           id = self$oauth_client_id,
           secret = obfuscated(self$oauth_secret),

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -776,12 +776,6 @@ PetApi <- R6::R6Class(
       }
 
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `delete_pet`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `delete_pet`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "write:pets read:pets"
 
@@ -887,12 +881,6 @@ PetApi <- R6::R6Class(
 
       local_var_url_path <- "/pet/findByStatus"
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `find_pets_by_status`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `find_pets_by_status`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "read:pets"
 
@@ -1011,12 +999,6 @@ PetApi <- R6::R6Class(
 
       local_var_url_path <- "/pet/findByTags"
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `find_pets_by_tags`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `find_pets_by_tags`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "read:pets"
 
@@ -1522,12 +1504,6 @@ PetApi <- R6::R6Class(
 
       local_var_url_path <- "/pet"
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `update_pet`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `update_pet`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "write:pets read:pets"
 
@@ -1766,12 +1742,6 @@ PetApi <- R6::R6Class(
       }
 
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `upload_file`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `upload_file`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "write:pets read:pets"
 

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -776,12 +776,6 @@ PetApi <- R6::R6Class(
       }
 
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `DeletePet`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `DeletePet`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "write:pets read:pets"
 
@@ -887,12 +881,6 @@ PetApi <- R6::R6Class(
 
       local_var_url_path <- "/pet/findByStatus"
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `FindPetsByStatus`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `FindPetsByStatus`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "read:pets"
 
@@ -1011,12 +999,6 @@ PetApi <- R6::R6Class(
 
       local_var_url_path <- "/pet/findByTags"
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `FindPetsByTags`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `FindPetsByTags`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "read:pets"
 
@@ -1522,12 +1504,6 @@ PetApi <- R6::R6Class(
 
       local_var_url_path <- "/pet"
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `UpdatePet`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `UpdatePet`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "write:pets read:pets"
 
@@ -1766,12 +1742,6 @@ PetApi <- R6::R6Class(
       }
 
       # OAuth-related settings
-      if (is.null(self$api_client$oauth_client_id) || is.null(self$api_client$oauth_secret)) {
-        rlang::abort(message = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `UploadFile`.",
-                     .subclass = "ApiException",
-                     ApiException = ApiException$new(status = 0,
-                                                     reason = "oauth_client_id, oauth_secret in `api_client` must be set for authentication in the endpoint `UploadFile`."))
-      }
       is_oauth <- TRUE
       oauth_scopes <- "write:pets read:pets"
 


### PR DESCRIPTION
Skip client id, secret validation to allow multiple auth schemas

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
