### PR TITLE
fix deepcopy for allOf schemas

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/methods_shared.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/methods_shared.mustache
@@ -27,7 +27,7 @@
         if self.get("_spec_property_naming", False):
             new_inst = cls._new_from_openapi_data()
         else:
-            new_inst = cls.__new__(cls)
+            new_inst = cls.__new__(cls, **self.__dict__)
 
         for k, v in self.__dict__.items():
             setattr(new_inst, k, deepcopy(v, memo))

--- a/samples/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/client/petstore/python/petstore_api/model_utils.py
@@ -205,7 +205,7 @@ class OpenApiModel(object):
         if self.get("_spec_property_naming", False):
             new_inst = cls._new_from_openapi_data()
         else:
-            new_inst = cls.__new__(cls)
+            new_inst = cls.__new__(cls, **self.__dict__)
 
         for k, v in self.__dict__.items():
             setattr(new_inst, k, deepcopy(v, memo))

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model_utils.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model_utils.py
@@ -205,7 +205,7 @@ class OpenApiModel(object):
         if self.get("_spec_property_naming", False):
             new_inst = cls._new_from_openapi_data()
         else:
-            new_inst = cls.__new__(cls)
+            new_inst = cls.__new__(cls, **self.__dict__)
 
         for k, v in self.__dict__.items():
             setattr(new_inst, k, deepcopy(v, memo))

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
@@ -205,7 +205,7 @@ class OpenApiModel(object):
         if self.get("_spec_property_naming", False):
             new_inst = cls._new_from_openapi_data()
         else:
-            new_inst = cls.__new__(cls)
+            new_inst = cls.__new__(cls, **self.__dict__)
 
         for k, v in self.__dict__.items():
             setattr(new_inst, k, deepcopy(v, memo))

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
@@ -205,7 +205,7 @@ class OpenApiModel(object):
         if self.get("_spec_property_naming", False):
             new_inst = cls._new_from_openapi_data()
         else:
-            new_inst = cls.__new__(cls)
+            new_inst = cls.__new__(cls, **self.__dict__)
 
         for k, v in self.__dict__.items():
             setattr(new_inst, k, deepcopy(v, memo))

--- a/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
@@ -205,7 +205,7 @@ class OpenApiModel(object):
         if self.get("_spec_property_naming", False):
             new_inst = cls._new_from_openapi_data()
         else:
-            new_inst = cls.__new__(cls)
+            new_inst = cls.__new__(cls, **self.__dict__)
 
         for k, v in self.__dict__.items():
             setattr(new_inst, k, deepcopy(v, memo))

--- a/samples/openapi3/client/petstore/python/tests_manual/test_copy.py
+++ b/samples/openapi3/client/petstore/python/tests_manual/test_copy.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 import unittest
 from petstore_api.model.mammal import Mammal
 from petstore_api.model.triangle import Triangle
-
+from petstore_api.model.dog import Dog
 
 class TestCopy(unittest.TestCase):
     """TestCopy unit test stubs"""
@@ -26,6 +26,14 @@ class TestCopy(unittest.TestCase):
         assert deepcopy(obj) == obj
 
         obj = Triangle._new_from_openapi_data(shape_type="Triangle", triangle_type="EquilateralTriangle", foo="blah")
+        assert id(deepcopy(obj)) != id(obj)
+        assert deepcopy(obj) == obj
+
+        obj = Dog._new_from_openapi_data(class_name='Dog', color='white', breed='Jack Russel Terrier')
+        assert id(deepcopy(obj)) != id(obj)
+        assert deepcopy(obj) == obj
+
+        obj = Dog(class_name='Dog', color='white', breed='Jack Russel Terrier')
         assert id(deepcopy(obj)) != id(obj)
         assert deepcopy(obj) == obj
 


### PR DESCRIPTION
This PR solve the issue describe in https://github.com/OpenAPITools/openapi-generator/issues/13129.
The deepcopy function throws a ApiValueError (`Cannot deserialize input data due to missing discriminator. The discriminator property 'className' is missing at path: ()`) for some models with AllOf in schema e.g.,  `from petstore_api.model.dog import Dog`.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Python technical committee:
@taxpon @frol @mbohlool @cbornet  @kenjones-cisco @tomplus @arun-nalla @spacether 