### PR TITLE
[Java][Spring] Ensure class level tags match the operation level tags to stop each operation to appear twice - issue 11570

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
+import io.swagger.v3.oas.models.tags.Tag;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
@@ -783,7 +784,13 @@ public class SpringCodegen extends AbstractJavaCodegen
 
                 handleImplicitHeaders(operation);
             }
-            objs.put("tagDescription", ops.get(0).tags.get(0).getDescription());
+            // The tag for the controller is the first tag of the first operation
+            final CodegenOperation firstOperation = ops.get(0);
+            final Tag firstTag = firstOperation.tags.get(0);
+            final String firstTagName = firstTag.getName();
+            // But use a sensible tag name if there is none
+            objs.put("tagName", "default".equals(firstTagName) ? firstOperation.baseName : firstTagName);
+            objs.put("tagDescription", firstTag.getDescription());
         }
 
         return objs;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -78,10 +78,10 @@ import {{javaxPackage}}.annotation.Generated;
 @Controller
 {{/useSpringController}}
 {{#swagger2AnnotationLibrary}}
-@Tag(name = "{{{baseName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{baseName}}} API"{{/tagDescription}})
+@Tag(name = "{{{tagName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{tagName}}} API"{{/tagDescription}})
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
-@Api(value = "{{{baseName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{baseName}}} API"{{/tagDescription}})
+@Api(value = "{{{tagName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{tagName}}} API"{{/tagDescription}})
 {{/swagger1AnnotationLibrary}}
 {{#operations}}
 {{#virtualService}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1773,6 +1773,18 @@ public class SpringCodegenTest {
                 .assertMethod("typeConverter");
     }
 
+    @Test
+    public void shouldUseTheSameTagNameForTheInterfaceAndTheMethod_issue11570() throws IOException {
+        final Map<String, File> output = generateFromContract("src/test/resources/bugs/issue_11570.yml", SPRING_BOOT);
+
+        final String expectedTagName = "\"personTagWithExclamation!\"";
+        final String expectedTagDescription = "\"the personTagWithExclamation! API\"";
+
+        final String interfaceTag = "@Tag(name = " + expectedTagName + ", description = " + expectedTagDescription + ")";
+        final String methodTag = "tags = { " + expectedTagName + " }";
+        assertFileContains(output.get("PersonApi.java").toPath(), interfaceTag, methodTag);
+    }
+
     private Map<String, File> generateFromContract(String url, String library) throws IOException {
         return generateFromContract(url, library, new HashMap<>());
     }

--- a/modules/openapi-generator/src/test/resources/bugs/issue_11570.yml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_11570.yml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  description: Specification to reproduce issue 11570 where the wrong tags are applied to the controller
+  title: Required Api
+paths:
+  '/person':
+    post:
+      summary: Inserts a person
+      operationId: postPerson
+      tags:
+        - personTagWithExclamation!
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Person'
+
+      responses: ...
+
+components:
+  schemas:
+    Person:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          maxLength: 50
+          format: email
+        id:
+          type: integer
+    Alien:
+      type: object
+      properties:
+        name:
+          type: string
+        id:
+          type: integer

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
@@ -26,7 +26,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Pet", description = "Everything about your Pets")
+@Api(value = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -26,7 +26,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Store", description = "Access to Petstore orders")
+@Api(value = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -27,7 +27,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "User", description = "Operations about user")
+@Api(value = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApi.java
@@ -25,7 +25,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Pet", description = "Everything about your Pets")
+@Api(value = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/StoreApi.java
@@ -25,7 +25,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Store", description = "Access to Petstore orders")
+@Api(value = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/UserApi.java
@@ -26,7 +26,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "User", description = "Operations about user")
+@Api(value = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
@@ -27,7 +27,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Pet", description = "Everything about your Pets")
+@Api(value = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
@@ -25,7 +25,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Store", description = "Access to Petstore orders")
+@Api(value = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -26,7 +26,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "User", description = "Operations about user")
+@Api(value = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -25,7 +25,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Pet", description = "Everything about your Pets")
+@Api(value = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -25,7 +25,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "Store", description = "Access to Petstore orders")
+@Api(value = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -26,7 +26,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "User", description = "Operations about user")
+@Api(value = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
@@ -34,7 +34,7 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Pet", description = "Everything about your Pets")
+@Tag(name = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApi.java
@@ -34,7 +34,7 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Store", description = "Access to Petstore orders")
+@Tag(name = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApi.java
@@ -35,7 +35,7 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "User", description = "Operations about user")
+@Tag(name = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Pet", description = "Everything about your Pets")
+@Tag(name = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Store", description = "Access to Petstore orders")
+@Tag(name = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "User", description = "Operations about user")
+@Tag(name = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "AnotherFake", description = "the AnotherFake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
@@ -42,7 +42,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Fake", description = "the Fake API")
+@Tag(name = "fake", description = "the fake API")
 public interface FakeApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "FakeClassnameTags123", description = "the FakeClassnameTags123 API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTags123Api {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Pet", description = "Everything about your Pets")
+@Tag(name = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
@@ -34,7 +34,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Store", description = "Access to Petstore orders")
+@Tag(name = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "User", description = "Operations about user")
+@Tag(name = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Pet", description = "Everything about your Pets")
+@Tag(name = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
@@ -34,7 +34,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Store", description = "Access to Petstore orders")
+@Tag(name = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "User", description = "Operations about user")
+@Tag(name = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -34,7 +34,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Pet", description = "Everything about your Pets")
+@Tag(name = "pet", description = "Everything about your Pets")
 public interface PetApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -34,7 +34,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "Store", description = "Access to Petstore orders")
+@Tag(name = "store", description = "Access to Petstore orders")
 public interface StoreApi {
 
     /**

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "User", description = "Operations about user")
+@Tag(name = "user", description = "Operations about user")
 public interface UserApi {
 
     /**

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
@@ -34,7 +34,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "bar", description = "the bar API")
+@Tag(name = "Bar", description = "the Bar API")
 public interface BarApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
@@ -34,7 +34,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "foo", description = "the foo API")
+@Tag(name = "Foo", description = "the Foo API")
 public interface FooApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "another-fake", description = "the another-fake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "fake_classname_test", description = "the fake_classname_test API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -29,7 +29,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "another-fake", description = "the another-fake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default AnotherFakeApiDelegate getDelegate() {

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -29,7 +29,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "fake_classname_test", description = "the fake_classname_test API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default FakeClassnameTestApiDelegate getDelegate() {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "another-fake", description = "the another-fake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "fake_classname_test", description = "the fake_classname_test API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "another-fake", description = "the another-fake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default AnotherFakeApiDelegate getDelegate() {

--- a/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "fake_classname_test", description = "the fake_classname_test API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default FakeClassnameTestApiDelegate getDelegate() {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "another-fake", description = "the another-fake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "fake_classname_test", description = "the fake_classname_test API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "another-fake", description = "the another-fake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     /**

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "fake_classname_test", description = "the fake_classname_test API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     /**

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default AnotherFakeApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default FakeClassnameTestApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default AnotherFakeApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default FakeClassnameTestApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -25,7 +25,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default AnotherFakeApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -25,7 +25,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default FakeClassnameTestApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default AnotherFakeApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default FakeClassnameTestApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default AnotherFakeApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default FakeClassnameTestApiDelegate getDelegate() {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "another-fake", description = "the another-fake API")
+@Tag(name = "$another-fake?", description = "the $another-fake? API")
 @VirtualService
 public interface AnotherFakeApi {
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
@@ -35,7 +35,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Tag(name = "fake_classname_test", description = "the fake_classname_test API")
+@Tag(name = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 @VirtualService
 public interface FakeClassnameTestApi {
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "another-fake", description = "the another-fake API")
+@Api(value = "$another-fake?", description = "the $another-fake? API")
 public interface AnotherFakeApi {
 
     default Optional<NativeWebRequest> getRequest() {

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
-@Api(value = "fake_classname_test", description = "the fake_classname_test API")
+@Api(value = "fake_classname_tags 123#$%^", description = "the fake_classname_tags 123#$%^ API")
 public interface FakeClassnameTestApi {
 
     default Optional<NativeWebRequest> getRequest() {


### PR DESCRIPTION
~~This fixes https://github.com/OpenAPITools/openapi-generator/issues/11570 by removing the unnecessary tags at the class level. A tag appears in the spec at an operation level - https://swagger.io/docs/specification/grouping-operations-with-tags/~~

~~So applying these tags at both controller and operation level is unnecessary. And if you do, the operation appears twice when rendered by a swagger generator, once grouped under the tag for the controller, and once under the tag for the method.~~

Update: This fixes https://github.com/OpenAPITools/openapi-generator/issues/11570 by ensuring the tag at the class level has the same name as the tag in the operation (specifically, the first tag of the first operation). Previously the class level tag was similar to the operation level tag, but subtly different (e.g. `Store` vs. `store`) causing the operation to appear twice in the swagger-ui, once under each tag. Now it is consistent for both controller and operation - `store` - the operation appears just the once.

@cachescrubber @welshm @MelleD @borsch @Zomzog 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
