### PR TITLE
Refactor OpenApiResponse

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-experimental/api_client.handlebars
+++ b/modules/openapi-generator/src/main/resources/python-experimental/api_client.handlebars
@@ -812,26 +812,49 @@ class JSONDetector:
         return False
 
 
-class OpenApiResponse(JSONDetector):
-    __filename_content_disposition_pattern = re.compile('filename="(.+?)"')
+T = typing.TypeVar('T')
 
-    def __init__(
-        self,
-        response_cls: typing.Type[ApiResponse] = ApiResponse,
-        content: typing.Optional[typing.Dict[str, MediaType]] = None,
-        headers: typing.Optional[typing.List[HeaderParameter]] = None,
-    ):
-        self.headers = headers
-        if content is not None and len(content) == 0:
-            raise ValueError('Invalid value for content, the content dict must have >= 1 entry')
-        self.content = content
-        self.response_cls = response_cls
+
+class DeserializationStrategy(typing.Protocol[T]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse, ) -> T:
+        ...
 
     @staticmethod
-    def __deserialize_json(response: urllib3.HTTPResponse) -> typing.Any:
-        # python must be >= 3.9 so we can pass in bytes into json.loads
+    def validate(content_type: str) -> bool:
+        ...
+
+
+class JsonDeserializationStrategy(DeserializationStrategy[typing.Any]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
         return json.loads(response.data)
 
+    @staticmethod
+    def validate(content_type: str) -> bool:
+        return JSONDetector._content_type_is_json(content_type)
+
+
+class FormDataDeserializationStrategy(DeserializationStrategy[typing.Dict[str, typing.Any]]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
+        msg = email.message_from_bytes(response.data)
+        return {
+            part.get_param("name", header="Content-Disposition"): part.get_payload(
+                decode=True
+            ).decode(part.get_content_charset())
+            if part.get_content_charset()
+            else part.get_payload()
+            for part in msg.get_payload()
+        }
+
+    @staticmethod
+    def validate(content_type: str) -> bool:
+        return content_type.startswith('multipart/form-data')
+
+
+class OctetDtreamDeserializationStrategy(DeserializationStrategy[typing.Union[bytes, io.BufferedReader]]):
+    __filename_content_disposition_pattern = re.compile('filename="(.+?)"')
     @staticmethod
     def __file_name_from_response_url(response_url: typing.Optional[str]) -> typing.Optional[str]:
         if response_url is None:
@@ -854,9 +877,8 @@ class OpenApiResponse(JSONDetector):
             return None
         return match.group(1)
 
-    def __deserialize_application_octet_stream(
-        self, response: urllib3.HTTPResponse
-    ) -> typing.Union[bytes, io.BufferedReader]:
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
         """
         urllib3 use cases:
         1. when preload_content=True (stream=False) then supports_chunked_reads is False and bytes are returned
@@ -865,8 +887,8 @@ class OpenApiResponse(JSONDetector):
         """
         if response.supports_chunked_reads():
             file_name = (
-                self.__file_name_from_content_disposition(response.headers.get('content-disposition'))
-                or self.__file_name_from_response_url(response.geturl())
+                cls.__file_name_from_content_disposition(response.headers.get('content-disposition'))
+                or cls.__file_name_from_response_url(response.geturl())
             )
 
             if file_name is None:
@@ -889,18 +911,51 @@ class OpenApiResponse(JSONDetector):
             return response.data
 
     @staticmethod
-    def __deserialize_multipart_form_data(
-        response: urllib3.HTTPResponse
-    ) -> typing.Dict[str, typing.Any]:
-        msg = email.message_from_bytes(response.data)
-        return {
-            part.get_param("name", header="Content-Disposition"): part.get_payload(
-                decode=True
-            ).decode(part.get_content_charset())
-            if part.get_content_charset()
-            else part.get_payload()
-            for part in msg.get_payload()
-        }
+    def validate(content_type: str) -> bool:
+        return content_type == 'application/octet-stream'
+
+
+class OpenApiResponse(JSONDetector):
+    __deserialization_strategys: typing.Sequence[
+        DeserializationStrategy
+    ] = [
+        JsonDeserializationStrategy,
+        FormDataDeserializationStrategy,
+        OctetDtreamDeserializationStrategy,
+    ]
+    def __init__(
+        self,
+        response_cls: typing.Type[ApiResponse] = ApiResponse,
+        content: typing.Optional[typing.Dict[str, MediaType]] = None,
+        headers: typing.Optional[typing.List[HeaderParameter]] = None,
+    ):
+        self.headers = headers
+        if content is not None and len(content) == 0:
+            raise ValueError('Invalid value for content, the content dict must have >= 1 entry')
+        self.content = content
+        self.response_cls = response_cls
+
+    @classmethod
+    def detect_deserialization_strategy_by_content_type(
+        cls,
+        content_type: str
+    ) -> typing.Optional[DeserializationStrategy]:
+        for strategy in cls.__deserialization_strategys:
+            if strategy.validate(content_type):
+                return strategy
+        return None
+
+    def __ensure_body_schema(self, content_type: str, status_code: int)-> typing.Optional[typing.Type[Schema]]:
+        # some specs do not define response content media type schemas
+        if self.content is not None:
+            for content in self.content:
+                if content_type.startswith(content):
+                    return self.content[content].schema
+            raise ApiValueError(
+                f'Invalid content_type={content_type} returned for response with '
+                f'status_code={str(status_code)}'
+            )
+        return None
 
     def deserialize(self, response: urllib3.HTTPResponse, configuration: Configuration) -> ApiResponse:
         content_type = response.getheader('content-type')
@@ -912,32 +967,21 @@ class OpenApiResponse(JSONDetector):
             # TODO add header deserialiation here
             pass
 
-        if self.content is not None:
-            if content_type not in self.content:
-                raise ApiValueError(
-                    f'Invalid content_type={content_type} returned for response with '
-                    'status_code={str(response.status)}'
-                )
-            body_schema = self.content[content_type].schema
-            if body_schema is None:
-                # some specs do not define response content media type schemas
-                return self.response_cls(
-                    response=response,
-                    headers=deserialized_headers,
-                    body=unset
+        if content_type:
+            body_schema = self.__ensure_body_schema(content_type, status_code=response.status)
+            if body_schema:
+                deserialization_strategy = self.detect_deserialization_strategy_by_content_type(content_type)
+                if not deserialization_strategy:
+                    raise NotImplementedError(
+                        'Deserialization of {} has not yet been implemented'.format(content_type)
+                    )
+
+                body_data = deserialization_strategy.deserialize(response)
+                deserialized_body = body_schema.from_openapi_data_oapg(
+                    body_data,
+                    _configuration=configuration
                 )
 
-            if self._content_type_is_json(content_type):
-                body_data = self.__deserialize_json(response)
-            elif content_type == 'application/octet-stream':
-                body_data = self.__deserialize_application_octet_stream(response)
-            elif content_type.startswith('multipart/form-data'):
-                body_data = self.__deserialize_multipart_form_data(response)
-                content_type = 'multipart/form-data'
-            else:
-                raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
-            deserialized_body = body_schema.from_openapi_data_oapg(
-                body_data, _configuration=configuration)
         elif streamed:
             response.release_conn()
 

--- a/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/api_client.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python-experimental/unit_test_api/api_client.py
@@ -816,26 +816,49 @@ class JSONDetector:
         return False
 
 
-class OpenApiResponse(JSONDetector):
-    __filename_content_disposition_pattern = re.compile('filename="(.+?)"')
+T = typing.TypeVar('T')
 
-    def __init__(
-        self,
-        response_cls: typing.Type[ApiResponse] = ApiResponse,
-        content: typing.Optional[typing.Dict[str, MediaType]] = None,
-        headers: typing.Optional[typing.List[HeaderParameter]] = None,
-    ):
-        self.headers = headers
-        if content is not None and len(content) == 0:
-            raise ValueError('Invalid value for content, the content dict must have >= 1 entry')
-        self.content = content
-        self.response_cls = response_cls
+
+class DeserializationStrategy(typing.Protocol[T]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse, ) -> T:
+        ...
 
     @staticmethod
-    def __deserialize_json(response: urllib3.HTTPResponse) -> typing.Any:
-        # python must be >= 3.9 so we can pass in bytes into json.loads
+    def validate(content_type: str) -> bool:
+        ...
+
+
+class JsonDeserializationStrategy(DeserializationStrategy[typing.Any]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
         return json.loads(response.data)
 
+    @staticmethod
+    def validate(content_type: str) -> bool:
+        return JSONDetector._content_type_is_json(content_type)
+
+
+class FormDataDeserializationStrategy(DeserializationStrategy[typing.Dict[str, typing.Any]]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
+        msg = email.message_from_bytes(response.data)
+        return {
+            part.get_param("name", header="Content-Disposition"): part.get_payload(
+                decode=True
+            ).decode(part.get_content_charset())
+            if part.get_content_charset()
+            else part.get_payload()
+            for part in msg.get_payload()
+        }
+
+    @staticmethod
+    def validate(content_type: str) -> bool:
+        return content_type.startswith('multipart/form-data')
+
+
+class OctetDtreamDeserializationStrategy(DeserializationStrategy[typing.Union[bytes, io.BufferedReader]]):
+    __filename_content_disposition_pattern = re.compile('filename="(.+?)"')
     @staticmethod
     def __file_name_from_response_url(response_url: typing.Optional[str]) -> typing.Optional[str]:
         if response_url is None:
@@ -858,9 +881,8 @@ class OpenApiResponse(JSONDetector):
             return None
         return match.group(1)
 
-    def __deserialize_application_octet_stream(
-        self, response: urllib3.HTTPResponse
-    ) -> typing.Union[bytes, io.BufferedReader]:
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
         """
         urllib3 use cases:
         1. when preload_content=True (stream=False) then supports_chunked_reads is False and bytes are returned
@@ -869,8 +891,8 @@ class OpenApiResponse(JSONDetector):
         """
         if response.supports_chunked_reads():
             file_name = (
-                self.__file_name_from_content_disposition(response.headers.get('content-disposition'))
-                or self.__file_name_from_response_url(response.geturl())
+                cls.__file_name_from_content_disposition(response.headers.get('content-disposition'))
+                or cls.__file_name_from_response_url(response.geturl())
             )
 
             if file_name is None:
@@ -893,18 +915,51 @@ class OpenApiResponse(JSONDetector):
             return response.data
 
     @staticmethod
-    def __deserialize_multipart_form_data(
-        response: urllib3.HTTPResponse
-    ) -> typing.Dict[str, typing.Any]:
-        msg = email.message_from_bytes(response.data)
-        return {
-            part.get_param("name", header="Content-Disposition"): part.get_payload(
-                decode=True
-            ).decode(part.get_content_charset())
-            if part.get_content_charset()
-            else part.get_payload()
-            for part in msg.get_payload()
-        }
+    def validate(content_type: str) -> bool:
+        return content_type == 'application/octet-stream'
+
+
+class OpenApiResponse(JSONDetector):
+    __deserialization_strategys: typing.Sequence[
+        DeserializationStrategy
+    ] = [
+        JsonDeserializationStrategy,
+        FormDataDeserializationStrategy,
+        OctetDtreamDeserializationStrategy,
+    ]
+    def __init__(
+        self,
+        response_cls: typing.Type[ApiResponse] = ApiResponse,
+        content: typing.Optional[typing.Dict[str, MediaType]] = None,
+        headers: typing.Optional[typing.List[HeaderParameter]] = None,
+    ):
+        self.headers = headers
+        if content is not None and len(content) == 0:
+            raise ValueError('Invalid value for content, the content dict must have >= 1 entry')
+        self.content = content
+        self.response_cls = response_cls
+
+    @classmethod
+    def detect_deserialization_strategy_by_content_type(
+        cls,
+        content_type: str
+    ) -> typing.Optional[DeserializationStrategy]:
+        for strategy in cls.__deserialization_strategys:
+            if strategy.validate(content_type):
+                return strategy
+        return None
+
+    def __ensure_body_schema(self, content_type: str, status_code: int)-> typing.Optional[typing.Type[Schema]]:
+        # some specs do not define response content media type schemas
+        if self.content is not None:
+            for content in self.content:
+                if content_type.startswith(content):
+                    return self.content[content].schema
+            raise ApiValueError(
+                f'Invalid content_type={content_type} returned for response with '
+                f'status_code={str(status_code)}'
+            )
+        return None
 
     def deserialize(self, response: urllib3.HTTPResponse, configuration: Configuration) -> ApiResponse:
         content_type = response.getheader('content-type')
@@ -916,32 +971,21 @@ class OpenApiResponse(JSONDetector):
             # TODO add header deserialiation here
             pass
 
-        if self.content is not None:
-            if content_type not in self.content:
-                raise ApiValueError(
-                    f'Invalid content_type={content_type} returned for response with '
-                    'status_code={str(response.status)}'
-                )
-            body_schema = self.content[content_type].schema
-            if body_schema is None:
-                # some specs do not define response content media type schemas
-                return self.response_cls(
-                    response=response,
-                    headers=deserialized_headers,
-                    body=unset
+        if content_type:
+            body_schema = self.__ensure_body_schema(content_type, status_code=response.status)
+            if body_schema:
+                deserialization_strategy = self.detect_deserialization_strategy_by_content_type(content_type)
+                if not deserialization_strategy:
+                    raise NotImplementedError(
+                        'Deserialization of {} has not yet been implemented'.format(content_type)
+                    )
+
+                body_data = deserialization_strategy.deserialize(response)
+                deserialized_body = body_schema.from_openapi_data_oapg(
+                    body_data,
+                    _configuration=configuration
                 )
 
-            if self._content_type_is_json(content_type):
-                body_data = self.__deserialize_json(response)
-            elif content_type == 'application/octet-stream':
-                body_data = self.__deserialize_application_octet_stream(response)
-            elif content_type.startswith('multipart/form-data'):
-                body_data = self.__deserialize_multipart_form_data(response)
-                content_type = 'multipart/form-data'
-            else:
-                raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
-            deserialized_body = body_schema.from_openapi_data_oapg(
-                body_data, _configuration=configuration)
         elif streamed:
             response.release_conn()
 

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/api_client.py
@@ -816,26 +816,49 @@ class JSONDetector:
         return False
 
 
-class OpenApiResponse(JSONDetector):
-    __filename_content_disposition_pattern = re.compile('filename="(.+?)"')
+T = typing.TypeVar('T')
 
-    def __init__(
-        self,
-        response_cls: typing.Type[ApiResponse] = ApiResponse,
-        content: typing.Optional[typing.Dict[str, MediaType]] = None,
-        headers: typing.Optional[typing.List[HeaderParameter]] = None,
-    ):
-        self.headers = headers
-        if content is not None and len(content) == 0:
-            raise ValueError('Invalid value for content, the content dict must have >= 1 entry')
-        self.content = content
-        self.response_cls = response_cls
+
+class DeserializationStrategy(typing.Protocol[T]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse, ) -> T:
+        ...
 
     @staticmethod
-    def __deserialize_json(response: urllib3.HTTPResponse) -> typing.Any:
-        # python must be >= 3.9 so we can pass in bytes into json.loads
+    def validate(content_type: str) -> bool:
+        ...
+
+
+class JsonDeserializationStrategy(DeserializationStrategy[typing.Any]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
         return json.loads(response.data)
 
+    @staticmethod
+    def validate(content_type: str) -> bool:
+        return JSONDetector._content_type_is_json(content_type)
+
+
+class FormDataDeserializationStrategy(DeserializationStrategy[typing.Dict[str, typing.Any]]):
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
+        msg = email.message_from_bytes(response.data)
+        return {
+            part.get_param("name", header="Content-Disposition"): part.get_payload(
+                decode=True
+            ).decode(part.get_content_charset())
+            if part.get_content_charset()
+            else part.get_payload()
+            for part in msg.get_payload()
+        }
+
+    @staticmethod
+    def validate(content_type: str) -> bool:
+        return content_type.startswith('multipart/form-data')
+
+
+class OctetDtreamDeserializationStrategy(DeserializationStrategy[typing.Union[bytes, io.BufferedReader]]):
+    __filename_content_disposition_pattern = re.compile('filename="(.+?)"')
     @staticmethod
     def __file_name_from_response_url(response_url: typing.Optional[str]) -> typing.Optional[str]:
         if response_url is None:
@@ -858,9 +881,8 @@ class OpenApiResponse(JSONDetector):
             return None
         return match.group(1)
 
-    def __deserialize_application_octet_stream(
-        self, response: urllib3.HTTPResponse
-    ) -> typing.Union[bytes, io.BufferedReader]:
+    @classmethod
+    def deserialize(cls, response: urllib3.HTTPResponse):
         """
         urllib3 use cases:
         1. when preload_content=True (stream=False) then supports_chunked_reads is False and bytes are returned
@@ -869,8 +891,8 @@ class OpenApiResponse(JSONDetector):
         """
         if response.supports_chunked_reads():
             file_name = (
-                self.__file_name_from_content_disposition(response.headers.get('content-disposition'))
-                or self.__file_name_from_response_url(response.geturl())
+                cls.__file_name_from_content_disposition(response.headers.get('content-disposition'))
+                or cls.__file_name_from_response_url(response.geturl())
             )
 
             if file_name is None:
@@ -893,18 +915,51 @@ class OpenApiResponse(JSONDetector):
             return response.data
 
     @staticmethod
-    def __deserialize_multipart_form_data(
-        response: urllib3.HTTPResponse
-    ) -> typing.Dict[str, typing.Any]:
-        msg = email.message_from_bytes(response.data)
-        return {
-            part.get_param("name", header="Content-Disposition"): part.get_payload(
-                decode=True
-            ).decode(part.get_content_charset())
-            if part.get_content_charset()
-            else part.get_payload()
-            for part in msg.get_payload()
-        }
+    def validate(content_type: str) -> bool:
+        return content_type == 'application/octet-stream'
+
+
+class OpenApiResponse(JSONDetector):
+    __deserialization_strategys: typing.Sequence[
+        DeserializationStrategy
+    ] = [
+        JsonDeserializationStrategy,
+        FormDataDeserializationStrategy,
+        OctetDtreamDeserializationStrategy,
+    ]
+    def __init__(
+        self,
+        response_cls: typing.Type[ApiResponse] = ApiResponse,
+        content: typing.Optional[typing.Dict[str, MediaType]] = None,
+        headers: typing.Optional[typing.List[HeaderParameter]] = None,
+    ):
+        self.headers = headers
+        if content is not None and len(content) == 0:
+            raise ValueError('Invalid value for content, the content dict must have >= 1 entry')
+        self.content = content
+        self.response_cls = response_cls
+
+    @classmethod
+    def detect_deserialization_strategy_by_content_type(
+        cls,
+        content_type: str
+    ) -> typing.Optional[DeserializationStrategy]:
+        for strategy in cls.__deserialization_strategys:
+            if strategy.validate(content_type):
+                return strategy
+        return None
+
+    def __ensure_body_schema(self, content_type: str, status_code: int)-> typing.Optional[typing.Type[Schema]]:
+        # some specs do not define response content media type schemas
+        if self.content is not None:
+            for content in self.content:
+                if content_type.startswith(content):
+                    return self.content[content].schema
+            raise ApiValueError(
+                f'Invalid content_type={content_type} returned for response with '
+                f'status_code={str(status_code)}'
+            )
+        return None
 
     def deserialize(self, response: urllib3.HTTPResponse, configuration: Configuration) -> ApiResponse:
         content_type = response.getheader('content-type')
@@ -916,32 +971,21 @@ class OpenApiResponse(JSONDetector):
             # TODO add header deserialiation here
             pass
 
-        if self.content is not None:
-            if content_type not in self.content:
-                raise ApiValueError(
-                    f'Invalid content_type={content_type} returned for response with '
-                    'status_code={str(response.status)}'
-                )
-            body_schema = self.content[content_type].schema
-            if body_schema is None:
-                # some specs do not define response content media type schemas
-                return self.response_cls(
-                    response=response,
-                    headers=deserialized_headers,
-                    body=unset
+        if content_type:
+            body_schema = self.__ensure_body_schema(content_type, status_code=response.status)
+            if body_schema:
+                deserialization_strategy = self.detect_deserialization_strategy_by_content_type(content_type)
+                if not deserialization_strategy:
+                    raise NotImplementedError(
+                        'Deserialization of {} has not yet been implemented'.format(content_type)
+                    )
+
+                body_data = deserialization_strategy.deserialize(response)
+                deserialized_body = body_schema.from_openapi_data_oapg(
+                    body_data,
+                    _configuration=configuration
                 )
 
-            if self._content_type_is_json(content_type):
-                body_data = self.__deserialize_json(response)
-            elif content_type == 'application/octet-stream':
-                body_data = self.__deserialize_application_octet_stream(response)
-            elif content_type.startswith('multipart/form-data'):
-                body_data = self.__deserialize_multipart_form_data(response)
-                content_type = 'multipart/form-data'
-            else:
-                raise NotImplementedError('Deserialization of {} has not yet been implemented'.format(content_type))
-            deserialized_body = body_schema.from_openapi_data_oapg(
-                body_data, _configuration=configuration)
         elif streamed:
             response.release_conn()
 

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_deserialization.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_deserialization.py
@@ -456,3 +456,8 @@ class DeserializationTests(unittest.TestCase):
             }
             response = self.__response(data)
             _response_for_200.deserialize(response, configuration)
+
+
+class Utf8JSONDeserializationTests(DeserializationTests):
+    json_content_type = 'application/json'
+    json_content_type_headers = {'content-type': json_content_type + "; charset=utf-8"}


### PR DESCRIPTION
+ Fix error message string concating.
+ Introduce DeserializationStrategy. Users can add strategy when they need.
+ Fix unexpected raised error when content-type is `application/json; charset=utf-8`.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
