### PR TITLE
Add set support to model properties in R client

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
@@ -81,14 +81,15 @@
         {{/isPrimitiveType}}
         {{/isContainer}}
         {{#isContainer}}
-        {{#isPrimitiveType}}
         stopifnot(is.vector(`{{name}}`), length(`{{name}}`) != 0)
-        sapply(`{{name}}`, function(x) stopifnot(is.character(x)))
-        {{/isPrimitiveType}}
-        {{^isPrimitiveType}}
-        stopifnot(is.vector(`{{name}}`), length(`{{name}}`) != 0)
-        sapply(`{{name}}`, function(x) stopifnot(R6::is.R6(x)))
-        {{/isPrimitiveType}}
+        sapply(`{{name}}`, function(x) stopifnot({{#isPrimitiveType}}is.character(x){{/isPrimitiveType}}{{^isPrimitiveType}}R6::is.R6(x){{/isPrimitiveType}}))
+        {{#isArray}}
+        {{#uniqueItems}}
+        if (!identical(`{{name}}`, unique(`{{name}}`))) {
+          stop("Error! Items in `{{name}}` are not unique.")
+        }
+        {{/uniqueItems}}
+        {{/isArray}}
         {{/isContainer}}
         self$`{{name}}` <- `{{name}}`
       }
@@ -125,14 +126,15 @@
         {{/isPrimitiveType}}
         {{/isContainer}}
         {{#isContainer}}
-        {{#isPrimitiveType}}
         stopifnot(is.vector(`{{name}}`), length(`{{name}}`) != 0)
-        sapply(`{{name}}`, function(x) stopifnot(is.character(x)))
-        {{/isPrimitiveType}}
-        {{^isPrimitiveType}}
-        stopifnot(is.vector(`{{name}}`), length(`{{name}}`) != 0)
-        sapply(`{{name}}`, function(x) stopifnot(R6::is.R6(x)))
-        {{/isPrimitiveType}}
+        sapply(`{{name}}`, function(x) stopifnot({{#isPrimitiveType}}is.character(x){{/isPrimitiveType}}{{^isPrimitiveType}}R6::is.R6(x){{/isPrimitiveType}}))
+        {{#isArray}}
+        {{#uniqueItems}}
+        if (!identical(`{{name}}`, unique(`{{name}}`))) {
+          stop("Error! Items in `{{name}}` are not unique.")
+        }
+        {{/uniqueItems}}
+        {{/isArray}}
         {{/isContainer}}
         self$`{{name}}` <- `{{name}}`
       }
@@ -207,6 +209,13 @@
       if (!is.null(this_object$`{{baseName}}`)) {
         {{#isContainer}}
         self$`{{name}}` <- ApiClient$new()$deserializeObj(this_object$`{{baseName}}`, "{{dataType}}", loadNamespace("{{packageName}}"))
+        {{#isArray}}
+        {{#uniqueItems}}
+        if (!identical(self$`{{name}}`, unique(self$`{{name}}`))) {
+          stop("Error! Items in `{{name}}` are not unique.")
+        }
+        {{/uniqueItems}}
+        {{/isArray}}
         {{/isContainer}}
         {{^isContainer}}
         {{#isPrimitiveType}}
@@ -321,6 +330,13 @@
       {{! AAPI - added condition for handling container type of parameters, map and array}}
       {{#isContainer}}
       self$`{{name}}` <- ApiClient$new()$deserializeObj(this_object$`{{name}}`, "{{dataType}}", loadNamespace("{{packageName}}"))
+      {{#isArray}}
+      {{#uniqueItems}}
+      if (!identical(self$`{{name}}`, unique(self$`{{name}}`))) {
+        stop("Error! Items in `{{name}}` are not unique.")
+      }
+      {{/uniqueItems}}
+      {{/isArray}}
       {{/isContainer}}
       {{^isContainer}}
       {{#isPrimitiveType}}
@@ -384,14 +400,15 @@
         {{/isPrimitiveType}}
         {{/isContainer}}
         {{#isContainer}}
-        {{#isPrimitiveType}}
         stopifnot(is.vector(input_json$`{{name}}`), length(input_json$`{{name}}`) != 0)
-        tmp <- sapply(input_json$`{{name}}`, function(x) stopifnot(is.character(x)))
-        {{/isPrimitiveType}}
-        {{^isPrimitiveType}}
-        stopifnot(is.vector(input_json$`{{name}}`), length(json_input$`{{name}}`) != 0)
-        tmp <- sapply(input_json$`{{name}}`, function(x) stopifnot(R6::is.R6(x)))
-        {{/isPrimitiveType}}
+        {{#isArray}}
+        {{#uniqueItems}}
+        if (!identical(input_json$`{{name}}`, unique(input_json$`{{name}}`))) {
+          stop("Error! Items in `{{name}}` are not unique.")
+        }
+        {{/uniqueItems}}
+        {{/isArray}}
+        tmp <- sapply(input_json$`{{name}}`, function(x) stopifnot({{#isPrimitiveType}}is.character(x){{/isPrimitiveType}}{{^isPrimitiveType}}R6::is.R6(x){{/isPrimitiveType}}))
         {{/isContainer}}
       } else {
         stop(paste("The JSON input `", input, "` is invalid for {{classname}}: the required field `{{name}}` is missing."))

--- a/modules/openapi-generator/src/test/resources/3_0/r/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/r/petstore.yaml
@@ -905,6 +905,11 @@ components:
       description: Describes the result of uploading an image resource
       type: object
       properties:
+        set_test:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
         self:
           type: integer
           format: int32

--- a/samples/client/petstore/R-httr2-wrapper/R/special.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/special.R
@@ -7,6 +7,7 @@
 #' @title Special
 #' @description Special Class
 #' @format An \code{R6Class} generator object
+#' @field set_test  list(character) [optional]
 #' @field item_self  integer [optional]
 #' @field item_private  character [optional]
 #' @field item_super  character [optional]
@@ -21,19 +22,21 @@
 Special <- R6::R6Class(
   "Special",
   public = list(
+    `set_test` = NULL,
     `item_self` = NULL,
     `item_private` = NULL,
     `item_super` = NULL,
     `123_number` = NULL,
     `array[test]` = NULL,
     `empty_string` = NULL,
-    `_field_list` = c("item_self", "item_private", "item_super", "123_number", "array[test]", "empty_string"),
+    `_field_list` = c("set_test", "item_self", "item_private", "item_super", "123_number", "array[test]", "empty_string"),
     `additional_properties` = list(),
     #' Initialize a new Special class.
     #'
     #' @description
     #' Initialize a new Special class.
     #'
+    #' @param set_test set_test
     #' @param item_self item_self
     #' @param item_private item_private
     #' @param item_super item_super
@@ -44,8 +47,16 @@ Special <- R6::R6Class(
     #' @param ... Other optional arguments.
     #' @export
     initialize = function(
-        `item_self` = NULL, `item_private` = NULL, `item_super` = NULL, `123_number` = NULL, `array[test]` = NULL, `empty_string` = NULL, additional_properties = NULL, ...
+        `set_test` = NULL, `item_self` = NULL, `item_private` = NULL, `item_super` = NULL, `123_number` = NULL, `array[test]` = NULL, `empty_string` = NULL, additional_properties = NULL, ...
     ) {
+      if (!is.null(`set_test`)) {
+        stopifnot(is.vector(`set_test`), length(`set_test`) != 0)
+        sapply(`set_test`, function(x) stopifnot(is.character(x)))
+        if (!identical(`set_test`, unique(`set_test`))) {
+          stop("Error! Items in `set_test` are not unique.")
+        }
+        self$`set_test` <- `set_test`
+      }
       if (!is.null(`item_self`)) {
         stopifnot(is.numeric(`item_self`), length(`item_self`) == 1)
         self$`item_self` <- `item_self`
@@ -85,6 +96,10 @@ Special <- R6::R6Class(
     #' @export
     toJSON = function() {
       SpecialObject <- list()
+      if (!is.null(self$`set_test`)) {
+        SpecialObject[["set_test"]] <-
+          self$`set_test`
+      }
       if (!is.null(self$`item_self`)) {
         SpecialObject[["self"]] <-
           self$`item_self`
@@ -125,6 +140,12 @@ Special <- R6::R6Class(
     #' @export
     fromJSON = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
+      if (!is.null(this_object$`set_test`)) {
+        self$`set_test` <- ApiClient$new()$deserializeObj(this_object$`set_test`, "set[character]", loadNamespace("petstore"))
+        if (!identical(self$`set_test`, unique(self$`set_test`))) {
+          stop("Error! Items in `set_test` are not unique.")
+        }
+      }
       if (!is.null(this_object$`self`)) {
         self$`item_self` <- this_object$`self`
       }
@@ -161,6 +182,14 @@ Special <- R6::R6Class(
     #' @export
     toJSONString = function() {
       jsoncontent <- c(
+        if (!is.null(self$`set_test`)) {
+          sprintf(
+          '"set_test":
+             [%s]
+          ',
+          paste(unlist(lapply(self$`set_test`, function(x) paste0('"', x, '"'))), collapse = ",")
+          )
+        },
         if (!is.null(self$`item_self`)) {
           sprintf(
           '"self":
@@ -228,6 +257,10 @@ Special <- R6::R6Class(
     #' @export
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
+      self$`set_test` <- ApiClient$new()$deserializeObj(this_object$`set_test`, "set[character]", loadNamespace("petstore"))
+      if (!identical(self$`set_test`, unique(self$`set_test`))) {
+        stop("Error! Items in `set_test` are not unique.")
+      }
       self$`item_self` <- this_object$`item_self`
       self$`item_private` <- this_object$`item_private`
       self$`item_super` <- this_object$`item_super`
@@ -271,6 +304,7 @@ Special <- R6::R6Class(
     #' @return true if the values in all fields are valid.
     #' @export
     isValid = function() {
+
       TRUE
     },
     #' Return a list of invalid fields (if any).
@@ -282,6 +316,7 @@ Special <- R6::R6Class(
     #' @export
     getInvalidFields = function() {
       invalid_fields <- list()
+
       invalid_fields
     },
     #' Print the object

--- a/samples/client/petstore/R-httr2-wrapper/docs/Special.md
+++ b/samples/client/petstore/R-httr2-wrapper/docs/Special.md
@@ -5,6 +5,7 @@ Describes the result of uploading an image resource
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**set_test** | **set[character]** |  | [optional] 
 **item_self** | **integer** |  | [optional] 
 **item_private** | **character** |  | [optional] 
 **item_super** | **character** |  | [optional] 

--- a/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
@@ -332,6 +332,33 @@ test_that("Tests validateJSON", {
   
 })
 
+# test set in object
+test_that("Tests set in object", {
+  invalid_set  <-
+  '{"self": 123, "private": "red", "super": "something", "set_test": ["1","2","2","4"]}'
+  expect_error(Special$new()$fromJSON(invalid_set), "Error! Items in `set_test` are not unique")
+
+  special_json <-
+  '{"self": 123, "private": "red", "super": "something", "set_test": ["1","2","4"]}'
+  # test fromJSON
+  special <- Special$new()$fromJSON(special_json)
+  expect_equal(special$item_self, 123)
+  expect_equal(special$item_private, "red")
+  expect_equal(special$item_super, "something")
+
+  # test toJSONString
+  expect_true(grepl('"private"', special$toJSONString()))
+  expect_true(grepl('"self"', special$toJSONString()))
+  expect_true(grepl('"super"', special$toJSONString()))
+  expect_equal('{"set_test":["1","2","4"],"self":123,"private":"red","super":"something"}', special$toJSONString())
+
+  # round trip test
+  s1 <- Special$new()$fromJSONString(special_json)
+  s2 <- Special$new()$fromJSONString(s1$toJSONString())
+  expect_equal(s1, s2)
+
+})
+
 # test object with special item names: self, private, super
 test_that("Tests special item names", {
   special_json <-
@@ -343,7 +370,7 @@ test_that("Tests special item names", {
   expect_equal(special$item_private, "red")
   expect_equal(special$item_super, "something")
 
-  # test toJSONString 
+  # test toJSONString
   expect_true(grepl('"private"', special$toJSONString()))
   expect_true(grepl('"self"', special$toJSONString()))
   expect_true(grepl('"super"', special$toJSONString()))

--- a/samples/client/petstore/R-httr2/R/special.R
+++ b/samples/client/petstore/R-httr2/R/special.R
@@ -7,6 +7,7 @@
 #' @title Special
 #' @description Special Class
 #' @format An \code{R6Class} generator object
+#' @field set_test  list(character) [optional]
 #' @field item_self  integer [optional]
 #' @field item_private  character [optional]
 #' @field item_super  character [optional]
@@ -19,6 +20,7 @@
 Special <- R6::R6Class(
   "Special",
   public = list(
+    `set_test` = NULL,
     `item_self` = NULL,
     `item_private` = NULL,
     `item_super` = NULL,
@@ -30,6 +32,7 @@ Special <- R6::R6Class(
     #' @description
     #' Initialize a new Special class.
     #'
+    #' @param set_test set_test
     #' @param item_self item_self
     #' @param item_private item_private
     #' @param item_super item_super
@@ -39,8 +42,16 @@ Special <- R6::R6Class(
     #' @param ... Other optional arguments.
     #' @export
     initialize = function(
-        `item_self` = NULL, `item_private` = NULL, `item_super` = NULL, `123_number` = NULL, `array[test]` = NULL, `empty_string` = NULL, ...
+        `set_test` = NULL, `item_self` = NULL, `item_private` = NULL, `item_super` = NULL, `123_number` = NULL, `array[test]` = NULL, `empty_string` = NULL, ...
     ) {
+      if (!is.null(`set_test`)) {
+        stopifnot(is.vector(`set_test`), length(`set_test`) != 0)
+        sapply(`set_test`, function(x) stopifnot(is.character(x)))
+        if (!identical(`set_test`, unique(`set_test`))) {
+          stop("Error! Items in `set_test` are not unique.")
+        }
+        self$`set_test` <- `set_test`
+      }
       if (!is.null(`item_self`)) {
         stopifnot(is.numeric(`item_self`), length(`item_self`) == 1)
         self$`item_self` <- `item_self`
@@ -75,6 +86,10 @@ Special <- R6::R6Class(
     #' @export
     toJSON = function() {
       SpecialObject <- list()
+      if (!is.null(self$`set_test`)) {
+        SpecialObject[["set_test"]] <-
+          self$`set_test`
+      }
       if (!is.null(self$`item_self`)) {
         SpecialObject[["self"]] <-
           self$`item_self`
@@ -111,6 +126,12 @@ Special <- R6::R6Class(
     #' @export
     fromJSON = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
+      if (!is.null(this_object$`set_test`)) {
+        self$`set_test` <- ApiClient$new()$deserializeObj(this_object$`set_test`, "set[character]", loadNamespace("petstore"))
+        if (!identical(self$`set_test`, unique(self$`set_test`))) {
+          stop("Error! Items in `set_test` are not unique.")
+        }
+      }
       if (!is.null(this_object$`self`)) {
         self$`item_self` <- this_object$`self`
       }
@@ -140,6 +161,14 @@ Special <- R6::R6Class(
     #' @export
     toJSONString = function() {
       jsoncontent <- c(
+        if (!is.null(self$`set_test`)) {
+          sprintf(
+          '"set_test":
+             [%s]
+          ',
+          paste(unlist(lapply(self$`set_test`, function(x) paste0('"', x, '"'))), collapse = ",")
+          )
+        },
         if (!is.null(self$`item_self`)) {
           sprintf(
           '"self":
@@ -202,6 +231,10 @@ Special <- R6::R6Class(
     #' @export
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
+      self$`set_test` <- ApiClient$new()$deserializeObj(this_object$`set_test`, "set[character]", loadNamespace("petstore"))
+      if (!identical(self$`set_test`, unique(self$`set_test`))) {
+        stop("Error! Items in `set_test` are not unique.")
+      }
       self$`item_self` <- this_object$`item_self`
       self$`item_private` <- this_object$`item_private`
       self$`item_super` <- this_object$`item_super`
@@ -238,6 +271,7 @@ Special <- R6::R6Class(
     #' @return true if the values in all fields are valid.
     #' @export
     isValid = function() {
+
       TRUE
     },
     #' Return a list of invalid fields (if any).
@@ -249,6 +283,7 @@ Special <- R6::R6Class(
     #' @export
     getInvalidFields = function() {
       invalid_fields <- list()
+
       invalid_fields
     },
     #' Print the object

--- a/samples/client/petstore/R-httr2/docs/Special.md
+++ b/samples/client/petstore/R-httr2/docs/Special.md
@@ -5,6 +5,7 @@ Describes the result of uploading an image resource
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**set_test** | **set[character]** |  | [optional] 
 **item_self** | **integer** |  | [optional] 
 **item_private** | **character** |  | [optional] 
 **item_super** | **character** |  | [optional] 

--- a/samples/client/petstore/R/R/special.R
+++ b/samples/client/petstore/R/R/special.R
@@ -7,6 +7,7 @@
 #' @title Special
 #' @description Special Class
 #' @format An \code{R6Class} generator object
+#' @field set_test  list(character) [optional]
 #' @field item_self  integer [optional]
 #' @field item_private  character [optional]
 #' @field item_super  character [optional]
@@ -21,19 +22,21 @@
 Special <- R6::R6Class(
   "Special",
   public = list(
+    `set_test` = NULL,
     `item_self` = NULL,
     `item_private` = NULL,
     `item_super` = NULL,
     `123_number` = NULL,
     `array[test]` = NULL,
     `empty_string` = NULL,
-    `_field_list` = c("item_self", "item_private", "item_super", "123_number", "array[test]", "empty_string"),
+    `_field_list` = c("set_test", "item_self", "item_private", "item_super", "123_number", "array[test]", "empty_string"),
     `additional_properties` = list(),
     #' Initialize a new Special class.
     #'
     #' @description
     #' Initialize a new Special class.
     #'
+    #' @param set_test set_test
     #' @param item_self item_self
     #' @param item_private item_private
     #' @param item_super item_super
@@ -44,8 +47,16 @@ Special <- R6::R6Class(
     #' @param ... Other optional arguments.
     #' @export
     initialize = function(
-        `item_self` = NULL, `item_private` = NULL, `item_super` = NULL, `123_number` = NULL, `array[test]` = NULL, `empty_string` = NULL, additional_properties = NULL, ...
+        `set_test` = NULL, `item_self` = NULL, `item_private` = NULL, `item_super` = NULL, `123_number` = NULL, `array[test]` = NULL, `empty_string` = NULL, additional_properties = NULL, ...
     ) {
+      if (!is.null(`set_test`)) {
+        stopifnot(is.vector(`set_test`), length(`set_test`) != 0)
+        sapply(`set_test`, function(x) stopifnot(is.character(x)))
+        if (!identical(`set_test`, unique(`set_test`))) {
+          stop("Error! Items in `set_test` are not unique.")
+        }
+        self$`set_test` <- `set_test`
+      }
       if (!is.null(`item_self`)) {
         stopifnot(is.numeric(`item_self`), length(`item_self`) == 1)
         self$`item_self` <- `item_self`
@@ -85,6 +96,10 @@ Special <- R6::R6Class(
     #' @export
     toJSON = function() {
       SpecialObject <- list()
+      if (!is.null(self$`set_test`)) {
+        SpecialObject[["set_test"]] <-
+          self$`set_test`
+      }
       if (!is.null(self$`item_self`)) {
         SpecialObject[["self"]] <-
           self$`item_self`
@@ -125,6 +140,12 @@ Special <- R6::R6Class(
     #' @export
     fromJSON = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
+      if (!is.null(this_object$`set_test`)) {
+        self$`set_test` <- ApiClient$new()$deserializeObj(this_object$`set_test`, "set[character]", loadNamespace("petstore"))
+        if (!identical(self$`set_test`, unique(self$`set_test`))) {
+          stop("Error! Items in `set_test` are not unique.")
+        }
+      }
       if (!is.null(this_object$`self`)) {
         self$`item_self` <- this_object$`self`
       }
@@ -161,6 +182,14 @@ Special <- R6::R6Class(
     #' @export
     toJSONString = function() {
       jsoncontent <- c(
+        if (!is.null(self$`set_test`)) {
+          sprintf(
+          '"set_test":
+             [%s]
+          ',
+          paste(unlist(lapply(self$`set_test`, function(x) paste0('"', x, '"'))), collapse = ",")
+          )
+        },
         if (!is.null(self$`item_self`)) {
           sprintf(
           '"self":
@@ -228,6 +257,10 @@ Special <- R6::R6Class(
     #' @export
     fromJSONString = function(input_json) {
       this_object <- jsonlite::fromJSON(input_json)
+      self$`set_test` <- ApiClient$new()$deserializeObj(this_object$`set_test`, "set[character]", loadNamespace("petstore"))
+      if (!identical(self$`set_test`, unique(self$`set_test`))) {
+        stop("Error! Items in `set_test` are not unique.")
+      }
       self$`item_self` <- this_object$`item_self`
       self$`item_private` <- this_object$`item_private`
       self$`item_super` <- this_object$`item_super`
@@ -271,6 +304,7 @@ Special <- R6::R6Class(
     #' @return true if the values in all fields are valid.
     #' @export
     isValid = function() {
+
       TRUE
     },
     #' Return a list of invalid fields (if any).
@@ -282,6 +316,7 @@ Special <- R6::R6Class(
     #' @export
     getInvalidFields = function() {
       invalid_fields <- list()
+
       invalid_fields
     },
     #' Print the object

--- a/samples/client/petstore/R/docs/Special.md
+++ b/samples/client/petstore/R/docs/Special.md
@@ -5,6 +5,7 @@ Describes the result of uploading an image resource
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**set_test** | **set[character]** |  | [optional] 
 **item_self** | **integer** |  | [optional] 
 **item_private** | **character** |  | [optional] 
 **item_super** | **character** |  | [optional] 


### PR DESCRIPTION
- Add set support to model properties in R client
- minor refactoring in the template
- add tests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)
