### PR TITLE
[R] override `print`, lock classes

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
@@ -152,5 +152,25 @@
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+{{classname}}$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+{{classname}}$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+{{classname}}$lock()
+

--- a/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
@@ -479,5 +479,24 @@
       {{/allVars}}
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+{{classname}}$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+{{classname}}$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+{{classname}}$lock()

--- a/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
@@ -167,5 +167,24 @@
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+{{classname}}$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+{{classname}}$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+{{classname}}$lock()

--- a/samples/client/petstore/R-httr2-wrapper/R/allof_tag_api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/allof_tag_api_response.R
@@ -229,6 +229,25 @@ AllofTagApiResponse <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AllofTagApiResponse$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AllofTagApiResponse$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AllofTagApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/animal.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/animal.R
@@ -176,6 +176,25 @@ Animal <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Animal$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Animal$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Animal$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
@@ -157,5 +157,26 @@ AnyOfPig <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AnyOfPig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AnyOfPig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AnyOfPig$lock()
+
+

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
@@ -175,5 +175,25 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AnyOfPrimitiveTypeTest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AnyOfPrimitiveTypeTest$lock()
+

--- a/samples/client/petstore/R-httr2-wrapper/R/basque_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/basque_pig.R
@@ -192,6 +192,25 @@ BasquePig <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+BasquePig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+BasquePig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+BasquePig$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/cat.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/cat.R
@@ -200,6 +200,25 @@ Cat <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Cat$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Cat$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Cat$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/cat_all_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/cat_all_of.R
@@ -137,6 +137,25 @@ CatAllOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+CatAllOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+CatAllOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+CatAllOf$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/category.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/category.R
@@ -168,6 +168,25 @@ Category <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Category$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Category$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Category$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/danish_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/danish_pig.R
@@ -192,6 +192,25 @@ DanishPig <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+DanishPig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+DanishPig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+DanishPig$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/dog.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/dog.R
@@ -200,6 +200,25 @@ Dog <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Dog$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Dog$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Dog$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/dog_all_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/dog_all_of.R
@@ -137,6 +137,25 @@ DogAllOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+DogAllOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+DogAllOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+DogAllOf$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/model_api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/model_api_response.R
@@ -183,6 +183,25 @@ ModelApiResponse <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+ModelApiResponse$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+ModelApiResponse$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+ModelApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
@@ -162,6 +162,25 @@ NestedOneOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+NestedOneOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+NestedOneOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+NestedOneOf$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
@@ -175,5 +175,25 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+OneOfPrimitiveTypeTest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+OneOfPrimitiveTypeTest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+OneOfPrimitiveTypeTest$lock()
+

--- a/samples/client/petstore/R-httr2-wrapper/R/order.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/order.R
@@ -252,6 +252,25 @@ Order <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Order$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Order$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Order$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/pet.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet.R
@@ -289,6 +289,25 @@ Pet <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Pet$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Pet$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Pet$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pig.R
@@ -173,5 +173,25 @@ Pig <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Pig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Pig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Pig$lock()
+

--- a/samples/client/petstore/R-httr2-wrapper/R/special.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/special.R
@@ -252,6 +252,25 @@ Special <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Special$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Special$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Special$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/tag.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/tag.R
@@ -160,6 +160,25 @@ Tag <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Tag$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Tag$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Tag$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
@@ -161,6 +161,25 @@ UpdatePetRequest <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+UpdatePetRequest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+UpdatePetRequest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+UpdatePetRequest$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/user.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user.R
@@ -298,6 +298,25 @@ User <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+User$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+User$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+User$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/test_petstore.R
+++ b/samples/client/petstore/R-httr2-wrapper/test_petstore.R
@@ -19,7 +19,9 @@ cat(api_wrapper$pet_api$api_client$password)
 print("DONE")
 
 var_pet <- Pet$new("name_example", list("photoUrls_example"), 56, Category$new(56, "name_example"), list(Tag$new(56, "name_example")), "available") # Pet | Pet object that needs to be added to the store
+print(var_pet)
 
+print("DONE print")
 #Add a new pet to the store
 api_instance <- PetApi$new()
 # Configure OAuth2 access token for authorization: petstore_auth

