### PR TITLE
[Dart] Properly handle DateTime arrays using DateTimeHelper extension method

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -98,3 +98,18 @@ DateTime? mapDateTime(dynamic map, String key, [String? pattern]) {
   }
   return null;
 }
+
+extension DateTimeHelper on DateTime {
+  static List<DateTime>? listFromJson(dynamic json, {bool growable = false}) {
+    final result = <DateTime>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = DateTime.tryParse(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+}

--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -98,18 +98,3 @@ DateTime? mapDateTime(dynamic map, String key, [String? pattern]) {
   }
   return null;
 }
-
-extension DateTimeHelper on DateTime {
-  static List<DateTime>? listFromJson(dynamic json, {bool growable = false}) {
-    final result = <DateTime>[];
-    if (json is List && json.isNotEmpty) {
-      for (final row in json) {
-        final value = DateTime.tryParse(row);
-        if (value != null) {
-          result.add(value);
-        }
-      }
-    }
-    return result.toList(growable: growable);
-  }
-}

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -2,32 +2,32 @@ class {{{classname}}} {
 {{>dart_constructor}}
 {{#vars}}
   {{#description}}
-  /// {{{.}}}
+    /// {{{.}}}
   {{/description}}
   {{^isEnum}}
     {{#minimum}}
       {{#description}}
-  ///
+        ///
       {{/description}}
-  /// Minimum value: {{{.}}}
+      /// Minimum value: {{{.}}}
     {{/minimum}}
     {{#maximum}}
       {{#description}}
         {{^minimum}}
-  ///
+          ///
         {{/minimum}}
       {{/description}}
-  /// Maximum value: {{{.}}}
+      /// Maximum value: {{{.}}}
     {{/maximum}}
     {{^isNullable}}
       {{^required}}
         {{^defaultValue}}
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
+          ///
+          /// Please note: This property should have been non-nullable! Since the specification file
+          /// does not include a default value (using the "default:" property), however, the generated
+          /// source code must fall back to having a nullable type.
+          /// Consider adding a "default:" property in the specification file to hide this note.
+          ///
         {{/defaultValue}}
       {{/required}}
     {{/isNullable}}
@@ -35,24 +35,24 @@ class {{{classname}}} {
   {{{datatypeWithEnum}}}{{#isNullable}}?{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}?{{/defaultValue}}{{/required}}{{/isNullable}} {{{name}}};
 
 {{/vars}}
-  @override
-  bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
+@override
+bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
   {{#vars}}
-     other.{{{name}}} == {{{name}}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
+  other.{{{name}}} == {{{name}}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
-  @override
-  int get hashCode =>
-    // ignore: unnecessary_parenthesis
+@override
+int get hashCode =>
+// ignore: unnecessary_parenthesis
   {{#vars}}
-    ({{#isNullable}}{{{name}}} == null ? 0 : {{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}{{{name}}} == null ? 0 : {{/defaultValue}}{{/required}}{{/isNullable}}{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.hashCode){{^-last}} +{{/-last}}{{#-last}};{{/-last}}
+  ({{#isNullable}}{{{name}}} == null ? 0 : {{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}{{{name}}} == null ? 0 : {{/defaultValue}}{{/required}}{{/isNullable}}{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.hashCode){{^-last}} +{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
-  @override
-  String toString() => '{{{classname}}}[{{#vars}}{{{name}}}=${{{name}}}{{^-last}}, {{/-last}}{{/vars}}]';
+@override
+String toString() => '{{{classname}}}[{{#vars}}{{{name}}}=${{{name}}}{{^-last}}, {{/-last}}{{/vars}}]';
 
-  Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
+Map<String, dynamic> toJson() {
+final json = <String, dynamic>{};
   {{#vars}}
     {{#isNullable}}
     if (this.{{{name}}} != null) {
@@ -60,15 +60,15 @@ class {{{classname}}} {
     {{^isNullable}}
       {{^required}}
         {{^defaultValue}}
-    if (this.{{{name}}} != null) {
+        if (this.{{{name}}} != null) {
         {{/defaultValue}}
       {{/required}}
     {{/isNullable}}
     {{#isDateTime}}
       {{#pattern}}
       json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
-        ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
-        : this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
+      ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
+          : this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
       {{/pattern}}
       {{^pattern}}
       json[r'{{{baseName}}}'] = this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
@@ -77,8 +77,8 @@ class {{{classname}}} {
     {{#isDate}}
       {{#pattern}}
       json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
-        ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
-        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
+      ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
+          : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
       {{/pattern}}
       {{^pattern}}
       json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
@@ -91,105 +91,110 @@ class {{{classname}}} {
     {{/isDateTime}}
     {{#isNullable}}
     } else {
-      json[r'{{{baseName}}}'] = null;
+    json[r'{{{baseName}}}'] = null;
     }
     {{/isNullable}}
     {{^isNullable}}
       {{^required}}
         {{^defaultValue}}
-    } else {
-      json[r'{{{baseName}}}'] = null;
-    }
+        } else {
+        json[r'{{{baseName}}}'] = null;
+        }
         {{/defaultValue}}
       {{/required}}
     {{/isNullable}}
   {{/vars}}
-    return json;
-  }
+return json;
+}
 
-  /// Returns a new [{{{classname}}}] instance and imports its values from
-  /// [value] if it's a [Map], null otherwise.
-  // ignore: prefer_constructors_over_static_methods
-  static {{{classname}}}? fromJson(dynamic value) {
-    if (value is Map) {
-      final json = value.cast<String, dynamic>();
+/// Returns a new [{{{classname}}}] instance and imports its values from
+/// [value] if it's a [Map], null otherwise.
+// ignore: prefer_constructors_over_static_methods
+static {{{classname}}}? fromJson(dynamic value) {
+if (value is Map) {
+final json = value.cast<String, dynamic>();
 
-      // Ensure that the map contains the required keys.
-      // Note 1: the values aren't checked for validity beyond being non-null.
-      // Note 2: this code is stripped in release mode!
-      assert(() {
-        requiredKeys.forEach((key) {
-          assert(json.containsKey(key), 'Required key "{{{classname}}}[$key]" is missing from JSON.');
-          assert(json[key] != null, 'Required key "{{{classname}}}[$key]" has a null value in JSON.');
-        });
-        return true;
-      }());
+// Ensure that the map contains the required keys.
+// Note 1: the values aren't checked for validity beyond being non-null.
+// Note 2: this code is stripped in release mode!
+assert(() {
+requiredKeys.forEach((key) {
+assert(json.containsKey(key), 'Required key "{{{classname}}}[$key]" is missing from JSON.');
+assert(json[key] != null, 'Required key "{{{classname}}}[$key]" has a null value in JSON.');
+});
+return true;
+}());
 
-      return {{{classname}}}(
+return {{{classname}}}(
   {{#vars}}
     {{#isDateTime}}
-        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+      {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
     {{/isDateTime}}
     {{#isDate}}
-        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+      {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
     {{/isDate}}
     {{^isDateTime}}
       {{^isDate}}
         {{#complexType}}
           {{#isArray}}
             {{#items.isArray}}
-        {{{name}}}: json[r'{{{baseName}}}'] is List
-          ? (json[r'{{{baseName}}}'] as List).map(
+              {{{name}}}: json[r'{{{baseName}}}'] is List
+            ? (json[r'{{{baseName}}}'] as List).map(
               {{#items.complexType}}
-              {{items.complexType}}.listFromJson(json[r'{{{baseName}}}'])
+                {{items.complexType}}.listFromJson(json[r'{{{baseName}}}'])
               {{/items.complexType}}
               {{^items.complexType}}
               (e) => e == null ? null : (e as List).cast<{{items.items.dataType}}>()
               {{/items.complexType}}
             ).toList()
-          : null,
+                : null,
             {{/items.isArray}}
             {{^items.isArray}}
-        {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+              {{#items.isDateTime}}
+                {{{name}}}: DateTimeHelper.listFromJson(json[r'{{{baseName}}}']){{^isNullable}}!{{/isNullable}},
+              {{/items.isDateTime}}
+              {{^items.isDateTime}}
+                {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+              {{/items.isDateTime}}
             {{/items.isArray}}
           {{/isArray}}
           {{^isArray}}
             {{#isMap}}
               {{#items.isArray}}
-        {{{name}}}: json[r'{{{baseName}}}'] == null
-          ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
+                {{{name}}}: json[r'{{{baseName}}}'] == null
+              ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
                 {{#items.complexType}}
-            : {{items.complexType}}.mapListFromJson(json[r'{{{baseName}}}']),
+                    : {{items.complexType}}.mapListFromJson(json[r'{{{baseName}}}']),
                 {{/items.complexType}}
                 {{^items.complexType}}
-            : mapCastOfType<String, List>(json, r'{{{baseName}}}'),
+                    : mapCastOfType<String, List>(json, r'{{{baseName}}}'),
                 {{/items.complexType}}
               {{/items.isArray}}
               {{^items.isArray}}
                 {{#items.isMap}}
                   {{#items.complexType}}
-        {{{name}}}: {{items.complexType}}.mapFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                    {{{name}}}: {{items.complexType}}.mapFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                   {{^items.complexType}}
-        {{{name}}}: mapCastOfType<String, dynamic>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                    {{{name}}}: mapCastOfType<String, dynamic>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                 {{/items.isMap}}
                 {{^items.isMap}}
                   {{#items.complexType}}
-        {{{name}}}: {{{items.complexType}}}.mapFromJson(json[r'{{{baseName}}}'{{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}}]) ?? {{{.}}}{{/defaultValue}}{{/required}},
+                    {{{name}}}: {{{items.complexType}}}.mapFromJson(json[r'{{{baseName}}}'{{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}}]) ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                   {{^items.complexType}}
-        {{{name}}}: mapCastOfType<String, {{items.dataType}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                    {{{name}}}: mapCastOfType<String, {{items.dataType}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                 {{/items.isMap}}
               {{/items.isArray}}
             {{/isMap}}
             {{^isMap}}
               {{#isBinary}}
-        {{{name}}}: null, // No support for decoding binary content from JSON
+                {{{name}}}: null, // No support for decoding binary content from JSON
               {{/isBinary}}
               {{^isBinary}}
-        {{{name}}}: {{{complexType}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                {{{name}}}: {{{complexType}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
               {{/isBinary}}
             {{/isMap}}
           {{/isArray}}
@@ -197,30 +202,30 @@ class {{{classname}}} {
         {{^complexType}}
           {{#isArray}}
             {{#isEnum}}
-        {{{name}}}: {{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+              {{{name}}}: {{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
             {{/isEnum}}
             {{^isEnum}}
-        {{{name}}}: json[r'{{{baseName}}}'] is {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}
+              {{{name}}}: json[r'{{{baseName}}}'] is {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}
             ? (json[r'{{{baseName}}}'] as {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}).cast<{{{items.datatype}}}>()
-            : {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}},
+                : {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}},
             {{/isEnum}}
           {{/isArray}}
           {{^isArray}}
             {{#isMap}}
-        {{{name}}}: mapCastOfType<String, {{{items.datatype}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+              {{{name}}}: mapCastOfType<String, {{{items.datatype}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
             {{/isMap}}
             {{^isMap}}
               {{#isNumber}}
-        {{{name}}}: json[r'{{{baseName}}}'] == null
-            ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
-            : {{{datatypeWithEnum}}}.parse(json[r'{{{baseName}}}'].toString()),
+                {{{name}}}: json[r'{{{baseName}}}'] == null
+              ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
+                  : {{{datatypeWithEnum}}}.parse(json[r'{{{baseName}}}'].toString()),
               {{/isNumber}}
               {{^isNumber}}
                 {{^isEnum}}
-        {{{name}}}: mapValueOfType<{{{datatypeWithEnum}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                  {{{name}}}: mapValueOfType<{{{datatypeWithEnum}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
                 {{#isEnum}}
-        {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+                  {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
               {{/isNumber}}
             {{/isMap}}
@@ -229,75 +234,75 @@ class {{{classname}}} {
       {{/isDate}}
     {{/isDateTime}}
   {{/vars}}
-      );
-    }
-    return null;
-  }
+);
+}
+return null;
+}
 
-  static List<{{{classname}}}>? listFromJson(dynamic json, {bool growable = false,}) {
-    final result = <{{{classname}}}>[];
-    if (json is List && json.isNotEmpty) {
-      for (final row in json) {
-        final value = {{{classname}}}.fromJson(row);
-        if (value != null) {
-          result.add(value);
-        }
-      }
-    }
-    return result.toList(growable: growable);
-  }
+static List<{{{classname}}}>? listFromJson(dynamic json, {bool growable = false,}) {
+final result = <{{{classname}}}>[];
+if (json is List && json.isNotEmpty) {
+for (final row in json) {
+final value = {{{classname}}}.fromJson(row);
+if (value != null) {
+result.add(value);
+}
+}
+}
+return result.toList(growable: growable);
+}
 
-  static Map<String, {{{classname}}}> mapFromJson(dynamic json) {
-    final map = <String, {{{classname}}}>{};
-    if (json is Map && json.isNotEmpty) {
-      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
-      for (final entry in json.entries) {
-        final value = {{{classname}}}.fromJson(entry.value);
-        if (value != null) {
-          map[entry.key] = value;
-        }
-      }
-    }
-    return map;
-  }
+static Map<String, {{{classname}}}> mapFromJson(dynamic json) {
+final map = <String, {{{classname}}}>{};
+if (json is Map && json.isNotEmpty) {
+json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+for (final entry in json.entries) {
+final value = {{{classname}}}.fromJson(entry.value);
+if (value != null) {
+map[entry.key] = value;
+}
+}
+}
+return map;
+}
 
-  // maps a json object with a list of {{{classname}}}-objects as value to a dart map
-  static Map<String, List<{{{classname}}}>> mapListFromJson(dynamic json, {bool growable = false,}) {
-    final map = <String, List<{{{classname}}}>>{};
-    if (json is Map && json.isNotEmpty) {
-      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
-      for (final entry in json.entries) {
-        final value = {{{classname}}}.listFromJson(entry.value, growable: growable,);
-        if (value != null) {
-          map[entry.key] = value;
-        }
-      }
-    }
-    return map;
-  }
+// maps a json object with a list of {{{classname}}}-objects as value to a dart map
+static Map<String, List<{{{classname}}}>> mapListFromJson(dynamic json, {bool growable = false,}) {
+final map = <String, List<{{{classname}}}>>{};
+if (json is Map && json.isNotEmpty) {
+json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+for (final entry in json.entries) {
+final value = {{{classname}}}.listFromJson(entry.value, growable: growable,);
+if (value != null) {
+map[entry.key] = value;
+}
+}
+}
+return map;
+}
 
-  /// The list of required keys that must be present in a JSON.
-  static const requiredKeys = <String>{
-{{#vars}}
-  {{#required}}
+/// The list of required keys that must be present in a JSON.
+static const requiredKeys = <String>{
+  {{#vars}}
+    {{#required}}
     '{{{baseName}}}',
-  {{/required}}
-{{/vars}}
-  };
+    {{/required}}
+  {{/vars}}
+};
 }
 {{#vars}}
-    {{^isModel}}
+  {{^isModel}}
     {{#isEnum}}
-        {{^isContainer}}
+      {{^isContainer}}
 
-{{>serialization/native/native_enum_inline}}
-        {{/isContainer}}
-        {{#isContainer}}
-            {{#mostInnerItems}}
+        {{>serialization/native/native_enum_inline}}
+      {{/isContainer}}
+      {{#isContainer}}
+        {{#mostInnerItems}}
 
-{{>serialization/native/native_enum_inline}}
-            {{/mostInnerItems}}
-        {{/isContainer}}
+          {{>serialization/native/native_enum_inline}}
+        {{/mostInnerItems}}
+      {{/isContainer}}
     {{/isEnum}}
-    {{/isModel}}
+  {{/isModel}}
 {{/vars}}

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -2,32 +2,32 @@ class {{{classname}}} {
 {{>dart_constructor}}
 {{#vars}}
   {{#description}}
-    /// {{{.}}}
+  /// {{{.}}}
   {{/description}}
   {{^isEnum}}
     {{#minimum}}
       {{#description}}
-        ///
+  ///
       {{/description}}
-      /// Minimum value: {{{.}}}
+  /// Minimum value: {{{.}}}
     {{/minimum}}
     {{#maximum}}
       {{#description}}
         {{^minimum}}
-          ///
+  ///
         {{/minimum}}
       {{/description}}
-      /// Maximum value: {{{.}}}
+  /// Maximum value: {{{.}}}
     {{/maximum}}
     {{^isNullable}}
       {{^required}}
         {{^defaultValue}}
-          ///
-          /// Please note: This property should have been non-nullable! Since the specification file
-          /// does not include a default value (using the "default:" property), however, the generated
-          /// source code must fall back to having a nullable type.
-          /// Consider adding a "default:" property in the specification file to hide this note.
-          ///
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
         {{/defaultValue}}
       {{/required}}
     {{/isNullable}}
@@ -35,24 +35,24 @@ class {{{classname}}} {
   {{{datatypeWithEnum}}}{{#isNullable}}?{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}?{{/defaultValue}}{{/required}}{{/isNullable}} {{{name}}};
 
 {{/vars}}
-@override
-bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} &&
   {{#vars}}
-  other.{{{name}}} == {{{name}}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
+     other.{{{name}}} == {{{name}}}{{^-last}} &&{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
-@override
-int get hashCode =>
-// ignore: unnecessary_parenthesis
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
   {{#vars}}
-  ({{#isNullable}}{{{name}}} == null ? 0 : {{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}{{{name}}} == null ? 0 : {{/defaultValue}}{{/required}}{{/isNullable}}{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.hashCode){{^-last}} +{{/-last}}{{#-last}};{{/-last}}
+    ({{#isNullable}}{{{name}}} == null ? 0 : {{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}{{{name}}} == null ? 0 : {{/defaultValue}}{{/required}}{{/isNullable}}{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.hashCode){{^-last}} +{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
-@override
-String toString() => '{{{classname}}}[{{#vars}}{{{name}}}=${{{name}}}{{^-last}}, {{/-last}}{{/vars}}]';
+  @override
+  String toString() => '{{{classname}}}[{{#vars}}{{{name}}}=${{{name}}}{{^-last}}, {{/-last}}{{/vars}}]';
 
-Map<String, dynamic> toJson() {
-final json = <String, dynamic>{};
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
   {{#vars}}
     {{#isNullable}}
     if (this.{{{name}}} != null) {
@@ -60,15 +60,15 @@ final json = <String, dynamic>{};
     {{^isNullable}}
       {{^required}}
         {{^defaultValue}}
-        if (this.{{{name}}} != null) {
+    if (this.{{{name}}} != null) {
         {{/defaultValue}}
       {{/required}}
     {{/isNullable}}
     {{#isDateTime}}
       {{#pattern}}
       json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
-      ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
-          : this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
+        ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
+        : this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
       {{/pattern}}
       {{^pattern}}
       json[r'{{{baseName}}}'] = this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc().toIso8601String();
@@ -77,8 +77,8 @@ final json = <String, dynamic>{};
     {{#isDate}}
       {{#pattern}}
       json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
-      ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
-          : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
+        ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
+        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
       {{/pattern}}
       {{^pattern}}
       json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
@@ -91,110 +91,105 @@ final json = <String, dynamic>{};
     {{/isDateTime}}
     {{#isNullable}}
     } else {
-    json[r'{{{baseName}}}'] = null;
+      json[r'{{{baseName}}}'] = null;
     }
     {{/isNullable}}
     {{^isNullable}}
       {{^required}}
         {{^defaultValue}}
-        } else {
-        json[r'{{{baseName}}}'] = null;
-        }
+    } else {
+      json[r'{{{baseName}}}'] = null;
+    }
         {{/defaultValue}}
       {{/required}}
     {{/isNullable}}
   {{/vars}}
-return json;
-}
+    return json;
+  }
 
-/// Returns a new [{{{classname}}}] instance and imports its values from
-/// [value] if it's a [Map], null otherwise.
-// ignore: prefer_constructors_over_static_methods
-static {{{classname}}}? fromJson(dynamic value) {
-if (value is Map) {
-final json = value.cast<String, dynamic>();
+  /// Returns a new [{{{classname}}}] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static {{{classname}}}? fromJson(dynamic value) {
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
 
-// Ensure that the map contains the required keys.
-// Note 1: the values aren't checked for validity beyond being non-null.
-// Note 2: this code is stripped in release mode!
-assert(() {
-requiredKeys.forEach((key) {
-assert(json.containsKey(key), 'Required key "{{{classname}}}[$key]" is missing from JSON.');
-assert(json[key] != null, 'Required key "{{{classname}}}[$key]" has a null value in JSON.');
-});
-return true;
-}());
+      // Ensure that the map contains the required keys.
+      // Note 1: the values aren't checked for validity beyond being non-null.
+      // Note 2: this code is stripped in release mode!
+      assert(() {
+        requiredKeys.forEach((key) {
+          assert(json.containsKey(key), 'Required key "{{{classname}}}[$key]" is missing from JSON.');
+          assert(json[key] != null, 'Required key "{{{classname}}}[$key]" has a null value in JSON.');
+        });
+        return true;
+      }());
 
-return {{{classname}}}(
+      return {{{classname}}}(
   {{#vars}}
     {{#isDateTime}}
-      {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
     {{/isDateTime}}
     {{#isDate}}
-      {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapDateTime(json, r'{{{baseName}}}', '{{{pattern}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
     {{/isDate}}
     {{^isDateTime}}
       {{^isDate}}
         {{#complexType}}
           {{#isArray}}
             {{#items.isArray}}
-              {{{name}}}: json[r'{{{baseName}}}'] is List
-            ? (json[r'{{{baseName}}}'] as List).map(
+        {{{name}}}: json[r'{{{baseName}}}'] is List
+          ? (json[r'{{{baseName}}}'] as List).map(
               {{#items.complexType}}
-                {{items.complexType}}.listFromJson(json[r'{{{baseName}}}'])
+              {{items.complexType}}.listFromJson(json[r'{{{baseName}}}'])
               {{/items.complexType}}
               {{^items.complexType}}
               (e) => e == null ? null : (e as List).cast<{{items.items.dataType}}>()
               {{/items.complexType}}
             ).toList()
-                : null,
+          : null,
             {{/items.isArray}}
             {{^items.isArray}}
-              {{#items.isDateTime}}
-                {{{name}}}: DateTimeHelper.listFromJson(json[r'{{{baseName}}}']){{^isNullable}}!{{/isNullable}},
-              {{/items.isDateTime}}
-              {{^items.isDateTime}}
-                {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
-              {{/items.isDateTime}}
+        {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
             {{/items.isArray}}
           {{/isArray}}
           {{^isArray}}
             {{#isMap}}
               {{#items.isArray}}
-                {{{name}}}: json[r'{{{baseName}}}'] == null
-              ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
+        {{{name}}}: json[r'{{{baseName}}}'] == null
+          ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
                 {{#items.complexType}}
-                    : {{items.complexType}}.mapListFromJson(json[r'{{{baseName}}}']),
+            : {{items.complexType}}.mapListFromJson(json[r'{{{baseName}}}']),
                 {{/items.complexType}}
                 {{^items.complexType}}
-                    : mapCastOfType<String, List>(json, r'{{{baseName}}}'),
+            : mapCastOfType<String, List>(json, r'{{{baseName}}}'),
                 {{/items.complexType}}
               {{/items.isArray}}
               {{^items.isArray}}
                 {{#items.isMap}}
                   {{#items.complexType}}
-                    {{{name}}}: {{items.complexType}}.mapFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: {{items.complexType}}.mapFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                   {{^items.complexType}}
-                    {{{name}}}: mapCastOfType<String, dynamic>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapCastOfType<String, dynamic>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                 {{/items.isMap}}
                 {{^items.isMap}}
                   {{#items.complexType}}
-                    {{{name}}}: {{{items.complexType}}}.mapFromJson(json[r'{{{baseName}}}'{{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}}]) ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: {{{items.complexType}}}.mapFromJson(json[r'{{{baseName}}}'{{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}}]) ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                   {{^items.complexType}}
-                    {{{name}}}: mapCastOfType<String, {{items.dataType}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapCastOfType<String, {{items.dataType}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                   {{/items.complexType}}
                 {{/items.isMap}}
               {{/items.isArray}}
             {{/isMap}}
             {{^isMap}}
               {{#isBinary}}
-                {{{name}}}: null, // No support for decoding binary content from JSON
+        {{{name}}}: null, // No support for decoding binary content from JSON
               {{/isBinary}}
               {{^isBinary}}
-                {{{name}}}: {{{complexType}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: {{{complexType}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
               {{/isBinary}}
             {{/isMap}}
           {{/isArray}}
@@ -202,30 +197,30 @@ return {{{classname}}}(
         {{^complexType}}
           {{#isArray}}
             {{#isEnum}}
-              {{{name}}}: {{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: {{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
             {{/isEnum}}
             {{^isEnum}}
-              {{{name}}}: json[r'{{{baseName}}}'] is {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}
+        {{{name}}}: json[r'{{{baseName}}}'] is {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}
             ? (json[r'{{{baseName}}}'] as {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}).cast<{{{items.datatype}}}>()
-                : {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}},
+            : {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}},
             {{/isEnum}}
           {{/isArray}}
           {{^isArray}}
             {{#isMap}}
-              {{{name}}}: mapCastOfType<String, {{{items.datatype}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapCastOfType<String, {{{items.datatype}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
             {{/isMap}}
             {{^isMap}}
               {{#isNumber}}
-                {{{name}}}: json[r'{{{baseName}}}'] == null
-              ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
-                  : {{{datatypeWithEnum}}}.parse(json[r'{{{baseName}}}'].toString()),
+        {{{name}}}: json[r'{{{baseName}}}'] == null
+            ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
+            : {{{datatypeWithEnum}}}.parse(json[r'{{{baseName}}}'].toString()),
               {{/isNumber}}
               {{^isNumber}}
                 {{^isEnum}}
-                  {{{name}}}: mapValueOfType<{{{datatypeWithEnum}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: mapValueOfType<{{{datatypeWithEnum}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
                 {{#isEnum}}
-                  {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
               {{/isNumber}}
             {{/isMap}}
@@ -234,75 +229,75 @@ return {{{classname}}}(
       {{/isDate}}
     {{/isDateTime}}
   {{/vars}}
-);
-}
-return null;
-}
+      );
+    }
+    return null;
+  }
 
-static List<{{{classname}}}>? listFromJson(dynamic json, {bool growable = false,}) {
-final result = <{{{classname}}}>[];
-if (json is List && json.isNotEmpty) {
-for (final row in json) {
-final value = {{{classname}}}.fromJson(row);
-if (value != null) {
-result.add(value);
-}
-}
-}
-return result.toList(growable: growable);
-}
+  static List<{{{classname}}}>? listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <{{{classname}}}>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = {{{classname}}}.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
 
-static Map<String, {{{classname}}}> mapFromJson(dynamic json) {
-final map = <String, {{{classname}}}>{};
-if (json is Map && json.isNotEmpty) {
-json = json.cast<String, dynamic>(); // ignore: parameter_assignments
-for (final entry in json.entries) {
-final value = {{{classname}}}.fromJson(entry.value);
-if (value != null) {
-map[entry.key] = value;
-}
-}
-}
-return map;
-}
+  static Map<String, {{{classname}}}> mapFromJson(dynamic json) {
+    final map = <String, {{{classname}}}>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = {{{classname}}}.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
 
-// maps a json object with a list of {{{classname}}}-objects as value to a dart map
-static Map<String, List<{{{classname}}}>> mapListFromJson(dynamic json, {bool growable = false,}) {
-final map = <String, List<{{{classname}}}>>{};
-if (json is Map && json.isNotEmpty) {
-json = json.cast<String, dynamic>(); // ignore: parameter_assignments
-for (final entry in json.entries) {
-final value = {{{classname}}}.listFromJson(entry.value, growable: growable,);
-if (value != null) {
-map[entry.key] = value;
-}
-}
-}
-return map;
-}
+  // maps a json object with a list of {{{classname}}}-objects as value to a dart map
+  static Map<String, List<{{{classname}}}>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<{{{classname}}}>>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = {{{classname}}}.listFromJson(entry.value, growable: growable,);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
 
-/// The list of required keys that must be present in a JSON.
-static const requiredKeys = <String>{
-  {{#vars}}
-    {{#required}}
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+{{#vars}}
+  {{#required}}
     '{{{baseName}}}',
-    {{/required}}
-  {{/vars}}
-};
+  {{/required}}
+{{/vars}}
+  };
 }
 {{#vars}}
-  {{^isModel}}
+    {{^isModel}}
     {{#isEnum}}
-      {{^isContainer}}
+        {{^isContainer}}
 
-        {{>serialization/native/native_enum_inline}}
-      {{/isContainer}}
-      {{#isContainer}}
-        {{#mostInnerItems}}
+{{>serialization/native/native_enum_inline}}
+        {{/isContainer}}
+        {{#isContainer}}
+            {{#mostInnerItems}}
 
-          {{>serialization/native/native_enum_inline}}
-        {{/mostInnerItems}}
-      {{/isContainer}}
+{{>serialization/native/native_enum_inline}}
+            {{/mostInnerItems}}
+        {{/isContainer}}
     {{/isEnum}}
-  {{/isModel}}
+    {{/isModel}}
 {{/vars}}

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -150,7 +150,12 @@ class {{{classname}}} {
           : null,
             {{/items.isArray}}
             {{^items.isArray}}
-        {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+              {{#items.isDateTime}}
+                {{{name}}}: DateTimeHelper.listFromJson(json[r'{{{baseName}}}']){{^isNullable}}!{{/isNullable}},
+              {{/items.isDateTime}}
+              {{^items.isDateTime}}
+                {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+              {{/items.isDateTime}}
             {{/items.isArray}}
           {{/isArray}}
           {{^isArray}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This change addresses https://github.com/OpenAPITools/openapi-generator/issues/11462.

Prior to this change, the dart generator would not properly handle DateTime arrays. Instead, it would generate code that relies on a method that doesn't exist (DateTime.listFromJson).

This update adds a DateTimeHelper extension to the api_helper.dart file and uses it anywhere there is a list of DateTimes.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)
