### PR TITLE
Add request info into ApiException

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/exceptions.mustache
+++ b/modules/openapi-generator/src/main/resources/python/exceptions.mustache
@@ -89,7 +89,8 @@ class ApiKeyError(OpenApiException, KeyError):
 
 class ApiException(OpenApiException):
 
-    def __init__(self, status=None, reason=None, http_resp=None):
+    def __init__(self, status=None, reason=None, http_resp=None,
+                 request_method=None, request_url=None, request_headers=None):
         if http_resp:
             self.status = http_resp.status
             self.reason = http_resp.reason
@@ -100,6 +101,9 @@ class ApiException(OpenApiException):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.request_method = request_method
+        self.request_url = request_url
+        self.request_headers = request_headers
 
     def __str__(self):
         """Custom error messages for exception"""
@@ -112,31 +116,32 @@ class ApiException(OpenApiException):
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)
 
+        if self.request_method:
+            error_message += "HTTP request method: {0}\n".format(self.request_method)
+
+        if self.request_url:
+            error_message += "HTTP request url: {0}\n".format(self.request_url)
+
+        if self.request_headers:
+            error_message += "HTTP request headers: {0}\n".format(self.request_headers)
+
         return error_message
 
 
 class NotFoundException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(NotFoundException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class UnauthorizedException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(UnauthorizedException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ForbiddenException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ForbiddenException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ServiceException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ServiceException, self).__init__(status, reason, http_resp)
+    pass
 
 
 def render_path(path_to_item):

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -206,19 +206,25 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            exception_kwargs = {
+                    "http_resp": r,
+                    "request_method": method,
+                    "request_url": url,
+                    "request_headers": headers,
+                }
             if r.status == 401:
-                raise UnauthorizedException(http_resp=r)
+                raise UnauthorizedException(**exception_kwargs)
 
             if r.status == 403:
-                raise ForbiddenException(http_resp=r)
+                raise ForbiddenException(**exception_kwargs)
 
             if r.status == 404:
-                raise NotFoundException(http_resp=r)
+                raise NotFoundException(**exception_kwargs)
 
             if 500 <= r.status <= 599:
-                raise ServiceException(http_resp=r)
+                raise ServiceException(**exception_kwargs)
 
-            raise ApiException(http_resp=r)
+            raise ApiException(**exception_kwargs)
 
         return r
 

--- a/samples/client/petstore/python/petstore_api/exceptions.py
+++ b/samples/client/petstore/python/petstore_api/exceptions.py
@@ -97,7 +97,8 @@ class ApiKeyError(OpenApiException, KeyError):
 
 class ApiException(OpenApiException):
 
-    def __init__(self, status=None, reason=None, http_resp=None):
+    def __init__(self, status=None, reason=None, http_resp=None,
+                 request_method=None, request_url=None, request_headers=None):
         if http_resp:
             self.status = http_resp.status
             self.reason = http_resp.reason
@@ -108,6 +109,9 @@ class ApiException(OpenApiException):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.request_method = request_method
+        self.request_url = request_url
+        self.request_headers = request_headers
 
     def __str__(self):
         """Custom error messages for exception"""
@@ -120,31 +124,32 @@ class ApiException(OpenApiException):
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)
 
+        if self.request_method:
+            error_message += "HTTP request method: {0}\n".format(self.request_method)
+
+        if self.request_url:
+            error_message += "HTTP request url: {0}\n".format(self.request_url)
+
+        if self.request_headers:
+            error_message += "HTTP request headers: {0}\n".format(self.request_headers)
+
         return error_message
 
 
 class NotFoundException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(NotFoundException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class UnauthorizedException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(UnauthorizedException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ForbiddenException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ForbiddenException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ServiceException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ServiceException, self).__init__(status, reason, http_resp)
+    pass
 
 
 def render_path(path_to_item):

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -214,19 +214,25 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            exception_kwargs = {
+                    "http_resp": r,
+                    "request_method": method,
+                    "request_url": url,
+                    "request_headers": headers,
+                }
             if r.status == 401:
-                raise UnauthorizedException(http_resp=r)
+                raise UnauthorizedException(**exception_kwargs)
 
             if r.status == 403:
-                raise ForbiddenException(http_resp=r)
+                raise ForbiddenException(**exception_kwargs)
 
             if r.status == 404:
-                raise NotFoundException(http_resp=r)
+                raise NotFoundException(**exception_kwargs)
 
             if 500 <= r.status <= 599:
-                raise ServiceException(http_resp=r)
+                raise ServiceException(**exception_kwargs)
 
-            raise ApiException(http_resp=r)
+            raise ApiException(**exception_kwargs)
 
         return r
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/exceptions.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/exceptions.py
@@ -97,7 +97,8 @@ class ApiKeyError(OpenApiException, KeyError):
 
 class ApiException(OpenApiException):
 
-    def __init__(self, status=None, reason=None, http_resp=None):
+    def __init__(self, status=None, reason=None, http_resp=None,
+                 request_method=None, request_url=None, request_headers=None):
         if http_resp:
             self.status = http_resp.status
             self.reason = http_resp.reason
@@ -108,6 +109,9 @@ class ApiException(OpenApiException):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.request_method = request_method
+        self.request_url = request_url
+        self.request_headers = request_headers
 
     def __str__(self):
         """Custom error messages for exception"""
@@ -120,31 +124,32 @@ class ApiException(OpenApiException):
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)
 