--- a/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
@@ -21,10 +21,11 @@ pet_api$api_client$username <- "username123"
 pet_api$api_client$password <- "password123"
 result <- pet_api$add_pet(pet)
 
-test_that("Test toJSON toJSONString fromJSON fromJSONString", {
+test_that("Test toJSON toJSONString fromJSON fromJSONString print", {
   # test pet
   expect_equal(pet_id, 123321)
   expect_equal(pet$toJSONString(), '{"id":123321,"category":{"id":450,"name":"test_cat"},"name":"name_test","photoUrls":["photo_test","second test"],"tags":[{"id":123,"name":"tag_test"},{"id":456,"name":"unknown"}],"status":"available"}')
+  print(pet) # should not return anything and output the result to the console
 
   # tests for other pet objects
   pet0 <- Pet$new()

--- a/samples/client/petstore/R-httr2/R/allof_tag_api_response.R
+++ b/samples/client/petstore/R-httr2/R/allof_tag_api_response.R
@@ -229,6 +229,25 @@ AllofTagApiResponse <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AllofTagApiResponse$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AllofTagApiResponse$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AllofTagApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2/R/animal.R
+++ b/samples/client/petstore/R-httr2/R/animal.R
@@ -176,6 +176,25 @@ Animal <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Animal$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Animal$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Animal$lock()
 

--- a/samples/client/petstore/R-httr2/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2/R/any_of_pig.R
@@ -157,5 +157,26 @@ AnyOfPig <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AnyOfPig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AnyOfPig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AnyOfPig$lock()
+
+

--- a/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
@@ -175,5 +175,25 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AnyOfPrimitiveTypeTest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AnyOfPrimitiveTypeTest$lock()
+

--- a/samples/client/petstore/R-httr2/R/basque_pig.R
+++ b/samples/client/petstore/R-httr2/R/basque_pig.R
@@ -192,6 +192,25 @@ BasquePig <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+BasquePig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+BasquePig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+BasquePig$lock()
 

--- a/samples/client/petstore/R-httr2/R/cat.R
+++ b/samples/client/petstore/R-httr2/R/cat.R
@@ -200,6 +200,25 @@ Cat <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Cat$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Cat$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Cat$lock()
 

--- a/samples/client/petstore/R-httr2/R/cat_all_of.R
+++ b/samples/client/petstore/R-httr2/R/cat_all_of.R
@@ -137,6 +137,25 @@ CatAllOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+CatAllOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+CatAllOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+CatAllOf$lock()
 

--- a/samples/client/petstore/R-httr2/R/category.R
+++ b/samples/client/petstore/R-httr2/R/category.R
@@ -168,6 +168,25 @@ Category <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Category$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Category$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Category$lock()
 

--- a/samples/client/petstore/R-httr2/R/danish_pig.R
+++ b/samples/client/petstore/R-httr2/R/danish_pig.R
@@ -192,6 +192,25 @@ DanishPig <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+DanishPig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+DanishPig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+DanishPig$lock()
 

--- a/samples/client/petstore/R-httr2/R/dog.R
+++ b/samples/client/petstore/R-httr2/R/dog.R
@@ -200,6 +200,25 @@ Dog <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Dog$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Dog$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Dog$lock()
 

--- a/samples/client/petstore/R-httr2/R/dog_all_of.R
+++ b/samples/client/petstore/R-httr2/R/dog_all_of.R
@@ -137,6 +137,25 @@ DogAllOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+DogAllOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+DogAllOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+DogAllOf$lock()
 

--- a/samples/client/petstore/R-httr2/R/model_api_response.R
+++ b/samples/client/petstore/R-httr2/R/model_api_response.R
@@ -183,6 +183,25 @@ ModelApiResponse <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+ModelApiResponse$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+ModelApiResponse$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+ModelApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2/R/nested_one_of.R
@@ -162,6 +162,25 @@ NestedOneOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+NestedOneOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+NestedOneOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+NestedOneOf$lock()
 

--- a/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
@@ -175,5 +175,25 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+OneOfPrimitiveTypeTest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+OneOfPrimitiveTypeTest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+OneOfPrimitiveTypeTest$lock()
+

--- a/samples/client/petstore/R-httr2/R/order.R
+++ b/samples/client/petstore/R-httr2/R/order.R
@@ -252,6 +252,25 @@ Order <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Order$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Order$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Order$lock()
 

--- a/samples/client/petstore/R-httr2/R/pet.R
+++ b/samples/client/petstore/R-httr2/R/pet.R
@@ -289,6 +289,25 @@ Pet <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Pet$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Pet$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Pet$lock()
 

--- a/samples/client/petstore/R-httr2/R/pig.R
+++ b/samples/client/petstore/R-httr2/R/pig.R
@@ -173,5 +173,25 @@ Pig <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Pig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Pig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Pig$lock()
+

--- a/samples/client/petstore/R-httr2/R/special.R
+++ b/samples/client/petstore/R-httr2/R/special.R
@@ -252,6 +252,25 @@ Special <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Special$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Special$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Special$lock()
 

--- a/samples/client/petstore/R-httr2/R/tag.R
+++ b/samples/client/petstore/R-httr2/R/tag.R
@@ -160,6 +160,25 @@ Tag <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Tag$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Tag$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Tag$lock()
 

--- a/samples/client/petstore/R-httr2/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2/R/update_pet_request.R
@@ -161,6 +161,25 @@ UpdatePetRequest <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+UpdatePetRequest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+UpdatePetRequest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+UpdatePetRequest$lock()
 

--- a/samples/client/petstore/R-httr2/R/user.R
+++ b/samples/client/petstore/R-httr2/R/user.R
@@ -298,6 +298,25 @@ User <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+User$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+User$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+User$lock()
 

--- a/samples/client/petstore/R-httr2/test_petstore.R
+++ b/samples/client/petstore/R-httr2/test_petstore.R
@@ -5,10 +5,11 @@ library(jsonlite)
 
 t <- OneOfPrimitiveTypeTest$new()
 
-t$fromJSONString("[1,2,3]")
+#t$fromJSONString("[1,2,3]")
 
 
-###var_pet <- Pet$new("name_example", list("photoUrls_example"), 56, Category$new(56, "name_example"), list(Tag$new(56, "name_example")), "available") # Pet | Pet object that needs to be added to the store
+var_pet <- Pet$new("name_example", list("photoUrls_example"), 56, Category$new(56, "name_example"), list(Tag$new(56, "name_example")), "available") # Pet | Pet object that needs to be added to the store
+print(var_pet)
 ###
 ####Add a new pet to the store
 ###api_instance <- PetApi$new()

--- a/samples/client/petstore/R/R/allof_tag_api_response.R
+++ b/samples/client/petstore/R/R/allof_tag_api_response.R
@@ -229,6 +229,25 @@ AllofTagApiResponse <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AllofTagApiResponse$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AllofTagApiResponse$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AllofTagApiResponse$lock()
 

--- a/samples/client/petstore/R/R/animal.R
+++ b/samples/client/petstore/R/R/animal.R
@@ -176,6 +176,25 @@ Animal <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Animal$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Animal$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Animal$lock()
 

--- a/samples/client/petstore/R/R/any_of_pig.R
+++ b/samples/client/petstore/R/R/any_of_pig.R
@@ -157,5 +157,26 @@ AnyOfPig <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AnyOfPig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AnyOfPig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AnyOfPig$lock()
+
+

--- a/samples/client/petstore/R/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/any_of_primitive_type_test.R
@@ -175,5 +175,25 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+AnyOfPrimitiveTypeTest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+AnyOfPrimitiveTypeTest$lock()
+

--- a/samples/client/petstore/R/R/basque_pig.R
+++ b/samples/client/petstore/R/R/basque_pig.R
@@ -192,6 +192,25 @@ BasquePig <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+BasquePig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+BasquePig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+BasquePig$lock()
 

--- a/samples/client/petstore/R/R/cat.R
+++ b/samples/client/petstore/R/R/cat.R
@@ -200,6 +200,25 @@ Cat <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Cat$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Cat$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Cat$lock()
 

--- a/samples/client/petstore/R/R/cat_all_of.R
+++ b/samples/client/petstore/R/R/cat_all_of.R
@@ -137,6 +137,25 @@ CatAllOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+CatAllOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+CatAllOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+CatAllOf$lock()
 

--- a/samples/client/petstore/R/R/category.R
+++ b/samples/client/petstore/R/R/category.R
@@ -168,6 +168,25 @@ Category <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Category$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Category$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Category$lock()
 

--- a/samples/client/petstore/R/R/danish_pig.R
+++ b/samples/client/petstore/R/R/danish_pig.R
@@ -192,6 +192,25 @@ DanishPig <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+DanishPig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+DanishPig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+DanishPig$lock()
 

--- a/samples/client/petstore/R/R/dog.R
+++ b/samples/client/petstore/R/R/dog.R
@@ -200,6 +200,25 @@ Dog <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Dog$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Dog$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Dog$lock()
 

--- a/samples/client/petstore/R/R/dog_all_of.R
+++ b/samples/client/petstore/R/R/dog_all_of.R
@@ -137,6 +137,25 @@ DogAllOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+DogAllOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+DogAllOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+DogAllOf$lock()
 

--- a/samples/client/petstore/R/R/model_api_response.R
+++ b/samples/client/petstore/R/R/model_api_response.R
@@ -183,6 +183,25 @@ ModelApiResponse <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+ModelApiResponse$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+ModelApiResponse$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+ModelApiResponse$lock()
 

--- a/samples/client/petstore/R/R/nested_one_of.R
+++ b/samples/client/petstore/R/R/nested_one_of.R
@@ -162,6 +162,25 @@ NestedOneOf <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+NestedOneOf$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+NestedOneOf$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+NestedOneOf$lock()
 

--- a/samples/client/petstore/R/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/one_of_primitive_type_test.R
@@ -175,5 +175,25 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+OneOfPrimitiveTypeTest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+OneOfPrimitiveTypeTest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+OneOfPrimitiveTypeTest$lock()
+

--- a/samples/client/petstore/R/R/order.R
+++ b/samples/client/petstore/R/R/order.R
@@ -252,6 +252,25 @@ Order <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Order$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Order$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Order$lock()
 

--- a/samples/client/petstore/R/R/pet.R
+++ b/samples/client/petstore/R/R/pet.R
@@ -289,6 +289,25 @@ Pet <- R6::R6Class(
 
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Pet$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Pet$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Pet$lock()
 

--- a/samples/client/petstore/R/R/pig.R
+++ b/samples/client/petstore/R/R/pig.R
@@ -173,5 +173,25 @@ Pig <- R6::R6Class(
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Pig$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Pig$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Pig$lock()
+

--- a/samples/client/petstore/R/R/special.R
+++ b/samples/client/petstore/R/R/special.R
@@ -252,6 +252,25 @@ Special <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Special$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Special$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Special$lock()
 

--- a/samples/client/petstore/R/R/tag.R
+++ b/samples/client/petstore/R/R/tag.R
@@ -160,6 +160,25 @@ Tag <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+Tag$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+Tag$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+Tag$lock()
 

--- a/samples/client/petstore/R/R/update_pet_request.R
+++ b/samples/client/petstore/R/R/update_pet_request.R
@@ -161,6 +161,25 @@ UpdatePetRequest <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+UpdatePetRequest$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+UpdatePetRequest$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+UpdatePetRequest$lock()
 

--- a/samples/client/petstore/R/R/user.R
+++ b/samples/client/petstore/R/R/user.R
@@ -298,6 +298,25 @@ User <- R6::R6Class(
       invalid_fields <- list()
       invalid_fields
     }
-  )
+  ),
+  # Lock the class to prevent modifications to the method or field
+  lock_class = TRUE
 )
+
+# Unlock the class to allow modifications of the method or field
+User$unlock()
+
+#' Print the object
+#'
+#' @description
+#' Print the object
+#'
+#' @export
+User$set("public", "print", function(...) {
+  print(jsonlite::prettify(self$toJSONString()))
+  invisible(self)
+})
+
+# Lock the class to prevent modifications to the method or field
+User$lock()
 


### PR DESCRIPTION
- override `print`
- lock classes

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
