### PR TITLE
[python-experimental] moves composed schemas into cls

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-experimental/model_templates/composed_schemas.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/model_templates/composed_schemas.handlebars
@@ -1,7 +1,32 @@
+{{#with composedSchemas}}
+{{#each allOf}}
+{{#unless complexType}}
+{{> model_templates/schema }}
+{{/unless}}
+{{/each}}
+{{#each oneOf}}
+{{#unless complexType}}
+{{> model_templates/schema }}
+{{/unless}}
+{{/each}}
+{{#each anyOf}}
+{{#unless complexType}}
+{{> model_templates/schema }}
+{{/unless}}
+{{/each}}
+{{#with not}}
+{{#unless complexType}}
+{{> model_templates/schema }}
+{{/unless}}
+{{/with}}
+{{/with}}
+{{#with composedSchemas}}
+{{#if allOf}}
+
 @classmethod
 @property
 @functools.cache
-def _composed_schemas(cls):
+def _all_of(cls):
     # we need this here to make our import statements work
     # we must store _composed_schemas in here so the code is only run
     # when we invoke this method. If we kept this at the class
@@ -9,82 +34,101 @@ def _composed_schemas(cls):
     # code would be run when this module is imported, and these composed
     # classes don't exist yet because their module has not finished
     # loading
-{{#with composedSchemas}}
-{{#each allOf}}
-{{#unless complexType}}
-    {{> model_templates/schema }}
-{{/unless}}
-{{/each}}
-{{#each oneOf}}
-{{#unless complexType}}
-    {{> model_templates/schema }}
-{{/unless}}
-{{/each}}
-{{#each anyOf}}
-{{#unless complexType}}
-    {{> model_templates/schema }}
-{{/unless}}
-{{/each}}
-{{#with not}}
-{{#unless complexType}}
-    {{> model_templates/schema }}
-{{/unless}}
-{{/with}}
-{{/with}}
-    return {
-        'allOf': [
-{{#with composedSchemas}}
+    return [
 {{#each allOf}}
 {{#if complexType}}
-            {{complexType}},
+        {{complexType}},
 {{else}}
     {{#if nameInSnakeCase}}
-            {{name}},
+        cls.{{name}},
     {{else}}
-            {{baseName}},
+        cls.{{baseName}},
     {{/if}}
 {{/if}}
 {{/each}}
-        ],
-        'oneOf': [
+    ]
+{{/if}}
+{{#if oneOf}}
+
+@classmethod
+@property
+@functools.cache
+def _one_of(cls):
+    # we need this here to make our import statements work
+    # we must store _composed_schemas in here so the code is only run
+    # when we invoke this method. If we kept this at the class
+    # level we would get an error because the class level
+    # code would be run when this module is imported, and these composed
+    # classes don't exist yet because their module has not finished
+    # loading
+    return [
 {{#each oneOf}}
 {{#if complexType}}
-            {{complexType}},
+        {{complexType}},
 {{else}}
     {{#if nameInSnakeCase}}
-            {{name}},
+        cls.{{name}},
     {{else}}
-            {{baseName}},
+        cls.{{baseName}},
     {{/if}}
 {{/if}}
 {{/each}}
-        ],
-        'anyOf': [
+    ]
+{{/if}}
+{{#if anyOf}}
+
+@classmethod
+@property
+@functools.cache
+def _any_of(cls):
+    # we need this here to make our import statements work
+    # we must store _composed_schemas in here so the code is only run
+    # when we invoke this method. If we kept this at the class
+    # level we would get an error because the class level
+    # code would be run when this module is imported, and these composed
+    # classes don't exist yet because their module has not finished
+    # loading
+    return [
 {{#each anyOf}}
 {{#if complexType}}
-            {{complexType}},
+        {{complexType}},
 {{else}}
     {{#if nameInSnakeCase}}
-            {{name}},
+        cls.{{name}},
     {{else}}
-            {{baseName}},
+        cls.{{baseName}},
     {{/if}}
 {{/if}}
 {{/each}}
-        ],
-        'not':
+    ]
+{{/if}}
+{{#if not}}
+
+@classmethod
+@property
+@functools.cache
+def _not(cls):
+    # we need this here to make our import statements work
+    # we must store _composed_schemas in here so the code is only run
+    # when we invoke this method. If we kept this at the class
+    # level we would get an error because the class level
+    # code would be run when this module is imported, and these composed
+    # classes don't exist yet because their module has not finished
+    # loading
+    return (
 {{#with not}}
 {{#if complexType}}
-            {{complexType}}
+        {{complexType}}
 {{else}}
     {{#if nameInSnakeCase}}
-            {{name}}
+        cls.{{name}}
     {{else}}
-            {{baseName}}
+        cls.{{baseName}}
     {{/if}}
 {{/if}}
 {{else}}
-            None
+        None
 {{/with}}
+    )
+{{/if}}
 {{/with}}
-    }

--- a/modules/openapi-generator/src/main/resources/python-experimental/schemas.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/schemas.handlebars
@@ -942,20 +942,20 @@ class Discriminable:
         discriminated_cls = disc[disc_property_name].get(disc_payload_value)
         if discriminated_cls is not None:
             return discriminated_cls
-        elif not hasattr(cls, '_composed_schemas'):
+        elif not (hasattr(cls, '_all_of') or hasattr(cls, '_one_of') or hasattr(cls, '_any_of')):
             return None
         # TODO stop traveling if a cycle is hit
-        for allof_cls in cls._composed_schemas['allOf']:
+        for allof_cls in getattr(cls, '_all_of', []):
             discriminated_cls = allof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
                 return discriminated_cls
-        for oneof_cls in cls._composed_schemas['oneOf']:
+        for oneof_cls in getattr(cls, '_one_of', []):
             discriminated_cls = oneof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
                 return discriminated_cls
-        for anyof_cls in cls._composed_schemas['anyOf']:
+        for anyof_cls in getattr(cls, '_any_of', []):
             discriminated_cls = anyof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
@@ -1560,7 +1560,7 @@ class ComposedBase(Discriminable):
     @classmethod
     def __get_allof_classes(cls, arg, validation_metadata: ValidationMetadata):
         path_to_schemas = defaultdict(set)
-        for allof_cls in cls._composed_schemas['allOf']:
+        for allof_cls in cls._all_of:
             if validation_metadata.validation_ran_earlier(allof_cls):
                 continue
             other_path_to_schemas = allof_cls._validate(arg, validation_metadata=validation_metadata)
@@ -1576,7 +1576,7 @@ class ComposedBase(Discriminable):
     ):
         oneof_classes = []
         path_to_schemas = defaultdict(set)
-        for oneof_cls in cls._composed_schemas['oneOf']:
+        for oneof_cls in cls._one_of:
             if oneof_cls in path_to_schemas[validation_metadata.path_to_item]:
                 oneof_classes.append(oneof_cls)
                 continue
@@ -1611,7 +1611,7 @@ class ComposedBase(Discriminable):
     ):
         anyof_classes = []
         path_to_schemas = defaultdict(set)
-        for anyof_cls in cls._composed_schemas['anyOf']:
+        for anyof_cls in cls._any_of:
             if validation_metadata.validation_ran_earlier(anyof_cls):
                 anyof_classes.append(anyof_cls)
                 continue
@@ -1683,24 +1683,24 @@ class ComposedBase(Discriminable):
                     )
                 )
 
-        if cls._composed_schemas['allOf']:
+        if hasattr(cls, '_all_of'):
             other_path_to_schemas = cls.__get_allof_classes(arg, validation_metadata=updated_vm)
             update(path_to_schemas, other_path_to_schemas)
-        if cls._composed_schemas['oneOf']:
+        if hasattr(cls, '_one_of'):
             other_path_to_schemas = cls.__get_oneof_class(
                 arg,
                 discriminated_cls=discriminated_cls,
                 validation_metadata=updated_vm
             )
             update(path_to_schemas, other_path_to_schemas)
-        if cls._composed_schemas['anyOf']:
+        if hasattr(cls, '_any_of'):
             other_path_to_schemas = cls.__get_anyof_classes(
                 arg,
                 discriminated_cls=discriminated_cls,
                 validation_metadata=updated_vm
             )
             update(path_to_schemas, other_path_to_schemas)
-        not_cls = cls._composed_schemas['not']
+        not_cls = getattr(cls, '_not', None)
         if not_cls:
             other_path_to_schemas = None
             not_exception = ApiValueError(
@@ -1994,27 +1994,10 @@ class BinarySchema(
     BinaryBase,
     Schema,
 ):
-
-    @classmethod
-    @property
-    def _composed_schemas(cls):
-        # we need this here to make our import statements work
-        # we must store _composed_schemas in here so the code is only run
-        # when we invoke this method. If we kept this at the class
-        # level we would get an error because the class level
-        # code would be run when this module is imported, and these composed
-        # classes don't exist yet because their module has not finished
-        # loading
-        return {
-            'allOf': [],
-            'oneOf': [
-                BytesSchema,
-                FileSchema,
-            ],
-            'anyOf': [
-            ],
-            'not': None
-        }
+    _one_of = [
+        BytesSchema,
+        FileSchema,
+    ]
 
     def __new__(cls, arg: typing.Union[io.FileIO, io.BufferedReader, bytes], **kwargs: typing.Union[ValidationMetadata]):
         return super().__new__(cls, arg)

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+6.1.0-SNAPSHOT

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-6.1.0-SNAPSHOT
+unset

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/additionalproperties_should_not_look_in_applicators.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/additionalproperties_should_not_look_in_applicators.py
@@ -33,10 +33,32 @@ class AdditionalpropertiesShouldNotLookInApplicators(
     """
     _additional_properties = schemas.BoolSchema
 
+    
+    
+    class all_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        foo = schemas.AnyTypeSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            foo: typing.Union[foo, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,38 +66,9 @@ class AdditionalpropertiesShouldNotLookInApplicators(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            foo = schemas.AnyTypeSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                foo: typing.Union[foo, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof.py
@@ -32,10 +32,59 @@ class Allof(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "bar",
+        }
+        bar = schemas.IntSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            bar: bar,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                bar=bar,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class all_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "foo",
+        }
+        foo = schemas.StrSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            foo: foo,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,66 +92,10 @@ class Allof(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "bar",
-            }
-            bar = schemas.IntSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                bar: bar,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    bar=bar,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class all_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "foo",
-            }
-            foo = schemas.StrSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                foo: foo,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                all_of_0,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_combined_with_anyof_oneof.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_combined_with_anyof_oneof.py
@@ -32,10 +32,68 @@ class AllofCombinedWithAnyofOneof(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _multiple_of=2
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class one_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _multiple_of=5
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class any_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _multiple_of=3
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'any_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,76 +101,39 @@ class AllofCombinedWithAnyofOneof(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _multiple_of=2
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class one_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _multiple_of=5
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class any_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _multiple_of=3
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'any_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-                one_of_0,
-            ],
-            'anyOf': [
-                any_of_0,
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
+    
+    @classmethod
+    @property
+    @functools.cache
+    def _one_of(cls):
+        # we need this here to make our import statements work
+        # we must store _composed_schemas in here so the code is only run
+        # when we invoke this method. If we kept this at the class
+        # level we would get an error because the class level
+        # code would be run when this module is imported, and these composed
+        # classes don't exist yet because their module has not finished
+        # loading
+        return [
+            cls.one_of_0,
+        ]
+    
+    @classmethod
+    @property
+    @functools.cache
+    def _any_of(cls):
+        # we need this here to make our import statements work
+        # we must store _composed_schemas in here so the code is only run
+        # when we invoke this method. If we kept this at the class
+        # level we would get an error because the class level
+        # code would be run when this module is imported, and these composed
+        # classes don't exist yet because their module has not finished
+        # loading
+        return [
+            cls.any_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_simple_types.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_simple_types.py
@@ -32,10 +32,49 @@ class AllofSimpleTypes(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _inclusive_maximum=30
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class all_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _inclusive_minimum=20
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,56 +82,10 @@ class AllofSimpleTypes(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _inclusive_maximum=30
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class all_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _inclusive_minimum=20
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                all_of_0,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_base_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_base_schema.py
@@ -36,10 +36,59 @@ class AllofWithBaseSchema(
     }
     bar = schemas.IntSchema
 
+    
+    
+    class all_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "foo",
+        }
+        foo = schemas.StrSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            foo: foo,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class all_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "baz",
+        }
+        baz = schemas.NoneSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            baz: baz,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                baz=baz,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -47,66 +96,10 @@ class AllofWithBaseSchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "foo",
-            }
-            foo = schemas.StrSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                foo: foo,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class all_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "baz",
-            }
-            baz = schemas.NoneSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                baz: baz,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    baz=baz,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                all_of_0,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_one_empty_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_one_empty_schema.py
@@ -32,10 +32,12 @@ class AllofWithOneEmptySchema(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,18 +45,9 @@ class AllofWithOneEmptySchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_the_first_empty_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_the_first_empty_schema.py
@@ -32,10 +32,13 @@ class AllofWithTheFirstEmptySchema(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    all_of_1 = schemas.NumberSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,20 +46,10 @@ class AllofWithTheFirstEmptySchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        all_of_1 = schemas.NumberSchema
-        return {
-            'allOf': [
-                all_of_0,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_the_last_empty_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_the_last_empty_schema.py
@@ -32,10 +32,13 @@ class AllofWithTheLastEmptySchema(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.NumberSchema
+    all_of_1 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,20 +46,10 @@ class AllofWithTheLastEmptySchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.NumberSchema
-        all_of_1 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_two_empty_schemas.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/allof_with_two_empty_schemas.py
@@ -32,10 +32,13 @@ class AllofWithTwoEmptySchemas(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    all_of_1 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,20 +46,10 @@ class AllofWithTwoEmptySchemas(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        all_of_1 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof.py
@@ -32,10 +32,31 @@ class Anyof(
     Do not edit the class manually.
     """
 
+    any_of_0 = schemas.IntSchema
+    
+    
+    class any_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _inclusive_minimum=2
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'any_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,38 +64,10 @@ class Anyof(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        any_of_0 = schemas.IntSchema
-        
-        
-        class any_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _inclusive_minimum=2
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'any_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                any_of_0,
-                any_of_1,
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.any_of_0,
+            cls.any_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof_complex_types.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof_complex_types.py
@@ -32,10 +32,59 @@ class AnyofComplexTypes(
     Do not edit the class manually.
     """
 
+    
+    
+    class any_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "bar",
+        }
+        bar = schemas.IntSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            bar: bar,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'any_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                bar=bar,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class any_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "foo",
+        }
+        foo = schemas.StrSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            foo: foo,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'any_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,66 +92,10 @@ class AnyofComplexTypes(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class any_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "bar",
-            }
-            bar = schemas.IntSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                bar: bar,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'any_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    bar=bar,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class any_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "foo",
-            }
-            foo = schemas.StrSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                foo: foo,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'any_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                any_of_0,
-                any_of_1,
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.any_of_0,
+            cls.any_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof_with_base_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof_with_base_schema.py
@@ -33,10 +33,49 @@ class AnyofWithBaseSchema(
     Do not edit the class manually.
     """
 
+    
+    
+    class any_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _max_length=2
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'any_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class any_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _min_length=4
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'any_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,56 +83,10 @@ class AnyofWithBaseSchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class any_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _max_length=2
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'any_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class any_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _min_length=4
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'any_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                any_of_0,
-                any_of_1,
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.any_of_0,
+            cls.any_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof_with_one_empty_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/anyof_with_one_empty_schema.py
@@ -32,10 +32,13 @@ class AnyofWithOneEmptySchema(
     Do not edit the class manually.
     """
 
+    any_of_0 = schemas.NumberSchema
+    any_of_1 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,20 +46,10 @@ class AnyofWithOneEmptySchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        any_of_0 = schemas.NumberSchema
-        any_of_1 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                any_of_0,
-                any_of_1,
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.any_of_0,
+            cls.any_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/forbidden_property.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/forbidden_property.py
@@ -37,10 +37,12 @@ class ForbiddenProperty(
         schemas.ComposedSchema,
     ):
     
+        not_schema = schemas.AnyTypeSchema
+        
         @classmethod
         @property
         @functools.cache
-        def _composed_schemas(cls):
+        def _not(cls):
             # we need this here to make our import statements work
             # we must store _composed_schemas in here so the code is only run
             # when we invoke this method. If we kept this at the class
@@ -48,17 +50,9 @@ class ForbiddenProperty(
             # code would be run when this module is imported, and these composed
             # classes don't exist yet because their module has not finished
             # loading
-            not_schema = schemas.AnyTypeSchema
-            return {
-                'allOf': [
-                ],
-                'oneOf': [
-                ],
-                'anyOf': [
-                ],
-                'not':
-                    not_schema
-            }
+            return (
+                cls.not_schema
+            )
     
         def __new__(
             cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/model_not.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/model_not.py
@@ -32,10 +32,12 @@ class ModelNot(
     Do not edit the class manually.
     """
 
+    not_schema = schemas.IntSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,17 +45,9 @@ class ModelNot(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        not_schema = schemas.IntSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                not_schema
-        }
+        return (
+            cls.not_schema
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/nested_allof_to_check_validation_semantics.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/nested_allof_to_check_validation_semantics.py
@@ -32,10 +32,46 @@ class NestedAllofToCheckValidationSemantics(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_0(
+        schemas.ComposedSchema,
+    ):
+    
+        all_of_0 = schemas.NoneSchema
+        
+        @classmethod
+        @property
+        @functools.cache
+        def _all_of(cls):
+            # we need this here to make our import statements work
+            # we must store _composed_schemas in here so the code is only run
+            # when we invoke this method. If we kept this at the class
+            # level we would get an error because the class level
+            # code would be run when this module is imported, and these composed
+            # classes don't exist yet because their module has not finished
+            # loading
+            return [
+                cls.all_of_0,
+            ]
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,59 +79,9 @@ class NestedAllofToCheckValidationSemantics(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.ComposedSchema,
-        ):
-        
-            @classmethod
-            @property
-            @functools.cache
-            def _composed_schemas(cls):
-                # we need this here to make our import statements work
-                # we must store _composed_schemas in here so the code is only run
-                # when we invoke this method. If we kept this at the class
-                # level we would get an error because the class level
-                # code would be run when this module is imported, and these composed
-                # classes don't exist yet because their module has not finished
-                # loading
-                all_of_0 = schemas.NoneSchema
-                return {
-                    'allOf': [
-                        all_of_0,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not':
-                        None
-                }
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/nested_anyof_to_check_validation_semantics.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/nested_anyof_to_check_validation_semantics.py
@@ -32,10 +32,46 @@ class NestedAnyofToCheckValidationSemantics(
     Do not edit the class manually.
     """
 
+    
+    
+    class any_of_0(
+        schemas.ComposedSchema,
+    ):
+    
+        any_of_0 = schemas.NoneSchema
+        
+        @classmethod
+        @property
+        @functools.cache
+        def _any_of(cls):
+            # we need this here to make our import statements work
+            # we must store _composed_schemas in here so the code is only run
+            # when we invoke this method. If we kept this at the class
+            # level we would get an error because the class level
+            # code would be run when this module is imported, and these composed
+            # classes don't exist yet because their module has not finished
+            # loading
+            return [
+                cls.any_of_0,
+            ]
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'any_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,59 +79,9 @@ class NestedAnyofToCheckValidationSemantics(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class any_of_0(
-            schemas.ComposedSchema,
-        ):
-        
-            @classmethod
-            @property
-            @functools.cache
-            def _composed_schemas(cls):
-                # we need this here to make our import statements work
-                # we must store _composed_schemas in here so the code is only run
-                # when we invoke this method. If we kept this at the class
-                # level we would get an error because the class level
-                # code would be run when this module is imported, and these composed
-                # classes don't exist yet because their module has not finished
-                # loading
-                any_of_0 = schemas.NoneSchema
-                return {
-                    'allOf': [
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                        any_of_0,
-                    ],
-                    'not':
-                        None
-                }
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'any_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                any_of_0,
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.any_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/nested_oneof_to_check_validation_semantics.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/nested_oneof_to_check_validation_semantics.py
@@ -32,10 +32,46 @@ class NestedOneofToCheckValidationSemantics(
     Do not edit the class manually.
     """
 
+    
+    
+    class one_of_0(
+        schemas.ComposedSchema,
+    ):
+    
+        one_of_0 = schemas.NoneSchema
+        
+        @classmethod
+        @property
+        @functools.cache
+        def _one_of(cls):
+            # we need this here to make our import statements work
+            # we must store _composed_schemas in here so the code is only run
+            # when we invoke this method. If we kept this at the class
+            # level we would get an error because the class level
+            # code would be run when this module is imported, and these composed
+            # classes don't exist yet because their module has not finished
+            # loading
+            return [
+                cls.one_of_0,
+            ]
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,59 +79,9 @@ class NestedOneofToCheckValidationSemantics(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class one_of_0(
-            schemas.ComposedSchema,
-        ):
-        
-            @classmethod
-            @property
-            @functools.cache
-            def _composed_schemas(cls):
-                # we need this here to make our import statements work
-                # we must store _composed_schemas in here so the code is only run
-                # when we invoke this method. If we kept this at the class
-                # level we would get an error because the class level
-                # code would be run when this module is imported, and these composed
-                # classes don't exist yet because their module has not finished
-                # loading
-                one_of_0 = schemas.NoneSchema
-                return {
-                    'allOf': [
-                    ],
-                    'oneOf': [
-                        one_of_0,
-                    ],
-                    'anyOf': [
-                    ],
-                    'not':
-                        None
-                }
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/not_more_complex_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/not_more_complex_schema.py
@@ -32,10 +32,33 @@ class NotMoreComplexSchema(
     Do not edit the class manually.
     """
 
+    
+    
+    class not_schema(
+        schemas.DictSchema
+    ):
+        foo = schemas.StrSchema
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            foo: typing.Union[foo, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'not_schema':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,38 +66,9 @@ class NotMoreComplexSchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class not_schema(
-            schemas.DictSchema
-        ):
-            foo = schemas.StrSchema
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                foo: typing.Union[foo, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'not_schema':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                not_schema
-        }
+        return (
+            cls.not_schema
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof.py
@@ -32,10 +32,31 @@ class Oneof(
     Do not edit the class manually.
     """
 
+    one_of_0 = schemas.IntSchema
+    
+    
+    class one_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _inclusive_minimum=2
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,38 +64,10 @@ class Oneof(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        one_of_0 = schemas.IntSchema
-        
-        
-        class one_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _inclusive_minimum=2
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-                one_of_1,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+            cls.one_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_complex_types.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_complex_types.py
@@ -32,10 +32,59 @@ class OneofComplexTypes(
     Do not edit the class manually.
     """
 
+    
+    
+    class one_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "bar",
+        }
+        bar = schemas.IntSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            bar: bar,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                bar=bar,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class one_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "foo",
+        }
+        foo = schemas.StrSchema
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            foo: foo,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,66 +92,10 @@ class OneofComplexTypes(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class one_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "bar",
-            }
-            bar = schemas.IntSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                bar: bar,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    bar=bar,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class one_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "foo",
-            }
-            foo = schemas.StrSchema
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                foo: foo,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-                one_of_1,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+            cls.one_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_with_base_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_with_base_schema.py
@@ -33,10 +33,49 @@ class OneofWithBaseSchema(
     Do not edit the class manually.
     """
 
+    
+    
+    class one_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _min_length=2
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class one_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _max_length=4
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,56 +83,10 @@ class OneofWithBaseSchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class one_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _min_length=2
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class one_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _max_length=4
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-                one_of_1,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+            cls.one_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_with_empty_schema.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_with_empty_schema.py
@@ -32,10 +32,13 @@ class OneofWithEmptySchema(
     Do not edit the class manually.
     """
 
+    one_of_0 = schemas.NumberSchema
+    one_of_1 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,20 +46,10 @@ class OneofWithEmptySchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        one_of_0 = schemas.NumberSchema
-        one_of_1 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-                one_of_1,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+            cls.one_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_with_required.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/oneof_with_required.py
@@ -33,10 +33,55 @@ class OneofWithRequired(
     Do not edit the class manually.
     """
 
+    
+    
+    class one_of_0(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "bar",
+            "foo",
+        }
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_0':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class one_of_1(
+        schemas.AnyTypeSchema,
+    ):
+        _required_property_names = {
+            "foo",
+            "baz",
+        }
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,62 +89,10 @@ class OneofWithRequired(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class one_of_0(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "bar",
-                "foo",
-            }
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_0':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class one_of_1(
-            schemas.AnyTypeSchema,
-        ):
-            _required_property_names = {
-                "foo",
-                "baz",
-            }
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, str, date, datetime, int, float, decimal.Decimal, None, list, tuple, bytes],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-                one_of_1,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+            cls.one_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_allof.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_allof.py
@@ -32,10 +32,11 @@ class RefInAllof(
     Do not edit the class manually.
     """
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,17 +44,9 @@ class RefInAllof(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-                PropertyNamedRefThatIsNotAReference,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            PropertyNamedRefThatIsNotAReference,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_anyof.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_anyof.py
@@ -32,10 +32,11 @@ class RefInAnyof(
     Do not edit the class manually.
     """
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,17 +44,9 @@ class RefInAnyof(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                PropertyNamedRefThatIsNotAReference,
-            ],
-            'not':
-                None
-        }
+        return [
+            PropertyNamedRefThatIsNotAReference,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_not.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_not.py
@@ -32,10 +32,11 @@ class RefInNot(
     Do not edit the class manually.
     """
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,16 +44,9 @@ class RefInNot(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                PropertyNamedRefThatIsNotAReference
-        }
+        return (
+            PropertyNamedRefThatIsNotAReference
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_oneof.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/model/ref_in_oneof.py
@@ -32,10 +32,11 @@ class RefInOneof(
     Do not edit the class manually.
     """
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,17 +44,9 @@ class RefInOneof(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                PropertyNamedRefThatIsNotAReference,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            PropertyNamedRefThatIsNotAReference,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/request_body_post_not_more_complex_schema_request_body/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/request_body_post_not_more_complex_schema_request_body/post.py
@@ -30,10 +30,33 @@ class SchemaForRequestBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    
+    
+    class not_schema(
+        schemas.DictSchema
+    ):
+        foo = schemas.StrSchema
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            foo: typing.Union[foo, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'not_schema':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -41,38 +64,9 @@ class SchemaForRequestBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class not_schema(
-            schemas.DictSchema
-        ):
-            foo = schemas.StrSchema
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                foo: typing.Union[foo, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'not_schema':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                not_schema
-        }
+        return (
+            cls.not_schema
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/request_body_post_not_request_body/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/request_body_post_not_request_body/post.py
@@ -30,10 +30,12 @@ class SchemaForRequestBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    not_schema = schemas.IntSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -41,17 +43,9 @@ class SchemaForRequestBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        not_schema = schemas.IntSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                not_schema
-        }
+        return (
+            cls.not_schema
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/request_body_post_ref_in_not_request_body/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/request_body_post_ref_in_not_request_body/post.py
@@ -32,10 +32,11 @@ class SchemaForRequestBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,16 +44,9 @@ class SchemaForRequestBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                PropertyNamedRefThatIsNotAReference
-        }
+        return (
+            PropertyNamedRefThatIsNotAReference
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/response_body_post_not_more_complex_schema_response_body_for_content_types/post.py
@@ -29,10 +29,33 @@ class SchemaFor200ResponseBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    
+    
+    class not_schema(
+        schemas.DictSchema
+    ):
+        foo = schemas.StrSchema
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            foo: typing.Union[foo, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'not_schema':
+            return super().__new__(
+                cls,
+                *args,
+                foo=foo,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -40,38 +63,9 @@ class SchemaFor200ResponseBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class not_schema(
-            schemas.DictSchema
-        ):
-            foo = schemas.StrSchema
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                foo: typing.Union[foo, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'not_schema':
-                return super().__new__(
-                    cls,
-                    *args,
-                    foo=foo,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                not_schema
-        }
+        return (
+            cls.not_schema
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/response_body_post_not_response_body_for_content_types/post.py
@@ -29,10 +29,12 @@ class SchemaFor200ResponseBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    not_schema = schemas.IntSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -40,17 +42,9 @@ class SchemaFor200ResponseBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        not_schema = schemas.IntSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                not_schema
-        }
+        return (
+            cls.not_schema
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/paths/response_body_post_ref_in_not_response_body_for_content_types/post.py
@@ -31,10 +31,11 @@ class SchemaFor200ResponseBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -42,16 +43,9 @@ class SchemaFor200ResponseBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                PropertyNamedRefThatIsNotAReference
-        }
+        return (
+            PropertyNamedRefThatIsNotAReference
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/schemas.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/schemas.py
@@ -949,20 +949,20 @@ class Discriminable:
         discriminated_cls = disc[disc_property_name].get(disc_payload_value)
         if discriminated_cls is not None:
             return discriminated_cls
-        elif not hasattr(cls, '_composed_schemas'):
+        elif not (hasattr(cls, '_all_of') or hasattr(cls, '_one_of') or hasattr(cls, '_any_of')):
             return None
         # TODO stop traveling if a cycle is hit
-        for allof_cls in cls._composed_schemas['allOf']:
+        for allof_cls in getattr(cls, '_all_of', []):
             discriminated_cls = allof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
                 return discriminated_cls
-        for oneof_cls in cls._composed_schemas['oneOf']:
+        for oneof_cls in getattr(cls, '_one_of', []):
             discriminated_cls = oneof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
                 return discriminated_cls
-        for anyof_cls in cls._composed_schemas['anyOf']:
+        for anyof_cls in getattr(cls, '_any_of', []):
             discriminated_cls = anyof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
@@ -1567,7 +1567,7 @@ class ComposedBase(Discriminable):
     @classmethod
     def __get_allof_classes(cls, arg, validation_metadata: ValidationMetadata):
         path_to_schemas = defaultdict(set)
-        for allof_cls in cls._composed_schemas['allOf']:
+        for allof_cls in cls._all_of:
             if validation_metadata.validation_ran_earlier(allof_cls):
                 continue
             other_path_to_schemas = allof_cls._validate(arg, validation_metadata=validation_metadata)
@@ -1583,7 +1583,7 @@ class ComposedBase(Discriminable):
     ):
         oneof_classes = []
         path_to_schemas = defaultdict(set)
-        for oneof_cls in cls._composed_schemas['oneOf']:
+        for oneof_cls in cls._one_of:
             if oneof_cls in path_to_schemas[validation_metadata.path_to_item]:
                 oneof_classes.append(oneof_cls)
                 continue
@@ -1618,7 +1618,7 @@ class ComposedBase(Discriminable):
     ):
         anyof_classes = []
         path_to_schemas = defaultdict(set)
-        for anyof_cls in cls._composed_schemas['anyOf']:
+        for anyof_cls in cls._any_of:
             if validation_metadata.validation_ran_earlier(anyof_cls):
                 anyof_classes.append(anyof_cls)
                 continue
@@ -1690,24 +1690,24 @@ class ComposedBase(Discriminable):
                     )
                 )
 
-        if cls._composed_schemas['allOf']:
+        if hasattr(cls, '_all_of'):
             other_path_to_schemas = cls.__get_allof_classes(arg, validation_metadata=updated_vm)
             update(path_to_schemas, other_path_to_schemas)
-        if cls._composed_schemas['oneOf']:
+        if hasattr(cls, '_one_of'):
             other_path_to_schemas = cls.__get_oneof_class(
                 arg,
                 discriminated_cls=discriminated_cls,
                 validation_metadata=updated_vm
             )
             update(path_to_schemas, other_path_to_schemas)
-        if cls._composed_schemas['anyOf']:
+        if hasattr(cls, '_any_of'):
             other_path_to_schemas = cls.__get_anyof_classes(
                 arg,
                 discriminated_cls=discriminated_cls,
                 validation_metadata=updated_vm
             )
             update(path_to_schemas, other_path_to_schemas)
-        not_cls = cls._composed_schemas['not']
+        not_cls = getattr(cls, '_not', None)
         if not_cls:
             other_path_to_schemas = None
             not_exception = ApiValueError(
@@ -2001,27 +2001,10 @@ class BinarySchema(
     BinaryBase,
     Schema,
 ):
-
-    @classmethod
-    @property
-    def _composed_schemas(cls):
-        # we need this here to make our import statements work
-        # we must store _composed_schemas in here so the code is only run
-        # when we invoke this method. If we kept this at the class
-        # level we would get an error because the class level
-        # code would be run when this module is imported, and these composed
-        # classes don't exist yet because their module has not finished
-        # loading
-        return {
-            'allOf': [],
-            'oneOf': [
-                BytesSchema,
-                FileSchema,
-            ],
-            'anyOf': [
-            ],
-            'not': None
-        }
+    _one_of = [
+        BytesSchema,
+        FileSchema,
+    ]
 
     def __new__(cls, arg: typing.Union[io.FileIO, io.BufferedReader, bytes], **kwargs: typing.Union[ValidationMetadata]):
         return super().__new__(cls, arg)

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+6.1.0-SNAPSHOT

--- a/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python-experimental/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-6.1.0-SNAPSHOT
+unset

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/any_type_not_string.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/any_type_not_string.py
@@ -32,10 +32,12 @@ class AnyTypeNotString(
     Do not edit the class manually.
     """
 
+    not_schema = schemas.StrSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _not(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,17 +45,9 @@ class AnyTypeNotString(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        not_schema = schemas.StrSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                not_schema
-        }
+        return (
+            cls.not_schema
+        )
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/cat.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/cat.py
@@ -32,10 +32,33 @@ class Cat(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        declawed = schemas.BoolSchema
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            declawed: typing.Union[declawed, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                declawed=declawed,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,40 +66,10 @@ class Cat(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            declawed = schemas.BoolSchema
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                declawed: typing.Union[declawed, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    declawed=declawed,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                Animal,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            Animal,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/child_cat.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/child_cat.py
@@ -32,10 +32,33 @@ class ChildCat(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        name = schemas.StrSchema
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            name: typing.Union[name, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                name=name,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,40 +66,10 @@ class ChildCat(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            name = schemas.StrSchema
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                name: typing.Union[name, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    name=name,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                ParentPet,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            ParentPet,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/complex_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/complex_quadrilateral.py
@@ -32,10 +32,47 @@ class ComplexQuadrilateral(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        
+        
+        class quadrilateralType(
+            schemas.SchemaEnumMakerClsFactory(
+                enum_value_to_name={
+                    "ComplexQuadrilateral": "COMPLEX_QUADRILATERAL",
+                }
+            ),
+            schemas.StrSchema
+        ):
+            
+            @classmethod
+            @property
+            def COMPLEX_QUADRILATERAL(cls):
+                return cls("ComplexQuadrilateral")
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            quadrilateralType: typing.Union[quadrilateralType, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                quadrilateralType=quadrilateralType,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,54 +80,10 @@ class ComplexQuadrilateral(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            
-            
-            class quadrilateralType(
-                schemas.SchemaEnumMakerClsFactory(
-                    enum_value_to_name={
-                        "ComplexQuadrilateral": "COMPLEX_QUADRILATERAL",
-                    }
-                ),
-                schemas.StrSchema
-            ):
-                
-                @classmethod
-                @property
-                def COMPLEX_QUADRILATERAL(cls):
-                    return cls("ComplexQuadrilateral")
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                quadrilateralType: typing.Union[quadrilateralType, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    quadrilateralType=quadrilateralType,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                QuadrilateralInterface,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            QuadrilateralInterface,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_any_of_different_types_no_validations.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_any_of_different_types_no_validations.py
@@ -32,10 +32,32 @@ class ComposedAnyOfDifferentTypesNoValidations(
     Do not edit the class manually.
     """
 
+    any_of_0 = schemas.DictSchema
+    any_of_1 = schemas.DateSchema
+    any_of_2 = schemas.DateTimeSchema
+    any_of_3 = schemas.BinarySchema
+    any_of_4 = schemas.StrSchema
+    any_of_5 = schemas.StrSchema
+    any_of_6 = schemas.DictSchema
+    any_of_7 = schemas.BoolSchema
+    any_of_8 = schemas.NoneSchema
+    
+    
+    class any_of_9(
+        schemas.ListSchema
+    ):
+        _items = schemas.AnyTypeSchema
+    any_of_10 = schemas.NumberSchema
+    any_of_11 = schemas.Float32Schema
+    any_of_12 = schemas.Float64Schema
+    any_of_13 = schemas.IntSchema
+    any_of_14 = schemas.Int32Schema
+    any_of_15 = schemas.Int64Schema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,53 +65,24 @@ class ComposedAnyOfDifferentTypesNoValidations(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        any_of_0 = schemas.DictSchema
-        any_of_1 = schemas.DateSchema
-        any_of_2 = schemas.DateTimeSchema
-        any_of_3 = schemas.BinarySchema
-        any_of_4 = schemas.StrSchema
-        any_of_5 = schemas.StrSchema
-        any_of_6 = schemas.DictSchema
-        any_of_7 = schemas.BoolSchema
-        any_of_8 = schemas.NoneSchema
-        
-        
-        class any_of_9(
-            schemas.ListSchema
-        ):
-            _items = schemas.AnyTypeSchema
-        any_of_10 = schemas.NumberSchema
-        any_of_11 = schemas.Float32Schema
-        any_of_12 = schemas.Float64Schema
-        any_of_13 = schemas.IntSchema
-        any_of_14 = schemas.Int32Schema
-        any_of_15 = schemas.Int64Schema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                any_of_0,
-                any_of_1,
-                any_of_2,
-                any_of_3,
-                any_of_4,
-                any_of_5,
-                any_of_6,
-                any_of_7,
-                any_of_8,
-                any_of_9,
-                any_of_10,
-                any_of_11,
-                any_of_12,
-                any_of_13,
-                any_of_14,
-                any_of_15,
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.any_of_0,
+            cls.any_of_1,
+            cls.any_of_2,
+            cls.any_of_3,
+            cls.any_of_4,
+            cls.any_of_5,
+            cls.any_of_6,
+            cls.any_of_7,
+            cls.any_of_8,
+            cls.any_of_9,
+            cls.any_of_10,
+            cls.any_of_11,
+            cls.any_of_12,
+            cls.any_of_13,
+            cls.any_of_14,
+            cls.any_of_15,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_bool.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_bool.py
@@ -33,10 +33,12 @@ class ComposedBool(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,18 +46,9 @@ class ComposedBool(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_none.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_none.py
@@ -33,10 +33,12 @@ class ComposedNone(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,18 +46,9 @@ class ComposedNone(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_number.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_number.py
@@ -33,10 +33,12 @@ class ComposedNumber(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,18 +46,9 @@ class ComposedNumber(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_object.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_object.py
@@ -33,10 +33,12 @@ class ComposedObject(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,18 +46,9 @@ class ComposedObject(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_one_of_different_types.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_one_of_different_types.py
@@ -34,10 +34,51 @@ class ComposedOneOfDifferentTypes(
     this is a model that allows payloads of type object or number
     """
 
+    one_of_2 = schemas.NoneSchema
+    one_of_3 = schemas.DateSchema
+    
+    
+    class one_of_4(
+        schemas.DictSchema
+    ):
+        _max_properties=4
+        _min_properties=4
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'one_of_4':
+            return super().__new__(
+                cls,
+                *args,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
+    
+    class one_of_5(
+        schemas.ListSchema
+    ):
+        _max_items=4
+        _min_items=4
+        _items = schemas.AnyTypeSchema
+    
+    
+    class one_of_6(
+        schemas.DateTimeSchema
+    ):
+        _regex=[{
+            'pattern': r'^2020.*',  # noqa: E501
+        }]
+        pass
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -45,63 +86,15 @@ class ComposedOneOfDifferentTypes(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        one_of_2 = schemas.NoneSchema
-        one_of_3 = schemas.DateSchema
-        
-        
-        class one_of_4(
-            schemas.DictSchema
-        ):
-            _max_properties=4
-            _min_properties=4
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'one_of_4':
-                return super().__new__(
-                    cls,
-                    *args,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        
-        
-        class one_of_5(
-            schemas.ListSchema
-        ):
-            _max_items=4
-            _min_items=4
-            _items = schemas.AnyTypeSchema
-        
-        
-        class one_of_6(
-            schemas.DateTimeSchema
-        ):
-            _regex=[{
-                'pattern': r'^2020.*',  # noqa: E501
-            }]
-            pass
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                NumberWithValidations,
-                Animal,
-                one_of_2,
-                one_of_3,
-                one_of_4,
-                one_of_5,
-                one_of_6,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            NumberWithValidations,
+            Animal,
+            cls.one_of_2,
+            cls.one_of_3,
+            cls.one_of_4,
+            cls.one_of_5,
+            cls.one_of_6,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_string.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/composed_string.py
@@ -33,10 +33,12 @@ class ComposedString(
     Do not edit the class manually.
     """
 
+    all_of_0 = schemas.AnyTypeSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,18 +46,9 @@ class ComposedString(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        all_of_0 = schemas.AnyTypeSchema
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/dog.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/dog.py
@@ -32,10 +32,33 @@ class Dog(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        breed = schemas.StrSchema
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            breed: typing.Union[breed, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                breed=breed,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,40 +66,10 @@ class Dog(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            breed = schemas.StrSchema
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                breed: typing.Union[breed, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    breed=breed,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                Animal,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            Animal,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/equilateral_triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/equilateral_triangle.py
@@ -32,10 +32,47 @@ class EquilateralTriangle(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        
+        
+        class triangleType(
+            schemas.SchemaEnumMakerClsFactory(
+                enum_value_to_name={
+                    "EquilateralTriangle": "EQUILATERAL_TRIANGLE",
+                }
+            ),
+            schemas.StrSchema
+        ):
+            
+            @classmethod
+            @property
+            def EQUILATERAL_TRIANGLE(cls):
+                return cls("EquilateralTriangle")
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            triangleType: typing.Union[triangleType, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                triangleType=triangleType,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,54 +80,10 @@ class EquilateralTriangle(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            
-            
-            class triangleType(
-                schemas.SchemaEnumMakerClsFactory(
-                    enum_value_to_name={
-                        "EquilateralTriangle": "EQUILATERAL_TRIANGLE",
-                    }
-                ),
-                schemas.StrSchema
-            ):
-                
-                @classmethod
-                @property
-                def EQUILATERAL_TRIANGLE(cls):
-                    return cls("EquilateralTriangle")
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                triangleType: typing.Union[triangleType, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    triangleType=triangleType,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                TriangleInterface,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            TriangleInterface,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/fruit.py
@@ -33,10 +33,11 @@ class Fruit(
     """
     color = schemas.StrSchema
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,18 +45,10 @@ class Fruit(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                Apple,
-                Banana,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            Apple,
+            Banana,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/fruit_req.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/fruit_req.py
@@ -32,10 +32,12 @@ class FruitReq(
     Do not edit the class manually.
     """
 
+    one_of_0 = schemas.NoneSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,20 +45,11 @@ class FruitReq(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        one_of_0 = schemas.NoneSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-                AppleReq,
-                BananaReq,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+            AppleReq,
+            BananaReq,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/gm_fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/gm_fruit.py
@@ -33,10 +33,11 @@ class GmFruit(
     """
     color = schemas.StrSchema
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _any_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -44,18 +45,10 @@ class GmFruit(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-                Apple,
-                Banana,
-            ],
-            'not':
-                None
-        }
+        return [
+            Apple,
+            Banana,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/isosceles_triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/isosceles_triangle.py
@@ -32,10 +32,47 @@ class IsoscelesTriangle(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        
+        
+        class triangleType(
+            schemas.SchemaEnumMakerClsFactory(
+                enum_value_to_name={
+                    "IsoscelesTriangle": "ISOSCELES_TRIANGLE",
+                }
+            ),
+            schemas.StrSchema
+        ):
+            
+            @classmethod
+            @property
+            def ISOSCELES_TRIANGLE(cls):
+                return cls("IsoscelesTriangle")
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            triangleType: typing.Union[triangleType, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                triangleType=triangleType,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,54 +80,10 @@ class IsoscelesTriangle(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            
-            
-            class triangleType(
-                schemas.SchemaEnumMakerClsFactory(
-                    enum_value_to_name={
-                        "IsoscelesTriangle": "ISOSCELES_TRIANGLE",
-                    }
-                ),
-                schemas.StrSchema
-            ):
-                
-                @classmethod
-                @property
-                def ISOSCELES_TRIANGLE(cls):
-                    return cls("IsoscelesTriangle")
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                triangleType: typing.Union[triangleType, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    triangleType=triangleType,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                TriangleInterface,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            TriangleInterface,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/mammal.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/mammal.py
@@ -43,10 +43,11 @@ class Mammal(
             }
         }
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -54,19 +55,11 @@ class Mammal(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                Whale,
-                Zebra,
-                Pig,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            Whale,
+            Zebra,
+            Pig,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/nullable_shape.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/nullable_shape.py
@@ -34,10 +34,12 @@ class NullableShape(
     The value may be a shape or the 'null' value. For a composed schema to validate a null payload, one of its chosen oneOf schemas must be type null or nullable (introduced in OAS schema >= 3.0)
     """
 
+    one_of_2 = schemas.NoneSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -45,20 +47,11 @@ class NullableShape(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        one_of_2 = schemas.NoneSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                Triangle,
-                Quadrilateral,
-                one_of_2,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            Triangle,
+            Quadrilateral,
+            cls.one_of_2,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/object_with_inline_composition_property.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/object_with_inline_composition_property.py
@@ -37,10 +37,18 @@ class ObjectWithInlineCompositionProperty(
         schemas.ComposedSchema,
     ):
     
+        
+        
+        class all_of_0(
+            schemas.StrSchema
+        ):
+            _min_length=1
+            pass
+        
         @classmethod
         @property
         @functools.cache
-        def _composed_schemas(cls):
+        def _all_of(cls):
             # we need this here to make our import statements work
             # we must store _composed_schemas in here so the code is only run
             # when we invoke this method. If we kept this at the class
@@ -48,24 +56,9 @@ class ObjectWithInlineCompositionProperty(
             # code would be run when this module is imported, and these composed
             # classes don't exist yet because their module has not finished
             # loading
-            
-            
-            class all_of_0(
-                schemas.StrSchema
-            ):
-                _min_length=1
-                pass
-            return {
-                'allOf': [
-                    all_of_0,
-                ],
-                'oneOf': [
-                ],
-                'anyOf': [
-                ],
-                'not':
-                    None
-            }
+            return [
+                cls.all_of_0,
+            ]
     
         def __new__(
             cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/parent_pet.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/parent_pet.py
@@ -42,10 +42,11 @@ class ParentPet(
             }
         }
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -53,17 +54,9 @@ class ParentPet(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-                GrandparentAnimal,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            GrandparentAnimal,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/pig.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/pig.py
@@ -42,10 +42,11 @@ class Pig(
             }
         }
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -53,18 +54,10 @@ class Pig(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                BasquePig,
-                DanishPig,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            BasquePig,
+            DanishPig,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/quadrilateral.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/quadrilateral.py
@@ -42,10 +42,11 @@ class Quadrilateral(
             }
         }
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -53,18 +54,10 @@ class Quadrilateral(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                SimpleQuadrilateral,
-                ComplexQuadrilateral,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            SimpleQuadrilateral,
+            ComplexQuadrilateral,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/scalene_triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/scalene_triangle.py
@@ -32,10 +32,47 @@ class ScaleneTriangle(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        
+        
+        class triangleType(
+            schemas.SchemaEnumMakerClsFactory(
+                enum_value_to_name={
+                    "ScaleneTriangle": "SCALENE_TRIANGLE",
+                }
+            ),
+            schemas.StrSchema
+        ):
+            
+            @classmethod
+            @property
+            def SCALENE_TRIANGLE(cls):
+                return cls("ScaleneTriangle")
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            triangleType: typing.Union[triangleType, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                triangleType=triangleType,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,54 +80,10 @@ class ScaleneTriangle(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            
-            
-            class triangleType(
-                schemas.SchemaEnumMakerClsFactory(
-                    enum_value_to_name={
-                        "ScaleneTriangle": "SCALENE_TRIANGLE",
-                    }
-                ),
-                schemas.StrSchema
-            ):
-                
-                @classmethod
-                @property
-                def SCALENE_TRIANGLE(cls):
-                    return cls("ScaleneTriangle")
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                triangleType: typing.Union[triangleType, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    triangleType=triangleType,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                TriangleInterface,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            TriangleInterface,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/shape.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/shape.py
@@ -42,10 +42,11 @@ class Shape(
             }
         }
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -53,18 +54,10 @@ class Shape(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                Triangle,
-                Quadrilateral,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            Triangle,
+            Quadrilateral,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/shape_or_null.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/shape_or_null.py
@@ -44,10 +44,12 @@ class ShapeOrNull(
             }
         }
 
+    one_of_0 = schemas.NoneSchema
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -55,20 +57,11 @@ class ShapeOrNull(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        one_of_0 = schemas.NoneSchema
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                one_of_0,
-                Triangle,
-                Quadrilateral,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.one_of_0,
+            Triangle,
+            Quadrilateral,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/simple_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/simple_quadrilateral.py
@@ -32,10 +32,47 @@ class SimpleQuadrilateral(
     Do not edit the class manually.
     """
 
+    
+    
+    class all_of_1(
+        schemas.DictSchema
+    ):
+        
+        
+        class quadrilateralType(
+            schemas.SchemaEnumMakerClsFactory(
+                enum_value_to_name={
+                    "SimpleQuadrilateral": "SIMPLE_QUADRILATERAL",
+                }
+            ),
+            schemas.StrSchema
+        ):
+            
+            @classmethod
+            @property
+            def SIMPLE_QUADRILATERAL(cls):
+                return cls("SimpleQuadrilateral")
+    
+    
+        def __new__(
+            cls,
+            *args: typing.Union[dict, frozendict, ],
+            quadrilateralType: typing.Union[quadrilateralType, schemas.Unset] = schemas.unset,
+            _configuration: typing.Optional[schemas.Configuration] = None,
+            **kwargs: typing.Type[schemas.Schema],
+        ) -> 'all_of_1':
+            return super().__new__(
+                cls,
+                *args,
+                quadrilateralType=quadrilateralType,
+                _configuration=_configuration,
+                **kwargs,
+            )
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,54 +80,10 @@ class SimpleQuadrilateral(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_1(
-            schemas.DictSchema
-        ):
-            
-            
-            class quadrilateralType(
-                schemas.SchemaEnumMakerClsFactory(
-                    enum_value_to_name={
-                        "SimpleQuadrilateral": "SIMPLE_QUADRILATERAL",
-                    }
-                ),
-                schemas.StrSchema
-            ):
-                
-                @classmethod
-                @property
-                def SIMPLE_QUADRILATERAL(cls):
-                    return cls("SimpleQuadrilateral")
-        
-        
-            def __new__(
-                cls,
-                *args: typing.Union[dict, frozendict, ],
-                quadrilateralType: typing.Union[quadrilateralType, schemas.Unset] = schemas.unset,
-                _configuration: typing.Optional[schemas.Configuration] = None,
-                **kwargs: typing.Type[schemas.Schema],
-            ) -> 'all_of_1':
-                return super().__new__(
-                    cls,
-                    *args,
-                    quadrilateralType=quadrilateralType,
-                    _configuration=_configuration,
-                    **kwargs,
-                )
-        return {
-            'allOf': [
-                QuadrilateralInterface,
-                all_of_1,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            QuadrilateralInterface,
+            cls.all_of_1,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/some_object.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/some_object.py
@@ -32,10 +32,11 @@ class SomeObject(
     Do not edit the class manually.
     """
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -43,17 +44,9 @@ class SomeObject(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-                ObjectInterface,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            ObjectInterface,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/triangle.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/triangle.py
@@ -43,10 +43,11 @@ class Triangle(
             }
         }
 
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _one_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -54,19 +55,11 @@ class Triangle(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        return {
-            'allOf': [
-            ],
-            'oneOf': [
-                EquilateralTriangle,
-                IsoscelesTriangle,
-                ScaleneTriangle,
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            EquilateralTriangle,
+            IsoscelesTriangle,
+            ScaleneTriangle,
+        ]
 
     def __new__(
         cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model/user.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model/user.py
@@ -68,10 +68,12 @@ class User(
         schemas.ComposedSchema,
     ):
     
+        not_schema = schemas.NoneSchema
+        
         @classmethod
         @property
         @functools.cache
-        def _composed_schemas(cls):
+        def _not(cls):
             # we need this here to make our import statements work
             # we must store _composed_schemas in here so the code is only run
             # when we invoke this method. If we kept this at the class
@@ -79,17 +81,9 @@ class User(
             # code would be run when this module is imported, and these composed
             # classes don't exist yet because their module has not finished
             # loading
-            not_schema = schemas.NoneSchema
-            return {
-                'allOf': [
-                ],
-                'oneOf': [
-                ],
-                'anyOf': [
-                ],
-                'not':
-                    not_schema
-            }
+            return (
+                cls.not_schema
+            )
     
         def __new__(
             cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/paths/fake_inline_composition_/post.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/paths/fake_inline_composition_/post.py
@@ -30,10 +30,18 @@ class CompositionAtRootSchema(
     schemas.ComposedSchema,
 ):
 
+    
+    
+    class all_of_0(
+        schemas.StrSchema
+    ):
+        _min_length=1
+        pass
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -41,24 +49,9 @@ class CompositionAtRootSchema(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.StrSchema
-        ):
-            _min_length=1
-            pass
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,
@@ -83,10 +76,18 @@ class CompositionInPropertySchema(
         schemas.ComposedSchema,
     ):
     
+        
+        
+        class all_of_0(
+            schemas.StrSchema
+        ):
+            _min_length=1
+            pass
+        
         @classmethod
         @property
         @functools.cache
-        def _composed_schemas(cls):
+        def _all_of(cls):
             # we need this here to make our import statements work
             # we must store _composed_schemas in here so the code is only run
             # when we invoke this method. If we kept this at the class
@@ -94,24 +95,9 @@ class CompositionInPropertySchema(
             # code would be run when this module is imported, and these composed
             # classes don't exist yet because their module has not finished
             # loading
-            
-            
-            class all_of_0(
-                schemas.StrSchema
-            ):
-                _min_length=1
-                pass
-            return {
-                'allOf': [
-                    all_of_0,
-                ],
-                'oneOf': [
-                ],
-                'anyOf': [
-                ],
-                'not':
-                    None
-            }
+            return [
+                cls.all_of_0,
+            ]
     
         def __new__(
             cls,
@@ -179,10 +165,18 @@ class SchemaForRequestBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    
+    
+    class all_of_0(
+        schemas.StrSchema
+    ):
+        _min_length=1
+        pass
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -190,24 +184,9 @@ class SchemaForRequestBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.StrSchema
-        ):
-            _min_length=1
-            pass
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,
@@ -232,10 +211,18 @@ class SchemaForRequestBodyMultipartFormData(
         schemas.ComposedSchema,
     ):
     
+        
+        
+        class all_of_0(
+            schemas.StrSchema
+        ):
+            _min_length=1
+            pass
+        
         @classmethod
         @property
         @functools.cache
-        def _composed_schemas(cls):
+        def _all_of(cls):
             # we need this here to make our import statements work
             # we must store _composed_schemas in here so the code is only run
             # when we invoke this method. If we kept this at the class
@@ -243,24 +230,9 @@ class SchemaForRequestBodyMultipartFormData(
             # code would be run when this module is imported, and these composed
             # classes don't exist yet because their module has not finished
             # loading
-            
-            
-            class all_of_0(
-                schemas.StrSchema
-            ):
-                _min_length=1
-                pass
-            return {
-                'allOf': [
-                    all_of_0,
-                ],
-                'oneOf': [
-                ],
-                'anyOf': [
-                ],
-                'not':
-                    None
-            }
+            return [
+                cls.all_of_0,
+            ]
     
         def __new__(
             cls,
@@ -306,10 +278,18 @@ class SchemaFor200ResponseBodyApplicationJson(
     schemas.ComposedSchema,
 ):
 
+    
+    
+    class all_of_0(
+        schemas.StrSchema
+    ):
+        _min_length=1
+        pass
+    
     @classmethod
     @property
     @functools.cache
-    def _composed_schemas(cls):
+    def _all_of(cls):
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class
@@ -317,24 +297,9 @@ class SchemaFor200ResponseBodyApplicationJson(
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        
-        
-        class all_of_0(
-            schemas.StrSchema
-        ):
-            _min_length=1
-            pass
-        return {
-            'allOf': [
-                all_of_0,
-            ],
-            'oneOf': [
-            ],
-            'anyOf': [
-            ],
-            'not':
-                None
-        }
+        return [
+            cls.all_of_0,
+        ]
 
     def __new__(
         cls,
@@ -359,10 +324,18 @@ class SchemaFor200ResponseBodyMultipartFormData(
         schemas.ComposedSchema,
     ):
     
+        
+        
+        class all_of_0(
+            schemas.StrSchema
+        ):
+            _min_length=1
+            pass
+        
         @classmethod
         @property
         @functools.cache
-        def _composed_schemas(cls):
+        def _all_of(cls):
             # we need this here to make our import statements work
             # we must store _composed_schemas in here so the code is only run
             # when we invoke this method. If we kept this at the class
@@ -370,24 +343,9 @@ class SchemaFor200ResponseBodyMultipartFormData(
             # code would be run when this module is imported, and these composed
             # classes don't exist yet because their module has not finished
             # loading
-            
-            
-            class all_of_0(
-                schemas.StrSchema
-            ):
-                _min_length=1
-                pass
-            return {
-                'allOf': [
-                    all_of_0,
-                ],
-                'oneOf': [
-                ],
-                'anyOf': [
-                ],
-                'not':
-                    None
-            }
+            return [
+                cls.all_of_0,
+            ]
     
         def __new__(
             cls,

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/schemas.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/schemas.py
@@ -949,20 +949,20 @@ class Discriminable:
         discriminated_cls = disc[disc_property_name].get(disc_payload_value)
         if discriminated_cls is not None:
             return discriminated_cls
-        elif not hasattr(cls, '_composed_schemas'):
+        elif not (hasattr(cls, '_all_of') or hasattr(cls, '_one_of') or hasattr(cls, '_any_of')):
             return None
         # TODO stop traveling if a cycle is hit
-        for allof_cls in cls._composed_schemas['allOf']:
+        for allof_cls in getattr(cls, '_all_of', []):
             discriminated_cls = allof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
                 return discriminated_cls
-        for oneof_cls in cls._composed_schemas['oneOf']:
+        for oneof_cls in getattr(cls, '_one_of', []):
             discriminated_cls = oneof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
                 return discriminated_cls
-        for anyof_cls in cls._composed_schemas['anyOf']:
+        for anyof_cls in getattr(cls, '_any_of', []):
             discriminated_cls = anyof_cls._get_discriminated_class(
                 disc_property_name=disc_property_name, disc_payload_value=disc_payload_value)
             if discriminated_cls is not None:
@@ -1567,7 +1567,7 @@ class ComposedBase(Discriminable):
     @classmethod
     def __get_allof_classes(cls, arg, validation_metadata: ValidationMetadata):
         path_to_schemas = defaultdict(set)
-        for allof_cls in cls._composed_schemas['allOf']:
+        for allof_cls in cls._all_of:
             if validation_metadata.validation_ran_earlier(allof_cls):
                 continue
             other_path_to_schemas = allof_cls._validate(arg, validation_metadata=validation_metadata)
@@ -1583,7 +1583,7 @@ class ComposedBase(Discriminable):
     ):
         oneof_classes = []
         path_to_schemas = defaultdict(set)
-        for oneof_cls in cls._composed_schemas['oneOf']:
+        for oneof_cls in cls._one_of:
             if oneof_cls in path_to_schemas[validation_metadata.path_to_item]:
                 oneof_classes.append(oneof_cls)
                 continue
@@ -1618,7 +1618,7 @@ class ComposedBase(Discriminable):
     ):
         anyof_classes = []
         path_to_schemas = defaultdict(set)
-        for anyof_cls in cls._composed_schemas['anyOf']:
+        for anyof_cls in cls._any_of:
             if validation_metadata.validation_ran_earlier(anyof_cls):
                 anyof_classes.append(anyof_cls)
                 continue
@@ -1690,24 +1690,24 @@ class ComposedBase(Discriminable):
                     )
                 )
 
-        if cls._composed_schemas['allOf']:
+        if hasattr(cls, '_all_of'):
             other_path_to_schemas = cls.__get_allof_classes(arg, validation_metadata=updated_vm)
             update(path_to_schemas, other_path_to_schemas)
-        if cls._composed_schemas['oneOf']:
+        if hasattr(cls, '_one_of'):
             other_path_to_schemas = cls.__get_oneof_class(
                 arg,
                 discriminated_cls=discriminated_cls,
                 validation_metadata=updated_vm
             )
             update(path_to_schemas, other_path_to_schemas)
-        if cls._composed_schemas['anyOf']:
+        if hasattr(cls, '_any_of'):
             other_path_to_schemas = cls.__get_anyof_classes(
                 arg,
                 discriminated_cls=discriminated_cls,
                 validation_metadata=updated_vm
             )
             update(path_to_schemas, other_path_to_schemas)
-        not_cls = cls._composed_schemas['not']
+        not_cls = getattr(cls, '_not', None)
         if not_cls:
             other_path_to_schemas = None
             not_exception = ApiValueError(
@@ -2001,27 +2001,10 @@ class BinarySchema(
     BinaryBase,
     Schema,
 ):
-
-    @classmethod
-    @property
-    def _composed_schemas(cls):
-        # we need this here to make our import statements work
-        # we must store _composed_schemas in here so the code is only run
-        # when we invoke this method. If we kept this at the class
-        # level we would get an error because the class level
-        # code would be run when this module is imported, and these composed
-        # classes don't exist yet because their module has not finished
-        # loading
-        return {
-            'allOf': [],
-            'oneOf': [
-                BytesSchema,
-                FileSchema,
-            ],
-            'anyOf': [
-            ],
-            'not': None
-        }
+    _one_of = [
+        BytesSchema,
+        FileSchema,
+    ]
 
     def __new__(cls, arg: typing.Union[io.FileIO, io.BufferedReader, bytes], **kwargs: typing.Union[ValidationMetadata]):
         return super().__new__(cls, arg)

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_animal.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_animal.py
@@ -42,7 +42,7 @@ class TestAnimal(unittest.TestCase):
         assert isinstance(animal, Animal)
         assert isinstance(animal, frozendict)
         assert isinstance(animal, Cat)
-        assert isinstance(animal, Cat._composed_schemas['allOf'][1])
+        assert isinstance(animal, Cat._all_of[1])
         assert set(animal.keys()) == {'className', 'color'}
         assert animal.className == 'Cat'
         assert animal.color == 'black'
@@ -54,7 +54,7 @@ class TestAnimal(unittest.TestCase):
         assert isinstance(animal, Animal)
         assert isinstance(animal, frozendict)
         assert isinstance(animal, Cat)
-        assert isinstance(animal, Cat._composed_schemas['allOf'][1])
+        assert isinstance(animal, Cat._all_of[1])
         assert set(animal.keys()) == {'className', 'color', 'declawed'}
         assert animal.className == 'Cat'
         assert animal.color == 'black'
@@ -68,7 +68,7 @@ class TestAnimal(unittest.TestCase):
         assert isinstance(animal, Animal)
         assert isinstance(animal, frozendict)
         assert isinstance(animal, Dog)
-        assert isinstance(animal, Dog._composed_schemas['allOf'][1])
+        assert isinstance(animal, Dog._all_of[1])
         assert set(animal.keys()) == {'className', 'color'}
         assert animal.className == 'Dog'
         assert animal.color == 'black'
@@ -80,7 +80,7 @@ class TestAnimal(unittest.TestCase):
         assert isinstance(animal, Animal)
         assert isinstance(animal, frozendict)
         assert isinstance(animal, Dog)
-        assert isinstance(animal, Dog._composed_schemas['allOf'][1])
+        assert isinstance(animal, Dog._all_of[1])
         assert set(animal.keys()) == {'className', 'color', 'breed'}
         assert animal.className == 'Dog'
         assert animal.color == 'black'

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_any_type_schema.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_any_type_schema.py
@@ -38,20 +38,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testDictSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        DictSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                DictSchema,
+            ]
 
         m = Model(a=1, b='hi')
         assert isinstance(m, Model)
@@ -63,20 +53,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testListSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        ListSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                ListSchema,
+            ]
 
         m = Model([1, 'hi'])
         assert isinstance(m, Model)
@@ -88,20 +68,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testStrSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        StrSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                StrSchema,
+            ]
 
         m = Model('hi')
         assert isinstance(m, Model)
@@ -113,20 +83,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testNumberSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        NumberSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                NumberSchema,
+            ]
 
         m = Model(1)
         assert isinstance(m, Model)
@@ -145,20 +105,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testIntSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        IntSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                IntSchema,
+            ]
 
         m = Model(1)
         assert isinstance(m, Model)
@@ -174,20 +124,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testBoolSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        BoolSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                BoolSchema,
+            ]
 
         m = Model(True)
         assert isinstance(m, Model)
@@ -206,20 +146,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testNoneSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        NoneSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                NoneSchema,
+            ]
 
         m = Model(None)
         assert isinstance(m, Model)
@@ -231,20 +161,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testDateSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        DateSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                DateSchema,
+            ]
 
         m = Model('1970-01-01')
         assert isinstance(m, Model)
@@ -256,20 +176,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testDateTimeSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        DateTimeSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                DateTimeSchema,
+            ]
 
         m = Model('2020-01-01T00:00:00')
         assert isinstance(m, Model)
@@ -281,20 +191,10 @@ class TestAnyTypeSchema(unittest.TestCase):
     def testDecimalSchema(self):
         class Model(ComposedSchema):
 
-            @classmethod
-            @property
-            def _composed_schemas(cls):
-                return {
-                    'allOf': [
-                        AnyTypeSchema,
-                        DecimalSchema,
-                    ],
-                    'oneOf': [
-                    ],
-                    'anyOf': [
-                    ],
-                    'not': None
-                }
+            _all_of = [
+                AnyTypeSchema,
+                DecimalSchema,
+            ]
 
         m = Model('12.34')
         assert isinstance(m, Model)

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_fruit.py
@@ -84,16 +84,11 @@ class TestFruit(unittest.TestCase):
         # make sure that the ModelComposed class properties are correct
         # model._composed_schemas stores the anyOf/allOf/oneOf info
         self.assertEqual(
-            fruit._composed_schemas,
-            {
-                'anyOf': [],
-                'allOf': [],
-                'oneOf': [
-                    apple.Apple,
-                    banana.Banana,
-                ],
-                'not': None
-            }
+            fruit._one_of,
+            [
+                apple.Apple,
+                banana.Banana,
+            ],
         )
 
         """

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_fruit_req.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_fruit_req.py
@@ -69,17 +69,12 @@ class TestFruitReq(unittest.TestCase):
         # make sure that the ModelComposed class properties are correct
         # model._composed_schemas stores the anyOf/allOf/oneOf info
         self.assertEqual(
-            fruit._composed_schemas,
-            {
-                'anyOf': [],
-                'allOf': [],
-                'oneOf': [
-                    NoneSchema,
-                    apple_req.AppleReq,
-                    banana_req.BananaReq,
-                ],
-                'not': None
-            }
+            fruit._one_of,
+            [
+                NoneSchema,
+                apple_req.AppleReq,
+                banana_req.BananaReq,
+            ],
         )
 
         # including extra parameters raises an exception

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_gm_fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_gm_fruit.py
@@ -66,16 +66,11 @@ class TestGmFruit(unittest.TestCase):
         # make sure that the ModelComposed class properties are correct
         # model._composed_schemas stores the anyOf/allOf/oneOf info
         self.assertEqual(
-            fruit._composed_schemas,
-            {
-                'anyOf': [
-                    apple.Apple,
-                    banana.Banana,
-                ],
-                'allOf': [],
-                'oneOf': [],
-                'not': None
-            }
+            fruit._any_of,
+            [
+                apple.Apple,
+                banana.Banana,
+            ],
         )
 
         # including extra parameters works

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_validate.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_validate.py
@@ -100,7 +100,7 @@ class TestValidateResults(unittest.TestCase):
             frozendict(className="Dog", color="black"), validation_metadata=vm
         )
         assert path_to_schemas == {
-            ("args[0]",): set([Animal, Dog, Dog._composed_schemas['allOf'][1], frozendict]),
+            ("args[0]",): set([Animal, Dog, Dog._all_of[1], frozendict]),
             ("args[0]", "className"): set([StrSchema, AnyTypeSchema, str]),
             ("args[0]", "color"): set([StrSchema, AnyTypeSchema, str]),
         }


### PR DESCRIPTION
moves composed schemas into cls
This paves the way for moving all schema properties that are not object properties into
a metadata class like MetaOapg which is what Django does with its Meta model class.

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
