### PR TITLE
Fix applying optional query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/libraries/apollo/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/libraries/apollo/ApiClient.mustache
@@ -185,10 +185,12 @@ export default class ApiClient extends RESTDataSource {
         queryParams, headerParams, formParams, bodyParam, authNames,
         contentTypes, accepts, returnType, requestInit) {
 
+        var normalizedQueryParams = this.normalizeParams(queryParams);
+
         var parameterizedPath = this.parametrizePath(path, pathParams);
         var fetchOptions = {
             headers: headerParams,
-            params: queryParams
+            params: normalizedQueryParams
         };
 
         this.applyAuthOptions(fetchOptions, authNames);
@@ -210,7 +212,7 @@ export default class ApiClient extends RESTDataSource {
         var httpMethodFn = httpMethod.toLowerCase();
 
         if (httpMethodFn == 'get' || httpMethodFn == 'delete') {
-            response = await this[httpMethodFn](parameterizedPath, [], requestInit);
+            response = await this[httpMethodFn](parameterizedPath, normalizedQueryParams, requestInit);
         } else {
             response = await this[httpMethodFn](parameterizedPath, body, requestInit)
         }

--- a/samples/client/petstore/javascript-apollo/src/ApiClient.js
+++ b/samples/client/petstore/javascript-apollo/src/ApiClient.js
@@ -186,10 +186,12 @@ export default class ApiClient extends RESTDataSource {
         queryParams, headerParams, formParams, bodyParam, authNames,
         contentTypes, accepts, returnType, requestInit) {
 
+        var normalizedQueryParams = this.normalizeParams(queryParams);
+
         var parameterizedPath = this.parametrizePath(path, pathParams);
         var fetchOptions = {
             headers: headerParams,
-            params: queryParams
+            params: normalizedQueryParams
         };
 
         this.applyAuthOptions(fetchOptions, authNames);
@@ -211,7 +213,7 @@ export default class ApiClient extends RESTDataSource {
         var httpMethodFn = httpMethod.toLowerCase();
 
         if (httpMethodFn == 'get' || httpMethodFn == 'delete') {
-            response = await this[httpMethodFn](parameterizedPath, [], requestInit);
+            response = await this[httpMethodFn](parameterizedPath, normalizedQueryParams, requestInit);
         } else {
             response = await this[httpMethodFn](parameterizedPath, body, requestInit)
         }


### PR DESCRIPTION
Optional query parameters are currently ignored when making API calls (sorry about that!). This fixes it.

<sup><sub>CC NodeJS/Javascript technical committee: @CodeNinjai @frol @cliffano </sub></sup>

---

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