+        if self.request_method:
+            error_message += "HTTP request method: {0}\n".format(self.request_method)
+
+        if self.request_url:
+            error_message += "HTTP request url: {0}\n".format(self.request_url)
+
+        if self.request_headers:
+            error_message += "HTTP request headers: {0}\n".format(self.request_headers)
+
         return error_message
 
 
 class NotFoundException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(NotFoundException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class UnauthorizedException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(UnauthorizedException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ForbiddenException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ForbiddenException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ServiceException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ServiceException, self).__init__(status, reason, http_resp)
+    pass
 
 
 def render_path(path_to_item):

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/rest.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/rest.py
@@ -214,19 +214,25 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            exception_kwargs = {
+                    "http_resp": r,
+                    "request_method": method,
+                    "request_url": url,
+                    "request_headers": headers,
+                }
             if r.status == 401:
-                raise UnauthorizedException(http_resp=r)
+                raise UnauthorizedException(**exception_kwargs)
 
             if r.status == 403:
-                raise ForbiddenException(http_resp=r)
+                raise ForbiddenException(**exception_kwargs)
 
             if r.status == 404:
-                raise NotFoundException(http_resp=r)
+                raise NotFoundException(**exception_kwargs)
 
             if 500 <= r.status <= 599:
-                raise ServiceException(http_resp=r)
+                raise ServiceException(**exception_kwargs)
 
-            raise ApiException(http_resp=r)
+            raise ApiException(**exception_kwargs)
 
         return r
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/exceptions.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/exceptions.py
@@ -97,7 +97,8 @@ class ApiKeyError(OpenApiException, KeyError):
 
 class ApiException(OpenApiException):
 
-    def __init__(self, status=None, reason=None, http_resp=None):
+    def __init__(self, status=None, reason=None, http_resp=None,
+                 request_method=None, request_url=None, request_headers=None):
         if http_resp:
             self.status = http_resp.status
             self.reason = http_resp.reason
@@ -108,6 +109,9 @@ class ApiException(OpenApiException):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.request_method = request_method
+        self.request_url = request_url
+        self.request_headers = request_headers
 
     def __str__(self):
         """Custom error messages for exception"""
@@ -120,31 +124,32 @@ class ApiException(OpenApiException):
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)
 
+        if self.request_method:
+            error_message += "HTTP request method: {0}\n".format(self.request_method)
+
+        if self.request_url:
+            error_message += "HTTP request url: {0}\n".format(self.request_url)
+
+        if self.request_headers:
+            error_message += "HTTP request headers: {0}\n".format(self.request_headers)
+
         return error_message
 
 
 class NotFoundException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(NotFoundException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class UnauthorizedException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(UnauthorizedException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ForbiddenException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ForbiddenException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ServiceException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ServiceException, self).__init__(status, reason, http_resp)
+    pass
 
 
 def render_path(path_to_item):

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
@@ -214,19 +214,25 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            exception_kwargs = {
+                    "http_resp": r,
+                    "request_method": method,
+                    "request_url": url,
+                    "request_headers": headers,
+                }
             if r.status == 401:
-                raise UnauthorizedException(http_resp=r)
+                raise UnauthorizedException(**exception_kwargs)
 
             if r.status == 403:
-                raise ForbiddenException(http_resp=r)
+                raise ForbiddenException(**exception_kwargs)
 
             if r.status == 404:
-                raise NotFoundException(http_resp=r)
+                raise NotFoundException(**exception_kwargs)
 
             if 500 <= r.status <= 599:
-                raise ServiceException(http_resp=r)
+                raise ServiceException(**exception_kwargs)
 
-            raise ApiException(http_resp=r)
+            raise ApiException(**exception_kwargs)
 
         return r
 

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/exceptions.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/exceptions.py
@@ -97,7 +97,8 @@ class ApiKeyError(OpenApiException, KeyError):
 
 class ApiException(OpenApiException):
 
-    def __init__(self, status=None, reason=None, http_resp=None):
+    def __init__(self, status=None, reason=None, http_resp=None,
+                 request_method=None, request_url=None, request_headers=None):
         if http_resp:
             self.status = http_resp.status
             self.reason = http_resp.reason
@@ -108,6 +109,9 @@ class ApiException(OpenApiException):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.request_method = request_method
+        self.request_url = request_url
+        self.request_headers = request_headers
 
     def __str__(self):
         """Custom error messages for exception"""
@@ -120,31 +124,32 @@ class ApiException(OpenApiException):
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)
 
