### PR TITLE
[cpp-pistache-server]: Add support for AnyType objects

### DIFF
--- a/docs/generators/cpp-pistache-server.md
+++ b/docs/generators/cpp-pistache-server.md
@@ -29,6 +29,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Imports |
 | ---------- | ------- |
 |Object|#include &quot;Object.h&quot;|
+|nlohmann::json|#include &lt;nlohmann/json.hpp&gt;|
 |std::map|#include &lt;map&gt;|
 |std::string|#include &lt;string&gt;|
 |std::vector|#include &lt;vector&gt;|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -139,12 +139,14 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         typeMapping.put("UUID", "std::string");
         typeMapping.put("URI", "std::string");
         typeMapping.put("ByteArray", "std::string");
+        typeMapping.put("AnyType", "nlohmann::json");
 
         super.importMapping = new HashMap<>();
         importMapping.put("std::vector", "#include <vector>");
         importMapping.put("std::map", "#include <map>");
         importMapping.put("std::string", "#include <string>");
         importMapping.put("Object", "#include \"Object.h\"");
+        importMapping.put("nlohmann::json", "#include <nlohmann/json.hpp>");
     }
 
     @Override


### PR DESCRIPTION
Add support for AnyType objects to fix a compile-time error when generating code for an arbitrary typed object:
```
arrayOfSomething:
  type: array
  items: {}
```

Replace `AnyType` with `nlohmann::json` so that the correct type can be manually unpacked later. This JSON library is already used in the [cpp-pistache-server templates](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator/src/main/resources/cpp-pistache-server)

- Related:
  - #12641
  - #12642
  - #10266
  - #7458
  - #6332
  - #7617

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC: @ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd