### PR TITLE
[typescript-angular] Support body for DELETE requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -366,12 +366,19 @@ export class {{classname}} {
 
     {{/isResponseFile}}
         let localVarPath = `{{{path}}}`;
-        return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.configuration.basePath}${localVarPath}`,{{#isBodyAllowed}}
-            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
+        return this.httpClient.request{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}('{{httpMethod}}', `${this.configuration.basePath}${localVarPath}`,
             {
     {{#httpContextInOptions}}
                 context: localVarHttpContext,
     {{/httpContextInOptions}}
+    {{#bodyParam}}
+                body: {{paramName}},
+    {{/bodyParam}}
+    {{^bodyParam}}
+    {{#hasFormParams}}
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+    {{/hasFormParams}}
+    {{/bodyParam}}
     {{#hasQueryParamsOrAuth}}
                 params: localVarQueryParameters,
     {{/hasQueryParamsOrAuth}}

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api/user.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/additional-properties-expected/api/user.service.ts
@@ -142,10 +142,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -206,10 +206,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api/project.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/array-and-object-expected/api/project.service.ts
@@ -185,10 +185,10 @@ export class ProjectService {
         }
 
         let localVarPath = `/projects`;
-        return this.httpClient.post<ProjectEntity>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ProjectEntity>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -245,7 +245,7 @@ export class ProjectService {
         }
 
         let localVarPath = `/projects/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int32"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -304,7 +304,7 @@ export class ProjectService {
         }
 
         let localVarPath = `/projects/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int32"})}`;
-        return this.httpClient.get<ProjectEntity>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<ProjectEntity>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -401,7 +401,7 @@ export class ProjectService {
         }
 
         let localVarPath = `/projects`;
-        return this.httpClient.get<ProjectList>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<ProjectList>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -503,10 +503,10 @@ export class ProjectService {
         }
 
         let localVarPath = `/projects/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int32"})}`;