+        if self.request_method:
+            error_message += "HTTP request method: {0}\n".format(self.request_method)
+
+        if self.request_url:
+            error_message += "HTTP request url: {0}\n".format(self.request_url)
+
+        if self.request_headers:
+            error_message += "HTTP request headers: {0}\n".format(self.request_headers)
+
         return error_message
 
 
 class NotFoundException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(NotFoundException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class UnauthorizedException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(UnauthorizedException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ForbiddenException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ForbiddenException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ServiceException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ServiceException, self).__init__(status, reason, http_resp)
+    pass
 
 
 def render_path(path_to_item):

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
@@ -214,19 +214,25 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            exception_kwargs = {
+                    "http_resp": r,
+                    "request_method": method,
+                    "request_url": url,
+                    "request_headers": headers,
+                }
             if r.status == 401:
-                raise UnauthorizedException(http_resp=r)
+                raise UnauthorizedException(**exception_kwargs)
 
             if r.status == 403:
-                raise ForbiddenException(http_resp=r)
+                raise ForbiddenException(**exception_kwargs)
 
             if r.status == 404:
-                raise NotFoundException(http_resp=r)
+                raise NotFoundException(**exception_kwargs)
 
             if 500 <= r.status <= 599:
-                raise ServiceException(http_resp=r)
+                raise ServiceException(**exception_kwargs)
 
-            raise ApiException(http_resp=r)
+            raise ApiException(**exception_kwargs)
 
         return r
 

--- a/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
@@ -97,7 +97,8 @@ class ApiKeyError(OpenApiException, KeyError):
 
 class ApiException(OpenApiException):
 
-    def __init__(self, status=None, reason=None, http_resp=None):
+    def __init__(self, status=None, reason=None, http_resp=None,
+                 request_method=None, request_url=None, request_headers=None):
         if http_resp:
             self.status = http_resp.status
             self.reason = http_resp.reason
@@ -108,6 +109,9 @@ class ApiException(OpenApiException):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.request_method = request_method
+        self.request_url = request_url
+        self.request_headers = request_headers
 
     def __str__(self):
         """Custom error messages for exception"""
@@ -120,31 +124,32 @@ class ApiException(OpenApiException):
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)
 
+        if self.request_method:
+            error_message += "HTTP request method: {0}\n".format(self.request_method)
+
+        if self.request_url:
+            error_message += "HTTP request url: {0}\n".format(self.request_url)
+
+        if self.request_headers:
+            error_message += "HTTP request headers: {0}\n".format(self.request_headers)
+
         return error_message
 
 
 class NotFoundException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(NotFoundException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class UnauthorizedException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(UnauthorizedException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ForbiddenException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ForbiddenException, self).__init__(status, reason, http_resp)
+    pass
 
 
 class ServiceException(ApiException):
-
-    def __init__(self, status=None, reason=None, http_resp=None):
-        super(ServiceException, self).__init__(status, reason, http_resp)
+    pass
 
 
 def render_path(path_to_item):

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -214,19 +214,25 @@ class RESTClientObject(object):
             logger.debug("response body: %s", r.data)
 
         if not 200 <= r.status <= 299:
+            exception_kwargs = {
+                    "http_resp": r,
+                    "request_method": method,
+                    "request_url": url,
+                    "request_headers": headers,
+                }
             if r.status == 401:
-                raise UnauthorizedException(http_resp=r)
+                raise UnauthorizedException(**exception_kwargs)
 
             if r.status == 403:
-                raise ForbiddenException(http_resp=r)
+                raise ForbiddenException(**exception_kwargs)
 
             if r.status == 404:
-                raise NotFoundException(http_resp=r)
+                raise NotFoundException(**exception_kwargs)
 
             if 500 <= r.status <= 599:
-                raise ServiceException(http_resp=r)
+                raise ServiceException(**exception_kwargs)
 
-            raise ApiException(http_resp=r)
+            raise ApiException(**exception_kwargs)
 
         return r
 


### PR DESCRIPTION
Add request info to ApiException

Sample exception:
```
kubernetes.client.exceptions.ApiException: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict(......)
HTTP response body: b'404 page not found\n'
HTTP request method: GET
HTTP request url: https://10.7.1.3:8443/apis/example.com/v1alpha1/namespaces/default/invalid
HTTP request headers: {'Accept': 'application/json', ......}
```

Fixes #13214 