### PR TITLE
[Rust] Issue 13171: Prefix reserved words with raw identifiers (r#)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -415,7 +415,8 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         if (this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }
-        return '_' + name;
+        // https://doc.rust-lang.org/book/appendix-01-keywords.html#raw-identifiers
+        return "r#" + name;
     }
 
     @Override
@@ -443,11 +444,11 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         // snake_case, e.g. PetId => pet_id
         name = underscore(name);
 
-        // for reserved word or word starting with number, append _
+        // for reserved word, prepend r#
         if (isReservedWord(name))
             name = escapeReservedWord(name);
 
-        // for reserved word or word starting with number, append _
+        // for word starting with number, prepend var_
         if (name.matches("^\\d.*"))
             name = "var_" + name;
 
@@ -755,8 +756,9 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        if (isReservedWord(enumName) || enumName.matches("\\d.*")) { // reserved word or starts with number
-            return escapeReservedWord(enumName);
+        // Reserved words are not possible because we have already converted to camelcase
+        if (enumName.matches("\\d.*")) { // word starts with number
+            return "Variant" + enumName;
         } else {
             return enumName;
         }

--- a/samples/client/petstore/rust/hyper/petstore/docs/ApiResponse.md
+++ b/samples/client/petstore/rust/hyper/petstore/docs/ApiResponse.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **code** | Option<**i32**> |  | [optional]
-**_type** | Option<**String**> |  | [optional]
+**r#type** | Option<**String**> |  | [optional]
 **message** | Option<**String**> |  | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/hyper/petstore/src/models/api_response.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/api_response.rs
@@ -17,7 +17,7 @@ pub struct ApiResponse {
     #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
+    pub r#type: Option<String>,
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
@@ -27,7 +27,7 @@ impl ApiResponse {
     pub fn new() -> ApiResponse {
         ApiResponse {
             code: None,
-            _type: None,
+            r#type: None,
             message: None,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-async/docs/ApiResponse.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async/docs/ApiResponse.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **code** | Option<**i32**> |  | [optional]
-**_type** | Option<**String**> |  | [optional]
+**r#type** | Option<**String**> |  | [optional]
 **message** | Option<**String**> |  | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/api_response.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/api_response.rs
@@ -17,7 +17,7 @@ pub struct ApiResponse {
     #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
+    pub r#type: Option<String>,
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
@@ -27,7 +27,7 @@ impl ApiResponse {
     pub fn new() -> ApiResponse {
         ApiResponse {
             code: None,
-            _type: None,
+            r#type: None,
             message: None,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/ApiResponse.md
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/ApiResponse.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **code** | Option<**i32**> |  | [optional]
-**_type** | Option<**String**> |  | [optional]
+**r#type** | Option<**String**> |  | [optional]
 **message** | Option<**String**> |  | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/api_response.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/api_response.rs
@@ -17,7 +17,7 @@ pub struct ApiResponse {
     #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
+    pub r#type: Option<String>,
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
@@ -27,7 +27,7 @@ impl ApiResponse {
     pub fn new() -> ApiResponse {
         ApiResponse {
             code: None,
-            _type: None,
+            r#type: None,
             message: None,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore/docs/ApiResponse.md
+++ b/samples/client/petstore/rust/reqwest/petstore/docs/ApiResponse.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **code** | Option<**i32**> |  | [optional]
-**_type** | Option<**String**> |  | [optional]
+**r#type** | Option<**String**> |  | [optional]
 **message** | Option<**String**> |  | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/api_response.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/api_response.rs
@@ -17,7 +17,7 @@ pub struct ApiResponse {
     #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub _type: Option<String>,
+    pub r#type: Option<String>,
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
@@ -27,7 +27,7 @@ impl ApiResponse {
     pub fn new() -> ApiResponse {
         ApiResponse {
             code: None,
-            _type: None,
+            r#type: None,
             message: None,
         }
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Solves the issue I opened here: https://github.com/OpenAPITools/openapi-generator/issues/13171

> Raw identifiers are the syntax that lets you use keywords where they wouldn’t normally be allowed. You use a raw identifier by prefixing a keyword with r#.

Rust technical committee tags:
@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
