### PR TITLE
Generating deserializers from OpenAPI Spec for kotlin models using Jackson

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -83,6 +83,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
     public static final String SUPPORT_ANDROID_API_LEVEL_25_AND_BELLOW = "supportAndroidApiLevel25AndBelow";
 
+    public static final String GENERATE_CUSTOM_JSON_DESERIALIZERS = "generateCustomJSONDeserializers";
+
     protected static final String VENDOR_EXTENSION_BASE_NAME_LITERAL = "x-base-name-literal";
 
     protected String dateLibrary = DateLibrary.JAVA8.value;
@@ -92,6 +94,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     protected boolean useRxJava2 = false;
     protected boolean useRxJava3 = false;
     protected boolean useCoroutines = false;
+    protected boolean generateCustomJSONDeserializers = false;
     // backwards compatibility for openapi configs that specify neither rx1 nor rx2
     // (mustache does not allow for boolean operators so we need this extra field)
     protected boolean doNotUseRxAndCoroutines = true;
@@ -243,6 +246,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         cliOptions.add(CliOption.newBoolean(GENERATE_ROOM_MODELS, "Generate Android Room database models in addition to API models (JVM Volley library only)", false));
 
         cliOptions.add(CliOption.newBoolean(SUPPORT_ANDROID_API_LEVEL_25_AND_BELLOW, "[WARNING] This flag will generate code that has a known security vulnerability. It uses `kotlin.io.createTempFile` instead of `java.nio.file.Files.createTempFile` in order to support Android API level 25 and bellow. For more info, please check the following links https://github.com/OpenAPITools/openapi-generator/security/advisories/GHSA-23x4-m842-fmwf, https://github.com/OpenAPITools/openapi-generator/pull/9284"));
+
+        cliOptions.add(CliOption.newBoolean(GENERATE_CUSTOM_JSON_DESERIALIZERS, "Wheter to generate custom JSON deserializers for models."));
     }
 
     public CodegenType getTag() {
@@ -330,6 +335,14 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
     public void setRoomModelPackage(String roomModelPackage) {
         this.roomModelPackage = roomModelPackage;
+    }
+
+    public boolean getGenerateCustomJSONDeserializers() {
+        return generateCustomJSONDeserializers;
+    }
+
+    public void setGenerateCustomJSONDeserializers(boolean generateCustomJSONDeserializers) {
+        this.generateCustomJSONDeserializers = generateCustomJSONDeserializers;
     }
 
     @Override
@@ -482,6 +495,18 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
             if (ProcessUtils.hasHttpBasicMethods(openAPI)) {
                 supportingFiles.add(new SupportingFile("auth/HttpBasicAuth.kt.mustache", authFolder, "HttpBasicAuth.kt"));
+            }
+        }
+
+        if(additionalProperties.containsKey(GENERATE_CUSTOM_JSON_DESERIALIZERS)) {
+            if(getSerializationLibrary().equals(SERIALIZATION_LIBRARY_TYPE.jackson)) {
+                this.setGenerateCustomJSONDeserializers(Boolean.parseBoolean(additionalProperties.get(GENERATE_CUSTOM_JSON_DESERIALIZERS).toString()));
+            }
+            else {
+                if(Boolean.parseBoolean(additionalProperties.get(GENERATE_CUSTOM_JSON_DESERIALIZERS).toString())){
+                    LOGGER.warn("Generating custom JSON deserializers is only supported with Jackson serialization.");
+                }
+                setGenerateCustomJSONDeserializers(false);
             }
         }
     }
