### PR TITLE
[Java][Feign] convert expirationTimeSeconds to milliseconds

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/auth/OAuth.mustache
@@ -77,7 +77,7 @@ public abstract class OAuth implements RequestInterceptor {
 
   public synchronized String getAccessToken() {
     // If first time, get the token
-    if (expirationTimeSeconds == null || System.currentTimeMillis() >= expirationTimeSeconds) {
+    if (expirationTimeSeconds == null || System.currentTimeMillis() >= expirationTimeSeconds * MILLIS_PER_SECOND) {
       updateAccessToken();
     }
     return accessToken;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -77,7 +77,7 @@ public abstract class OAuth implements RequestInterceptor {
 
   public synchronized String getAccessToken() {
     // If first time, get the token
-    if (expirationTimeSeconds == null || System.currentTimeMillis() >= expirationTimeSeconds) {
+    if (expirationTimeSeconds == null || System.currentTimeMillis() >= expirationTimeSeconds * MILLIS_PER_SECOND) {
       updateAccessToken();
     }
     return accessToken;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -77,7 +77,7 @@ public abstract class OAuth implements RequestInterceptor {
 
   public synchronized String getAccessToken() {
     // If first time, get the token
-    if (expirationTimeSeconds == null || System.currentTimeMillis() >= expirationTimeSeconds) {
+    if (expirationTimeSeconds == null || System.currentTimeMillis() >= expirationTimeSeconds * MILLIS_PER_SECOND) {
       updateAccessToken();
     }
     return accessToken;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hi @wing328 @bbdouglas @sreeshas, @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608,
this is my proposed fix for https://github.com/OpenAPITools/openapi-generator/issues/13339

The Java OAuth RequestInterceptor implementation for Feign currently verifies if a previously obtained access token needs to be renewed by checking if `System.currentTimeMillis()` is greater than `expirationTimeSeconds`. This causes a new access token to be requested for each interaction. Converting `expirationTimeSeconds` to milliseconds should fix this. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
