### PR TITLE
Elixir: Improve generated API options docs

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/api.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/api.mustache
@@ -29,7 +29,7 @@ defmodule {{moduleName}}.Api.{{classname}} do
     - `:body` ({{dataType}}): {{&description}}
 {{/isBodyParam}}
 {{^isBodyParam}}
-    - `{{#atom}}{{#underscored}}{{&paramName}}{{/underscored}}{{/atom}}` ({{&dataType}}): {{&description}}
+    - `{{#atom}}{{&baseName}}{{/atom}}` ({{&dataType}}): {{&description}}
 {{/isBodyParam}}
 {{/optionalParams}}
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -45,8 +45,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - `connection` (OpenapiPetstore.Connection): Connection to server
   - `pet` (Pet): Pet object that needs to be added to the store
   - `opts` (keyword): Optional parameters
-    - `:query1` (String.t): query parameter
-    - `:header1` (String.t): header parameter
+    - `:query_1` (String.t): query parameter
+    - `:header_1` (String.t): header parameter
 
   ### Returns
 
@@ -386,7 +386,7 @@ defmodule OpenapiPetstore.Api.Fake do
     - `:string` (String.t): None
     - `:binary` (String.t): None
     - `:date` (Date.t): None
-    - `:date_time` (DateTime.t): None
+    - `:dateTime` (DateTime.t): None
     - `:password` (String.t): None
     - `:callback` (String.t): None
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
@@ -257,7 +257,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `connection` (OpenapiPetstore.Connection): Connection to server
   - `pet_id` (integer()): ID of pet to update
   - `opts` (keyword): Optional parameters
-    - `:additional_metadata` (String.t): Additional data to pass to server
+    - `:additionalMetadata` (String.t): Additional data to pass to server
     - `:file` (String.t): file to upload
 
   ### Returns
@@ -297,7 +297,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `pet_id` (integer()): ID of pet to update
   - `required_file` (String.t): file to upload
   - `opts` (keyword): Optional parameters
-    - `:additional_metadata` (String.t): Additional data to pass to server
+    - `:additionalMetadata` (String.t): Additional data to pass to server
 
   ### Returns
 


### PR DESCRIPTION
@mrmstn

While working with the Magento 2.4 API definition to generate an Elixir client, there were several issues found. The easiest to resolve is a documentation naming issue. (The others will be raised for discussion.)

This is known to be an issue with query parameters, but may not be limited to *just* query parameters.

In the event that a parameter is a mix of arrays and objects, the template in the documentation for the API function was expanding out the parameter name such that `foo[0]` would be turned into `:foo_left_square_bracket0_right_square_bracket`, but the actual parameter name was being left as `:foo[0]`, which meant that the documentation did not reflect the actual parameter.

> Note: there are issues with the way that query parameters are put
> together in this sense, which is going to require substantially more
> work to resolve as well as discussion on how these options should be
> implemented, as what the Magento API requires may not be what is
> expected by a different server, and the nature of the input parameters
> is itself incorrect.

~As a small drive-by fix, changed `run-in-docker.sh` to use `set -euo pipefail` instead of `set -exo pipefail`. The script does not need tracing turned on but should check for previously unreferenced variables. This makes the output of `run-in-docker.sh` slightly nicer.~

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.