### PR TITLE
Fixed regular expression in python client codegen that was removing any trailing chars instead of only expected ones

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -1175,7 +1175,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
                     RxGen does not support our ECMA dialect https://github.com/curious-odd-man/RgxGen/issues/56
                     So strip off the leading / and trailing / and turn on ignore case if we have it
                      */
-                    Pattern valueExtractor = Pattern.compile("^/?(.+?)/?(.?)$");
+                    Pattern valueExtractor = Pattern.compile("^/?(.+?)/?(i?)$");
                     Matcher m = valueExtractor.matcher(pattern);
                     RgxGen rgxGen = null;
                     if (m.find()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -1173,7 +1173,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
                     String pattern = schema.getPattern();
                     /*
                     RxGen does not support our ECMA dialect https://github.com/curious-odd-man/RgxGen/issues/56
-                    So strip off the leading / and trailing / and turn on ignore case if we have it
+                    So strip off the leading /, trailing / and trailing /i, and turn on ignore case if we have it
                      */
                     Pattern valueExtractor = Pattern.compile("^/?(.+?)/?(i?)$");
                     Matcher m = valueExtractor.matcher(pattern);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -35,6 +35,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.PythonClientCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -453,6 +456,30 @@ public class PythonClientTest {
         Assert.assertEquals(property1.baseName, "datetime");
         Assert.assertEquals(property1.pattern, "/[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{1,2}:[\\d]{2}Z/");
         Assert.assertEquals(property1.vendorExtensions.get("x-regex"), "[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{1,2}:[\\d]{2}Z");
+
+        // ignore warnings, should be the same as in issue_11521.yaml
+        Pattern pattern = Pattern.compile("[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{1,2}:[\\d]{2}Z");
+        Matcher matcher = pattern.matcher(property1.example);
+        Assert.assertTrue(matcher.find());
+    }
+
+    @Test(description = "tests uuid example works even if a pattern is provided")
+    public void testUuidExampleWorksEvenIfPatternIsDefined() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issues_13069.yaml");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Operation operation = openAPI.getPaths().get("/test").getGet();
+        CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
+        codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
+
+        String modelName = "UUID";
+        Schema modelSchema = ModelUtils.getSchema(openAPI, modelName);
+        final CodegenModel model = codegen.fromModel(modelName, modelSchema);
+
+        Pattern pattern = Pattern.compile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}");
+        Matcher matcher = pattern.matcher(codegenParameter.example);
+        Assert.assertTrue(matcher.find());
     }
 
     @Test(description = "tests RecursiveToExample")

--- a/modules/openapi-generator/src/test/resources/3_0/issues_13069.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issues_13069.yaml
@@ -1,0 +1,23 @@
+---
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0-SNAPSHOT
+paths:
+  /test:
+    get:
+      parameters:
+        - name: uuid
+          in: query
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    UUID:
+      format: uuid
+      pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+      type: string

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -865,7 +865,7 @@ with petstore_api.ApiClient(configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
     number = 32.1 # float | None
     double = 67.8 # float | None
-    pattern_without_delimiter = "Aj" # str | None
+    pattern_without_delimiter = "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C>" # str | None
     byte = 'YQ==' # str | None
     integer = 10 # int | None (optional)
     int32 = 20 # int | None (optional)

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/docs/FakeApi.md
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/docs/FakeApi.md
@@ -865,7 +865,7 @@ with petstore_api.ApiClient(configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
     number = 32.1 # float | None
     double = 67.8 # float | None
-    pattern_without_delimiter = "Aj" # str | None
+    pattern_without_delimiter = "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C>" # str | None
     byte = 'YQ==' # str | None
     integer = 10 # int | None (optional)
     int32 = 20 # int | None (optional)

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -1327,7 +1327,7 @@ with petstore_api.ApiClient(configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
     number = 32.1 # float | None
     double = 67.8 # float | None
-    pattern_without_delimiter = "Aj" # str | None
+    pattern_without_delimiter = "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C>" # str | None
     byte = 'YQ==' # str | None
     integer = 10 # int | None (optional)
     int32 = 20 # int | None (optional)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The previous regular expression was too open, including any last character in the second group. This commit fixes that, making sure we only remove leading forward slashes, trailing forward slashes or trailing `\i`.

Added a UT that failed prior to this change and edited an existing UT to cover the case where the regex field is not a first class citizen but instead a property inside an object (or Schema).

You can see the original issue for more details.

This commit closes [13069](https://github.com/OpenAPITools/openapi-generator/issues/13069).


**Weird things for reviewers to pay attention to:**

1.  In the testRegexObjects there is an assert that the `property1.pattern` was appended with the leading and trailing slashes (this is done in DefaultCodegen#toRegularExpression). However, if we check the generated `property1.example` prior to my change, it was wrong because the example generation uses the schema.pattern that does not have the leading and trailing slashes appended. I'm unsure if there is another bug somewhere... perhaps we want to use the pattern with appended slashes in the schema ? 
2. The appending of / to the regular expressions in DefaultCodegen#toRegularExpression is used in DefaultCodegen#fromParameter, DefaultCodegen#fromResponse, DefaultCodegen#fromFormProperty but if the UUID is a first class citizen like in the example I provided in the issue or the file I added for the new test, it does not pass in any of these meaning the pattern does not have the slashes added. Is this the expected behavior ? 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
