### PR TITLE
Mark overrides in typescript-fetch and typescript-rxjs

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -223,21 +223,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -131,7 +131,7 @@ export class BaseAPI {
  * export for not being a breaking change
  */
 export class RequiredError extends Error {
-    name: 'RequiredError' = 'RequiredError';
+    override name: 'RequiredError' = 'RequiredError';
 }
 
 export const COLLECTION_FORMATS = {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -234,21 +234,21 @@ function isFormData(value: any): value is FormData {
 }
 
 export class ResponseError extends Error {
-    name: "ResponseError" = "ResponseError";
+    override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
     }
 }
 
 export class FetchError extends Error {
-    name: "FetchError" = "FetchError";
+    override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
     }
 }
 
 export class RequiredError extends Error {
-    name: "RequiredError" = "RequiredError";
+    override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
     }

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -139,7 +139,7 @@ export class BaseAPI {
  * export for not being a breaking change
  */
 export class RequiredError extends Error {
-    name: 'RequiredError' = 'RequiredError';
+    override name: 'RequiredError' = 'RequiredError';
 }
 
 export const COLLECTION_FORMATS = {

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -139,7 +139,7 @@ export class BaseAPI {
  * export for not being a breaking change
  */
 export class RequiredError extends Error {
-    name: 'RequiredError' = 'RequiredError';
+    override name: 'RequiredError' = 'RequiredError';
 }
 
 export const COLLECTION_FORMATS = {

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -139,7 +139,7 @@ export class BaseAPI {
  * export for not being a breaking change
  */
 export class RequiredError extends Error {
-    name: 'RequiredError' = 'RequiredError';
+    override name: 'RequiredError' = 'RequiredError';
 }
 
 export const COLLECTION_FORMATS = {

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/runtime.ts
@@ -140,7 +140,7 @@ export class BaseAPI {
  * export for not being a breaking change
  */
 export class RequiredError extends Error {
-    name: 'RequiredError' = 'RequiredError';
+    override name: 'RequiredError' = 'RequiredError';
 }
 
 export const COLLECTION_FORMATS = {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #12948

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI as instructed @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo  @amakhrov @davidgamero @mkusaka
