### PR TITLE
Added some null and length checks to titlecase function

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/TitlecaseLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/TitlecaseLambda.java
@@ -61,7 +61,15 @@ public class TitlecaseLambda implements Mustache.Lambda  {
     }
 
     private String titleCase(final String input) {
-        return input.substring(0, 1).toUpperCase(Locale.ROOT) + input.substring(1);
+        if(input == null || "".equals(input)){
+            return "";
+        }
+
+        String firstLetter = input.substring(0, 1).toUpperCase(Locale.ROOT);
+        if (input.length() == 1) {
+            return firstLetter;
+        }
+        return firstLetter + input.substring(1);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/TitlecaseLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/TitlecaseLambdaTest.java
@@ -16,6 +16,24 @@ public class TitlecaseLambdaTest extends LambdaTest {
     }
 
     @Test
+    public void titlecaseSingleLetterTest() {
+        // Given
+        Map<String, Object> ctx = context("titlecase", new TitlecaseLambda());
+
+        // When & Then
+        test("O", "{{#titlecase}}o{{/titlecase}}", ctx);
+    }
+
+    @Test
+    public void titlecaseEmptyStringTest() {
+        // Given
+        Map<String, Object> ctx = context("titlecase", new TitlecaseLambda());
+
+        // When & Then
+        test("", "{{#titlecase}}{{/titlecase}}", ctx);
+    }
+
+    @Test
     public void titlecaseWithDelimiterTest() {
         // Given
         Map<String, Object> ctx = context("titlecase", new TitlecaseLambda("-"));


### PR DESCRIPTION
Added some null and length checks to titlecase function. It crashes in some cases otherwise

to fix https://github.com/OpenAPITools/openapi-generator/issues/12738


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
