### PR TITLE
[Dart] Fix array of array nullable and non-nullable value generation

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -139,15 +139,15 @@ class {{{classname}}} {
           {{#isArray}}
             {{#items.isArray}}
         {{{name}}}: json[r'{{{baseName}}}'] is List
-          ? (json[r'{{{baseName}}}'] as List).map(
+          ? (json[r'{{{baseName}}}'] as List).map((e) =>
               {{#items.complexType}}
-              {{items.complexType}}.listFromJson(json[r'{{{baseName}}}'])
+              {{items.complexType}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}}
               {{/items.complexType}}
               {{^items.complexType}}
-              (e) => e == null ? null : (e as List).cast<{{items.items.dataType}}>()
+              e == null ? {{#items.isNullable}}null{{/items.isNullable}}{{^items.isNullable}}const  <{{items.items.dataType}}>[]{{/items.isNullable}} : (e as List).cast<{{items.items.dataType}}>()
               {{/items.complexType}}
             ).toList()
-          : null,
+          :  {{#isNullable}}null{{/isNullable}}{{^isNullable}}const []{{/isNullable}},
             {{/items.isArray}}
             {{^items.isArray}}
         {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -56,10 +56,10 @@ class ArrayOfArrayOfNumberOnly {
 
       return ArrayOfArrayOfNumberOnly(
         arrayArrayNumber: json[r'ArrayArrayNumber'] is List
-          ? (json[r'ArrayArrayNumber'] as List).map(
-              (e) => e == null ? null : (e as List).cast<num>()
+          ? (json[r'ArrayArrayNumber'] as List).map((e) =>
+              e == null ? const  <num>[] : (e as List).cast<num>()
             ).toList()
-          : null,
+          :  const [],
       );
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -71,15 +71,15 @@ class ArrayTest {
             ? (json[r'array_of_string'] as List).cast<String>()
             : const [],
         arrayArrayOfInteger: json[r'array_array_of_integer'] is List
-          ? (json[r'array_array_of_integer'] as List).map(
-              (e) => e == null ? null : (e as List).cast<int>()
+          ? (json[r'array_array_of_integer'] as List).map((e) =>
+              e == null ? const  <int>[] : (e as List).cast<int>()
             ).toList()
-          : null,
+          :  const [],
         arrayArrayOfModel: json[r'array_array_of_model'] is List
-          ? (json[r'array_array_of_model'] as List).map(
-              ReadOnlyFirst.listFromJson(json[r'array_array_of_model'])
+          ? (json[r'array_array_of_model'] as List).map((e) =>
+              ReadOnlyFirst.listFromJson(json[r'array_array_of_model']) ?? const []
             ).toList()
-          : null,
+          :  const [],
       );
     }
     return null;


### PR DESCRIPTION
Fixes #13460


This PR adds better support for array-of-arrays such that non-nullable/required properties will no longer generate invalid dart code.

This just required changes to the native_class.mustache file

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela
