### PR TITLE
Escape % in description in R model @field

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
@@ -8,7 +8,7 @@
 #' @description {{classname}} Class
 #' @format An \code{R6Class} generator object
 {{#vars}}
-#' @field {{name}} {{{description}}} {{{vendorExtensions.x-r-doc-type}}}{{^required}} [optional]{{/required}}
+#' @field {{name}} {{#lambdaRdocEscape}}{{{description}}}{{/lambdaRdocEscape}} {{{vendorExtensions.x-r-doc-type}}}{{^required}} [optional]{{/required}}
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
 #' @field _field_list a list of fields list(character)

--- a/modules/openapi-generator/src/test/resources/3_0/r/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/r/petstore.yaml
@@ -1007,5 +1007,8 @@ components:
       properties:
         className:
           type: string
+        percent_description:
+          description: using % in the description
+          type: string
       required:
         - className

--- a/samples/client/petstore/R-httr2-wrapper/R/date.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/date.R
@@ -8,6 +8,7 @@
 #' @description Date Class
 #' @format An \code{R6Class} generator object
 #' @field className  character
+#' @field percent_description using \% in the description character [optional]
 #' @field _field_list a list of fields list(character)
 #' @field additional_properties additional properties list(character) [optional]
 #' @importFrom R6 R6Class
@@ -17,7 +18,8 @@ Date <- R6::R6Class(
   "Date",
   public = list(
     `className` = NULL,
-    `_field_list` = c("className"),
+    `percent_description` = NULL,
+    `_field_list` = c("className", "percent_description"),
     `additional_properties` = list(),
     #' Initialize a new Date class.
     #'
@@ -25,15 +27,20 @@ Date <- R6::R6Class(
     #' Initialize a new Date class.
     #'
     #' @param className className
+    #' @param percent_description using \% in the description
     #' @param additional_properties additonal properties (optional)
     #' @param ... Other optional arguments.
     #' @export
     initialize = function(
-        `className`, additional_properties = NULL, ...
+        `className`, `percent_description` = NULL, additional_properties = NULL, ...
     ) {
       if (!missing(`className`)) {
         stopifnot(is.character(`className`), length(`className`) == 1)
         self$`className` <- `className`
+      }
+      if (!is.null(`percent_description`)) {
+        stopifnot(is.character(`percent_description`), length(`percent_description`) == 1)
+        self$`percent_description` <- `percent_description`
       }
       if (!is.null(additional_properties)) {
         for (key in names(additional_properties)) {
@@ -54,6 +61,10 @@ Date <- R6::R6Class(
         DateObject[["className"]] <-
           self$`className`
       }
+      if (!is.null(self$`percent_description`)) {
+        DateObject[["percent_description"]] <-
+          self$`percent_description`
+      }
       for (key in names(self$additional_properties)) {
         DateObject[[key]] <- self$additional_properties[[key]]
       }
@@ -72,6 +83,9 @@ Date <- R6::R6Class(
       this_object <- jsonlite::fromJSON(input_json)
       if (!is.null(this_object$`className`)) {
         self$`className` <- this_object$`className`
+      }
+      if (!is.null(this_object$`percent_description`)) {
+        self$`percent_description` <- this_object$`percent_description`
       }
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
@@ -98,6 +112,14 @@ Date <- R6::R6Class(
                     ',
           self$`className`
           )
+        },
+        if (!is.null(self$`percent_description`)) {
+          sprintf(
+          '"percent_description":
+            "%s"
+                    ',
+          self$`percent_description`
+          )
         }
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
@@ -119,6 +141,7 @@ Date <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`className` <- this_object$`className`
+      self$`percent_description` <- this_object$`percent_description`
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
         if (!(key %in% self$`_field_list`)) { # json key not in list of fields

--- a/samples/client/petstore/R-httr2-wrapper/docs/Date.md
+++ b/samples/client/petstore/R-httr2-wrapper/docs/Date.md
@@ -6,5 +6,6 @@ to test the model name `Date`
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
+**percent_description** | **character** | using % in the description | [optional] 
 
 

--- a/samples/client/petstore/R-httr2/R/date.R
+++ b/samples/client/petstore/R-httr2/R/date.R
@@ -8,6 +8,7 @@
 #' @description Date Class
 #' @format An \code{R6Class} generator object
 #' @field className  character
+#' @field percent_description using \% in the description character [optional]
 #' @importFrom R6 R6Class
 #' @importFrom jsonlite fromJSON toJSON
 #' @export
@@ -15,20 +16,26 @@ Date <- R6::R6Class(
   "Date",
   public = list(
     `className` = NULL,
+    `percent_description` = NULL,
     #' Initialize a new Date class.
     #'
     #' @description
     #' Initialize a new Date class.
     #'
     #' @param className className
+    #' @param percent_description using \% in the description
     #' @param ... Other optional arguments.
     #' @export
     initialize = function(
-        `className`, ...
+        `className`, `percent_description` = NULL, ...
     ) {
       if (!missing(`className`)) {
         stopifnot(is.character(`className`), length(`className`) == 1)
         self$`className` <- `className`
+      }
+      if (!is.null(`percent_description`)) {
+        stopifnot(is.character(`percent_description`), length(`percent_description`) == 1)
+        self$`percent_description` <- `percent_description`
       }
     },
     #' To JSON string
@@ -44,6 +51,10 @@ Date <- R6::R6Class(
         DateObject[["className"]] <-
           self$`className`
       }
+      if (!is.null(self$`percent_description`)) {
+        DateObject[["percent_description"]] <-
+          self$`percent_description`
+      }
       DateObject
     },
     #' Deserialize JSON string into an instance of Date
@@ -58,6 +69,9 @@ Date <- R6::R6Class(
       this_object <- jsonlite::fromJSON(input_json)
       if (!is.null(this_object$`className`)) {
         self$`className` <- this_object$`className`
+      }
+      if (!is.null(this_object$`percent_description`)) {
+        self$`percent_description` <- this_object$`percent_description`
       }
       self
     },
@@ -77,6 +91,14 @@ Date <- R6::R6Class(
                     ',
           self$`className`
           )
+        },
+        if (!is.null(self$`percent_description`)) {
+          sprintf(
+          '"percent_description":
+            "%s"
+                    ',
+          self$`percent_description`
+          )
         }
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
@@ -93,6 +115,7 @@ Date <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`className` <- this_object$`className`
+      self$`percent_description` <- this_object$`percent_description`
       self
     },
     #' Validate JSON input with respect to Date

--- a/samples/client/petstore/R-httr2/docs/Date.md
+++ b/samples/client/petstore/R-httr2/docs/Date.md
@@ -6,5 +6,6 @@ to test the model name `Date`
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
+**percent_description** | **character** | using % in the description | [optional] 
 
 

--- a/samples/client/petstore/R/R/date.R
+++ b/samples/client/petstore/R/R/date.R
@@ -8,6 +8,7 @@
 #' @description Date Class
 #' @format An \code{R6Class} generator object
 #' @field className  character
+#' @field percent_description using \% in the description character [optional]
 #' @field _field_list a list of fields list(character)
 #' @field additional_properties additional properties list(character) [optional]
 #' @importFrom R6 R6Class
@@ -17,7 +18,8 @@ Date <- R6::R6Class(
   "Date",
   public = list(
     `className` = NULL,
-    `_field_list` = c("className"),
+    `percent_description` = NULL,
+    `_field_list` = c("className", "percent_description"),
     `additional_properties` = list(),
     #' Initialize a new Date class.
     #'
@@ -25,15 +27,20 @@ Date <- R6::R6Class(
     #' Initialize a new Date class.
     #'
     #' @param className className
+    #' @param percent_description using \% in the description
     #' @param additional_properties additonal properties (optional)
     #' @param ... Other optional arguments.
     #' @export
     initialize = function(
-        `className`, additional_properties = NULL, ...
+        `className`, `percent_description` = NULL, additional_properties = NULL, ...
     ) {
       if (!missing(`className`)) {
         stopifnot(is.character(`className`), length(`className`) == 1)
         self$`className` <- `className`
+      }
+      if (!is.null(`percent_description`)) {
+        stopifnot(is.character(`percent_description`), length(`percent_description`) == 1)
+        self$`percent_description` <- `percent_description`
       }
       if (!is.null(additional_properties)) {
         for (key in names(additional_properties)) {
@@ -54,6 +61,10 @@ Date <- R6::R6Class(
         DateObject[["className"]] <-
           self$`className`
       }
+      if (!is.null(self$`percent_description`)) {
+        DateObject[["percent_description"]] <-
+          self$`percent_description`
+      }
       for (key in names(self$additional_properties)) {
         DateObject[[key]] <- self$additional_properties[[key]]
       }
@@ -72,6 +83,9 @@ Date <- R6::R6Class(
       this_object <- jsonlite::fromJSON(input_json)
       if (!is.null(this_object$`className`)) {
         self$`className` <- this_object$`className`
+      }
+      if (!is.null(this_object$`percent_description`)) {
+        self$`percent_description` <- this_object$`percent_description`
       }
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
@@ -98,6 +112,14 @@ Date <- R6::R6Class(
                     ',
           self$`className`
           )
+        },
+        if (!is.null(self$`percent_description`)) {
+          sprintf(
+          '"percent_description":
+            "%s"
+                    ',
+          self$`percent_description`
+          )
         }
       )
       jsoncontent <- paste(jsoncontent, collapse = ",")
@@ -119,6 +141,7 @@ Date <- R6::R6Class(
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
       self$`className` <- this_object$`className`
+      self$`percent_description` <- this_object$`percent_description`
       # process additional properties/fields in the payload
       for (key in names(this_object)) {
         if (!(key %in% self$`_field_list`)) { # json key not in list of fields

--- a/samples/client/petstore/R/docs/Date.md
+++ b/samples/client/petstore/R/docs/Date.md
@@ -6,5 +6,6 @@ to test the model name `Date`
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **character** |  | 
+**percent_description** | **character** | using % in the description | [optional] 
 
 


### PR DESCRIPTION
- Escape % in description in R model @field to address rdoc warning.
- Add a test


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@Ramanth (2019/07) @saigiridhar21 (2019/07)
