### PR TITLE
[PHP] BUGFIX: model_generic: fix missing setOpenAPInullablesSetToNull method

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -89,6 +89,16 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -131,6 +131,16 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
@@ -131,6 +131,16 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -131,6 +131,16 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -134,6 +134,16 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -128,6 +128,16 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -128,6 +128,16 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -134,6 +134,16 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -143,6 +143,16 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -126,6 +126,16 @@ class Cat extends Animal
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -128,6 +128,16 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -131,6 +131,16 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -129,6 +129,16 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -128,6 +128,16 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
@@ -128,6 +128,16 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -126,6 +126,16 @@ class Dog extends Animal
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -128,6 +128,16 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -131,6 +131,16 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -149,6 +149,16 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -129,6 +129,16 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -131,6 +131,16 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -128,6 +128,16 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
@@ -128,6 +128,16 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -173,6 +173,16 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -131,6 +131,16 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -129,6 +129,16 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -137,6 +137,16 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -134,6 +134,16 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -132,6 +132,16 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -128,6 +128,16 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -129,6 +129,16 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -138,6 +138,16 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -161,6 +161,16 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -128,6 +128,16 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -137,6 +137,16 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -143,6 +143,16 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -134,6 +134,16 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
@@ -128,6 +128,16 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -143,6 +143,16 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -131,6 +131,16 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -128,6 +128,16 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -131,6 +131,16 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -149,6 +149,16 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     }
 
     /**
+     * Setter - Array of nullable field names deliberately set to null
+     *
+     * @param boolean[] $openAPINullablesSetToNull
+     */
+    private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
+    {
+        $this->openAPINullablesSetToNull = $openAPINullablesSetToNull;
+    }
+
+    /**
      * Checks if a property is nullable
      *
      * @param string $property

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/NullableTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/NullableTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OpenAPI\Client;
+
+use InvalidArgumentException;
+use OpenAPI\Client\Model\Name;
+use OpenAPI\Client\Model\NullableClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * class NullableTest
+ *
+ * @package OpenAPI\Client
+ */
+class NullableTest extends TestCase
+{
+    public function testNotNullableException(): void
+    {
+        $name = new Name();
+        $name->setName(1);
+        $this->assertEquals(1, $name->getName(), 'Non-nullable property can be set and retains its value');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('non-nullable name cannot be null');
+
+        $name->setName(null);
+    }
+
+    public function testNullableobject(): void
+    {
+        $nullable = new NullableClass();
+
+        $nullable->setIntegerProp(null);
+        $this->assertNull($nullable->getIntegerProp(), 'Nullable property can be set to null retains its value');
+
+        $nullable->setIntegerProp(1);
+        $this->assertEquals(1, $nullable->getIntegerProp(), 'Nullable property can be set and retains its value');
+    }
+}


### PR DESCRIPTION
This is a bugfix for PR #12794. The method `setOpenAPInullablesSetToNull()` (which is used in the setters logic) was accidentally deleted by me from the model_generic.mustache, before the PR was merged. This PR re-adds it, and also adds tests for the "nullable" logic (that, if present, would have caught this bug).
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon
