### PR TITLE
[R] add refresh token setting, use oauth_client_secret instead

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -24,7 +24,7 @@
 {{#hasOAuthMethods}}
 #' @field access_token Access token
 #' @field oauth_client_id OAuth client ID
-#' @field oauth_secret OAuth secret
+#' @field oauth_client_secret OAuth secret
 #' @field oauth_refresh_token OAuth refresh token
 {{#authMethods}}
 {{#isOAuth}}
@@ -65,7 +65,7 @@ ApiClient  <- R6::R6Class(
     # OAuth2 client ID
     oauth_client_id = NULL,
     # OAuth2 secret
-    oauth_secret = NULL,
+    oauth_client_secret = NULL,
     # OAuth2 refresh token
     oauth_refresh_token = NULL,
     # OAuth2

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -24,7 +24,7 @@
 {{#hasOAuthMethods}}
 #' @field access_token Access token
 #' @field oauth_client_id OAuth client ID
-#' @field oauth_secret OAuth secret
+#' @field oauth_client_secret OAuth secret
 #' @field oauth_refresh_token OAuth refresh token
 {{#authMethods}}
 {{#isOAuth}}
@@ -32,6 +32,7 @@
 #' @field oauth_authorization_url Authoriziation URL
 #' @field oauth_token_url Token URL
 #' @field oauth_pkce Boolean flag to enable PKCE
+#' @field oauth_scopes OAuth scopes
 #' @field oauth_scopes OAuth scopes
 {{/isOAuth}}
 {{/authMethods}}
@@ -65,9 +66,11 @@ ApiClient  <- R6::R6Class(
     # OAuth2 client ID
     oauth_client_id = NULL,
     # OAuth2 secret
-    oauth_secret = NULL,
+    oauth_client_secret = NULL,
     # OAuth2 refresh token
     oauth_refresh_token = NULL,
+    # OAuth2 auto refresh token
+    oauth_auto_refresh_token = FALSE,
     # OAuth2
     {{#authMethods}}
     {{#isOAuth}}
@@ -187,6 +190,7 @@ ApiClient  <- R6::R6Class(
       # set the URL
       req <- request(url)
 
+      # make the call via httr, which comes with retry logic
       resp <- self$Execute(req, method, query_params, header_params, form_params,
                            file_params, accepts, content_types, body, is_oauth = is_oauth,
                            oauth_scopes = oauth_scopes, stream_callback = stream_callback, ...)
@@ -278,10 +282,10 @@ ApiClient  <- R6::R6Class(
 
       {{#hasOAuthMethods}}
       # use oauth authentication if the endpoint requires it
-      if (is_oauth && !is.null(self$oauth_client_id) && !is.null(self$oauth_secret)) {
+      if (is_oauth && !is.null(self$oauth_client_id) && !is.null(self$oauth_client_secret)) {
         client <- oauth_client(
           id = self$oauth_client_id,
-          secret = obfuscated(self$oauth_secret),
+          secret = obfuscated(self$oauth_client_secret),
           token_url = self$oauth_token_url,
           name = "{{packageName}}-oauth"
         )

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -30,12 +30,13 @@
 #' @field api_keys API keys
 #' @field access_token Access token
 #' @field oauth_client_id OAuth client ID
-#' @field oauth_secret OAuth secret
+#' @field oauth_client_secret OAuth secret
 #' @field oauth_refresh_token OAuth refresh token
 #' @field oauth_flow_type OAuth flow type
 #' @field oauth_authorization_url Authoriziation URL
 #' @field oauth_token_url Token URL
 #' @field oauth_pkce Boolean flag to enable PKCE
+#' @field oauth_scopes OAuth scopes
 #' @field oauth_scopes OAuth scopes
 #' @field bearer_token Bearer token
 #' @field timeout Default timeout in seconds
@@ -63,9 +64,11 @@ ApiClient  <- R6::R6Class(
     # OAuth2 client ID
     oauth_client_id = NULL,
     # OAuth2 secret
-    oauth_secret = NULL,
+    oauth_client_secret = NULL,
     # OAuth2 refresh token
     oauth_refresh_token = NULL,
+    # OAuth2 auto refresh token
+    oauth_auto_refresh_token = FALSE,
     # OAuth2
     # Flow type
     oauth_flow_type = "implicit",
@@ -180,6 +183,7 @@ ApiClient  <- R6::R6Class(
       # set the URL
       req <- request(url)
 
+      # make the call via httr, which comes with retry logic
       resp <- self$Execute(req, method, query_params, header_params, form_params,
                            file_params, accepts, content_types, body, is_oauth = is_oauth,
                            oauth_scopes = oauth_scopes, stream_callback = stream_callback, ...)
@@ -269,10 +273,10 @@ ApiClient  <- R6::R6Class(
       req <- req %>% req_method(method)
 
       # use oauth authentication if the endpoint requires it
-      if (is_oauth && !is.null(self$oauth_client_id) && !is.null(self$oauth_secret)) {
+      if (is_oauth && !is.null(self$oauth_client_id) && !is.null(self$oauth_client_secret)) {
         client <- oauth_client(
           id = self$oauth_client_id,
-          secret = obfuscated(self$oauth_secret),
+          secret = obfuscated(self$oauth_client_secret),
           token_url = self$oauth_token_url,
           name = "petstore-oauth"
         )

--- a/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
@@ -113,7 +113,7 @@ test_that("update_pet_with_form", {
 
   ## update pet with form
   pet_api$api_client$oauth_client_id <- "client_id_aaa"
-  pet_api$api_client$oauth_secret <- "secrete_bbb"
+  pet_api$api_client$oauth_client_secret <- "secrete_bbb"
   pet_api$api_client$oauth_scopes <- "write:pets read:pets"
   update_result <- pet_api$update_pet_with_form(update_pet_id, name = "pet2", status = "sold")
 

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -30,7 +30,7 @@
 #' @field api_keys API keys
 #' @field access_token Access token
 #' @field oauth_client_id OAuth client ID
-#' @field oauth_secret OAuth secret
+#' @field oauth_client_secret OAuth secret
 #' @field oauth_refresh_token OAuth refresh token
 #' @field oauth_flow_type OAuth flow type
 #' @field oauth_authorization_url Authoriziation URL
@@ -63,7 +63,7 @@ ApiClient  <- R6::R6Class(
     # OAuth2 client ID
     oauth_client_id = NULL,
     # OAuth2 secret
-    oauth_secret = NULL,
+    oauth_client_secret = NULL,
     # OAuth2 refresh token
     oauth_refresh_token = NULL,
     # OAuth2


### PR DESCRIPTION
- add refresh token setting
- use oauth_client_secret instead

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
