### PR TITLE
Typescript axios object parameters fix

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -80,7 +80,7 @@ function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
         } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            Object.keys(parameter as Record<string, any>).forEach( currentKey => flattenQueryParams(urlSearchParams, parameter[currentKey], currentKey));
         }
     } else {
         urlSearchParams[key] = parameter;

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -81,13 +81,13 @@ function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -82,7 +82,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -75,23 +75,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -75,7 +75,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -76,13 +76,17 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 }
 
 function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( currentKey => flattenQueryParams(urlSearchParams, parameter[currentKey], currentKey));
+            (parameter as any[]).forEach(item => flattenQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                flattenQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
+    } 
+    else {
         urlSearchParams[key] = parameter;
     }
 }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -75,26 +75,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => flattenQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                flattenQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
             );
         }
     } 
     else {
-        urlSearchParams[key] = parameter;
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -103,10 +102,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -78,7 +78,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -84,22 +84,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -108,10 +111,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -84,23 +84,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -87,7 +87,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -84,19 +84,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -83,23 +83,33 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
+function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if(typeof parameter === "object") {
+        if (Array.isArray(parameter)) {
+            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
+        } else {
+            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+        }
+    } else {
+        urlSearchParams[key] = parameter;
+    }
+}
+
+function getFlattenedQueryParams(parameter: any): Record<string, any> {
+    const flattenedParameters = {};
+    flattenQueryParams(flattenedParameters, parameter);
+    return flattenedParameters;
+}
+
 /**
  *
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    for (const object of objects) {
-        for (const key in object) {
-            if (Array.isArray(object[key])) {
-                searchParams.delete(key);
-                for (const item of object[key]) {
-                    searchParams.append(key, item);
-                }
-            } else {
-                searchParams.set(key, object[key]);
-            }
-        }
+    const flattenedParameters = getFlattenedQueryParams(objects);
+    for (const key of Object.keys(flattenedParameters)) {
+        searchParams.append(key, flattenedParameters[key]);
     }
     url.search = searchParams.toString();
 }

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -86,7 +86,7 @@ export const setOAuthToObject = async function (object: any, name: string, scope
 function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
             Object.keys(parameter as Record<string, any>).forEach(currentKey => 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -83,22 +83,25 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function flattenQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
-    if(typeof parameter === "object") {
+function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+    if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach( item => flattenQueryParams(urlSearchParams, item));
-        } else {
-            Object.keys(parameter as Record<string, any>).forEach( _key => flattenQueryParams(urlSearchParams, parameter[_key], _key));
+            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item));
+        } 
+        else {
+            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            );
         }
-    } else {
-        urlSearchParams[key] = parameter;
+    } 
+    else {
+        if (urlSearchParams.get(key)) {
+            urlSearchParams.append(key, parameter);
+        } 
+        else {
+            urlSearchParams.set(key, parameter);
+        }
     }
-}
-
-function getFlattenedQueryParams(parameter: any): Record<string, any> {
-    const flattenedParameters = {};
-    flattenQueryParams(flattenedParameters, parameter);
-    return flattenedParameters;
 }
 
 /**
@@ -107,10 +110,7 @@ function getFlattenedQueryParams(parameter: any): Record<string, any> {
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
-    const flattenedParameters = getFlattenedQueryParams(objects);
-    for (const key of Object.keys(flattenedParameters)) {
-        searchParams.append(key, flattenedParameters[key]);
-    }
+    setFlattenedQueryParams(searchParams, objects);
     url.search = searchParams.toString();
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -83,19 +83,19 @@ export const setOAuthToObject = async function (object: any, name: string, scope
     }
 }
 
-function setFlattenedQueryParams(urlSearchParams: Record<string, any>, parameter: any, key: string=""): void {
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
     if (typeof parameter === "object") {
         if (Array.isArray(parameter)) {
             (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
         } 
         else {
-            Object.keys(parameter as Record<string, any>).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], currentKey)
+            Object.keys(parameter).forEach(currentKey => 
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
             );
         }
     } 
     else {
-        if (urlSearchParams.get(key)) {
+        if (urlSearchParams.has(key)) {
             urlSearchParams.append(key, parameter);
         } 
         else {


### PR DESCRIPTION
Referring to a recently merged PR - https://github.com/OpenAPITools/openapi-generator/pull/13051
The current output with the above merge is buggy:
`cool/api?.pageable.page=10&.pageable.size=20`

There is a "." before every parameter. The fix for "." prefix before every query parameter is added in [this](https://github.com/OpenAPITools/openapi-generator/pull/13148/commits/b9805234be02d959c752421c1a5f964d8ad016d9) commit of this PR.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
