### PR TITLE
[R] move print to public method, leave commented code to lock/unlock class

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -2,7 +2,7 @@
 {{#operations}}
 #' @docType class
 #' @title {{baseName}} operations
-#' @description {{{description}}}
+#' @description {{{description}}}{{^description}}{{{classname}}}{{/description}}
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
@@ -151,26 +151,28 @@
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-{{classname}}$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-{{classname}}$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-{{classname}}$lock()
-
+## Uncomment below to unlock the class to allow modifications of the method or field
+#{{classname}}$unlock()
+#
+## Below is an example to define the print fnuction
+#{{classname}}$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#{{classname}}$lock()

--- a/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
@@ -526,25 +526,27 @@
       {{/hasValidation}}
       {{/allVars}}
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-{{classname}}$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-{{classname}}$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-{{classname}}$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#{{classname}}$unlock()
+#
+## Below is an example to define the print fnuction
+#{{classname}}$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#{{classname}}$lock()

--- a/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
@@ -199,25 +199,28 @@
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-{{classname}}$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-{{classname}}$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-{{classname}}$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#{{classname}}$unlock()
+#
+## Below is an example to define the print fnuction
+#{{classname}}$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#{{classname}}$lock()

--- a/samples/client/petstore/R-httr2-wrapper/R/allof_tag_api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/allof_tag_api_response.R
@@ -260,26 +260,28 @@ AllofTagApiResponse <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AllofTagApiResponse$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AllofTagApiResponse$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AllofTagApiResponse$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AllofTagApiResponse$unlock()
+#
+## Below is an example to define the print fnuction
+#AllofTagApiResponse$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AllofTagApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/animal.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/animal.R
@@ -207,26 +207,28 @@ Animal <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Animal$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Animal$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Animal$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Animal$unlock()
+#
+## Below is an example to define the print fnuction
+#Animal$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Animal$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
@@ -156,27 +156,29 @@ AnyOfPig <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AnyOfPig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AnyOfPig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AnyOfPig$lock()
-
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AnyOfPig$unlock()
+#
+## Below is an example to define the print fnuction
+#AnyOfPig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AnyOfPig$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
@@ -174,26 +174,29 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AnyOfPrimitiveTypeTest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AnyOfPrimitiveTypeTest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AnyOfPrimitiveTypeTest$unlock()
+#
+## Below is an example to define the print fnuction
+#AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AnyOfPrimitiveTypeTest$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/basque_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/basque_pig.R
@@ -223,26 +223,28 @@ BasquePig <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-BasquePig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-BasquePig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-BasquePig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#BasquePig$unlock()
+#
+## Below is an example to define the print fnuction
+#BasquePig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#BasquePig$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/cat.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/cat.R
@@ -231,26 +231,28 @@ Cat <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Cat$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Cat$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Cat$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Cat$unlock()
+#
+## Below is an example to define the print fnuction
+#Cat$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Cat$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/cat_all_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/cat_all_of.R
@@ -168,26 +168,28 @@ CatAllOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-CatAllOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-CatAllOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-CatAllOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#CatAllOf$unlock()
+#
+## Below is an example to define the print fnuction
+#CatAllOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#CatAllOf$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/category.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/category.R
@@ -199,26 +199,28 @@ Category <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Category$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Category$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Category$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Category$unlock()
+#
+## Below is an example to define the print fnuction
+#Category$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Category$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/danish_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/danish_pig.R
@@ -223,26 +223,28 @@ DanishPig <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-DanishPig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-DanishPig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-DanishPig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#DanishPig$unlock()
+#
+## Below is an example to define the print fnuction
+#DanishPig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#DanishPig$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/dog.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/dog.R
@@ -231,26 +231,28 @@ Dog <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Dog$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Dog$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Dog$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Dog$unlock()
+#
+## Below is an example to define the print fnuction
+#Dog$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Dog$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/dog_all_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/dog_all_of.R
@@ -168,26 +168,28 @@ DogAllOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-DogAllOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-DogAllOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-DogAllOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#DogAllOf$unlock()
+#
+## Below is an example to define the print fnuction
+#DogAllOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#DogAllOf$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Fake operations
-#' @description 
+#' @description FakeApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2-wrapper/R/mammal.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/mammal.R
@@ -195,26 +195,29 @@ Mammal <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Mammal$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Mammal$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Mammal$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Mammal$unlock()
+#
+## Below is an example to define the print fnuction
+#Mammal$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Mammal$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/model_api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/model_api_response.R
@@ -214,26 +214,28 @@ ModelApiResponse <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-ModelApiResponse$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-ModelApiResponse$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-ModelApiResponse$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#ModelApiResponse$unlock()
+#
+## Below is an example to define the print fnuction
+#ModelApiResponse$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#ModelApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
@@ -193,26 +193,28 @@ NestedOneOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-NestedOneOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-NestedOneOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-NestedOneOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#NestedOneOf$unlock()
+#
+## Below is an example to define the print fnuction
+#NestedOneOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#NestedOneOf$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
@@ -174,26 +174,29 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-OneOfPrimitiveTypeTest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-OneOfPrimitiveTypeTest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-OneOfPrimitiveTypeTest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#OneOfPrimitiveTypeTest$unlock()
+#
+## Below is an example to define the print fnuction
+#OneOfPrimitiveTypeTest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#OneOfPrimitiveTypeTest$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/order.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/order.R
@@ -283,26 +283,28 @@ Order <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Order$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Order$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Order$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Order$unlock()
+#
+## Below is an example to define the print fnuction
+#Order$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Order$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/pet.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet.R
@@ -320,26 +320,28 @@ Pet <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Pet$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Pet$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Pet$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Pet$unlock()
+#
+## Below is an example to define the print fnuction
+#Pet$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Pet$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Pet operations
-#' @description 
+#' @description PetApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2-wrapper/R/pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pig.R
@@ -195,26 +195,29 @@ Pig <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Pig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Pig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Pig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Pig$unlock()
+#
+## Below is an example to define the print fnuction
+#Pig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Pig$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/special.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/special.R
@@ -283,26 +283,28 @@ Special <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Special$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Special$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Special$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Special$unlock()
+#
+## Below is an example to define the print fnuction
+#Special$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Special$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/store_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/store_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Store operations
-#' @description 
+#' @description StoreApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2-wrapper/R/tag.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/tag.R
@@ -191,26 +191,28 @@ Tag <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Tag$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Tag$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Tag$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Tag$unlock()
+#
+## Below is an example to define the print fnuction
+#Tag$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Tag$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
@@ -192,26 +192,28 @@ UpdatePetRequest <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-UpdatePetRequest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-UpdatePetRequest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-UpdatePetRequest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#UpdatePetRequest$unlock()
+#
+## Below is an example to define the print fnuction
+#UpdatePetRequest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#UpdatePetRequest$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/user.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user.R
@@ -329,26 +329,28 @@ User <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-User$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-User$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-User$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#User$unlock()
+#
+## Below is an example to define the print fnuction
+#User$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#User$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/user_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title User operations
-#' @description 
+#' @description UserApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2-wrapper/R/whale.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/whale.R
@@ -230,26 +230,28 @@ Whale <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Whale$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Whale$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Whale$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Whale$unlock()
+#
+## Below is an example to define the print fnuction
+#Whale$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Whale$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/R/zebra.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/zebra.R
@@ -207,26 +207,28 @@ Zebra <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Zebra$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Zebra$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Zebra$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Zebra$unlock()
+#
+## Below is an example to define the print fnuction
+#Zebra$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Zebra$lock()
 

--- a/samples/client/petstore/R-httr2-wrapper/test_petstore.R
+++ b/samples/client/petstore/R-httr2-wrapper/test_petstore.R
@@ -9,8 +9,10 @@ t$additional_properties <- c("abc" = 849, "array" = list('a', 'b', 'c'))
 t$additional_properties
 t$additional_properties["abc"]
 t$additional_properties["array"]
-print(t$toJSON())
-print(t$toJSONString())
+
+print(t)
+#print(t$toJSON())
+#print(t$toJSONString())
 
 print("done tag")
 

--- a/samples/client/petstore/R-httr2/R/allof_tag_api_response.R
+++ b/samples/client/petstore/R-httr2/R/allof_tag_api_response.R
@@ -227,26 +227,28 @@ AllofTagApiResponse <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AllofTagApiResponse$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AllofTagApiResponse$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AllofTagApiResponse$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AllofTagApiResponse$unlock()
+#
+## Below is an example to define the print fnuction
+#AllofTagApiResponse$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AllofTagApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2/R/animal.R
+++ b/samples/client/petstore/R-httr2/R/animal.R
@@ -174,26 +174,28 @@ Animal <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Animal$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Animal$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Animal$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Animal$unlock()
+#
+## Below is an example to define the print fnuction
+#Animal$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Animal$lock()
 

--- a/samples/client/petstore/R-httr2/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2/R/any_of_pig.R
@@ -156,27 +156,29 @@ AnyOfPig <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AnyOfPig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AnyOfPig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AnyOfPig$lock()
-
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AnyOfPig$unlock()
+#
+## Below is an example to define the print fnuction
+#AnyOfPig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AnyOfPig$lock()
 

--- a/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
@@ -174,26 +174,29 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AnyOfPrimitiveTypeTest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AnyOfPrimitiveTypeTest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AnyOfPrimitiveTypeTest$unlock()
+#
+## Below is an example to define the print fnuction
+#AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AnyOfPrimitiveTypeTest$lock()
 

--- a/samples/client/petstore/R-httr2/R/basque_pig.R
+++ b/samples/client/petstore/R-httr2/R/basque_pig.R
@@ -190,26 +190,28 @@ BasquePig <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-BasquePig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-BasquePig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-BasquePig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#BasquePig$unlock()
+#
+## Below is an example to define the print fnuction
+#BasquePig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#BasquePig$lock()
 

--- a/samples/client/petstore/R-httr2/R/cat.R
+++ b/samples/client/petstore/R-httr2/R/cat.R
@@ -198,26 +198,28 @@ Cat <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Cat$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Cat$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Cat$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Cat$unlock()
+#
+## Below is an example to define the print fnuction
+#Cat$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Cat$lock()
 

--- a/samples/client/petstore/R-httr2/R/cat_all_of.R
+++ b/samples/client/petstore/R-httr2/R/cat_all_of.R
@@ -135,26 +135,28 @@ CatAllOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-CatAllOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-CatAllOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-CatAllOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#CatAllOf$unlock()
+#
+## Below is an example to define the print fnuction
+#CatAllOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#CatAllOf$lock()
 

--- a/samples/client/petstore/R-httr2/R/category.R
+++ b/samples/client/petstore/R-httr2/R/category.R
@@ -166,26 +166,28 @@ Category <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Category$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Category$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Category$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Category$unlock()
+#
+## Below is an example to define the print fnuction
+#Category$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Category$lock()
 

--- a/samples/client/petstore/R-httr2/R/danish_pig.R
+++ b/samples/client/petstore/R-httr2/R/danish_pig.R
@@ -190,26 +190,28 @@ DanishPig <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-DanishPig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-DanishPig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-DanishPig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#DanishPig$unlock()
+#
+## Below is an example to define the print fnuction
+#DanishPig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#DanishPig$lock()
 

--- a/samples/client/petstore/R-httr2/R/dog.R
+++ b/samples/client/petstore/R-httr2/R/dog.R
@@ -198,26 +198,28 @@ Dog <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Dog$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Dog$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Dog$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Dog$unlock()
+#
+## Below is an example to define the print fnuction
+#Dog$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Dog$lock()
 

--- a/samples/client/petstore/R-httr2/R/dog_all_of.R
+++ b/samples/client/petstore/R-httr2/R/dog_all_of.R
@@ -135,26 +135,28 @@ DogAllOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-DogAllOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-DogAllOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-DogAllOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#DogAllOf$unlock()
+#
+## Below is an example to define the print fnuction
+#DogAllOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#DogAllOf$lock()
 

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Fake operations
-#' @description 
+#' @description FakeApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2/R/mammal.R
+++ b/samples/client/petstore/R-httr2/R/mammal.R
@@ -172,26 +172,29 @@ Mammal <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Mammal$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Mammal$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Mammal$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Mammal$unlock()
+#
+## Below is an example to define the print fnuction
+#Mammal$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Mammal$lock()
 

--- a/samples/client/petstore/R-httr2/R/model_api_response.R
+++ b/samples/client/petstore/R-httr2/R/model_api_response.R
@@ -181,26 +181,28 @@ ModelApiResponse <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-ModelApiResponse$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-ModelApiResponse$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-ModelApiResponse$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#ModelApiResponse$unlock()
+#
+## Below is an example to define the print fnuction
+#ModelApiResponse$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#ModelApiResponse$lock()
 

--- a/samples/client/petstore/R-httr2/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2/R/nested_one_of.R
@@ -160,26 +160,28 @@ NestedOneOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-NestedOneOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-NestedOneOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-NestedOneOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#NestedOneOf$unlock()
+#
+## Below is an example to define the print fnuction
+#NestedOneOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#NestedOneOf$lock()
 

--- a/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
@@ -174,26 +174,29 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-OneOfPrimitiveTypeTest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-OneOfPrimitiveTypeTest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-OneOfPrimitiveTypeTest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#OneOfPrimitiveTypeTest$unlock()
+#
+## Below is an example to define the print fnuction
+#OneOfPrimitiveTypeTest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#OneOfPrimitiveTypeTest$lock()
 

--- a/samples/client/petstore/R-httr2/R/order.R
+++ b/samples/client/petstore/R-httr2/R/order.R
@@ -250,26 +250,28 @@ Order <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Order$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Order$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Order$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Order$unlock()
+#
+## Below is an example to define the print fnuction
+#Order$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Order$lock()
 

--- a/samples/client/petstore/R-httr2/R/pet.R
+++ b/samples/client/petstore/R-httr2/R/pet.R
@@ -287,26 +287,28 @@ Pet <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Pet$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Pet$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Pet$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Pet$unlock()
+#
+## Below is an example to define the print fnuction
+#Pet$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Pet$lock()
 

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Pet operations
-#' @description 
+#' @description PetApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2/R/pig.R
+++ b/samples/client/petstore/R-httr2/R/pig.R
@@ -172,26 +172,29 @@ Pig <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Pig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Pig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Pig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Pig$unlock()
+#
+## Below is an example to define the print fnuction
+#Pig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Pig$lock()
 

--- a/samples/client/petstore/R-httr2/R/special.R
+++ b/samples/client/petstore/R-httr2/R/special.R
@@ -250,26 +250,28 @@ Special <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Special$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Special$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Special$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Special$unlock()
+#
+## Below is an example to define the print fnuction
+#Special$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Special$lock()
 

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Store operations
-#' @description 
+#' @description StoreApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2/R/tag.R
+++ b/samples/client/petstore/R-httr2/R/tag.R
@@ -158,26 +158,28 @@ Tag <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Tag$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Tag$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Tag$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Tag$unlock()
+#
+## Below is an example to define the print fnuction
+#Tag$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Tag$lock()
 

--- a/samples/client/petstore/R-httr2/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2/R/update_pet_request.R
@@ -159,26 +159,28 @@ UpdatePetRequest <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-UpdatePetRequest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-UpdatePetRequest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-UpdatePetRequest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#UpdatePetRequest$unlock()
+#
+## Below is an example to define the print fnuction
+#UpdatePetRequest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#UpdatePetRequest$lock()
 

--- a/samples/client/petstore/R-httr2/R/user.R
+++ b/samples/client/petstore/R-httr2/R/user.R
@@ -296,26 +296,28 @@ User <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-User$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-User$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-User$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#User$unlock()
+#
+## Below is an example to define the print fnuction
+#User$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#User$lock()
 

--- a/samples/client/petstore/R-httr2/R/user_api.R
+++ b/samples/client/petstore/R-httr2/R/user_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title User operations
-#' @description 
+#' @description UserApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R-httr2/R/whale.R
+++ b/samples/client/petstore/R-httr2/R/whale.R
@@ -197,26 +197,28 @@ Whale <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Whale$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Whale$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Whale$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Whale$unlock()
+#
+## Below is an example to define the print fnuction
+#Whale$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Whale$lock()
 

--- a/samples/client/petstore/R-httr2/R/zebra.R
+++ b/samples/client/petstore/R-httr2/R/zebra.R
@@ -174,26 +174,28 @@ Zebra <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Zebra$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Zebra$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Zebra$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Zebra$unlock()
+#
+## Below is an example to define the print fnuction
+#Zebra$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Zebra$lock()
 

--- a/samples/client/petstore/R/R/allof_tag_api_response.R
+++ b/samples/client/petstore/R/R/allof_tag_api_response.R
@@ -260,26 +260,28 @@ AllofTagApiResponse <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AllofTagApiResponse$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AllofTagApiResponse$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AllofTagApiResponse$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AllofTagApiResponse$unlock()
+#
+## Below is an example to define the print fnuction
+#AllofTagApiResponse$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AllofTagApiResponse$lock()
 

--- a/samples/client/petstore/R/R/animal.R
+++ b/samples/client/petstore/R/R/animal.R
@@ -207,26 +207,28 @@ Animal <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Animal$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Animal$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Animal$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Animal$unlock()
+#
+## Below is an example to define the print fnuction
+#Animal$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Animal$lock()
 

--- a/samples/client/petstore/R/R/any_of_pig.R
+++ b/samples/client/petstore/R/R/any_of_pig.R
@@ -156,27 +156,29 @@ AnyOfPig <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AnyOfPig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AnyOfPig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AnyOfPig$lock()
-
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AnyOfPig$unlock()
+#
+## Below is an example to define the print fnuction
+#AnyOfPig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AnyOfPig$lock()
 

--- a/samples/client/petstore/R/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/any_of_primitive_type_test.R
@@ -174,26 +174,29 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-AnyOfPrimitiveTypeTest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-AnyOfPrimitiveTypeTest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#AnyOfPrimitiveTypeTest$unlock()
+#
+## Below is an example to define the print fnuction
+#AnyOfPrimitiveTypeTest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#AnyOfPrimitiveTypeTest$lock()
 

--- a/samples/client/petstore/R/R/basque_pig.R
+++ b/samples/client/petstore/R/R/basque_pig.R
@@ -223,26 +223,28 @@ BasquePig <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-BasquePig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-BasquePig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-BasquePig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#BasquePig$unlock()
+#
+## Below is an example to define the print fnuction
+#BasquePig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#BasquePig$lock()
 

--- a/samples/client/petstore/R/R/cat.R
+++ b/samples/client/petstore/R/R/cat.R
@@ -231,26 +231,28 @@ Cat <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Cat$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Cat$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Cat$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Cat$unlock()
+#
+## Below is an example to define the print fnuction
+#Cat$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Cat$lock()
 

--- a/samples/client/petstore/R/R/cat_all_of.R
+++ b/samples/client/petstore/R/R/cat_all_of.R
@@ -168,26 +168,28 @@ CatAllOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-CatAllOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-CatAllOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-CatAllOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#CatAllOf$unlock()
+#
+## Below is an example to define the print fnuction
+#CatAllOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#CatAllOf$lock()
 

--- a/samples/client/petstore/R/R/category.R
+++ b/samples/client/petstore/R/R/category.R
@@ -199,26 +199,28 @@ Category <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Category$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Category$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Category$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Category$unlock()
+#
+## Below is an example to define the print fnuction
+#Category$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Category$lock()
 

--- a/samples/client/petstore/R/R/danish_pig.R
+++ b/samples/client/petstore/R/R/danish_pig.R
@@ -223,26 +223,28 @@ DanishPig <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-DanishPig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-DanishPig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-DanishPig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#DanishPig$unlock()
+#
+## Below is an example to define the print fnuction
+#DanishPig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#DanishPig$lock()
 

--- a/samples/client/petstore/R/R/dog.R
+++ b/samples/client/petstore/R/R/dog.R
@@ -231,26 +231,28 @@ Dog <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Dog$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Dog$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Dog$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Dog$unlock()
+#
+## Below is an example to define the print fnuction
+#Dog$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Dog$lock()
 

--- a/samples/client/petstore/R/R/dog_all_of.R
+++ b/samples/client/petstore/R/R/dog_all_of.R
@@ -168,26 +168,28 @@ DogAllOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-DogAllOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-DogAllOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-DogAllOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#DogAllOf$unlock()
+#
+## Below is an example to define the print fnuction
+#DogAllOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#DogAllOf$lock()
 

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Fake operations
-#' @description 
+#' @description FakeApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R/R/mammal.R
+++ b/samples/client/petstore/R/R/mammal.R
@@ -172,26 +172,29 @@ Mammal <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Mammal$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Mammal$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Mammal$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Mammal$unlock()
+#
+## Below is an example to define the print fnuction
+#Mammal$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Mammal$lock()
 

--- a/samples/client/petstore/R/R/model_api_response.R
+++ b/samples/client/petstore/R/R/model_api_response.R
@@ -214,26 +214,28 @@ ModelApiResponse <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-ModelApiResponse$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-ModelApiResponse$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-ModelApiResponse$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#ModelApiResponse$unlock()
+#
+## Below is an example to define the print fnuction
+#ModelApiResponse$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#ModelApiResponse$lock()
 

--- a/samples/client/petstore/R/R/nested_one_of.R
+++ b/samples/client/petstore/R/R/nested_one_of.R
@@ -193,26 +193,28 @@ NestedOneOf <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-NestedOneOf$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-NestedOneOf$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-NestedOneOf$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#NestedOneOf$unlock()
+#
+## Below is an example to define the print fnuction
+#NestedOneOf$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#NestedOneOf$lock()
 

--- a/samples/client/petstore/R/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/one_of_primitive_type_test.R
@@ -174,26 +174,29 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-OneOfPrimitiveTypeTest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-OneOfPrimitiveTypeTest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-OneOfPrimitiveTypeTest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#OneOfPrimitiveTypeTest$unlock()
+#
+## Below is an example to define the print fnuction
+#OneOfPrimitiveTypeTest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#OneOfPrimitiveTypeTest$lock()
 

--- a/samples/client/petstore/R/R/order.R
+++ b/samples/client/petstore/R/R/order.R
@@ -283,26 +283,28 @@ Order <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Order$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Order$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Order$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Order$unlock()
+#
+## Below is an example to define the print fnuction
+#Order$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Order$lock()
 

--- a/samples/client/petstore/R/R/pet.R
+++ b/samples/client/petstore/R/R/pet.R
@@ -320,26 +320,28 @@ Pet <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Pet$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Pet$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Pet$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Pet$unlock()
+#
+## Below is an example to define the print fnuction
+#Pet$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Pet$lock()
 

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Pet operations
-#' @description 
+#' @description PetApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R/R/pig.R
+++ b/samples/client/petstore/R/R/pig.R
@@ -172,26 +172,29 @@ Pig <- R6::R6Class(
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
       as.character(jsonlite::prettify(paste("{", jsoncontent, "}", sep = "")))
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
     }
   ),
   # Lock the class to prevent modifications to the method or field
   lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Pig$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Pig$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Pig$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Pig$unlock()
+#
+## Below is an example to define the print fnuction
+#Pig$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Pig$lock()
 

--- a/samples/client/petstore/R/R/special.R
+++ b/samples/client/petstore/R/R/special.R
@@ -283,26 +283,28 @@ Special <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Special$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Special$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Special$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Special$unlock()
+#
+## Below is an example to define the print fnuction
+#Special$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Special$lock()
 

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title Store operations
-#' @description 
+#' @description StoreApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R/R/tag.R
+++ b/samples/client/petstore/R/R/tag.R
@@ -191,26 +191,28 @@ Tag <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Tag$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Tag$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Tag$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Tag$unlock()
+#
+## Below is an example to define the print fnuction
+#Tag$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Tag$lock()
 

--- a/samples/client/petstore/R/R/update_pet_request.R
+++ b/samples/client/petstore/R/R/update_pet_request.R
@@ -192,26 +192,28 @@ UpdatePetRequest <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-UpdatePetRequest$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-UpdatePetRequest$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-UpdatePetRequest$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#UpdatePetRequest$unlock()
+#
+## Below is an example to define the print fnuction
+#UpdatePetRequest$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#UpdatePetRequest$lock()
 

--- a/samples/client/petstore/R/R/user.R
+++ b/samples/client/petstore/R/R/user.R
@@ -329,26 +329,28 @@ User <- R6::R6Class(
     getInvalidFields = function() {
       invalid_fields <- list()
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-User$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-User$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-User$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#User$unlock()
+#
+## Below is an example to define the print fnuction
+#User$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#User$lock()
 

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -7,7 +7,7 @@
 #'
 #' @docType class
 #' @title User operations
-#' @description 
+#' @description UserApi
 #' @format An \code{R6Class} generator object
 #' @field api_client Handles the client-server communication.
 #'

--- a/samples/client/petstore/R/R/whale.R
+++ b/samples/client/petstore/R/R/whale.R
@@ -230,26 +230,28 @@ Whale <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Whale$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Whale$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Whale$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Whale$unlock()
+#
+## Below is an example to define the print fnuction
+#Whale$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Whale$lock()
 

--- a/samples/client/petstore/R/R/zebra.R
+++ b/samples/client/petstore/R/R/zebra.R
@@ -207,26 +207,28 @@ Zebra <- R6::R6Class(
       }
 
       invalid_fields
-    }
-  ),
-  # Lock the class to prevent modifications to the method or field
-  lock_class = TRUE
+    },
+    #' Print the object
+    #'
+    #' @description
+    #' Print the object
+    #'
+    #' @export
+    print = function() {
+      print(jsonlite::prettify(self$toJSONString()))
+      invisible(self)
+    }),
+    # Lock the class to prevent modifications to the method or field
+    lock_class = TRUE
 )
-
-# Unlock the class to allow modifications of the method or field
-Zebra$unlock()
-
-#' Print the object
-#'
-#' @description
-#' Print the object
-#'
-#' @export
-Zebra$set("public", "print", function(...) {
-  print(jsonlite::prettify(self$toJSONString()))
-  invisible(self)
-})
-
-# Lock the class to prevent modifications to the method or field
-Zebra$lock()
+## Uncomment below to unlock the class to allow modifications of the method or field
+#Zebra$unlock()
+#
+## Below is an example to define the print fnuction
+#Zebra$set("public", "print", function(...) {
+#  print(jsonlite::prettify(self$toJSONString()))
+#  invisible(self)
+#})
+## Uncomment below to lock the class to prevent modifications to the method or field
+#Zebra$lock()
 


### PR DESCRIPTION
- move print to public method (to allow Rdoc warning)
- leave commented code to lock/unlock class if the user needs to add more functions to the class

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