@@ -776,7 +801,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
         for (ModelMap mo : objects.getModels()) {
             CodegenModel cm = mo.getModel();
-            if (getGenerateRoomModels()) {
+            if (getGenerateRoomModels() || getGenerateCustomJSONDeserializers()) {
                 cm.vendorExtensions.put("x-has-data-class-body", true);
             }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -14,6 +14,14 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 {{/discriminator}}
+{{#generateCustomJSONDeserializers}}
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.type.*
+
+{{/generateCustomJSONDeserializers}}
 {{/jackson}}
 {{#kotlinx_serialization}}
 import {{#serializableModel}}kotlinx.serialization.Serializable as KSerializable{{/serializableModel}}{{^serializableModel}}kotlinx.serialization.Serializable{{/serializableModel}}
@@ -142,6 +150,11 @@ import {{packageName}}.infrastructure.ITransformForStorage
 {{/isEnum}}
 {{/vars}}
 {{/hasEnums}}
+{{#jackson}}
+{{#generateCustomJSONDeserializers}}
+{{>jackson_deserializer}}
+{{/generateCustomJSONDeserializers}}
+{{/jackson}}
 {{#vendorExtensions.x-has-data-class-body}}
 }
 {{/vendorExtensions.x-has-data-class-body}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/deserialize_value.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/deserialize_value.mustache
@@ -1,0 +1,122 @@
+{{#isArray}}
+{{#items.isEnum}}
+                    "{{name}}" -> {
+                        val list : ArrayList<{{classname}}.{{items.nameInCamelCase}}> = ArrayList()
+                        while(p.nextToken() != JsonToken.END_ARRAY) {
+                            list.add({{classname}}.{{items.nameInCamelCase}}.valueOf(p.text))
+                        }
+                        parsedValues.{{name}} = list
+                      }
+{{/items.isEnum}}
+{{^items.isEnum}}
+{{#items.isString}}
+                    "{{name}}" -> {
+                        val list : ArrayList<String> = ArrayList()
+                        while(p.nextToken() != JsonToken.END_ARRAY) {
+                            list.add(p.text)
+                        }
+                        parsedValues.{{name}} = list
+                      }
+{{/items.isString}}
+{{^items.isString}}
+{{#items.isModel}}
+                    "{{name}}" -> {
+                        val list : ArrayList<{{&items.dataType}}> = ArrayList()
+                        while(p.nextToken() != JsonToken.END_ARRAY) {
+                            list.add({{&items.dataType}}.deserializer.deserialize(p, ctx))
+                        }
+                        parsedValues.{{name}} = list
+                      }
+{{/items.isModel}}
+{{^items.isModel}}
+                    "{{name}}" -> parsedValues.{{name}} = ctx.readValue(
+                            p,
+                            {{#items.isEnum}}
+                            ArrayType<{{classname}}.{{items.nameInCamelCase}}>::class.java
+                            {{/items.isEnum}}
+                            {{^items.isEnum}}
+                            Array<{{&items.dataType}}>::class.java
+                            {{/items.isEnum}}
+                        ).toList()
+{{/items.isModel}}
+{{/items.isString}}
+{{/items.isEnum}}
+{{/isArray}}
+{{^isArray}}
+{{#isString}}{{#isEnum}}
+                    "{{name}}" -> parsedValues.{{name}} = {{classname}}.{{nameInCamelCase}}.valueOf(p.text)
+{{/isEnum}}
+{{^isEnum}}
+                    "{{name}}" -> parsedValues.{{name}} = p.text
+{{/isEnum}}
+{{/isString}}
+{{^isString}}
+{{#isInteger}}
+                    "{{name}}" -> parsedValues.{{name}} = p.text.toInt()
+{{/isInteger}}
+{{^isInteger}}
+{{#isLong}}
+                    "{{name}}" -> parsedValues.{{name}} = p.text.toLong()
+{{/isLong}}
+{{^isLong}}
+{{#isBoolean}}
+                    "{{name}}" -> parsedValues.{{name}} = p.text.toBoolean()
+{{/isBoolean}}
+{{^isBoolean}}
+{{#isDouble}}
+                    "{{name}}" -> parsedValues.{{name}} = p.text.toDouble()
+{{/isDouble}}
+{{^isDouble}}
+{{#isFloat}}
+                    "{{name}}" -> parsedValues.{{name}} = p.text.toFloat()
+{{/isFloat}}
+{{^isFloat}}
+{{#isDateTime}}
+                    "{{name}}" -> parsedValues.{{name}} = java.time.OffsetDateTime.parse(p.text)
+{{/isDateTime}}
+{{^isDateTime}}
+{{#isDate}}
+                    "{{name}}" -> parsedValues.{{name}} = java.time.LocalDate.parse(p.text)
+{{/isDate}}
+{{^isDate}}
+{{#isModel}}
+                    "{{name}}" -> parsedValues.{{name}} = {{&dataType}}.deserializer.deserialize(p, ctx)
+{{/isModel}}
+{{^isModel}}
+{{#isMap}}
+{{#items.isString}}
+                "{{name}}" -> {
+                        val map : HashMap<String, String> = HashMap()
+                        while(p.nextToken() != JsonToken.END_OBJECT) {
+                            val key = p.text
+                            p.nextToken()
+                            map.put(key, p.text)
+                        }
+                        parsedValues.{{name}} = map
+                      }
+{{/items.isString}}
+{{^items.isString}}
+/** {{.}} */
+                "{{name}}" -> parsedValues.{{name}} = ctx.readValue(
+                            p,
+                            ctx.typeFactory.constructMapLikeType(HashMap::class.java, SimpleType.constructUnsafe(String::class.java), SimpleType.constructUnsafe({{items.dataType}}::class.java))
+                        )
+{{/items.isString}}
+{{/isMap}}
+{{^isMap}}
+/** {{.}} */
+                "{{name}}" -> parsedValues.{{name}} = ctx.readValue(
+                            p,
+                            {{#isEnum}}{{classname}}.{{nameInCamelCase}}::class.java{{/isEnum}}{{^isEnum}}com.fasterxml.jackson.databind.type.SimpleType.constructUnsafe({{&dataType}}::class.java){{/isEnum}}
+                        )
+{{/isMap}}
+{{/isModel}}
+{{/isDate}}
+{{/isDateTime}}
+{{/isFloat}}
+{{/isDouble}}
+{{/isBoolean}}
+{{/isLong}}
+{{/isInteger}}
+{{/isString}}
+{{/isArray}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jackson_deserializer.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jackson_deserializer.mustache
@@ -1,0 +1,66 @@
+    class ParsedValues{
+        {{#requiredVars}}
+        {{#isArray}}
+        {{#items.isEnum}}
+        var {{name}}: List<{{classname}}.{{items.nameInCamelCase}}>? = null
+        {{/items.isEnum}}
+        {{^items.isEnum}}
+        var {{name}}: List<{{items.dataType}}>? = null
+        {{/items.isEnum}}
+        {{/isArray}}
+        {{^isArray}}
+        {{#isEnum}}
+        var {{name}}: {{classname}}.{{nameInCamelCase}}? = null
+        {{/isEnum}}
+        {{^isEnum}}
+        var {{name}}: {{&dataType}}? = null
+        {{/isEnum}}
+        {{/isArray}}
+        {{/requiredVars}}
+        {{#optionalVars}}
+        {{#isArray}}
+        {{#items.isEnum}}
+        var {{name}}: List<{{classname}}.{{items.nameInCamelCase}}>? = null
+        {{/items.isEnum}}
+        {{^items.isEnum}}
+        var {{name}}: List<{{items.dataType}}>? = null
+        {{/items.isEnum}}
+        {{/isArray}}
+        {{^isArray}}
+        {{#isEnum}}
+        var {{name}}: {{classname}}.{{nameInCamelCase}}? = null
+        {{/isEnum}}
+        {{^isEnum}}
+        var {{name}}: {{&dataType}}? = null
+        {{/isEnum}}
+        {{/isArray}}
+        {{/optionalVars}}
+    }
+
+    @Suppress("UNUSED_VALUE")
+    class Deserializer : JsonDeserializer<{{classname}}>() {
+        override fun deserialize(p: JsonParser, ctx: DeserializationContext): {{classname}} {
+            val parsedValues = ParsedValues()
+            var curr = p.currentToken
+            if (curr != JsonToken.START_OBJECT) {
+                throw IllegalStateException("Should be start object")
+            }
+            curr = p.nextToken()
+            while (curr == JsonToken.FIELD_NAME) {
+                val field = p.text
+                curr = p.nextToken()
+                when (field) {
+{{#requiredVars}}{{>deserialize_value}}{{/requiredVars}}
+{{#optionalVars}}{{>deserialize_value}}{{/optionalVars}}
+                    else -> p.skipChildren()
+                }
+                curr = p.nextToken()
+            }
+            return {{classname}}({{#requiredVars}}
+                {{name}} = parsedValues.{{name}}!!,{{/requiredVars}}{{#optionalVars}}
+                {{name}} = parsedValues.{{name}},{{/optionalVars}})
+        }
+    }
+    companion object {
+        val deserializer by lazy(LazyThreadSafetyMode.NONE) { Deserializer() }
+    }


### PR DESCRIPTION
Adds option in the kotlin-jackson model generator to generate deserializers.

By using generated deserializers instead of reflection based deserialization,
we can achieve approximatly 3x speedup
Resolves #13266

## Attn Kotlin Technical Commity:
@jimschubert @dr4ke616 @karismann  @Zomzog  @andrewemery  @4brunu @yutaka0m

CoAuthor: @kny78

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
