### PR TITLE
[C][Client] Treat "null" as a valid value for a field of a JSON map

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -781,45 +781,49 @@ fail:
     {{^required}}if ({{{name}}}) { {{/required}}
     {{#isPrimitiveType}}
     cJSON *{{{name}}}_local_map = NULL;
-    if(!cJSON_IsObject({{{name}}})) {
+    if(!cJSON_IsObject({{{name}}}) && !cJSON_IsNull({{{name}}}))
+    {
         goto end;//primitive map container
     }
-    {{{name}}}List = list_createList();
-    keyValuePair_t *localMapKeyPair;
-    cJSON_ArrayForEach({{{name}}}_local_map, {{{name}}})
+    if(cJSON_IsObject({{{name}}}))
     {
-		cJSON *localMapObject = {{{name}}}_local_map;
-        {{#items}}
-        {{#isString}}
-        if(!cJSON_IsString(localMapObject))
+        {{{name}}}List = list_createList();
+        keyValuePair_t *localMapKeyPair;
+        cJSON_ArrayForEach({{{name}}}_local_map, {{{name}}})
         {
-            goto end;
+            cJSON *localMapObject = {{{name}}}_local_map;
+            {{#items}}
+            {{#isString}}
+            if(!cJSON_IsString(localMapObject))
+            {
+                goto end;
+            }
+            localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),strdup(localMapObject->valuestring));
+            {{/isString}}
+            {{#isByteArray}}
+            if(!cJSON_IsString(localMapObject))
+            {
+                goto end;
+            }
+            localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),strdup(localMapObject->valuestring));
+            {{/isByteArray}}
+            {{#isBoolean}}
+            if(!cJSON_IsBool(localMapObject))
+            {
+                goto end;
+            }
+            localMapKeyPair = keyValuePair_create(strdup(localMapObject->string), &localMapObject->valueint);
+            {{/isBoolean}}
+            {{#isNumeric}}
+            if(!cJSON_IsNumber(localMapObject))
+            {
+                goto end;
+            }
+            localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
+            {{/isNumeric}}
+		    {{/items}}
+            list_addElement({{{name}}}List , localMapKeyPair);
         }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),strdup(localMapObject->valuestring));
-        {{/isString}}
-        {{#isByteArray}}
-        if(!cJSON_IsString(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),strdup(localMapObject->valuestring));
-        {{/isByteArray}}
-        {{#isBoolean}}
-        if(!cJSON_IsBool(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string), &localMapObject->valueint);
-        {{/isBoolean}}
-        {{#isNumeric}}
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
-        {{/isNumeric}}
-		{{/items}}
-        list_addElement({{{name}}}List , localMapKeyPair);
     }
     {{/isPrimitiveType}}
     {{^isPrimitiveType}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hi @wing328 @zhemant @michelealbano

When a field of a JSON map is null, e.g. in below example, `annotations` of  `metadata` is null

```json
{
    "apiVersion": "v1",
    "kind": "ServiceAccount",
    "metadata": {
        "name": "test-sa",
        "namespace": "smoking-test",
        "annotations": null
    }
}
```

`*_parseFromJSON` will treat `annotations` as invalid/error, and free the total memory of `metadata` 

The detail is at https://github.com/kubernetes-client/c/issues/138

This PR treats "null" as a valid value for a field of a JSON map.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
