### PR TITLE
Corrects dataType for maps of inner enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4029,6 +4029,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         if (baseItem != null) {
             // set both datatype and datetypeWithEnum as only the inner type is enum
+            property.dataType = property.dataType.replace(", " + baseItem.baseType, ", " + toEnumName(baseItem));
             property.datatypeWithEnum = property.datatypeWithEnum.replace(", " + baseItem.baseType, ", " + toEnumName(baseItem));
 
             // naming the enum with respect to the language enum naming convention

--- a/samples/client/petstore/bash/docs/MapTest.md
+++ b/samples/client/petstore/bash/docs/MapTest.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **mapUnderscoremapUnderscoreofUnderscorestring** | **map[String, map[String, string]]** |  | [optional] [default to null]
-**mapUnderscoreofUnderscoreenumUnderscorestring** | **map[String, string]** |  | [optional] [default to null]
+**mapUnderscoreofUnderscoreenumUnderscorestring** | **map[String, InnerEnum]** |  | [optional] [default to null]
 **directUnderscoremap** | **map[String, boolean]** |  | [optional] [default to null]
 **indirectUnderscoremap** | **map[String, boolean]** |  | [optional] [default to null]
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/docs/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/docs/models/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0-nrt/docs/models/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/docs/models/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-net6.0/docs/models/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/docs/models/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-generichost-netstandard2.0/docs/models/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/MapTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/MapTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/MapTest.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, InnerEnum&gt;** |  | [optional] 
 **DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 **IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 

--- a/samples/client/petstore/python-asyncio/docs/MapTest.md
+++ b/samples/client/petstore/python-asyncio/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **map_map_of_string** | **dict(str, dict(str, str))** |  | [optional] 
-**map_of_enum_string** | **dict(str, str)** |  | [optional] 
+**map_of_enum_string** | **dict(str, InnerEnum)** |  | [optional] 
 **direct_map** | **dict(str, bool)** |  | [optional] 
 **indirect_map** | **dict(str, bool)** |  | [optional] 
 

--- a/samples/client/petstore/python-asyncio/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/map_test.py
@@ -37,7 +37,7 @@ class MapTest(object):
     """
     openapi_types = {
         'map_map_of_string': 'dict(str, dict(str, str))',
-        'map_of_enum_string': 'dict(str, str)',
+        'map_of_enum_string': 'dict(str, InnerEnum)',
         'direct_map': 'dict(str, bool)',
         'indirect_map': 'dict(str, bool)'
     }
@@ -97,7 +97,7 @@ class MapTest(object):
 
 
         :return: The map_of_enum_string of this MapTest.  # noqa: E501
-        :rtype: dict(str, str)
+        :rtype: dict(str, InnerEnum)
         """
         return self._map_of_enum_string
 
@@ -107,7 +107,7 @@ class MapTest(object):
 
 
         :param map_of_enum_string: The map_of_enum_string of this MapTest.  # noqa: E501
-        :type map_of_enum_string: dict(str, str)
+        :type map_of_enum_string: dict(str, InnerEnum)
         """
         allowed_values = ["UPPER", "lower"]  # noqa: E501
         if (self.local_vars_configuration.client_side_validation and

--- a/samples/client/petstore/python-legacy/docs/MapTest.md
+++ b/samples/client/petstore/python-legacy/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **map_map_of_string** | **dict(str, dict(str, str))** |  | [optional] 
-**map_of_enum_string** | **dict(str, str)** |  | [optional] 
+**map_of_enum_string** | **dict(str, InnerEnum)** |  | [optional] 
 **direct_map** | **dict(str, bool)** |  | [optional] 
 **indirect_map** | **dict(str, bool)** |  | [optional] 
 

--- a/samples/client/petstore/python-legacy/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/map_test.py
@@ -37,7 +37,7 @@ class MapTest(object):
     """
     openapi_types = {
         'map_map_of_string': 'dict(str, dict(str, str))',
-        'map_of_enum_string': 'dict(str, str)',
+        'map_of_enum_string': 'dict(str, InnerEnum)',
         'direct_map': 'dict(str, bool)',
         'indirect_map': 'dict(str, bool)'
     }
@@ -97,7 +97,7 @@ class MapTest(object):
 
 
         :return: The map_of_enum_string of this MapTest.  # noqa: E501
-        :rtype: dict(str, str)
+        :rtype: dict(str, InnerEnum)
         """
         return self._map_of_enum_string
 
@@ -107,7 +107,7 @@ class MapTest(object):
 
 
         :param map_of_enum_string: The map_of_enum_string of this MapTest.  # noqa: E501
-        :type map_of_enum_string: dict(str, str)
+        :type map_of_enum_string: dict(str, InnerEnum)
         """
         allowed_values = ["UPPER", "lower"]  # noqa: E501
         if (self.local_vars_configuration.client_side_validation and

--- a/samples/client/petstore/python-tornado/docs/MapTest.md
+++ b/samples/client/petstore/python-tornado/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **map_map_of_string** | **dict(str, dict(str, str))** |  | [optional] 
-**map_of_enum_string** | **dict(str, str)** |  | [optional] 
+**map_of_enum_string** | **dict(str, InnerEnum)** |  | [optional] 
 **direct_map** | **dict(str, bool)** |  | [optional] 
 **indirect_map** | **dict(str, bool)** |  | [optional] 
 

--- a/samples/client/petstore/python-tornado/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/map_test.py
@@ -37,7 +37,7 @@ class MapTest(object):
     """
     openapi_types = {
         'map_map_of_string': 'dict(str, dict(str, str))',
-        'map_of_enum_string': 'dict(str, str)',
+        'map_of_enum_string': 'dict(str, InnerEnum)',
         'direct_map': 'dict(str, bool)',
         'indirect_map': 'dict(str, bool)'
     }
@@ -97,7 +97,7 @@ class MapTest(object):
 
 
         :return: The map_of_enum_string of this MapTest.  # noqa: E501
-        :rtype: dict(str, str)
+        :rtype: dict(str, InnerEnum)
         """
         return self._map_of_enum_string
 
@@ -107,7 +107,7 @@ class MapTest(object):
 
 
         :param map_of_enum_string: The map_of_enum_string of this MapTest.  # noqa: E501
-        :type map_of_enum_string: dict(str, str)
+        :type map_of_enum_string: dict(str, InnerEnum)
         """
         allowed_values = ["UPPER", "lower"]  # noqa: E501
         if (self.local_vars_configuration.client_side_validation and

--- a/samples/client/petstore/ruby-autoload/docs/MapTest.md
+++ b/samples/client/petstore/ruby-autoload/docs/MapTest.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | **map_map_of_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
-| **map_of_enum_string** | **Hash&lt;String, String&gt;** |  | [optional] |
+| **map_of_enum_string** | **Hash&lt;String, INNER&gt;** |  | [optional] |
 | **direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 | **indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/map_test.rb
@@ -64,7 +64,7 @@ module Petstore
     def self.openapi_types
       {
         :'map_map_of_string' => :'Hash<String, Hash<String, String>>',
-        :'map_of_enum_string' => :'Hash<String, String>',
+        :'map_of_enum_string' => :'Hash<String, INNER>',
         :'direct_map' => :'Hash<String, Boolean>',
         :'indirect_map' => :'Hash<String, Boolean>'
       }

--- a/samples/client/petstore/ruby-faraday/docs/MapTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/MapTest.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | **map_map_of_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
-| **map_of_enum_string** | **Hash&lt;String, String&gt;** |  | [optional] |
+| **map_of_enum_string** | **Hash&lt;String, INNER&gt;** |  | [optional] |
 | **direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 | **indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
@@ -64,7 +64,7 @@ module Petstore
     def self.openapi_types
       {
         :'map_map_of_string' => :'Hash<String, Hash<String, String>>',
-        :'map_of_enum_string' => :'Hash<String, String>',
+        :'map_of_enum_string' => :'Hash<String, INNER>',
         :'direct_map' => :'Hash<String, Boolean>',
         :'indirect_map' => :'Hash<String, Boolean>'
       }

--- a/samples/client/petstore/ruby/docs/MapTest.md
+++ b/samples/client/petstore/ruby/docs/MapTest.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | **map_map_of_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
-| **map_of_enum_string** | **Hash&lt;String, String&gt;** |  | [optional] |
+| **map_of_enum_string** | **Hash&lt;String, INNER&gt;** |  | [optional] |
 | **direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 | **indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 

--- a/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
@@ -64,7 +64,7 @@ module Petstore
     def self.openapi_types
       {
         :'map_map_of_string' => :'Hash<String, Hash<String, String>>',
-        :'map_of_enum_string' => :'Hash<String, String>',
+        :'map_of_enum_string' => :'Hash<String, INNER>',
         :'direct_map' => :'Hash<String, Boolean>',
         :'indirect_map' => :'Hash<String, Boolean>'
       }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/MapTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/doc/MapTest.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **mapMapOfString** | [**Map&lt;String, Map&lt;String, String&gt;&gt;**](Map.md) |  | [optional] 
-**mapOfEnumString** | **Map&lt;String, String&gt;** |  | [optional] 
+**mapOfEnumString** | **Map&lt;String, InnerEnum&gt;** |  | [optional] 
 **directMap** | **Map&lt;String, bool&gt;** |  | [optional] 
 **indirectMap** | **Map&lt;String, bool&gt;** |  | [optional] 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MapTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MapTest.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **mapMapOfString** | [**BuiltMap&lt;String, BuiltMap&lt;String, String&gt;&gt;**](BuiltMap.md) |  | [optional] 
-**mapOfEnumString** | **BuiltMap&lt;String, String&gt;** |  | [optional] 
+**mapOfEnumString** | **BuiltMap&lt;String, InnerEnum&gt;** |  | [optional] 
 **directMap** | **BuiltMap&lt;String, bool&gt;** |  | [optional] 
 **indirectMap** | **BuiltMap&lt;String, bool&gt;** |  | [optional] 
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/MapTest.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/MapTest.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **mapMapOfString** | [**Map<String, Map<String, String>>**](Map.md) |  | [optional] [default to const {}]
-**mapOfEnumString** | **Map<String, String>** |  | [optional] [default to const {}]
+**mapOfEnumString** | **Map<String, InnerEnum>** |  | [optional] [default to const {}]
 **directMap** | **Map<String, bool>** |  | [optional] [default to const {}]
 **indirectMap** | **Map<String, bool>** |  | [optional] [default to const {}]
 

--- a/samples/openapi3/client/petstore/python-legacy/docs/MapTest.md
+++ b/samples/openapi3/client/petstore/python-legacy/docs/MapTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **map_map_of_string** | **dict(str, dict(str, str))** |  | [optional] 
-**map_of_enum_string** | **dict(str, str)** |  | [optional] 
+**map_of_enum_string** | **dict(str, InnerEnum)** |  | [optional] 
 **direct_map** | **dict(str, bool)** |  | [optional] 
 **indirect_map** | **dict(str, bool)** |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/map_test.py
@@ -37,7 +37,7 @@ class MapTest(object):
     """
     openapi_types = {
         'map_map_of_string': 'dict(str, dict(str, str))',
-        'map_of_enum_string': 'dict(str, str)',
+        'map_of_enum_string': 'dict(str, InnerEnum)',
         'direct_map': 'dict(str, bool)',
         'indirect_map': 'dict(str, bool)'
     }
@@ -97,7 +97,7 @@ class MapTest(object):
 
 
         :return: The map_of_enum_string of this MapTest.  # noqa: E501
-        :rtype: dict(str, str)
+        :rtype: dict(str, InnerEnum)
         """
         return self._map_of_enum_string
 
@@ -107,7 +107,7 @@ class MapTest(object):
 
 
         :param map_of_enum_string: The map_of_enum_string of this MapTest.  # noqa: E501
-        :type map_of_enum_string: dict(str, str)
+        :type map_of_enum_string: dict(str, InnerEnum)
         """
         allowed_values = ["UPPER", "lower"]  # noqa: E501
         if (self.local_vars_configuration.client_side_validation and

--- a/samples/server/petstore/cpp-restbed/generated/3_0/model/MapTest.cpp
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/model/MapTest.cpp
@@ -97,7 +97,7 @@ void MapTest::fromPropertyTree(ptree const &pt)
         m_Map_map_of_string = fromPt<std::map<std::string, std::map<std::string, std::string>>>(pt.get_child("map_map_of_string"));
     }
     if (pt.get_child_optional("map_of_enum_string")) {
-        m_Map_of_enum_string = fromPt<std::map<std::string, std::string>>(pt.get_child("map_of_enum_string"));
+        m_Map_of_enum_string = fromPt<std::map<std::string, InnerEnum>>(pt.get_child("map_of_enum_string"));
     }
     if (pt.get_child_optional("direct_map")) {
         m_Direct_map = fromPt<std::map<std::string, bool>>(pt.get_child("direct_map"));
@@ -118,12 +118,12 @@ void MapTest::setMapMapOfString(std::map<std::string, std::map<std::string, std:
 }
 
 
-std::map<std::string, std::string> MapTest::getMapOfEnumString() const
+std::map<std::string, InnerEnum> MapTest::getMapOfEnumString() const
 {
     return m_Map_of_enum_string;
 }
 
-void MapTest::setMapOfEnumString(std::map<std::string, std::string> value)
+void MapTest::setMapOfEnumString(std::map<std::string, InnerEnum> value)
 {
     static const std::array<std::string, 2> allowedValues = {
         "UPPER", "lower"

--- a/samples/server/petstore/cpp-restbed/generated/3_0/model/MapTest.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/model/MapTest.h
@@ -68,8 +68,8 @@ public:
     /// <summary>
     /// 
     /// </summary>
-    std::map<std::string, std::string> getMapOfEnumString() const;
-    void setMapOfEnumString(std::map<std::string, std::string> value);
+    std::map<std::string, InnerEnum> getMapOfEnumString() const;
+    void setMapOfEnumString(std::map<std::string, InnerEnum> value);
 
     /// <summary>
     /// 
@@ -85,7 +85,7 @@ public:
 
 protected:
     std::map<std::string, std::map<std::string, std::string>> m_Map_map_of_string;
-    std::map<std::string, std::string> m_Map_of_enum_string;
+    std::map<std::string, InnerEnum> m_Map_of_enum_string;
     std::map<std::string, bool> m_Direct_map;
     std::map<std::string, bool> m_Indirect_map;
 };


### PR DESCRIPTION
Fixed the dataType to ensure maps of inner enums are correct. Note that the comment already said this was being done for both dataType and dataTypeWithEnum, but dataType was missed.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
