### PR TITLE
Fix php generators treating double as a native type

### DIFF
--- a/docs/generators/php-dt.md
+++ b/docs/generators/php-dt.md
@@ -56,7 +56,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>integer</li>

--- a/docs/generators/php-laravel.md
+++ b/docs/generators/php-laravel.md
@@ -57,7 +57,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>integer</li>

--- a/docs/generators/php-lumen.md
+++ b/docs/generators/php-lumen.md
@@ -57,7 +57,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>integer</li>

--- a/docs/generators/php-mezzio-ph.md
+++ b/docs/generators/php-mezzio-ph.md
@@ -56,7 +56,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>integer</li>

--- a/docs/generators/php-slim-deprecated.md
+++ b/docs/generators/php-slim-deprecated.md
@@ -57,7 +57,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>integer</li>

--- a/docs/generators/php-slim4.md
+++ b/docs/generators/php-slim4.md
@@ -58,7 +58,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>integer</li>

--- a/docs/generators/php-symfony.md
+++ b/docs/generators/php-symfony.md
@@ -62,7 +62,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>array</li>
 <li>bool</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>mixed</li>

--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -58,7 +58,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>
-<li>double</li>
 <li>float</li>
 <li>int</li>
 <li>integer</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -655,7 +655,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toEnumValue(String value, String datatype) {
-        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+        if ("int".equals(datatype) || "float".equals(datatype)) {
             return value;
         } else {
             return "\'" + escapeText(value) + "\'";
@@ -683,7 +683,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         }
 
         // number
-        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+        if ("int".equals(datatype) || "float".equals(datatype)) {
             String varName = name;
             varName = varName.replaceAll("-", "MINUS_");
             varName = varName.replaceAll("\\+", "PLUS_");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -91,7 +91,6 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
                         "boolean",
                         "int",
                         "integer",
-                        "double",
                         "float",
                         "string",
                         "object",
@@ -119,7 +118,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         typeMapping.put("number", "float");
         typeMapping.put("float", "float");
         typeMapping.put("decimal", "float");
-        typeMapping.put("double", "double");
+        typeMapping.put("double", "float");
         typeMapping.put("string", "string");
         typeMapping.put("byte", "int");
         typeMapping.put("boolean", "bool");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpDataTransferClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpDataTransferClientCodegen.java
@@ -92,9 +92,6 @@ public class PhpDataTransferClientCodegen extends AbstractPhpCodegen {
                 .stability(Stability.BETA)
                 .build();
 
-        //no point to use double - http://php.net/manual/en/language.types.float.php , especially because of PHP 7+ float type declaration
-        typeMapping.put("double", "float");
-
         // remove these from primitive types to make the output works
         languageSpecificPrimitives.remove("\\DateTime");
         languageSpecificPrimitives.remove("\\SplFileObject");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
@@ -382,7 +382,7 @@ public class PhpLaravelServerCodegen extends AbstractPhpCodegen {
         }
 
         // number
-        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+        if ("int".equals(datatype) || "float".equals(datatype)) {
             String varName = "NUMBER_" + value;
             varName = varName.replaceAll("-", "MINUS_");
             varName = varName.replaceAll("\\+", "PLUS_");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpMezzioPathHandlerServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpMezzioPathHandlerServerCodegen.java
@@ -87,9 +87,6 @@ public class PhpMezzioPathHandlerServerCodegen extends AbstractPhpCodegen {
                 )
         );
 
-        //no point to use double - http://php.net/manual/en/language.types.float.php , especially because of PHP 7+ float type declaration
-        typeMapping.put("double", "float");
-
         // remove these from primitive types to make the output works
         languageSpecificPrimitives.remove("\\DateTime");
         languageSpecificPrimitives.remove("\\SplFileObject");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSilexServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSilexServerCodegen.java
@@ -98,7 +98,6 @@ public class PhpSilexServerCodegen extends DefaultCodegen implements CodegenConf
                         "boolean",
                         "int",
                         "integer",
-                        "double",
                         "float",
                         "string",
                         "object",
@@ -115,7 +114,7 @@ public class PhpSilexServerCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("integer", "int");
         typeMapping.put("long", "int");
         typeMapping.put("float", "float");
-        typeMapping.put("double", "double");
+        typeMapping.put("double", "float");
         typeMapping.put("string", "string");
         typeMapping.put("byte", "int");
         typeMapping.put("boolean", "boolean");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -147,7 +147,6 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
                 Arrays.asList(
                         "bool",
                         "int",
-                        "double",
                         "float",
                         "string",
                         "object",
@@ -183,7 +182,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
         typeMapping.put("decimal", "float");
         typeMapping.put("number", "float");
         typeMapping.put("float", "float");
-        typeMapping.put("double", "double");
+        typeMapping.put("double", "float");
         typeMapping.put("string", "string");
         typeMapping.put("byte", "int");
         typeMapping.put("boolean", "bool");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -587,7 +587,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
 
     @Override
     public String toEnumValue(String value, String datatype) {
-        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+        if ("int".equals(datatype) || "float".equals(datatype)) {
             return value;
         } else {
             return "\"" + escapeText(value) + "\"";

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -664,7 +664,7 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     $config
 );
 $number = 3.4; // float | None
-$double = 3.4; // double | None
+$double = 3.4; // float | None
 $pattern_without_delimiter = 'pattern_without_delimiter_example'; // string | None
 $byte = 'byte_example'; // string | None
 $integer = 56; // int | None
@@ -690,7 +690,7 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **number** | **float**| None | |
-| **double** | **double**| None | |
+| **double** | **float**| None | |
 | **pattern_without_delimiter** | **string**| None | |
 | **byte** | **string**| None | |
 | **integer** | **int**| None | [optional] |
@@ -749,7 +749,7 @@ $enum_header_string = '-efg'; // string | Header parameter enum test (string)
 $enum_query_string_array = array('enum_query_string_array_example'); // string[] | Query parameter enum test (string array)
 $enum_query_string = '-efg'; // string | Query parameter enum test (string)
 $enum_query_integer = 56; // int | Query parameter enum test (double)
-$enum_query_double = 3.4; // double | Query parameter enum test (double)
+$enum_query_double = 3.4; // float | Query parameter enum test (double)
 $enum_query_model_array = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // \OpenAPI\Client\Model\EnumClass[]
 $enum_form_string_array = array('$'); // string[] | Form parameter enum test (string array)
 $enum_form_string = '-efg'; // string | Form parameter enum test (string)
@@ -770,7 +770,7 @@ try {
 | **enum_query_string_array** | [**string[]**](../Model/string.md)| Query parameter enum test (string array) | [optional] |
 | **enum_query_string** | **string**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;] |
 | **enum_query_integer** | **int**| Query parameter enum test (double) | [optional] |
-| **enum_query_double** | **double**| Query parameter enum test (double) | [optional] |
+| **enum_query_double** | **float**| Query parameter enum test (double) | [optional] |
 | **enum_query_model_array** | [**\OpenAPI\Client\Model\EnumClass[]**](../Model/\OpenAPI\Client\Model\EnumClass.md)|  | [optional] |
 | **enum_form_string_array** | [**string[]**](../Model/string.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;] |
 | **enum_form_string** | **string**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;] |

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/EnumTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/EnumTest.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **enum_string** | **string** |  | [optional]
 **enum_string_required** | **string** |  |
 **enum_integer** | **int** |  | [optional]
-**enum_number** | **double** |  | [optional]
+**enum_number** | **float** |  | [optional]
 **outer_enum** | [**\OpenAPI\Client\Model\OuterEnum**](OuterEnum.md) |  | [optional]
 **outer_enum_integer** | [**\OpenAPI\Client\Model\OuterEnumInteger**](OuterEnumInteger.md) |  | [optional]
 **outer_enum_default_value** | [**\OpenAPI\Client\Model\OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional]

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/FormatTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/FormatTest.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **int64** | **int** |  | [optional]
 **number** | **float** |  |
 **float** | **float** |  | [optional]
-**double** | **double** |  | [optional]
+**double** | **float** |  | [optional]
 **decimal** | **float** |  | [optional]
 **string** | **string** |  | [optional]
 **byte** | **string** |  |

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -2925,7 +2925,7 @@ class FakeApi
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
      *
      * @param  float $number None (required)
-     * @param  double $double None (required)
+     * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
      * @param  int $integer None (optional)
@@ -2954,7 +2954,7 @@ class FakeApi
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
      *
      * @param  float $number None (required)
-     * @param  double $double None (required)
+     * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
      * @param  int $integer None (optional)
@@ -3026,7 +3026,7 @@ class FakeApi
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
      *
      * @param  float $number None (required)
-     * @param  double $double None (required)
+     * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
      * @param  int $integer None (optional)
@@ -3059,7 +3059,7 @@ class FakeApi
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
      *
      * @param  float $number None (required)
-     * @param  double $double None (required)
+     * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
      * @param  int $integer None (optional)
@@ -3108,7 +3108,7 @@ class FakeApi
      * Create request for operation 'testEndpointParameters'
      *
      * @param  float $number None (required)
-     * @param  double $double None (required)
+     * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
      * @param  int $integer None (optional)
@@ -3360,7 +3360,7 @@ class FakeApi
      * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
      * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  double $enum_query_double Query parameter enum test (double) (optional)
+     * @param  float $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
@@ -3384,7 +3384,7 @@ class FakeApi
      * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
      * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  double $enum_query_double Query parameter enum test (double) (optional)
+     * @param  float $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
@@ -3451,7 +3451,7 @@ class FakeApi
      * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
      * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  double $enum_query_double Query parameter enum test (double) (optional)
+     * @param  float $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
@@ -3479,7 +3479,7 @@ class FakeApi
      * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
      * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  double $enum_query_double Query parameter enum test (double) (optional)
+     * @param  float $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
@@ -3523,7 +3523,7 @@ class FakeApi
      * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
      * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  double $enum_query_double Query parameter enum test (double) (optional)
+     * @param  float $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -60,7 +60,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         'enum_string' => 'string',
         'enum_string_required' => 'string',
         'enum_integer' => 'int',
-        'enum_number' => 'double',
+        'enum_number' => 'float',
         'outer_enum' => '\OpenAPI\Client\Model\OuterEnum',
         'outer_enum_integer' => '\OpenAPI\Client\Model\OuterEnumInteger',
         'outer_enum_default_value' => '\OpenAPI\Client\Model\OuterEnumDefaultValue',
@@ -551,7 +551,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets enum_number
      *
-     * @return double|null
+     * @return float|null
      */
     public function getEnumNumber()
     {
@@ -561,7 +561,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets enum_number
      *
-     * @param double|null $enum_number enum_number
+     * @param float|null $enum_number enum_number
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -62,7 +62,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         'int64' => 'int',
         'number' => 'float',
         'float' => 'float',
-        'double' => 'double',
+        'double' => 'float',
         'decimal' => 'float',
         'string' => 'string',
         'byte' => 'string',
@@ -636,7 +636,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets double
      *
-     * @return double|null
+     * @return float|null
      */
     public function getDouble()
     {
@@ -646,7 +646,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets double
      *
-     * @param double|null $double double
+     * @param float|null $double double
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -87,7 +87,7 @@ class ObjectSerializer
                 foreach ($data::openAPITypes() as $property => $openAPIType) {
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
-                    if ($value !== null && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+                    if ($value !== null && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
                         $callable = [$openAPIType, 'getAllowableEnumValues'];
                         if (is_callable($callable)) {
                             /** array $callable */
@@ -441,7 +441,7 @@ class ObjectSerializer
         }
 
         /** @psalm-suppress ParadoxicalCondition */
-        if (in_array($class, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+        if (in_array($class, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
             settype($data, $class);
             return $data;
         }

--- a/samples/server/petstore/php-laravel/lib/app/Models/EnumTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/EnumTest.php
@@ -18,7 +18,7 @@ class EnumTest {
     /** @var int $enumInteger */
     public $enumInteger = 0;
 
-    /** @var double $enumNumber */
+    /** @var float $enumNumber */
     public $enumNumber = 0;
 
     /** @var string|null $outerEnum */

--- a/samples/server/petstore/php-laravel/lib/app/Models/FormatTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/FormatTest.php
@@ -24,7 +24,7 @@ class FormatTest {
     /** @var float $float */
     public $float = 0;
 
-    /** @var double $double */
+    /** @var float $double */
     public $double = 0;
 
     /** @var float $decimal */


### PR DESCRIPTION
Fixes #13335 

Fixes inconsistent treating of double as a native type in php. Removes type from native primitives and consistently fixes the map in the AbstractPhpCodegen class 

References:
https://docs.phpdoc.org/3.0/guide/guides/types.html#primitives
http://php.net/manual/en/language.types.intro.php
https://www.php.net/manual/en/language.types.float.php

@jebentier  @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
