### PR TITLE
[Typescript-axios] Dot prefix on every query parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -82,7 +82,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -82,7 +82,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -91,7 +91,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -91,7 +91,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}.${currentKey}`)
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
             );
         }
     } 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -90,7 +90,7 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
         } 
         else {
             Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], (key ? `${key}.${currentKey}` : currentKey))
+                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
             );
         }
     } 


### PR DESCRIPTION
Referring to a recently merged PR - https://github.com/OpenAPITools/openapi-generator/pull/13051
@macjohnny The current output with the above merge is little buggy:
`cool/api?.pageable.page=10&.pageable.size=20`

There is a "." before every parameter. The fix for "." prefix before every query parameter is added.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
