### PR TITLE
[cpp-pistache-server] Fix enum generation for mode useStructModel=true

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-header.mustache
@@ -19,9 +19,21 @@ namespace {{modelNamespace}}
 
 struct {{classname}}
 {
+    {{#isEnum}}{{#allowableValues}}
+    enum e{{classname}} {
+        // To have a valid default value.
+        // Avoiding name clashes with user defined
+        // enum values
+        INVALID_VALUE_OPENAPI_GENERATED = 0,
+        {{#enumVars}}
+        {{{name}}}{{^-last}}, {{/-last}}
+        {{/enumVars}}
+    };{{/allowableValues}}{{/isEnum}}
+
     {{#vars}}
     {{^required}}std::optional<{{/required}}{{{dataType}}}{{^required}}>{{/required}} {{name}};
     {{/vars}}
+    {{#isEnum}}{{classname}}::e{{classname}} value = {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED;{{/isEnum}}{{#vendorExtensions.x-is-string-enum-container}}{{#anyOf}}{{#-first}}{{{this}}} m_value;{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
 
     bool operator==(const {{classname}}& other) const;
     bool operator!=(const {{classname}}& other) const;

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-struct-source.mustache
@@ -41,7 +41,7 @@ bool {{classname}}::validate(std::stringstream& msg, const std::string& pathPref
     const std::string _pathPrefix = pathPrefix.empty() ? "{{classname}}" : pathPrefix;
 
     {{#isEnum}}{{! Special case for enum types }}
-    if (m_value == {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED)
+    if (value == {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED)
     {
         success = false;
         msg << _pathPrefix << ": has no value;";
@@ -73,7 +73,9 @@ bool {{classname}}::validate(std::stringstream& msg, const std::string& pathPref
 
 bool {{classname}}::operator==(const {{classname}}& other) const
 {
-    return {{#vars}}{{name}} == other.{{name}}{{^-last}} && {{/-last}}{{/vars}};
+    return
+    {{#isEnum}}value == other.value{{/isEnum}}
+    {{#vars}}{{name}} == other.{{name}}{{^-last}} && {{/-last}}{{/vars}};
 }
 
 bool {{classname}}::operator!=(const {{classname}}& other) const
@@ -87,6 +89,20 @@ void to_json(nlohmann::json& j, const {{classname}}& o)
     {{^required}}if (o.{{name}}.has_value()){{/required}}
         j["{{baseName}}"] = o.{{name}}{{^required}}.value(){{/required}};
     {{/vars}}
+    {{#isEnum}}{{#allowableValues}}
+    switch (o.value)
+    {
+    {{#enumVars}}
+    {{#-first}}
+    case {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED:
+         j = "INVALID_VALUE_OPENAPI_GENERATED";
+         break;
+    {{/-first}}
+    case {{classname}}::e{{classname}}::{{name}}:
+         j = "{{value}}";
+         break;
+    {{/enumVars}}
+    }{{/allowableValues}}{{/isEnum}}{{#vendorExtensions.x-is-string-enum-container}}{{#anyOf}}{{#-first}}to_json(j, o.m_value);{{/-first}}{{/anyOf}}{{/vendorExtensions.x-is-string-enum-container}}
 }
 
 void from_json(const nlohmann::json& j, {{classname}}& o)
@@ -96,9 +112,23 @@ void from_json(const nlohmann::json& j, {{classname}}& o)
     {{^required}}if (j.find("{{baseName}}") != j.end()) {
         {{{dataType}}} temporary_{{name}};
         j.at("{{baseName}}").get_to(temporary_{{name}});
-        o.{{name}} = temporary_{{name}};
+        o.{{name}} = std::move(temporary_{{name}});
     }{{/required}}
     {{/vars}}
+    {{#isEnum}}{{#allowableValues}}
+    auto s = j.get<std::string>();
+    {{#enumVars}}
+    {{#-first}}
+    if{{/-first}}{{^-first}}else if{{/-first}}(s == "{{value}}") {
+        o.value = {{classname}}::e{{classname}}::{{name}};
+    } {{#-last}} else {
+        std::stringstream ss;
+        ss << "Unexpected value " << s << " in json"
+           << " cannot be converted to enum of type"
+           << " {{classname}}::e{{classname}}";
+        throw std::invalid_argument(ss.str());
+    } {{/-last}}
+    {{/enumVars}}{{/allowableValues}}{{/isEnum}}
 }
 
 } // namespace {{modelNamespace}}


### PR DESCRIPTION
Add support generating code for an enum when use "--additional-properties=useStructModel=true"

```
TestEnum:
   type: string
   enum: 
      - Value1
      - Value2
```

Command: `openapi-generator-cli.jar generate -g cpp-pistache-server --additional-properties=useStructModel=true`


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ravinikam  @stkrwork  @etherealjoy  @martindelille  @muttleyxd