### PR TITLE
[R] allow oauth scopes customization, remove unused import

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -287,7 +287,7 @@ ApiClient  <- R6::R6Class(
         )
 
         req_oauth_scopes <- NULL
-        if (is.null(self$oauth_scopes)) {
+        if (!is.null(self$oauth_scopes)) {
           # use oauth scopes provided by the user
           req_oauth_scopes <- self$oauth_scopes
         } else {

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -32,6 +32,7 @@
 #' @field oauth_authorization_url Authoriziation URL
 #' @field oauth_token_url Token URL
 #' @field oauth_pkce Boolean flag to enable PKCE
+#' @field oauth_scopes OAuth scopes
 {{/isOAuth}}
 {{/authMethods}}
 {{/hasOAuthMethods}}
@@ -39,7 +40,6 @@
 #' @field timeout Default timeout in seconds
 #' @field retry_status_codes vector of status codes to retry
 #' @field max_retry_attempts maximum number of retries for the status codes
-#' @importFrom httr add_headers accept timeout content
 {{#useRlangExceptionHandling}}
 #' @importFrom rlang abort
 {{/useRlangExceptionHandling}}
@@ -79,6 +79,8 @@ ApiClient  <- R6::R6Class(
     oauth_token_url = "{{tokenUrl}}",
     # Enable PKCE?
     oauth_pkce = TRUE,
+    # OAuth scopes
+    oauth_scopes = NULL,
     {{/isOAuth}}
     {{/authMethods}}
     {{/hasOAuthMethods}}
@@ -283,7 +285,17 @@ ApiClient  <- R6::R6Class(
           token_url = self$oauth_token_url,
           name = "{{packageName}}-oauth"
         )
-        req <- req %>% req_oauth_auth_code(client, scope = oauth_scopes,
+
+        req_oauth_scopes <- NULL
+        if (is.null(self$oauth_scopes)) {
+          # use oauth scopes provided by the user
+          req_oauth_scopes <- self$oauth_scopes
+        } else {
+          # use oauth scopes defined in openapi spec
+          req_oauth_scopes <- oauth_scopes
+        }
+
+        req <- req %>% req_oauth_auth_code(client, scope = req_oauth_scopes,
                                            pkce = self$oauth_pkce,
                                            auth_url = self$oauth_authoriziation_url)
       }

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -36,11 +36,11 @@
 #' @field oauth_authorization_url Authoriziation URL
 #' @field oauth_token_url Token URL
 #' @field oauth_pkce Boolean flag to enable PKCE
+#' @field oauth_scopes OAuth scopes
 #' @field bearer_token Bearer token
 #' @field timeout Default timeout in seconds
 #' @field retry_status_codes vector of status codes to retry
 #' @field max_retry_attempts maximum number of retries for the status codes
-#' @importFrom httr add_headers accept timeout content
 #' @importFrom rlang abort
 #' @export
 ApiClient  <- R6::R6Class(
@@ -75,6 +75,8 @@ ApiClient  <- R6::R6Class(
     oauth_token_url = "",
     # Enable PKCE?
     oauth_pkce = TRUE,
+    # OAuth scopes
+    oauth_scopes = NULL,
     # Bearer token
     bearer_token = NULL,
     # Time Out (seconds)
@@ -274,7 +276,17 @@ ApiClient  <- R6::R6Class(
           token_url = self$oauth_token_url,
           name = "petstore-oauth"
         )
-        req <- req %>% req_oauth_auth_code(client, scope = oauth_scopes,
+
+        req_oauth_scopes <- NULL
+        if (is.null(self$oauth_scopes)) {
+          # use oauth scopes provided by the user
+          req_oauth_scopes <- self$oauth_scopes
+        } else {
+          # use oauth scopes defined in openapi spec
+          req_oauth_scopes <- oauth_scopes
+        }
+
+        req <- req %>% req_oauth_auth_code(client, scope = req_oauth_scopes,
                                            pkce = self$oauth_pkce,
                                            auth_url = self$oauth_authoriziation_url)
       }

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -278,7 +278,7 @@ ApiClient  <- R6::R6Class(
         )
 
         req_oauth_scopes <- NULL
-        if (is.null(self$oauth_scopes)) {
+        if (!is.null(self$oauth_scopes)) {
           # use oauth scopes provided by the user
           req_oauth_scopes <- self$oauth_scopes
         } else {

--- a/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
@@ -114,6 +114,7 @@ test_that("update_pet_with_form", {
   ## update pet with form
   pet_api$api_client$oauth_client_id <- "client_id_aaa"
   pet_api$api_client$oauth_secret <- "secrete_bbb"
+  pet_api$api_client$oauth_scopes <- "write:pets read:pets"
   update_result <- pet_api$update_pet_with_form(update_pet_id, name = "pet2", status = "sold")
 
   # get pet


### PR DESCRIPTION
- allow oauth scopes customization
- remove unused import

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
