### PR TITLE
[fix][python-flask][python-aiohttp]: incorrect boolean literal in unit tests

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -16,6 +16,12 @@
 
 package org.openapitools.codegen.languages;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -42,11 +48,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 public abstract class AbstractPythonConnexionServerCodegen extends AbstractPythonCodegen implements CodegenConfig {
+    private static class PythonBooleanSerializer extends JsonSerializer<Boolean> {
+        @Override
+        public void serialize(Boolean value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            gen.writeRawValue(value ? "True" : "False");
+        }
+    }
+
     private final Logger LOGGER = LoggerFactory.getLogger(AbstractPythonConnexionServerCodegen.class);
 
     public static final String CONTROLLER_PACKAGE = "controllerPackage";
@@ -59,6 +73,10 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
     public static final String USE_PYTHON_SRC_ROOT_IN_IMPORTS = "usePythonSrcRootInImports";
     public static final String MOVE_TESTS_UNDER_PYTHON_SRC_ROOT = "testsUsePythonSrcRoot";
     static final String MEDIA_TYPE = "mediaType";
+
+    // An object mapper that is used to convert an example string to
+    // a "python-compliant" example string (boolean as True/False).
+    final ObjectMapper MAPPER = new ObjectMapper();
 
     protected int serverPort = 8080;
     protected String controllerPackage;
@@ -79,6 +97,10 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
         fixBodyName = fixBodyNameValue;
         modelPackage = "models";
         testPackage = "test";
+
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addSerializer(Boolean.class, new PythonBooleanSerializer());
+        MAPPER.registerModule(simpleModule);
 
         // TODO may remove these later to default to the setting in abstract python base class instead
         languageSpecificPrimitives.add("List");
@@ -695,7 +717,16 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
             if (operation.requestBodyExamples != null) {
                 for (Map<String, String> example : operation.requestBodyExamples) {
                     if (example.get("contentType") != null && example.get("contentType").equals("application/json")) {
-                        operation.bodyParam.example = example.get("example");
+                        // Make an example dictionary more python-like (Booleans True/False).
+                        // If fails, use the original string.
+                        try {
+                            Map<String, Object> result = MAPPER.readValue(example.get("example"),
+                                    new TypeReference<Map<String, Object>>() {
+                                    });
+                            operation.bodyParam.example = MAPPER.writeValueAsString(result);
+                        } catch (IOException e) {
+                            operation.bodyParam.example = example.get("example");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #9386

When using generators `python-flask`and `python-aiohttp`, the generated test body boolean values reads now as follows ("True" or "False"):
```python
body = {
  "boolean_property": True
}
```

Previous buggy generated code:
```python
body = {
  "boolean_property": true
}
```

Most of the code is copy-paste from generator `python-fastapi`(PythonFastAPIServerCodegen.java)

Steps to see the new generated code:
```console
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
   -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
   -g python-flask \
   -o /var/tmp/python-flask
cat /var/tmp/python-flask/openapi_server/test/test_store_controller.py

java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
   -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
   -g python-aiohttp \
   -o /var/tmp/python-aiohttp

cat /var/tmp/python-aiohttp/tests/test_store_controller.py
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @arun-nalla @spacether