### PR TITLE
fix: [csharp-netcore]: anyOf fixes for Primitive types

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelAnyOf.mustache
@@ -1,3 +1,4 @@
+{{#model}}
     /// <summary>
     /// {{description}}{{^description}}{{classname}}{{/description}}
     /// </summary>
@@ -22,20 +23,22 @@
         }
 
         {{/isNullable}}
-        {{#anyOf}}
+        {{#composedSchemas.anyOf}}
+        {{^isNull}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class
-        /// with the <see cref="{{#lambdaCref}}{{{.}}}{{/lambdaCref}}" /> class
+        /// with the <see cref="{{#lambdaCref}}{{{dataType}}}{{/lambdaCref}}" /> class
         /// </summary>
-        /// <param name="actualInstance">An instance of {{{.}}}.</param>
-        public {{classname}}({{{.}}} actualInstance)
+        /// <param name="actualInstance">An instance of {{dataType}}.</param>
+        public {{classname}}({{{dataType}}} actualInstance)
         {
-            this.IsNullable = {{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}};
+            this.IsNullable = {{#model.isNullable}}true{{/model.isNullable}}{{^model.isNullable}}false{{/model.isNullable}};
             this.SchemaType= "anyOf";
-            this.ActualInstance = actualInstance{{^isNullable}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isNullable}};
+            this.ActualInstance = actualInstance{{^model.isNullable}}{{^isPrimitiveType}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isPrimitiveType}}{{#isPrimitiveType}}{{#isArray}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isArray}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isFreeFormObject}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isFreeFormObject}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isString}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isString}}{{/isPrimitiveType}}{{/model.isNullable}};
         }
 
-        {{/anyOf}}
+        {{/isNull}}
+        {{/composedSchemas.anyOf}}
 
         private Object _actualInstance;
 
@@ -62,18 +65,20 @@
                 }
             }
         }
-        {{#anyOf}}
+        {{#composedSchemas.anyOf}}
+        {{^isNull}}
 
         /// <summary>
-        /// Get the actual instance of `{{{.}}}`. If the actual instance is not `{{{.}}}`,
+        /// Get the actual instance of `{{dataType}}`. If the actual instance is not `{{dataType}}`,
         /// the InvalidClassException will be thrown
         /// </summary>
-        /// <returns>An instance of {{{.}}}</returns>
-        public {{{.}}} Get{{{.}}}()
+        /// <returns>An instance of {{dataType}}</returns>
+        public {{{dataType}}} Get{{#lambda.titlecase}}{{baseType}}{{/lambda.titlecase}}{{#isArray}}{{#lambda.titlecase}}{{{dataFormat}}}{{/lambda.titlecase}}{{/isArray}}()
         {
-            return ({{{.}}})this.ActualInstance;
+            return ({{{dataType}}})this.ActualInstance;
         }
-        {{/anyOf}}
+        {{/isNull}}
+        {{/composedSchemas.anyOf}}
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -233,3 +238,4 @@
             return false;
         }
     }
+{{/model}}


### PR DESCRIPTION
* fixes issue [#13170 ](https://github.com/OpenAPITools/openapi-generator/issues/13170) : fixed null-coalescing operator incorrectly used for primitive types with the same changes than @jafin made in https://github.com/OpenAPITools/openapi-generator/pull/11427


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  **"nothing to commit", it appears there is no change in either petstore sample or docs.**
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @mandrean @frankyjuang @shibayan @Blackclaws @lucamazzanti

_I am not really used to github, feel free to advise if I should change something for the PR._