### PR TITLE
Support set in R client parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -382,6 +382,19 @@
       {{/headerParams}}
       {{#queryParams}}
       {{#isArray}}
+      {{#uniqueItems}}
+      # check if items are unique
+      if (!identical(`{{{paramName}}}`, unique(`{{{paramName}}}`))) {
+        {{#useDefaultExceptionHandling}}
+        stop("Invalid value for {{{paramName}}} when calling {{classname}}${{operationId}}. Items must be unqiue.")
+        {{/useDefaultExceptionHandling}}
+        {{#useRlangExceptionHandling}}
+        rlang::abort(message = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}. Items must be unique.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}. Items must be unique."))
+        {{/useRlangExceptionHandling}}
+      }
       {{#isExplode}}
       # explore
       for (query_item in `{{{paramName}}}`) {
@@ -426,6 +439,53 @@
       {{/items}}
       query_params[["{{{baseName}}}"]] <- I(paste(lapply(`{{{paramName}}}`, URLencode, reserved = TRUE), collapse = ","))
       {{/isExplode}}
+      {{/uniqueItems}}
+      {{^uniqueItems}}
+      {{#isExplode}}
+      # explore
+      for (query_item in `{{{paramName}}}`) {
+        {{#items}}
+        {{#isEnum}}
+        # validate enum values
+        if (!(query_item %in% c({{#_enum}}"{{{.}}}"{{^-last}}, {{/-last}}{{/_enum}}))) {
+          {{#useDefaultExceptionHandling}}
+          stop("Invalid value for {{{paramName}}} when calling {{classname}}${{operationId}}. Must be {{_enum}}.")
+          {{/useDefaultExceptionHandling}}
+          {{#useRlangExceptionHandling}}
+          rlang::abort(message = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}. Must be {{_enum}}.",
+                       .subclass = "ApiException",
+                       ApiException = ApiException$new(status = 0,
+                                                       reason = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}. Must be {{_enum}}."))
+          {{/useRlangExceptionHandling}}
+        }
+        {{/isEnum}}
+        {{/items}}
+        query_params[["{{{baseName}}}"]] <- c(query_params[["{{{baseName}}}"]], list(`{{{baseName}}}` = query_item))
+      }
+      {{/isExplode}}
+      {{^isExplode}}
+      # no explore
+      {{#items}}
+      {{#isEnum}}
+      # validate enum values
+      for (query_item in `{{{paramName}}}`) {
+        if (!(query_item %in% c({{#_enum}}"{{{.}}}"{{^-last}}, {{/-last}}{{/_enum}}))) {
+          {{#useDefaultExceptionHandling}}
+          stop("Invalid value for {{{paramName}}} when calling {{classname}}${{operationId}}. Must be {{_enum}}.")
+          {{/useDefaultExceptionHandling}}
+          {{#useRlangExceptionHandling}}
+          rlang::abort(message = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}. Must be {{_enum}}.",
+                       .subclass = "ApiException",
+                       ApiException = ApiException$new(status = 0,
+                                                       reason = "Invalid value for `{{paramName}}` when calling {{classname}}${{operationId}}. Must be {{_enum}}."))
+          {{/useRlangExceptionHandling}}
+        }
+      }
+      {{/isEnum}}
+      {{/items}}
+      query_params[["{{{baseName}}}"]] <- I(paste(lapply(`{{{paramName}}}`, URLencode, reserved = TRUE), collapse = ","))
+      {{/isExplode}}
+      {{/uniqueItems}}
       {{/isArray}}
       {{^isArray}}
       {{#isEnum}}

--- a/modules/openapi-generator/src/test/resources/3_0/r/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/r/petstore.yaml
@@ -677,6 +677,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+  /fake/set_query_parameter:
+    get:
+      tags:
+        - fake
+      summary: test set query parameter
+      description: ''
+      operationId: fake_set_query
+      parameters:
+        - name: set_dummy 
+          in: query 
+          description: set query
+          required: true
+          schema:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+        - name: array_dummy
+          in: query 
+          description: array query
+          required: true
+          schema:
+            type: array
+            uniqueItems: false
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -49,6 +49,24 @@
 #' }
 #' }
 #'
+#' \strong{ fake_set_query } \emph{ test set query parameter }
+#' 
+#'
+#' \itemize{
+#' \item \emph{ @param } set_dummy list( character )
+#' \item \emph{ @param } array_dummy list( character )
+#'
+#' \item On encountering errors, an error of subclass ApiException will be thrown.
+#'
+#' \item status code : 200 | successful operation
+#'
+#'
+#' \item response headers :
+#'
+#' \tabular{ll}{
+#' }
+#' }
+#'
 #' }
 #'
 #'
@@ -104,6 +122,32 @@
 #' # In case of error, print the error object
 #' if (!is.null(result$ApiException)) {
 #'   print("Exception occurs when calling `fake_regular_expression`:")
+#'   dput(result$ApiException$toString())
+#'   
+#'   # error object
+#'   dput(result$ApiException$error_object$toJSONString())
+#'   
+#' }#'
+#' # This endpoint doesn't return data
+#'
+#'
+#' ####################  fake_set_query  ####################
+#'
+#' library(petstore)
+#' var_set_dummy <- ["set_dummy_example"] # set[character] | set query
+#' var_array_dummy <- ["array_dummy_example"] # array[character] | array query
+#'
+#' #test set query parameter
+#' api_instance <- petstore_api$new()
+#'
+#' result <- tryCatch(
+#'              
+#'              api_instance$fake_api$fake_set_query(var_set_dummy, var_array_dummy),
+#'              ApiException = function(ex) ex
+#'           )
+#' # In case of error, print the error object
+#' if (!is.null(result$ApiException)) {
+#'   print("Exception occurs when calling `fake_set_query`:")
 #'   dput(result$ApiException$toString())
 #'   
 #'   # error object
@@ -313,6 +357,131 @@ FakeApi <- R6::R6Class(
       header_params["reg_exp_test"] <- `reg_exp_test`
 
       local_var_url_path <- "/fake/regular_expression"
+
+      # The Accept request HTTP header
+      local_var_accepts <- list()
+
+      # The Content-Type representation header
+      local_var_content_types <- list()
+
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
+                                 method = "GET",
+                                 query_params = query_params,
+                                 header_params = header_params,
+                                 form_params = form_params,
+                                 file_params = file_params,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
+                                 is_oauth = is_oauth,
+                                 oauth_scopes = oauth_scopes,
+                                 ...)
+
+      if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
+        local_var_resp$content <- NULL
+        local_var_resp
+      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
+        }
+        rlang::abort(message = error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      }
+    },
+    #' test set query parameter
+    #'
+    #' @description
+    #' test set query parameter
+    #'
+    #' @param set_dummy set query
+    #' @param array_dummy array query
+    #' @param ... Other optional arguments
+    #' @return void
+    #' @export
+    fake_set_query = function(set_dummy, array_dummy, ...) {
+      local_var_response <- self$fake_set_query_with_http_info(set_dummy, array_dummy, ...)
+      if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
+        local_var_response$content
+      } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
+        local_var_response
+      } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
+        local_var_response
+      } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
+        local_var_response
+      }
+    },
+    #' test set query parameter
+    #'
+    #' @description
+    #' test set query parameter
+    #'
+    #' @param set_dummy set query
+    #' @param array_dummy array query
+    #' @param ... Other optional arguments
+    #' @return API response (void) with additional information such as HTTP status code, headers
+    #' @export
+    fake_set_query_with_http_info = function(set_dummy, array_dummy, ...) {
+      args <- list(...)
+      query_params <- list()
+      header_params <- c()
+      form_params <- list()
+      file_params <- list()
+      local_var_body <- NULL
+      oauth_scopes <- NULL
+      is_oauth <- FALSE
+
+      if (missing(`set_dummy`)) {
+        rlang::abort(message = "Missing required parameter `set_dummy`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Missing required parameter `set_dummy`."))
+      }
+
+      if (missing(`array_dummy`)) {
+        rlang::abort(message = "Missing required parameter `array_dummy`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Missing required parameter `array_dummy`."))
+      }
+
+
+
+      # check if items are unique
+      if (!identical(`set_dummy`, unique(`set_dummy`))) {
+        rlang::abort(message = "Invalid value for `set_dummy` when calling FakeApi$fake_set_query. Items must be unique.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `set_dummy` when calling FakeApi$fake_set_query. Items must be unique."))
+      }
+      # explore
+      for (query_item in `set_dummy`) {
+        query_params[["set_dummy"]] <- c(query_params[["set_dummy"]], list(`set_dummy` = query_item))
+      }
+
+      # explore
+      for (query_item in `array_dummy`) {
+        query_params[["array_dummy"]] <- c(query_params[["array_dummy"]], list(`array_dummy` = query_item))
+      }
+
+      local_var_url_path <- "/fake/set_query_parameter"
 
       # The Accept request HTTP header
       local_var_accepts <- list()

--- a/samples/client/petstore/R-httr2-wrapper/README.md
+++ b/samples/client/petstore/R-httr2-wrapper/README.md
@@ -63,6 +63,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *FakeApi* | [**fake_data_file**](docs/FakeApi.md#fake_data_file) | **GET** /fake/data_file | test data_file to ensure it's escaped correctly
 *FakeApi* | [**fake_regular_expression**](docs/FakeApi.md#fake_regular_expression) | **GET** /fake/regular_expression | test regular expression to ensure no exception
+*FakeApi* | [**fake_set_query**](docs/FakeApi.md#fake_set_query) | **GET** /fake/set_query_parameter | test set query parameter
 *PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet
 *PetApi* | [**find_pets_by_status**](docs/PetApi.md#find_pets_by_status) | **GET** /pet/findByStatus | Finds Pets by status

--- a/samples/client/petstore/R-httr2-wrapper/docs/FakeApi.md
+++ b/samples/client/petstore/R-httr2-wrapper/docs/FakeApi.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**fake_data_file**](FakeApi.md#fake_data_file) | **GET** /fake/data_file | test data_file to ensure it&#39;s escaped correctly
 [**fake_regular_expression**](FakeApi.md#fake_regular_expression) | **GET** /fake/regular_expression | test regular expression to ensure no exception
+[**fake_set_query**](FakeApi.md#fake_set_query) | **GET** /fake/set_query_parameter | test set query parameter
 
 
 # **fake_data_file**
@@ -103,6 +104,61 @@ if (!is.null(result$ApiException)) {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **reg_exp_test** | **character**| dummy required parameter | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
+# **fake_set_query**
+> fake_set_query(set_dummy, array_dummy)
+
+test set query parameter
+
+
+
+### Example
+```R
+library(petstore)
+
+var_set_dummy <- list("inner_example") # set[character] | set query
+var_array_dummy <- list("inner_example") # array[character] | array query
+
+# test set query parameter
+api_instance <- petstore_api$new()
+result <- tryCatch(
+             api_instance$fake_api$fake_set_query(var_set_dummy, var_array_dummy),
+             ApiException = function(ex) ex
+          )
+# In case of error, print the error object
+if (!is.null(result$ApiException)) {
+  print("Exception occurs when calling `fake_set_query`:")
+  dput(result$ApiException$toString())
+  # error object
+  dput(result$ApiException$error_object$toJSONString())
+}
+# This endpoint doesn't return data
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **set_dummy** | list( **character** )| set query | 
+ **array_dummy** | list( **character** )| array query | 
 
 ### Return type
 

--- a/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
@@ -234,6 +234,27 @@ test_that("GetPetById with data_file", {
   expect_equal(response$name, "name_test")
 })
 
+test_that("set validation test", {
+  fake_api <- FakeApi$new()
+  # array input invalid (not unique)
+  set_dummy <- list(1, 2, 2, 3)
+  array_dummy <- list(1, 2, 2, 3)
+  result <- tryCatch(fake_api$fake_set_query(set_dummy, array_dummy),
+                     ApiException = function(ex) ex
+  )
+
+  expect_equal(result$ApiException$reason, "Invalid value for `set_dummy` when calling FakeApi$fake_set_query. Items must be unique.")
+
+  # vector input invalid (not unique)
+  set_dummy <- c(1, 2, 2, 3)
+  array_dummy <- c(1, 2, 2, 3)
+  result <- tryCatch(fake_api$fake_set_query(set_dummy, array_dummy),
+                     ApiException = function(ex) ex
+  )
+
+  expect_equal(result$ApiException$reason, "Invalid value for `set_dummy` when calling FakeApi$fake_set_query. Items must be unique.")
+})
+
 test_that("find_pets_by_status", {
   # input invalid
   var_status <- c("something") # array[character] | Tags to filter by

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -49,6 +49,24 @@
 #' }
 #' }
 #'
+#' \strong{ fake_set_query } \emph{ test set query parameter }
+#' 
+#'
+#' \itemize{
+#' \item \emph{ @param } set_dummy list( character )
+#' \item \emph{ @param } array_dummy list( character )
+#'
+#' \item On encountering errors, an error of subclass ApiException will be thrown.
+#'
+#' \item status code : 200 | successful operation
+#'
+#'
+#' \item response headers :
+#'
+#' \tabular{ll}{
+#' }
+#' }
+#'
 #' }
 #'
 #'
@@ -104,6 +122,32 @@
 #' # In case of error, print the error object
 #' if (!is.null(result$ApiException)) {
 #'   print("Exception occurs when calling `fake_regular_expression`:")
+#'   dput(result$ApiException$toString())
+#'   
+#'   # error object
+#'   dput(result$ApiException$error_object$toJSONString())
+#'   
+#' }#'
+#' # This endpoint doesn't return data
+#'
+#'
+#' ####################  fake_set_query  ####################
+#'
+#' library(petstore)
+#' var_set_dummy <- ["set_dummy_example"] # set[character] | set query
+#' var_array_dummy <- ["array_dummy_example"] # array[character] | array query
+#'
+#' #test set query parameter
+#' api_instance <- FakeApi$new()
+#'
+#' result <- tryCatch(
+#'              
+#'              api_instance$fake_set_query(var_set_dummy, var_array_dummy),
+#'              ApiException = function(ex) ex
+#'           )
+#' # In case of error, print the error object
+#' if (!is.null(result$ApiException)) {
+#'   print("Exception occurs when calling `fake_set_query`:")
 #'   dput(result$ApiException$toString())
 #'   
 #'   # error object
@@ -313,6 +357,131 @@ FakeApi <- R6::R6Class(
       header_params["reg_exp_test"] <- `reg_exp_test`
 
       local_var_url_path <- "/fake/regular_expression"
+
+      # The Accept request HTTP header
+      local_var_accepts <- list()
+
+      # The Content-Type representation header
+      local_var_content_types <- list()
+
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
+                                 method = "GET",
+                                 query_params = query_params,
+                                 header_params = header_params,
+                                 form_params = form_params,
+                                 file_params = file_params,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
+                                 is_oauth = is_oauth,
+                                 oauth_scopes = oauth_scopes,
+                                 ...)
+
+      if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
+        local_var_resp$content <- NULL
+        local_var_resp
+      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
+        }
+        rlang::abort(message = error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      }
+    },
+    #' test set query parameter
+    #'
+    #' @description
+    #' test set query parameter
+    #'
+    #' @param set_dummy set query
+    #' @param array_dummy array query
+    #' @param ... Other optional arguments
+    #' @return void
+    #' @export
+    fake_set_query = function(set_dummy, array_dummy, ...) {
+      local_var_response <- self$fake_set_query_with_http_info(set_dummy, array_dummy, ...)
+      if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
+        local_var_response$content
+      } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
+        local_var_response
+      } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
+        local_var_response
+      } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
+        local_var_response
+      }
+    },
+    #' test set query parameter
+    #'
+    #' @description
+    #' test set query parameter
+    #'
+    #' @param set_dummy set query
+    #' @param array_dummy array query
+    #' @param ... Other optional arguments
+    #' @return API response (void) with additional information such as HTTP status code, headers
+    #' @export
+    fake_set_query_with_http_info = function(set_dummy, array_dummy, ...) {
+      args <- list(...)
+      query_params <- list()
+      header_params <- c()
+      form_params <- list()
+      file_params <- list()
+      local_var_body <- NULL
+      oauth_scopes <- NULL
+      is_oauth <- FALSE
+
+      if (missing(`set_dummy`)) {
+        rlang::abort(message = "Missing required parameter `set_dummy`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Missing required parameter `set_dummy`."))
+      }
+
+      if (missing(`array_dummy`)) {
+        rlang::abort(message = "Missing required parameter `array_dummy`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Missing required parameter `array_dummy`."))
+      }
+
+
+
+      # check if items are unique
+      if (!identical(`set_dummy`, unique(`set_dummy`))) {
+        rlang::abort(message = "Invalid value for `set_dummy` when calling FakeApi$fake_set_query. Items must be unique.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `set_dummy` when calling FakeApi$fake_set_query. Items must be unique."))
+      }
+      # explore
+      for (query_item in `set_dummy`) {
+        query_params[["set_dummy"]] <- c(query_params[["set_dummy"]], list(`set_dummy` = query_item))
+      }
+
+      # explore
+      for (query_item in `array_dummy`) {
+        query_params[["array_dummy"]] <- c(query_params[["array_dummy"]], list(`array_dummy` = query_item))
+      }
+
+      local_var_url_path <- "/fake/set_query_parameter"
 
       # The Accept request HTTP header
       local_var_accepts <- list()

--- a/samples/client/petstore/R-httr2/README.md
+++ b/samples/client/petstore/R-httr2/README.md
@@ -63,6 +63,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *FakeApi* | [**fake_data_file**](docs/FakeApi.md#fake_data_file) | **GET** /fake/data_file | test data_file to ensure it's escaped correctly
 *FakeApi* | [**fake_regular_expression**](docs/FakeApi.md#fake_regular_expression) | **GET** /fake/regular_expression | test regular expression to ensure no exception
+*FakeApi* | [**fake_set_query**](docs/FakeApi.md#fake_set_query) | **GET** /fake/set_query_parameter | test set query parameter
 *PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet
 *PetApi* | [**find_pets_by_status**](docs/PetApi.md#find_pets_by_status) | **GET** /pet/findByStatus | Finds Pets by status

--- a/samples/client/petstore/R-httr2/docs/FakeApi.md
+++ b/samples/client/petstore/R-httr2/docs/FakeApi.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**fake_data_file**](FakeApi.md#fake_data_file) | **GET** /fake/data_file | test data_file to ensure it&#39;s escaped correctly
 [**fake_regular_expression**](FakeApi.md#fake_regular_expression) | **GET** /fake/regular_expression | test regular expression to ensure no exception
+[**fake_set_query**](FakeApi.md#fake_set_query) | **GET** /fake/set_query_parameter | test set query parameter
 
 
 # **fake_data_file**
@@ -103,6 +104,61 @@ if (!is.null(result$ApiException)) {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **reg_exp_test** | **character**| dummy required parameter | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
+# **fake_set_query**
+> fake_set_query(set_dummy, array_dummy)
+
+test set query parameter
+
+
+
+### Example
+```R
+library(petstore)
+
+var_set_dummy <- list("inner_example") # set[character] | set query
+var_array_dummy <- list("inner_example") # array[character] | array query
+
+# test set query parameter
+api_instance <- FakeApi$new()
+result <- tryCatch(
+             api_instance$fake_set_query(var_set_dummy, var_array_dummy),
+             ApiException = function(ex) ex
+          )
+# In case of error, print the error object
+if (!is.null(result$ApiException)) {
+  print("Exception occurs when calling `fake_set_query`:")
+  dput(result$ApiException$toString())
+  # error object
+  dput(result$ApiException$error_object$toJSONString())
+}
+# This endpoint doesn't return data
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **set_dummy** | list( **character** )| set query | 
+ **array_dummy** | list( **character** )| array query | 
 
 ### Return type
 

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -49,6 +49,24 @@
 #' }
 #' }
 #'
+#' \strong{ FakeSetQuery } \emph{ test set query parameter }
+#' 
+#'
+#' \itemize{
+#' \item \emph{ @param } set_dummy list( character )
+#' \item \emph{ @param } array_dummy list( character )
+#'
+#' \item On encountering errors, an error of subclass ApiException will be thrown.
+#'
+#' \item status code : 200 | successful operation
+#'
+#'
+#' \item response headers :
+#'
+#' \tabular{ll}{
+#' }
+#' }
+#'
 #' }
 #'
 #'
@@ -104,6 +122,32 @@
 #' # In case of error, print the error object
 #' if (!is.null(result$ApiException)) {
 #'   print("Exception occurs when calling `FakeRegularExpression`:")
+#'   dput(result$ApiException$toString())
+#'   
+#'   # error object
+#'   dput(result$ApiException$error_object$toJSONString())
+#'   
+#' }#'
+#' # This endpoint doesn't return data
+#'
+#'
+#' ####################  FakeSetQuery  ####################
+#'
+#' library(petstore)
+#' var_set_dummy <- ["set_dummy_example"] # set[character] | set query
+#' var_array_dummy <- ["array_dummy_example"] # array[character] | array query
+#'
+#' #test set query parameter
+#' api_instance <- FakeApi$new()
+#'
+#' result <- tryCatch(
+#'              
+#'              api_instance$FakeSetQuery(var_set_dummy, var_array_dummy),
+#'              ApiException = function(ex) ex
+#'           )
+#' # In case of error, print the error object
+#' if (!is.null(result$ApiException)) {
+#'   print("Exception occurs when calling `FakeSetQuery`:")
 #'   dput(result$ApiException$toString())
 #'   
 #'   # error object
@@ -313,6 +357,131 @@ FakeApi <- R6::R6Class(
       header_params["reg_exp_test"] <- `reg_exp_test`
 
       local_var_url_path <- "/fake/regular_expression"
+
+      # The Accept request HTTP header
+      local_var_accepts <- list()
+
+      # The Content-Type representation header
+      local_var_content_types <- list()
+
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
+                                 method = "GET",
+                                 query_params = query_params,
+                                 header_params = header_params,
+                                 form_params = form_params,
+                                 file_params = file_params,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
+                                 is_oauth = is_oauth,
+                                 oauth_scopes = oauth_scopes,
+                                 ...)
+
+      if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
+        local_var_resp$content <- NULL
+        local_var_resp
+      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- paste("Server returned ", local_var_resp$status_code, " response status code.")
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api client exception encountered."
+        }
+        rlang::abort(message = local_var_error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
+        local_var_error_msg <- local_var_resp$response
+        if (local_var_error_msg == "") {
+          local_var_error_msg <- "Api server exception encountered."
+        }
+        rlang::abort(message = error_msg,
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(http_response = local_var_resp))
+      }
+    },
+    #' test set query parameter
+    #'
+    #' @description
+    #' test set query parameter
+    #'
+    #' @param set_dummy set query
+    #' @param array_dummy array query
+    #' @param ... Other optional arguments
+    #' @return void
+    #' @export
+    FakeSetQuery = function(set_dummy, array_dummy, ...) {
+      local_var_response <- self$FakeSetQueryWithHttpInfo(set_dummy, array_dummy, ...)
+      if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
+        local_var_response$content
+      } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
+        local_var_response
+      } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
+        local_var_response
+      } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
+        local_var_response
+      }
+    },
+    #' test set query parameter
+    #'
+    #' @description
+    #' test set query parameter
+    #'
+    #' @param set_dummy set query
+    #' @param array_dummy array query
+    #' @param ... Other optional arguments
+    #' @return API response (void) with additional information such as HTTP status code, headers
+    #' @export
+    FakeSetQueryWithHttpInfo = function(set_dummy, array_dummy, ...) {
+      args <- list(...)
+      query_params <- list()
+      header_params <- c()
+      form_params <- list()
+      file_params <- list()
+      local_var_body <- NULL
+      oauth_scopes <- NULL
+      is_oauth <- FALSE
+
+      if (missing(`set_dummy`)) {
+        rlang::abort(message = "Missing required parameter `set_dummy`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Missing required parameter `set_dummy`."))
+      }
+
+      if (missing(`array_dummy`)) {
+        rlang::abort(message = "Missing required parameter `array_dummy`.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Missing required parameter `array_dummy`."))
+      }
+
+
+
+      # check if items are unique
+      if (!identical(`set_dummy`, unique(`set_dummy`))) {
+        rlang::abort(message = "Invalid value for `set_dummy` when calling FakeApi$FakeSetQuery. Items must be unique.",
+                     .subclass = "ApiException",
+                     ApiException = ApiException$new(status = 0,
+                                                     reason = "Invalid value for `set_dummy` when calling FakeApi$FakeSetQuery. Items must be unique."))
+      }
+      # explore
+      for (query_item in `set_dummy`) {
+        query_params[["set_dummy"]] <- c(query_params[["set_dummy"]], list(`set_dummy` = query_item))
+      }
+
+      # explore
+      for (query_item in `array_dummy`) {
+        query_params[["array_dummy"]] <- c(query_params[["array_dummy"]], list(`array_dummy` = query_item))
+      }
+
+      local_var_url_path <- "/fake/set_query_parameter"
 
       # The Accept request HTTP header
       local_var_accepts <- list()

--- a/samples/client/petstore/R/README.md
+++ b/samples/client/petstore/R/README.md
@@ -63,6 +63,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *FakeApi* | [**FakeDataFile**](docs/FakeApi.md#FakeDataFile) | **GET** /fake/data_file | test data_file to ensure it's escaped correctly
 *FakeApi* | [**FakeRegularExpression**](docs/FakeApi.md#FakeRegularExpression) | **GET** /fake/regular_expression | test regular expression to ensure no exception
+*FakeApi* | [**FakeSetQuery**](docs/FakeApi.md#FakeSetQuery) | **GET** /fake/set_query_parameter | test set query parameter
 *PetApi* | [**AddPet**](docs/PetApi.md#AddPet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**DeletePet**](docs/PetApi.md#DeletePet) | **DELETE** /pet/{petId} | Deletes a pet
 *PetApi* | [**FindPetsByStatus**](docs/PetApi.md#FindPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status

--- a/samples/client/petstore/R/docs/FakeApi.md
+++ b/samples/client/petstore/R/docs/FakeApi.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**FakeDataFile**](FakeApi.md#FakeDataFile) | **GET** /fake/data_file | test data_file to ensure it&#39;s escaped correctly
 [**FakeRegularExpression**](FakeApi.md#FakeRegularExpression) | **GET** /fake/regular_expression | test regular expression to ensure no exception
+[**FakeSetQuery**](FakeApi.md#FakeSetQuery) | **GET** /fake/set_query_parameter | test set query parameter
 
 
 # **FakeDataFile**
@@ -103,6 +104,61 @@ if (!is.null(result$ApiException)) {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **reg_exp_test** | **character**| dummy required parameter | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
+# **FakeSetQuery**
+> FakeSetQuery(set_dummy, array_dummy)
+
+test set query parameter
+
+
+
+### Example
+```R
+library(petstore)
+
+var_set_dummy <- list("inner_example") # set[character] | set query
+var_array_dummy <- list("inner_example") # array[character] | array query
+
+# test set query parameter
+api_instance <- FakeApi$new()
+result <- tryCatch(
+             api_instance$FakeSetQuery(var_set_dummy, var_array_dummy),
+             ApiException = function(ex) ex
+          )
+# In case of error, print the error object
+if (!is.null(result$ApiException)) {
+  print("Exception occurs when calling `FakeSetQuery`:")
+  dput(result$ApiException$toString())
+  # error object
+  dput(result$ApiException$error_object$toJSONString())
+}
+# This endpoint doesn't return data
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **set_dummy** | list( **character** )| set query | 
+ **array_dummy** | list( **character** )| array query | 
 
 ### Return type
 


### PR DESCRIPTION
- Support set in R client parameters (query)
- Add tests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
