### PR TITLE
[typescript-fetch]Fix subtype serialization with discriminators

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -22,3 +22,6 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 export function {{classname}}ToJSON(value?: {{classname}} | null): any {
     return value as any;
 }
+export function {{classname}}ToJSONTyped(value: any, ignoreDiscriminator: boolean): {{classname}} {
+    return value as {{classname}};
+}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -6,14 +6,19 @@ import {
     {{classname}}FromJSON,
     {{classname}}FromJSONTyped,
     {{classname}}ToJSON,
+    {{classname}}ToJSONTyped,
 } from './{{filename}}{{importFileExtension}}';
 {{/tsImports}}
 
 {{/hasImports}}
 {{#discriminator}}
 {{#discriminator.mappedModels}}
-import { {{modelName}}FromJSONTyped } from './{{modelName}}{{importFileExtension}}';
+import {
+  {{modelName}},
+  {{modelName}}ToJSONTyped,
+  {{modelName}}FromJSONTyped} from './{{modelName}}{{importFileExtension}}';
 {{/discriminator.mappedModels}}
+
 {{/discriminator}}
 {{>modelGenericInterfaces}}
 
@@ -96,14 +101,32 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     return json;
     {{/hasVars}}
 }
-
+{{#discriminator}}
+{{#discriminator.mappedModels}}
+function is{{modelName}}(value: {{classname}}):value is {{modelName}}{
+    return value['{{discriminator.propertyName}}'] === '{{mappingName}}';
+}
+{{/discriminator.mappedModels}}
+{{/discriminator}}
 export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null): any {
+    return {{classname}}ToJSONTyped(value);
+}
+export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDiscriminator = false): any {
     {{#hasVars}}
     if (value == null) {
         return value;
     }
+{{#discriminator}}
+    if (!ignoreDiscriminator) {
+{{#discriminator.mappedModels}}
+        if (is{{modelName}}(value)) {
+            return {{modelName}}ToJSONTyped(value, true);
+        }
+{{/discriminator.mappedModels}}
+    }
+{{/discriminator}}
     return {
-        {{#parent}}...{{{.}}}ToJSON(value),{{/parent}}
+        {{#parent}}...{{{.}}}ToJSONTyped(value, ignoreDiscriminator),{{/parent}}
         {{#additionalPropertiesType}}
             ...value,
         {{/additionalPropertiesType}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -6,6 +6,7 @@ import {
     {{{.}}}FromJSON,
     {{{.}}}FromJSONTyped,
     {{{.}}}ToJSON,
+    {{{.}}}ToJSONTyped,
 } from './{{.}}{{importFileExtension}}';
 {{/oneOf}}
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -18,10 +18,18 @@ import {
     BranchDtoFromJSON,
     BranchDtoFromJSONTyped,
     BranchDtoToJSON,
+    BranchDtoToJSONTyped,
 } from './BranchDto';
 
-import { InternalAuthenticatedUserDtoFromJSONTyped } from './InternalAuthenticatedUserDto';
-import { RemoteAuthenticatedUserDtoFromJSONTyped } from './RemoteAuthenticatedUserDto';
+import {
+  InternalAuthenticatedUserDto,
+  InternalAuthenticatedUserDtoToJSONTyped,
+  InternalAuthenticatedUserDtoFromJSONTyped} from './InternalAuthenticatedUserDto';
+import {
+  RemoteAuthenticatedUserDto,
+  RemoteAuthenticatedUserDtoToJSONTyped,
+  RemoteAuthenticatedUserDtoFromJSONTyped} from './RemoteAuthenticatedUserDto';
+
 /**
  * 
  * @export
@@ -78,10 +86,26 @@ export function AbstractUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
         'type': json['type'] == null ? undefined : json['type'],
     };
 }
-
+function isInternalAuthenticatedUserDto(value: AbstractUserDto):value is InternalAuthenticatedUserDto{
+    return value['type'] === 'internal-authenticated';
+}
+function isRemoteAuthenticatedUserDto(value: AbstractUserDto):value is RemoteAuthenticatedUserDto{
+    return value['type'] === 'remote-authenticated';
+}
 export function AbstractUserDtoToJSON(value?: AbstractUserDto | null): any {
+    return AbstractUserDtoToJSONTyped(value);
+}
+export function AbstractUserDtoToJSONTyped(value?: AbstractUserDto | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
+    }
+    if (!ignoreDiscriminator) {
+        if (isInternalAuthenticatedUserDto(value)) {
+            return InternalAuthenticatedUserDtoToJSONTyped(value, true);
+        }
+        if (isRemoteAuthenticatedUserDto(value)) {
+            return RemoteAuthenticatedUserDtoToJSONTyped(value, true);
+        }
     }
     return {
         

--- a/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/BranchDto.ts
@@ -47,8 +47,10 @@ export function BranchDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function BranchDtoToJSON(value?: BranchDto | null): any {
+    return BranchDtoToJSONTyped(value);
+}
+export function BranchDtoToJSONTyped(value?: BranchDto | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/InternalAuthenticatedUserDto.ts
@@ -18,13 +18,16 @@ import {
     BranchDtoFromJSON,
     BranchDtoFromJSONTyped,
     BranchDtoToJSON,
+    BranchDtoToJSONTyped,
 } from './BranchDto';
 import type { AbstractUserDto } from './AbstractUserDto';
 import {
     AbstractUserDtoFromJSON,
     AbstractUserDtoFromJSONTyped,
     AbstractUserDtoToJSON,
+    AbstractUserDtoToJSONTyped,
 } from './AbstractUserDto';
+
 
 /**
  * 
@@ -48,8 +51,10 @@ export function InternalAuthenticatedUserDtoFromJSON(json: any): InternalAuthent
 export function InternalAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean): InternalAuthenticatedUserDto {
     return json;
 }
-
 export function InternalAuthenticatedUserDtoToJSON(value?: InternalAuthenticatedUserDto | null): any {
+    return InternalAuthenticatedUserDtoToJSONTyped(value);
+}
+export function InternalAuthenticatedUserDtoToJSONTyped(value?: InternalAuthenticatedUserDto | null, ignoreDiscriminator = false): any {
     return value;
 }
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/RemoteAuthenticatedUserDto.ts
@@ -18,13 +18,16 @@ import {
     BranchDtoFromJSON,
     BranchDtoFromJSONTyped,
     BranchDtoToJSON,
+    BranchDtoToJSONTyped,
 } from './BranchDto';
 import type { AbstractUserDto } from './AbstractUserDto';
 import {
     AbstractUserDtoFromJSON,
     AbstractUserDtoFromJSONTyped,
     AbstractUserDtoToJSON,
+    AbstractUserDtoToJSONTyped,
 } from './AbstractUserDto';
+
 
 /**
  * 
@@ -48,8 +51,10 @@ export function RemoteAuthenticatedUserDtoFromJSON(json: any): RemoteAuthenticat
 export function RemoteAuthenticatedUserDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean): RemoteAuthenticatedUserDto {
     return json;
 }
-
 export function RemoteAuthenticatedUserDtoToJSON(value?: RemoteAuthenticatedUserDto | null): any {
+    return RemoteAuthenticatedUserDtoToJSONTyped(value);
+}
+export function RemoteAuthenticatedUserDtoToJSONTyped(value?: RemoteAuthenticatedUserDto | null, ignoreDiscriminator = false): any {
     return value;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -18,6 +18,7 @@ import {
     OwnerFromJSON,
     OwnerFromJSONTyped,
     OwnerToJSON,
+    OwnerToJSONTyped,
 } from './Owner';
 
 /**
@@ -54,8 +55,10 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
         'owner': json['owner'] == null ? undefined : OwnerFromJSON(json['owner']),
     };
 }
-
 export function ClubToJSON(value?: Club | null): any {
+    return ClubToJSONTyped(value);
+}
+export function ClubToJSONTyped(value?: Club | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -47,8 +47,10 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function OwnerToJSON(value?: Owner | null): any {
+    return OwnerToJSONTyped(value);
+}
+export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -18,6 +18,7 @@ import {
     OwnerFromJSON,
     OwnerFromJSONTyped,
     OwnerToJSON,
+    OwnerToJSONTyped,
 } from './Owner';
 
 /**
@@ -54,8 +55,10 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
         'owner': json['owner'] == null ? undefined : OwnerFromJSON(json['owner']),
     };
 }
-
 export function ClubToJSON(value?: Omit<Club, 'owner'> | null): any {
+    return ClubToJSONTyped(value);
+}
+export function ClubToJSONTyped(value?: Club | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -47,8 +47,10 @@ export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Own
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function OwnerToJSON(value?: Owner | null): any {
+    return OwnerToJSONTyped(value);
+}
+export function OwnerToJSONTyped(value?: Owner | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -54,8 +54,10 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
         'mapOfMapProperty': json['map_of_map_property'] == null ? undefined : json['map_of_map_property'],
     };
 }
-
 export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
+    return AdditionalPropertiesClassToJSONTyped(value);
+}
+export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -18,6 +18,7 @@ import {
     SingleRefTypeFromJSON,
     SingleRefTypeFromJSONTyped,
     SingleRefTypeToJSON,
+    SingleRefTypeToJSONTyped,
 } from './SingleRefType';
 
 /**
@@ -63,8 +64,10 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
         'singleRefType': json['SingleRefType'] == null ? undefined : SingleRefTypeFromJSON(json['SingleRefType']),
     };
 }
-
 export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
+    return AllOfWithSingleRefToJSONTyped(value);
+}
+export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -13,8 +13,15 @@
  */
 
 import { mapValues } from '../runtime';
-import { CatFromJSONTyped } from './Cat';
-import { DogFromJSONTyped } from './Dog';
+import {
+  Cat,
+  CatToJSONTyped,
+  CatFromJSONTyped} from './Cat';
+import {
+  Dog,
+  DogToJSONTyped,
+  DogFromJSONTyped} from './Dog';
+
 /**
  * 
  * @export
@@ -65,10 +72,26 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
         'color': json['color'] == null ? undefined : json['color'],
     };
 }
-
+function isCat(value: Animal):value is Cat{
+    return value['className'] === 'CAT';
+}
+function isDog(value: Animal):value is Dog{
+    return value['className'] === 'DOG';
+}
 export function AnimalToJSON(value?: Animal | null): any {
+    return AnimalToJSONTyped(value);
+}
+export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
+    }
+    if (!ignoreDiscriminator) {
+        if (isCat(value)) {
+            return CatToJSONTyped(value, true);
+        }
+        if (isDog(value)) {
+            return DogToJSONTyped(value, true);
+        }
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -47,8 +47,10 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
         'arrayArrayNumber': json['ArrayArrayNumber'] == null ? undefined : json['ArrayArrayNumber'],
     };
 }
-
 export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
+    return ArrayOfArrayOfNumberOnlyToJSONTyped(value);
+}
+export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -47,8 +47,10 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
         'arrayNumber': json['ArrayNumber'] == null ? undefined : json['ArrayNumber'],
     };
 }
-
 export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
+    return ArrayOfNumberOnlyToJSONTyped(value);
+}
+export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -18,6 +18,7 @@ import {
     ReadOnlyFirstFromJSON,
     ReadOnlyFirstFromJSONTyped,
     ReadOnlyFirstToJSON,
+    ReadOnlyFirstToJSONTyped,
 } from './ReadOnlyFirst';
 
 /**
@@ -68,8 +69,10 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'arrayArrayOfModel': json['array_array_of_model'] == null ? undefined : json['array_array_of_model'],
     };
 }
-
 export function ArrayTestToJSON(value?: ArrayTest | null): any {
+    return ArrayTestToJSONTyped(value);
+}
+export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -83,8 +83,10 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
         'aTTNAME': json['ATT_NAME'] == null ? undefined : json['ATT_NAME'],
     };
 }
-
 export function CapitalizationToJSON(value?: Capitalization | null): any {
+    return CapitalizationToJSONTyped(value);
+}
+export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -54,13 +55,15 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
         'declawed': json['declawed'] == null ? undefined : json['declawed'],
     };
 }
-
 export function CatToJSON(value?: Cat | null): any {
+    return CatToJSONTyped(value);
+}
+export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSONTyped(value, ignoreDiscriminator),
         'declawed': value['declawed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -55,8 +55,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -18,6 +18,7 @@ import {
     ParentWithNullableFromJSON,
     ParentWithNullableFromJSONTyped,
     ParentWithNullableToJSON,
+    ParentWithNullableToJSONTyped,
 } from './ParentWithNullable';
 
 /**
@@ -56,13 +57,15 @@ export function ChildWithNullableFromJSONTyped(json: any, ignoreDiscriminator: b
         'otherProperty': json['otherProperty'] == null ? undefined : json['otherProperty'],
     };
 }
-
 export function ChildWithNullableToJSON(value?: ChildWithNullable | null): any {
+    return ChildWithNullableToJSONTyped(value);
+}
+export function ChildWithNullableToJSONTyped(value?: ChildWithNullable | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }
     return {
-        ...ParentWithNullableToJSON(value),
+        ...ParentWithNullableToJSONTyped(value, ignoreDiscriminator),
         'otherProperty': value['otherProperty'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -47,8 +47,10 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         '_class': json['_class'] == null ? undefined : json['_class'],
     };
 }
-
 export function ClassModelToJSON(value?: ClassModel | null): any {
+    return ClassModelToJSONTyped(value);
+}
+export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -47,8 +47,10 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
         'client': json['client'] == null ? undefined : json['client'],
     };
 }
-
 export function ClientToJSON(value?: Client | null): any {
+    return ClientToJSONTyped(value);
+}
+export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -47,8 +47,10 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
+    return DeprecatedObjectToJSONTyped(value);
+}
+export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -54,13 +55,15 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
         'breed': json['breed'] == null ? undefined : json['breed'],
     };
 }
-
 export function DogToJSON(value?: Dog | null): any {
+    return DogToJSONTyped(value);
+}
+export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSONTyped(value, ignoreDiscriminator),
         'breed': value['breed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -74,8 +74,10 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'arrayEnum': json['array_enum'] == null ? undefined : json['array_enum'],
     };
 }
-
 export function EnumArraysToJSON(value?: EnumArrays | null): any {
+    return EnumArraysToJSONTyped(value);
+}
+export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -47,4 +47,7 @@ export function EnumClassFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 export function EnumClassToJSON(value?: EnumClass | null): any {
     return value as any;
 }
+export function EnumClassToJSONTyped(value: any, ignoreDiscriminator: boolean): EnumClass {
+    return value as EnumClass;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -18,24 +18,28 @@ import {
     OuterEnumFromJSON,
     OuterEnumFromJSONTyped,
     OuterEnumToJSON,
+    OuterEnumToJSONTyped,
 } from './OuterEnum';
 import type { OuterEnumIntegerDefaultValue } from './OuterEnumIntegerDefaultValue';
 import {
     OuterEnumIntegerDefaultValueFromJSON,
     OuterEnumIntegerDefaultValueFromJSONTyped,
     OuterEnumIntegerDefaultValueToJSON,
+    OuterEnumIntegerDefaultValueToJSONTyped,
 } from './OuterEnumIntegerDefaultValue';
 import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 import type { OuterEnumDefaultValue } from './OuterEnumDefaultValue';
 import {
     OuterEnumDefaultValueFromJSON,
     OuterEnumDefaultValueFromJSONTyped,
     OuterEnumDefaultValueToJSON,
+    OuterEnumDefaultValueToJSONTyped,
 } from './OuterEnumDefaultValue';
 
 /**
@@ -162,8 +166,10 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),
     };
 }
-
 export function EnumTestToJSON(value?: EnumTest | null): any {
+    return EnumTestToJSONTyped(value);
+}
+export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -54,8 +54,10 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
         'someMap': json['someMap'] == null ? undefined : json['someMap'],
     };
 }
-
 export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
+    return FakeBigDecimalMap200ResponseToJSONTyped(value);
+}
+export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -54,8 +54,10 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
         'files': json['files'] == null ? undefined : json['files'],
     };
 }
-
 export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
+    return FileSchemaTestClassToJSONTyped(value);
+}
+export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -47,8 +47,10 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
         'bar': json['bar'] == null ? undefined : json['bar'],
     };
 }
-
 export function FooToJSON(value?: Foo | null): any {
+    return FooToJSONTyped(value);
+}
+export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -18,6 +18,7 @@ import {
     FooFromJSON,
     FooFromJSONTyped,
     FooToJSON,
+    FooToJSONTyped,
 } from './Foo';
 
 /**
@@ -54,8 +55,10 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
         'string': json['string'] == null ? undefined : FooFromJSON(json['string']),
     };
 }
-
 export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
+    return FooGetDefaultResponseToJSONTyped(value);
+}
+export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -18,6 +18,7 @@ import {
     DecimalFromJSON,
     DecimalFromJSONTyped,
     DecimalToJSON,
+    DecimalToJSONTyped,
 } from './Decimal';
 
 /**
@@ -163,8 +164,10 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'patternWithDigitsAndDelimiter': json['pattern_with_digits_and_delimiter'] == null ? undefined : json['pattern_with_digits_and_delimiter'],
     };
 }
-
 export function FormatTestToJSON(value?: FormatTest | null): any {
+    return FormatTestToJSONTyped(value);
+}
+export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -54,8 +54,10 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
         'foo': json['foo'] == null ? undefined : json['foo'],
     };
 }
-
 export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null): any {
+    return HasOnlyReadOnlyToJSONTyped(value);
+}
+export function HasOnlyReadOnlyToJSONTyped(value?: HasOnlyReadOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -47,8 +47,10 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
         'nullableMessage': json['NullableMessage'] == null ? undefined : json['NullableMessage'],
     };
 }
-
 export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
+    return HealthCheckResultToJSONTyped(value);
+}
+export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -47,8 +47,10 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
         '_123list': json['123-list'] == null ? undefined : json['123-list'],
     };
 }
-
 export function ListToJSON(value?: List | null): any {
+    return ListToJSONTyped(value);
+}
+export function ListToJSONTyped(value?: List | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -79,8 +79,10 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
         'indirectMap': json['indirect_map'] == null ? undefined : json['indirect_map'],
     };
 }
-
 export function MapTestToJSON(value?: MapTest | null): any {
+    return MapTestToJSONTyped(value);
+}
+export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -68,8 +69,10 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
         'map': json['map'] == null ? undefined : (mapValues(json['map'], AnimalFromJSON)),
     };
 }
-
 export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
+    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value);
+}
+export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -54,8 +54,10 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         '_class': json['class'] == null ? undefined : json['class'],
     };
 }
-
 export function Model200ResponseToJSON(value?: Model200Response | null): any {
+    return Model200ResponseToJSONTyped(value);
+}
+export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -47,8 +47,10 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'sourceURI': json['sourceURI'] == null ? undefined : json['sourceURI'],
     };
 }
-
 export function ModelFileToJSON(value?: ModelFile | null): any {
+    return ModelFileToJSONTyped(value);
+}
+export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -69,8 +69,10 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
         '_123number': json['123Number'] == null ? undefined : json['123Number'],
     };
 }
-
 export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null): any {
+    return NameToJSONTyped(value);
+}
+export function NameToJSONTyped(value?: Name | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -126,8 +126,10 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }
-
 export function NullableClassToJSON(value?: NullableClass | null): any {
+    return NullableClassToJSONTyped(value);
+}
+export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -47,8 +47,10 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'justNumber': json['JustNumber'] == null ? undefined : json['JustNumber'],
     };
 }
-
 export function NumberOnlyToJSON(value?: NumberOnly | null): any {
+    return NumberOnlyToJSONTyped(value);
+}
+export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -18,6 +18,7 @@ import {
     DeprecatedObjectFromJSON,
     DeprecatedObjectFromJSONTyped,
     DeprecatedObjectToJSON,
+    DeprecatedObjectToJSONTyped,
 } from './DeprecatedObject';
 
 /**
@@ -78,8 +79,10 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
         'bars': json['bars'] == null ? undefined : json['bars'],
     };
 }
-
 export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
+    return ObjectWithDeprecatedFieldsToJSONTyped(value);
+}
+export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -61,8 +61,10 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
         'myBoolean': json['my_boolean'] == null ? undefined : json['my_boolean'],
     };
 }
-
 export function OuterCompositeToJSON(value?: OuterComposite | null): any {
+    return OuterCompositeToJSONTyped(value);
+}
+export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -47,4 +47,7 @@ export function OuterEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 export function OuterEnumToJSON(value?: OuterEnum | null): any {
     return value as any;
 }
+export function OuterEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnum {
+    return value as OuterEnum;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -47,4 +47,7 @@ export function OuterEnumDefaultValueFromJSONTyped(json: any, ignoreDiscriminato
 export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null): any {
     return value as any;
 }
+export function OuterEnumDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
+    return value as OuterEnumDefaultValue;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -47,4 +47,7 @@ export function OuterEnumIntegerFromJSONTyped(json: any, ignoreDiscriminator: bo
 export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
     return value as any;
 }
+export function OuterEnumIntegerToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumInteger {
+    return value as OuterEnumInteger;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -47,4 +47,7 @@ export function OuterEnumIntegerDefaultValueFromJSONTyped(json: any, ignoreDiscr
 export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefaultValue | null): any {
     return value as any;
 }
+export function OuterEnumIntegerDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
+    return value as OuterEnumIntegerDefaultValue;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -18,6 +18,7 @@ import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 
 /**
@@ -57,8 +58,10 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
         'value': OuterEnumIntegerFromJSON(json['value']),
     };
 }
-
 export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
+    return OuterObjectWithEnumPropertyToJSONTyped(value);
+}
+export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -13,7 +13,11 @@
  */
 
 import { mapValues } from '../runtime';
-import { ChildWithNullableFromJSONTyped } from './ChildWithNullable';
+import {
+  ChildWithNullable,
+  ChildWithNullableToJSONTyped,
+  ChildWithNullableFromJSONTyped} from './ChildWithNullable';
+
 /**
  * 
  * @export
@@ -70,10 +74,20 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
         'nullableProperty': json['nullableProperty'] == null ? undefined : json['nullableProperty'],
     };
 }
-
+function isChildWithNullable(value: ParentWithNullable):value is ChildWithNullable{
+    return value['type'] === 'ChildWithNullable';
+}
 export function ParentWithNullableToJSON(value?: ParentWithNullable | null): any {
+    return ParentWithNullableToJSONTyped(value);
+}
+export function ParentWithNullableToJSONTyped(value?: ParentWithNullable | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
+    }
+    if (!ignoreDiscriminator) {
+        if (isChildWithNullable(value)) {
+            return ChildWithNullableToJSONTyped(value, true);
+        }
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -54,8 +54,10 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
         'baz': json['baz'] == null ? undefined : json['baz'],
     };
 }
-
 export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null): any {
+    return ReadOnlyFirstToJSONTyped(value);
+}
+export function ReadOnlyFirstToJSONTyped(value?: ReadOnlyFirst | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -47,8 +47,10 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
         '_return': json['return'] == null ? undefined : json['return'],
     };
 }
-
 export function ReturnToJSON(value?: Return | null): any {
+    return ReturnToJSONTyped(value);
+}
+export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -46,4 +46,7 @@ export function SingleRefTypeFromJSONTyped(json: any, ignoreDiscriminator: boole
 export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
     return value as any;
 }
+export function SingleRefTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): SingleRefType {
+    return value as SingleRefType;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -47,8 +47,10 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
         '$specialPropertyName': json['$special[property.name]'] == null ? undefined : json['$special[property.name]'],
     };
 }
-
 export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
+    return SpecialModelNameToJSONTyped(value);
+}
+export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -49,8 +49,10 @@ export function TestInlineFreeformAdditionalPropertiesRequestFromJSONTyped(json:
         'someProperty': json['someProperty'] == null ? undefined : json['someProperty'],
     };
 }
-
 export function TestInlineFreeformAdditionalPropertiesRequestToJSON(value?: TestInlineFreeformAdditionalPropertiesRequest | null): any {
+    return TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value);
+}
+export function TestInlineFreeformAdditionalPropertiesRequestToJSONTyped(value?: TestInlineFreeformAdditionalPropertiesRequest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -18,12 +18,14 @@ import {
     NumberEnumFromJSON,
     NumberEnumFromJSONTyped,
     NumberEnumToJSON,
+    NumberEnumToJSONTyped,
 } from './NumberEnum';
 import type { StringEnum } from './StringEnum';
 import {
     StringEnumFromJSON,
     StringEnumFromJSONTyped,
     StringEnumToJSON,
+    StringEnumToJSONTyped,
 } from './StringEnum';
 
 /**
@@ -83,8 +85,10 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
         'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
-
 export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
+    return EnumPatternObjectToJSONTyped(value);
+}
+export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -110,8 +110,10 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
         'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : json['nullable-number-enum'],
     };
 }
-
 export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
+    return FakeEnumRequestGetInline200ResponseToJSONTyped(value);
+}
+export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -47,4 +47,7 @@ export function NumberEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 export function NumberEnumToJSON(value?: NumberEnum | null): any {
     return value as any;
 }
+export function NumberEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): NumberEnum {
+    return value as NumberEnum;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -47,4 +47,7 @@ export function StringEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 export function StringEnumToJSON(value?: StringEnum | null): any {
     return value as any;
 }
+export function StringEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): StringEnum {
+    return value as StringEnum;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestA.ts
@@ -48,8 +48,10 @@ export function TestAFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
         'foo': json['foo'],
     };
 }
-
 export function TestAToJSON(value?: TestA | null): any {
+    return TestAToJSONTyped(value);
+}
+export function TestAToJSONTyped(value?: TestA | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestB.ts
@@ -48,8 +48,10 @@ export function TestBFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tes
         'bar': json['bar'],
     };
 }
-
 export function TestBToJSON(value?: TestB | null): any {
+    return TestBToJSONTyped(value);
+}
+export function TestBToJSONTyped(value?: TestB | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
@@ -18,6 +18,7 @@ import {
     TestAFromJSON,
     TestAFromJSONTyped,
     TestAToJSON,
+    TestAToJSONTyped,
 } from './TestA';
 import type { TestB } from './TestB';
 import {
@@ -25,6 +26,7 @@ import {
     TestBFromJSON,
     TestBFromJSONTyped,
     TestBToJSON,
+    TestBToJSONTyped,
 } from './TestB';
 
 /**

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -47,4 +47,7 @@ export function BehaviorTypeFromJSONTyped(json: any, ignoreDiscriminator: boolea
 export function BehaviorTypeToJSON(value?: BehaviorType | null): any {
     return value as any;
 }
+export function BehaviorTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): BehaviorType {
+    return value as BehaviorType;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -18,6 +18,7 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -55,8 +56,10 @@ export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscrimina
         'meta': ResponseMetaFromJSON(json['meta']),
     };
 }
-
 export function DefaultMetaOnlyResponseToJSON(value?: DefaultMetaOnlyResponse | null): any {
+    return DefaultMetaOnlyResponseToJSONTyped(value);
+}
+export function DefaultMetaOnlyResponseToJSONTyped(value?: DefaultMetaOnlyResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -56,4 +56,7 @@ export function DeploymentRequestStatusFromJSONTyped(json: any, ignoreDiscrimina
 export function DeploymentRequestStatusToJSON(value?: DeploymentRequestStatus | null): any {
     return value as any;
 }
+export function DeploymentRequestStatusToJSONTyped(value: any, ignoreDiscriminator: boolean): DeploymentRequestStatus {
+    return value as DeploymentRequestStatus;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -62,4 +62,7 @@ export function ErrorCodeFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 export function ErrorCodeToJSON(value?: ErrorCode | null): any {
     return value as any;
 }
+export function ErrorCodeToJSONTyped(value: any, ignoreDiscriminator: boolean): ErrorCode {
+    return value as ErrorCode;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -18,12 +18,14 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 import type { Pet } from './Pet';
 import {
     PetFromJSON,
     PetFromJSONTyped,
     PetToJSON,
+    PetToJSONTyped,
 } from './Pet';
 
 /**
@@ -68,8 +70,10 @@ export function FindPetsByStatusResponseFromJSONTyped(json: any, ignoreDiscrimin
         'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(PetFromJSON)),
     };
 }
-
 export function FindPetsByStatusResponseToJSON(value?: FindPetsByStatusResponse | null): any {
+    return FindPetsByStatusResponseToJSONTyped(value);
+}
+export function FindPetsByStatusResponseToJSONTyped(value?: FindPetsByStatusResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -18,12 +18,14 @@ import {
     UserFromJSON,
     UserFromJSONTyped,
     UserToJSON,
+    UserToJSONTyped,
 } from './User';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -68,8 +70,10 @@ export function FindPetsByUserResponseFromJSONTyped(json: any, ignoreDiscriminat
         'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(UserFromJSON)),
     };
 }
-
 export function FindPetsByUserResponseToJSON(value?: FindPetsByUserResponse | null): any {
+    return FindPetsByUserResponseToJSONTyped(value);
+}
+export function FindPetsByUserResponseToJSONTyped(value?: FindPetsByUserResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -18,6 +18,7 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -62,8 +63,10 @@ export function GetBehaviorPermissionsResponseFromJSONTyped(json: any, ignoreDis
         'data': json['data'] == null ? undefined : json['data'],
     };
 }
-
 export function GetBehaviorPermissionsResponseToJSON(value?: GetBehaviorPermissionsResponse | null): any {
+    return GetBehaviorPermissionsResponseToJSONTyped(value);
+}
+export function GetBehaviorPermissionsResponseToJSONTyped(value?: GetBehaviorPermissionsResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -18,12 +18,14 @@ import {
     BehaviorTypeFromJSON,
     BehaviorTypeFromJSONTyped,
     BehaviorTypeToJSON,
+    BehaviorTypeToJSONTyped,
 } from './BehaviorType';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -70,8 +72,10 @@ export function GetBehaviorTypeResponseFromJSONTyped(json: any, ignoreDiscrimina
         'data': json['data'] == null ? undefined : BehaviorTypeFromJSON(json['data']),
     };
 }
-
 export function GetBehaviorTypeResponseToJSON(value?: GetBehaviorTypeResponse | null): any {
+    return GetBehaviorTypeResponseToJSONTyped(value);
+}
+export function GetBehaviorTypeResponseToJSONTyped(value?: GetBehaviorTypeResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -18,12 +18,14 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 import type { MatchingParts } from './MatchingParts';
 import {
     MatchingPartsFromJSON,
     MatchingPartsFromJSONTyped,
     MatchingPartsToJSON,
+    MatchingPartsToJSONTyped,
 } from './MatchingParts';
 
 /**
@@ -68,8 +70,10 @@ export function GetMatchingPartsResponseFromJSONTyped(json: any, ignoreDiscrimin
         'data': json['data'] == null ? undefined : MatchingPartsFromJSON(json['data']),
     };
 }
-
 export function GetMatchingPartsResponseToJSON(value?: GetMatchingPartsResponse | null): any {
+    return GetMatchingPartsResponseToJSONTyped(value);
+}
+export function GetMatchingPartsResponseToJSONTyped(value?: GetMatchingPartsResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -18,12 +18,14 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 import type { PetPartType } from './PetPartType';
 import {
     PetPartTypeFromJSON,
     PetPartTypeFromJSONTyped,
     PetPartTypeToJSON,
+    PetPartTypeToJSONTyped,
 } from './PetPartType';
 
 /**
@@ -70,8 +72,10 @@ export function GetPetPartTypeResponseFromJSONTyped(json: any, ignoreDiscriminat
         'data': json['data'] == null ? undefined : PetPartTypeFromJSON(json['data']),
     };
 }
-
 export function GetPetPartTypeResponseToJSON(value?: GetPetPartTypeResponse | null): any {
+    return GetPetPartTypeResponseToJSONTyped(value);
+}
+export function GetPetPartTypeResponseToJSONTyped(value?: GetPetPartTypeResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -56,8 +56,10 @@ export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): It
         'type': json['type'],
     };
 }
-
 export function ItemIdToJSON(value?: ItemId | null): any {
+    return ItemIdToJSONTyped(value);
+}
+export function ItemIdToJSONTyped(value?: ItemId | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -18,6 +18,7 @@ import {
     PartFromJSON,
     PartFromJSONTyped,
     PartToJSON,
+    PartToJSONTyped,
 } from './Part';
 
 /**
@@ -63,8 +64,10 @@ export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boole
         'related': ((json['related'] as Array<any>).map(PartFromJSON)),
     };
 }
-
 export function MatchingPartsToJSON(value?: MatchingParts | null): any {
+    return MatchingPartsToJSONTyped(value);
+}
+export function MatchingPartsToJSONTyped(value?: MatchingParts | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -18,6 +18,7 @@ import {
     ItemIdFromJSON,
     ItemIdFromJSONTyped,
     ItemIdToJSON,
+    ItemIdToJSONTyped,
 } from './ItemId';
 
 /**
@@ -76,8 +77,10 @@ export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'exception': json['exception'] == null ? undefined : json['exception'],
     };
 }
-
 export function ModelErrorToJSON(value?: ModelError | null): any {
+    return ModelErrorToJSONTyped(value);
+}
+export function ModelErrorToJSONTyped(value?: ModelError | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -56,8 +56,10 @@ export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part
         'name': json['name'],
     };
 }
-
 export function PartToJSON(value?: Part | null): any {
+    return PartToJSONTyped(value);
+}
+export function PartToJSONTyped(value?: Part | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -18,24 +18,28 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { DeploymentRequestStatus } from './DeploymentRequestStatus';
 import {
     DeploymentRequestStatusFromJSON,
     DeploymentRequestStatusFromJSONTyped,
     DeploymentRequestStatusToJSON,
+    DeploymentRequestStatusToJSONTyped,
 } from './DeploymentRequestStatus';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 import type { WarningCode } from './WarningCode';
 import {
     WarningCodeFromJSON,
     WarningCodeFromJSONTyped,
     WarningCodeToJSON,
+    WarningCodeToJSONTyped,
 } from './WarningCode';
 
 /**
@@ -238,8 +242,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'regions': json['regions'] == null ? undefined : json['regions'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -47,4 +47,7 @@ export function PetPartTypeFromJSONTyped(json: any, ignoreDiscriminator: boolean
 export function PetPartTypeToJSON(value?: PetPartType | null): any {
     return value as any;
 }
+export function PetPartTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): PetPartType {
+    return value as PetPartType;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -18,6 +18,7 @@ import {
     ResponseMetaFromJSON,
     ResponseMetaFromJSONTyped,
     ResponseMetaToJSON,
+    ResponseMetaToJSONTyped,
 } from './ResponseMeta';
 
 /**
@@ -62,8 +63,10 @@ export function PetRegionsResponseFromJSONTyped(json: any, ignoreDiscriminator: 
         'data': json['data'] == null ? undefined : json['data'],
     };
 }
-
 export function PetRegionsResponseToJSON(value?: PetRegionsResponse | null): any {
+    return PetRegionsResponseToJSONTyped(value);
+}
+export function PetRegionsResponseToJSONTyped(value?: PetRegionsResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -18,6 +18,7 @@ import {
     ErrorCodeFromJSON,
     ErrorCodeFromJSONTyped,
     ErrorCodeToJSON,
+    ErrorCodeToJSONTyped,
 } from './ErrorCode';
 
 /**
@@ -122,8 +123,10 @@ export function ResponseMetaFromJSONTyped(json: any, ignoreDiscriminator: boolea
         'errors': json['errors'] == null ? undefined : json['errors'],
     };
 }
-
 export function ResponseMetaToJSON(value?: ResponseMeta | null): any {
+    return ResponseMetaToJSONTyped(value);
+}
+export function ResponseMetaToJSONTyped(value?: ResponseMeta | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -112,8 +112,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'subUser2': UserFromJSON(json['subUser2']),
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -47,4 +47,7 @@ export function WarningCodeFromJSONTyped(json: any, ignoreDiscriminator: boolean
 export function WarningCodeToJSON(value?: WarningCode | null): any {
     return value as any;
 }
+export function WarningCodeToJSONTyped(value: any, ignoreDiscriminator: boolean): WarningCode {
+    return value as WarningCode;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -54,8 +54,10 @@ export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscrimi
         'mapOfMapProperty': json['map_of_map_property'] == null ? undefined : json['map_of_map_property'],
     };
 }
-
 export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
+    return AdditionalPropertiesClassToJSONTyped(value);
+}
+export function AdditionalPropertiesClassToJSONTyped(value?: AdditionalPropertiesClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -18,6 +18,7 @@ import {
     SingleRefTypeFromJSON,
     SingleRefTypeFromJSONTyped,
     SingleRefTypeToJSON,
+    SingleRefTypeToJSONTyped,
 } from './SingleRefType';
 
 /**
@@ -63,8 +64,10 @@ export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: 
         'singleRefType': json['SingleRefType'] == null ? undefined : SingleRefTypeFromJSON(json['SingleRefType']),
     };
 }
-
 export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
+    return AllOfWithSingleRefToJSONTyped(value);
+}
+export function AllOfWithSingleRefToJSONTyped(value?: AllOfWithSingleRef | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -13,8 +13,15 @@
  */
 
 import { mapValues } from '../runtime';
-import { CatFromJSONTyped } from './Cat';
-import { DogFromJSONTyped } from './Dog';
+import {
+  Cat,
+  CatToJSONTyped,
+  CatFromJSONTyped} from './Cat';
+import {
+  Dog,
+  DogToJSONTyped,
+  DogFromJSONTyped} from './Dog';
+
 /**
  * 
  * @export
@@ -65,10 +72,26 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
         'color': json['color'] == null ? undefined : json['color'],
     };
 }
-
+function isCat(value: Animal):value is Cat{
+    return value['className'] === 'CAT';
+}
+function isDog(value: Animal):value is Dog{
+    return value['className'] === 'DOG';
+}
 export function AnimalToJSON(value?: Animal | null): any {
+    return AnimalToJSONTyped(value);
+}
+export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
+    }
+    if (!ignoreDiscriminator) {
+        if (isCat(value)) {
+            return CatToJSONTyped(value, true);
+        }
+        if (isDog(value)) {
+            return DogToJSONTyped(value, true);
+        }
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -47,8 +47,10 @@ export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscrimin
         'arrayArrayNumber': json['ArrayArrayNumber'] == null ? undefined : json['ArrayArrayNumber'],
     };
 }
-
 export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
+    return ArrayOfArrayOfNumberOnlyToJSONTyped(value);
+}
+export function ArrayOfArrayOfNumberOnlyToJSONTyped(value?: ArrayOfArrayOfNumberOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -47,8 +47,10 @@ export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: b
         'arrayNumber': json['ArrayNumber'] == null ? undefined : json['ArrayNumber'],
     };
 }
-
 export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
+    return ArrayOfNumberOnlyToJSONTyped(value);
+}
+export function ArrayOfNumberOnlyToJSONTyped(value?: ArrayOfNumberOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -18,6 +18,7 @@ import {
     ReadOnlyFirstFromJSON,
     ReadOnlyFirstFromJSONTyped,
     ReadOnlyFirstToJSON,
+    ReadOnlyFirstToJSONTyped,
 } from './ReadOnlyFirst';
 
 /**
@@ -68,8 +69,10 @@ export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'arrayArrayOfModel': json['array_array_of_model'] == null ? undefined : json['array_array_of_model'],
     };
 }
-
 export function ArrayTestToJSON(value?: ArrayTest | null): any {
+    return ArrayTestToJSONTyped(value);
+}
+export function ArrayTestToJSONTyped(value?: ArrayTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -83,8 +83,10 @@ export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: bool
         'aTTNAME': json['ATT_NAME'] == null ? undefined : json['ATT_NAME'],
     };
 }
-
 export function CapitalizationToJSON(value?: Capitalization | null): any {
+    return CapitalizationToJSONTyped(value);
+}
+export function CapitalizationToJSONTyped(value?: Capitalization | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -54,13 +55,15 @@ export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
         'declawed': json['declawed'] == null ? undefined : json['declawed'],
     };
 }
-
 export function CatToJSON(value?: Cat | null): any {
+    return CatToJSONTyped(value);
+}
+export function CatToJSONTyped(value?: Cat | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSONTyped(value, ignoreDiscriminator),
         'declawed': value['declawed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -55,8 +55,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -47,8 +47,10 @@ export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         '_class': json['_class'] == null ? undefined : json['_class'],
     };
 }
-
 export function ClassModelToJSON(value?: ClassModel | null): any {
+    return ClassModelToJSONTyped(value);
+}
+export function ClassModelToJSONTyped(value?: ClassModel | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -47,8 +47,10 @@ export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cl
         'client': json['client'] == null ? undefined : json['client'],
     };
 }
-
 export function ClientToJSON(value?: Client | null): any {
+    return ClientToJSONTyped(value);
+}
+export function ClientToJSONTyped(value?: Client | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -47,8 +47,10 @@ export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: bo
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
+    return DeprecatedObjectToJSONTyped(value);
+}
+export function DeprecatedObjectToJSONTyped(value?: DeprecatedObject | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -54,13 +55,15 @@ export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
         'breed': json['breed'] == null ? undefined : json['breed'],
     };
 }
-
 export function DogToJSON(value?: Dog | null): any {
+    return DogToJSONTyped(value);
+}
+export function DogToJSONTyped(value?: Dog | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }
     return {
-        ...AnimalToJSON(value),
+        ...AnimalToJSONTyped(value, ignoreDiscriminator),
         'breed': value['breed'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -74,8 +74,10 @@ export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'arrayEnum': json['array_enum'] == null ? undefined : json['array_enum'],
     };
 }
-
 export function EnumArraysToJSON(value?: EnumArrays | null): any {
+    return EnumArraysToJSONTyped(value);
+}
+export function EnumArraysToJSONTyped(value?: EnumArrays | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -47,4 +47,7 @@ export function EnumClassFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 export function EnumClassToJSON(value?: EnumClass | null): any {
     return value as any;
 }
+export function EnumClassToJSONTyped(value: any, ignoreDiscriminator: boolean): EnumClass {
+    return value as EnumClass;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -18,24 +18,28 @@ import {
     OuterEnumFromJSON,
     OuterEnumFromJSONTyped,
     OuterEnumToJSON,
+    OuterEnumToJSONTyped,
 } from './OuterEnum';
 import type { OuterEnumIntegerDefaultValue } from './OuterEnumIntegerDefaultValue';
 import {
     OuterEnumIntegerDefaultValueFromJSON,
     OuterEnumIntegerDefaultValueFromJSONTyped,
     OuterEnumIntegerDefaultValueToJSON,
+    OuterEnumIntegerDefaultValueToJSONTyped,
 } from './OuterEnumIntegerDefaultValue';
 import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 import type { OuterEnumDefaultValue } from './OuterEnumDefaultValue';
 import {
     OuterEnumDefaultValueFromJSON,
     OuterEnumDefaultValueFromJSONTyped,
     OuterEnumDefaultValueToJSON,
+    OuterEnumDefaultValueToJSONTyped,
 } from './OuterEnumDefaultValue';
 
 /**
@@ -162,8 +166,10 @@ export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),
     };
 }
-
 export function EnumTestToJSON(value?: EnumTest | null): any {
+    return EnumTestToJSONTyped(value);
+}
+export function EnumTestToJSONTyped(value?: EnumTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -54,8 +54,10 @@ export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscr
         'someMap': json['someMap'] == null ? undefined : json['someMap'],
     };
 }
-
 export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
+    return FakeBigDecimalMap200ResponseToJSONTyped(value);
+}
+export function FakeBigDecimalMap200ResponseToJSONTyped(value?: FakeBigDecimalMap200Response | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -54,8 +54,10 @@ export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator:
         'files': json['files'] == null ? undefined : json['files'],
     };
 }
-
 export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
+    return FileSchemaTestClassToJSONTyped(value);
+}
+export function FileSchemaTestClassToJSONTyped(value?: FileSchemaTestClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -47,8 +47,10 @@ export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
         'bar': json['bar'] == null ? undefined : json['bar'],
     };
 }
-
 export function FooToJSON(value?: Foo | null): any {
+    return FooToJSONTyped(value);
+}
+export function FooToJSONTyped(value?: Foo | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -18,6 +18,7 @@ import {
     FooFromJSON,
     FooFromJSONTyped,
     FooToJSON,
+    FooToJSONTyped,
 } from './Foo';
 
 /**
@@ -54,8 +55,10 @@ export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminato
         'string': json['string'] == null ? undefined : FooFromJSON(json['string']),
     };
 }
-
 export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
+    return FooGetDefaultResponseToJSONTyped(value);
+}
+export function FooGetDefaultResponseToJSONTyped(value?: FooGetDefaultResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -18,6 +18,7 @@ import {
     DecimalFromJSON,
     DecimalFromJSONTyped,
     DecimalToJSON,
+    DecimalToJSONTyped,
 } from './Decimal';
 
 /**
@@ -163,8 +164,10 @@ export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'patternWithDigitsAndDelimiter': json['pattern_with_digits_and_delimiter'] == null ? undefined : json['pattern_with_digits_and_delimiter'],
     };
 }
-
 export function FormatTestToJSON(value?: FormatTest | null): any {
+    return FormatTestToJSONTyped(value);
+}
+export function FormatTestToJSONTyped(value?: FormatTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -54,8 +54,10 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
         'foo': json['foo'] == null ? undefined : json['foo'],
     };
 }
-
 export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null): any {
+    return HasOnlyReadOnlyToJSONTyped(value);
+}
+export function HasOnlyReadOnlyToJSONTyped(value?: HasOnlyReadOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -47,8 +47,10 @@ export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: b
         'nullableMessage': json['NullableMessage'] == null ? undefined : json['NullableMessage'],
     };
 }
-
 export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
+    return HealthCheckResultToJSONTyped(value);
+}
+export function HealthCheckResultToJSONTyped(value?: HealthCheckResult | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -47,8 +47,10 @@ export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List
         '_123list': json['123-list'] == null ? undefined : json['123-list'],
     };
 }
-
 export function ListToJSON(value?: List | null): any {
+    return ListToJSONTyped(value);
+}
+export function ListToJSONTyped(value?: List | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -79,8 +79,10 @@ export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): M
         'indirectMap': json['indirect_map'] == null ? undefined : json['indirect_map'],
     };
 }
-
 export function MapTestToJSON(value?: MapTest | null): any {
+    return MapTestToJSONTyped(value);
+}
+export function MapTestToJSONTyped(value?: MapTest | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -18,6 +18,7 @@ import {
     AnimalFromJSON,
     AnimalFromJSONTyped,
     AnimalToJSON,
+    AnimalToJSONTyped,
 } from './Animal';
 
 /**
@@ -68,8 +69,10 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: a
         'map': json['map'] == null ? undefined : (mapValues(json['map'], AnimalFromJSON)),
     };
 }
-
 export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
+    return MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value);
+}
+export function MixedPropertiesAndAdditionalPropertiesClassToJSONTyped(value?: MixedPropertiesAndAdditionalPropertiesClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -54,8 +54,10 @@ export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         '_class': json['class'] == null ? undefined : json['class'],
     };
 }
-
 export function Model200ResponseToJSON(value?: Model200Response | null): any {
+    return Model200ResponseToJSONTyped(value);
+}
+export function Model200ResponseToJSONTyped(value?: Model200Response | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -47,8 +47,10 @@ export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'sourceURI': json['sourceURI'] == null ? undefined : json['sourceURI'],
     };
 }
-
 export function ModelFileToJSON(value?: ModelFile | null): any {
+    return ModelFileToJSONTyped(value);
+}
+export function ModelFileToJSONTyped(value?: ModelFile | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -69,8 +69,10 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
         '_123number': json['123Number'] == null ? undefined : json['123Number'],
     };
 }
-
 export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null): any {
+    return NameToJSONTyped(value);
+}
+export function NameToJSONTyped(value?: Name | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -126,8 +126,10 @@ export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boole
         'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }
-
 export function NullableClassToJSON(value?: NullableClass | null): any {
+    return NullableClassToJSONTyped(value);
+}
+export function NullableClassToJSONTyped(value?: NullableClass | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -47,8 +47,10 @@ export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'justNumber': json['JustNumber'] == null ? undefined : json['JustNumber'],
     };
 }
-
 export function NumberOnlyToJSON(value?: NumberOnly | null): any {
+    return NumberOnlyToJSONTyped(value);
+}
+export function NumberOnlyToJSONTyped(value?: NumberOnly | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -18,6 +18,7 @@ import {
     DeprecatedObjectFromJSON,
     DeprecatedObjectFromJSONTyped,
     DeprecatedObjectToJSON,
+    DeprecatedObjectToJSONTyped,
 } from './DeprecatedObject';
 
 /**
@@ -78,8 +79,10 @@ export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscrim
         'bars': json['bars'] == null ? undefined : json['bars'],
     };
 }
-
 export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
+    return ObjectWithDeprecatedFieldsToJSONTyped(value);
+}
+export function ObjectWithDeprecatedFieldsToJSONTyped(value?: ObjectWithDeprecatedFields | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -61,8 +61,10 @@ export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: bool
         'myBoolean': json['my_boolean'] == null ? undefined : json['my_boolean'],
     };
 }
-
 export function OuterCompositeToJSON(value?: OuterComposite | null): any {
+    return OuterCompositeToJSONTyped(value);
+}
+export function OuterCompositeToJSONTyped(value?: OuterComposite | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -47,4 +47,7 @@ export function OuterEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean):
 export function OuterEnumToJSON(value?: OuterEnum | null): any {
     return value as any;
 }
+export function OuterEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnum {
+    return value as OuterEnum;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -47,4 +47,7 @@ export function OuterEnumDefaultValueFromJSONTyped(json: any, ignoreDiscriminato
 export function OuterEnumDefaultValueToJSON(value?: OuterEnumDefaultValue | null): any {
     return value as any;
 }
+export function OuterEnumDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumDefaultValue {
+    return value as OuterEnumDefaultValue;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -47,4 +47,7 @@ export function OuterEnumIntegerFromJSONTyped(json: any, ignoreDiscriminator: bo
 export function OuterEnumIntegerToJSON(value?: OuterEnumInteger | null): any {
     return value as any;
 }
+export function OuterEnumIntegerToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumInteger {
+    return value as OuterEnumInteger;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -47,4 +47,7 @@ export function OuterEnumIntegerDefaultValueFromJSONTyped(json: any, ignoreDiscr
 export function OuterEnumIntegerDefaultValueToJSON(value?: OuterEnumIntegerDefaultValue | null): any {
     return value as any;
 }
+export function OuterEnumIntegerDefaultValueToJSONTyped(value: any, ignoreDiscriminator: boolean): OuterEnumIntegerDefaultValue {
+    return value as OuterEnumIntegerDefaultValue;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -18,6 +18,7 @@ import {
     OuterEnumIntegerFromJSON,
     OuterEnumIntegerFromJSONTyped,
     OuterEnumIntegerToJSON,
+    OuterEnumIntegerToJSONTyped,
 } from './OuterEnumInteger';
 
 /**
@@ -57,8 +58,10 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
         'value': OuterEnumIntegerFromJSON(json['value']),
     };
 }
-
 export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
+    return OuterObjectWithEnumPropertyToJSONTyped(value);
+}
+export function OuterObjectWithEnumPropertyToJSONTyped(value?: OuterObjectWithEnumProperty | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -54,8 +54,10 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
         'baz': json['baz'] == null ? undefined : json['baz'],
     };
 }
-
 export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null): any {
+    return ReadOnlyFirstToJSONTyped(value);
+}
+export function ReadOnlyFirstToJSONTyped(value?: ReadOnlyFirst | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -47,8 +47,10 @@ export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
         '_return': json['return'] == null ? undefined : json['return'],
     };
 }
-
 export function ReturnToJSON(value?: Return | null): any {
+    return ReturnToJSONTyped(value);
+}
+export function ReturnToJSONTyped(value?: Return | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -46,4 +46,7 @@ export function SingleRefTypeFromJSONTyped(json: any, ignoreDiscriminator: boole
 export function SingleRefTypeToJSON(value?: SingleRefType | null): any {
     return value as any;
 }
+export function SingleRefTypeToJSONTyped(value: any, ignoreDiscriminator: boolean): SingleRefType {
+    return value as SingleRefType;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -47,8 +47,10 @@ export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: bo
         '$specialPropertyName': json['$special[property.name]'] == null ? undefined : json['$special[property.name]'],
     };
 }
-
 export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
+    return SpecialModelNameToJSONTyped(value);
+}
+export function SpecialModelNameToJSONTyped(value?: SpecialModelName | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Order.ts
@@ -96,8 +96,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -110,8 +112,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -54,8 +54,10 @@ export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function CategoryToJSON(value?: Category | null): any {
+    return CategoryToJSONTyped(value);
+}
+export function CategoryToJSONTyped(value?: Category | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -61,8 +61,10 @@ export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: bo
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
-
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
+    return ModelApiResponseToJSONTyped(value);
+}
+export function ModelApiResponseToJSONTyped(value?: ModelApiResponse | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -94,8 +94,10 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
-
 export function OrderToJSON(value?: Order | null): any {
+    return OrderToJSONTyped(value);
+}
+export function OrderToJSONTyped(value?: Order | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -18,12 +18,14 @@ import {
     CategoryFromJSON,
     CategoryFromJSONTyped,
     CategoryToJSON,
+    CategoryToJSONTyped,
 } from './Category';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
     TagFromJSONTyped,
     TagToJSON,
+    TagToJSONTyped,
 } from './Tag';
 
 /**
@@ -109,8 +111,10 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'status': json['status'] == null ? undefined : json['status'],
     };
 }
-
 export function PetToJSON(value?: Pet | null): any {
+    return PetToJSONTyped(value);
+}
+export function PetToJSONTyped(value?: Pet | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -54,8 +54,10 @@ export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
         'name': json['name'] == null ? undefined : json['name'],
     };
 }
-
 export function TagToJSON(value?: Tag | null): any {
+    return TagToJSONTyped(value);
+}
+export function TagToJSONTyped(value?: Tag | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -96,8 +96,10 @@ export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User
         'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
-
 export function UserToJSON(value?: User | null): any {
+    return UserToJSONTyped(value);
+}
+export function UserToJSONTyped(value?: User | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -18,12 +18,14 @@ import {
     NumberEnumFromJSON,
     NumberEnumFromJSONTyped,
     NumberEnumToJSON,
+    NumberEnumToJSONTyped,
 } from './NumberEnum';
 import type { StringEnum } from './StringEnum';
 import {
     StringEnumFromJSON,
     StringEnumFromJSONTyped,
     StringEnumToJSON,
+    StringEnumToJSONTyped,
 } from './StringEnum';
 
 /**
@@ -83,8 +85,10 @@ export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: b
         'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
-
 export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
+    return EnumPatternObjectToJSONTyped(value);
+}
+export function EnumPatternObjectToJSONTyped(value?: EnumPatternObject | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -106,8 +106,10 @@ export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, igno
         'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : json['nullable-number-enum'],
     };
 }
-
 export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
+    return FakeEnumRequestGetInline200ResponseToJSONTyped(value);
+}
+export function FakeEnumRequestGetInline200ResponseToJSONTyped(value?: FakeEnumRequestGetInline200Response | null, ignoreDiscriminator = false): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -46,4 +46,7 @@ export function NumberEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 export function NumberEnumToJSON(value?: NumberEnum | null): any {
     return value as any;
 }
+export function NumberEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): NumberEnum {
+    return value as NumberEnum;
+}
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -46,4 +46,7 @@ export function StringEnumFromJSONTyped(json: any, ignoreDiscriminator: boolean)
 export function StringEnumToJSON(value?: StringEnum | null): any {
     return value as any;
 }
+export function StringEnumToJSONTyped(value: any, ignoreDiscriminator: boolean): StringEnum {
+    return value as StringEnum;
+}
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Currently the generated typescript-fetch client only handles the decriminator value on deserialization to resolve the correct subtype, but not for serialization.
This PR fixes this by adding the same behaviour for serialization
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)