-        return this.httpClient.put<ProjectEntity>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ProjectEntity>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api/matrixParams.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/custom-path-params-expected/api/matrixParams.service.ts
@@ -132,8 +132,7 @@ export class MatrixParamsService {
         }
 
         let localVarPath = `/complexMatrixParamExploded${this.configuration.encodeParam({name: "matrixParamExploded", value: matrixParamExploded, in: "path", style: "matrix", explode: true, dataType: "ComplexParams", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            null,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -186,8 +185,7 @@ export class MatrixParamsService {
         }
 
         let localVarPath = `/complexMatrixParamFlat${this.configuration.encodeParam({name: "matrixParamFlat", value: matrixParamFlat, in: "path", style: "matrix", explode: false, dataType: "ComplexParams", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            null,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -240,8 +238,7 @@ export class MatrixParamsService {
         }
 
         let localVarPath = `/plainMatrixParamFlat${this.configuration.encodeParam({name: "plainParamFlat", value: plainParamFlat, in: "path", style: "matrix", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            null,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -294,8 +291,7 @@ export class MatrixParamsService {
         }
 
         let localVarPath = `/date-timeMatrixParamFlat${this.configuration.encodeParam({name: "dateTimeParamFlat", value: dateTimeParamFlat, in: "path", style: "matrix", explode: false, dataType: "string", dataFormat: "date-time"})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            null,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/pet.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/pet.service.ts
@@ -168,10 +168,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -237,7 +237,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -310,7 +310,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -384,7 +384,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -452,7 +452,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -526,10 +526,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -615,10 +615,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -708,10 +708,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/store.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -326,10 +326,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/user.service.ts
+++ b/modules/openapi-generator/src/test/resources/integrationtests/typescript/petstore-expected/api/user.service.ts
@@ -145,10 +145,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -211,10 +211,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -277,10 +277,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -336,7 +336,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -395,7 +395,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -468,7 +468,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -522,7 +522,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -592,10 +592,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-oneOf/builds/default/api/default.service.ts
@@ -132,7 +132,7 @@ export class DefaultService {
         }
 
         let localVarPath = `/`;
-        return this.httpClient.get<Fruit>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Fruit>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -194,10 +194,10 @@ export class DefaultService {
         }
 
         let localVarPath = `/`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/pet.service.ts
@@ -168,10 +168,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -237,7 +237,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -310,7 +310,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -385,7 +385,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -453,7 +453,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -527,10 +527,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -616,10 +616,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -709,10 +709,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -326,10 +326,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/api/user.service.ts
@@ -145,10 +145,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -211,10 +211,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -277,10 +277,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -336,7 +336,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -395,7 +395,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -468,7 +468,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -522,7 +522,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -592,10 +592,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/pet.service.ts
@@ -168,10 +168,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -237,7 +237,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -310,7 +310,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -385,7 +385,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -453,7 +453,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -527,10 +527,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -616,10 +616,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -709,10 +709,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -326,10 +326,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/api/user.service.ts
@@ -145,10 +145,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -211,10 +211,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -277,10 +277,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -336,7 +336,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -395,7 +395,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -468,7 +468,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -522,7 +522,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -592,10 +592,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -168,10 +168,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -237,7 +237,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -310,7 +310,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -385,7 +385,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -453,7 +453,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -527,10 +527,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -616,10 +616,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -709,10 +709,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -326,10 +326,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/api/user.service.ts
@@ -145,10 +145,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -211,10 +211,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -277,10 +277,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -336,7 +336,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -395,7 +395,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -468,7 +468,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -522,7 +522,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -592,10 +592,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/api/default.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-oneOf/builds/default/api/default.service.ts
@@ -132,7 +132,7 @@ export class DefaultService {
         }
 
         let localVarPath = `/`;
-        return this.httpClient.get<Fruit>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Fruit>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -194,10 +194,10 @@ export class DefaultService {
         }
 
         let localVarPath = `/`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/pet.service.ts
@@ -168,10 +168,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -237,7 +237,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -310,7 +310,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -385,7 +385,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -453,7 +453,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -527,10 +527,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -616,10 +616,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -709,10 +709,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -326,10 +326,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/api/user.service.ts
@@ -145,10 +145,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -211,10 +211,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -277,10 +277,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -336,7 +336,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -395,7 +395,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -468,7 +468,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -522,7 +522,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -592,10 +592,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            body,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: body,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/pet.service.ts
@@ -171,10 +171,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<Pet>(`${this.configuration.basePath}${localVarPath}`,
-            pet,
+        return this.httpClient.request<Pet>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: pet,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -241,7 +241,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -314,7 +314,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -389,7 +389,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -457,7 +457,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -534,10 +534,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<Pet>(`${this.configuration.basePath}${localVarPath}`,
-            pet,
+        return this.httpClient.request<Pet>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: pet,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -624,10 +624,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -718,10 +718,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -328,10 +328,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            order,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: order,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/api/user.service.ts
@@ -153,10 +153,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -228,10 +228,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -303,10 +303,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -369,7 +369,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -429,7 +429,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -503,7 +503,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -565,7 +565,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -643,10 +643,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -171,10 +171,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<Pet>(`${this.configuration.basePath}${localVarPath}`,
-            pet,
+        return this.httpClient.request<Pet>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: pet,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -241,7 +241,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -314,7 +314,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -389,7 +389,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -457,7 +457,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -534,10 +534,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<Pet>(`${this.configuration.basePath}${localVarPath}`,
-            pet,
+        return this.httpClient.request<Pet>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: pet,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -624,10 +624,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -718,10 +718,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -328,10 +328,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            order,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: order,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/api/user.service.ts
@@ -153,10 +153,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -228,10 +228,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -303,10 +303,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -369,7 +369,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -429,7 +429,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -503,7 +503,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -565,7 +565,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -643,10 +643,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/pet.service.ts
@@ -171,10 +171,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.post<Pet>(`${this.configuration.basePath}${localVarPath}`,
-            pet,
+        return this.httpClient.request<Pet>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: pet,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -241,7 +241,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -314,7 +314,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByStatus`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -389,7 +389,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/findByTags`;
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Array<Pet>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -457,7 +457,7 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Pet>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -534,10 +534,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet`;
-        return this.httpClient.put<Pet>(`${this.configuration.basePath}${localVarPath}`,
-            pet,
+        return this.httpClient.request<Pet>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: pet,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -624,10 +624,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -718,10 +718,10 @@ export class PetService {
         }
 
         let localVarPath = `/pet/${this.configuration.encodeParam({name: "petId", value: petId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/uploadImage`;
-        return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}${localVarPath}`,
-            localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+        return this.httpClient.request<ApiResponse>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/store.service.ts
@@ -137,7 +137,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -199,7 +199,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/inventory`;
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<{ [key: string]: number; }>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -259,7 +259,7 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order/${this.configuration.encodeParam({name: "orderId", value: orderId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}`;
-        return this.httpClient.get<Order>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Order>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -328,10 +328,10 @@ export class StoreService {
         }
 
         let localVarPath = `/store/order`;
-        return this.httpClient.post<Order>(`${this.configuration.basePath}${localVarPath}`,
-            order,
+        return this.httpClient.request<Order>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: order,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/api/user.service.ts
@@ -153,10 +153,10 @@ export class UserService {
         }
 
         let localVarPath = `/user`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -228,10 +228,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithArray`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -303,10 +303,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/createWithList`;
-        return this.httpClient.post<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('post', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,
@@ -369,7 +369,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.delete<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -429,7 +429,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.get<User>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<User>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -503,7 +503,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/login`;
-        return this.httpClient.get<string>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 params: localVarQueryParameters,
@@ -565,7 +565,7 @@ export class UserService {
         }
 
         let localVarPath = `/user/logout`;
-        return this.httpClient.get<any>(`${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -643,10 +643,10 @@ export class UserService {
         }
 
         let localVarPath = `/user/${this.configuration.encodeParam({name: "username", value: username, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.put<any>(`${this.configuration.basePath}${localVarPath}`,
-            user,
+        return this.httpClient.request<any>('put', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                body: user,
                 responseType: <any>responseType_,
                 withCredentials: this.configuration.withCredentials,
                 headers: localVarHeaders,


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes https://github.com/OpenAPITools/openapi-generator/issues/13380

This has somewhat long history:
- Earlier bug reports back in 2020: https://github.com/OpenAPITools/openapi-generator/issues/7557
- An attempt to fix the `isBodyAllowed` populated by the Java code: https://github.com/OpenAPITools/openapi-generator/pull/10751 .
- That PR resulted in broken generated TypeScript code (https://github.com/OpenAPITools/openapi-generator/issues/10975, https://github.com/OpenAPITools/openapi-generator/issues/10864) and was later reverted. This was unfortunate, because in its core, that PR did the right thing

The approach implemented in this PR only affects typescript-angular generator. Generated code uses [`HttpClient#request`](https://angular.io/api/common/http/HttpClient#request) directly instead of using its http-method-specific wrappers. Also the condition for `isBodyAllowed` was removed. It means body inclusion in the request only depends on the presence of body schema in the spec and doesn't depends on the http method. This generally matches a similar change in swagger-codegen: https://github.com/swagger-api/swagger-codegen-generators/pull/568.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)
