### PR TITLE
The Instance is not a Set, it is a GrowableList, After checking Itera…

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -86,7 +86,12 @@ class {{{classname}}} {
     {{/isDate}}
     {{^isDateTime}}
       {{^isDate}}
-      json[r'{{{baseName}}}'] = this.{{{name}}};
+        {{#isArray}}
+            json[r'{{{baseName}}}'] = this.{{{name}}}.toList();
+        {{/isArray}}
+        {{^isArray}}
+            json[r'{{{baseName}}}'] = this.{{{name}}};
+        {{/isArray}}
       {{/isDate}}
     {{/isDateTime}}
     {{#isNullable}}
@@ -200,9 +205,9 @@ class {{{classname}}} {
         {{{name}}}: {{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
             {{/isEnum}}
             {{^isEnum}}
-        {{{name}}}: json[r'{{{baseName}}}'] is {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}
-            ? (json[r'{{{baseName}}}'] as {{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}).cast<{{{items.datatype}}}>()
-            : {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}},
+        {{{name}}}: json[r'{{{baseName}}}'] is {{#uniqueItems}}Iterable{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}
+            ? Set.from(json[r'{{{baseName}}}'])
+            : {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}, // The Instance is not a Set, it is a GrowableList, After checking Iterable, convert from GrowableList to Set
             {{/isEnum}}
           {{/isArray}}
           {{^isArray}}


### PR DESCRIPTION

was marked as uniqueItems:true in API-DOC. The Instance is not a Set, it is a GrowableList, After checking Iterable, convert from GrowableList to Set
![image](https://user-images.githubusercontent.com/12383547/192565023-bb913e6a-300c-4901-a81d-7ffd2c78a112.png)


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hello there, I created a dart project using openapi-generator. In the api I used, the String Array inside a model was marked as uniqueItems=true. openapi-generator converted it to Set<String> . In the generated code, the Serizalize/Deserialize operations in the fromJson() and toJson() methods in the model were incorrect. I fixed in the code I used first, and then I downloaded the openapi-generator's codes, forked it myself and made the correction there. I wanted to ask if anyone has had this problem before. I have now made the change/tests and will send a PR to Master Branch.

Generated Code: 
- Model Constructure:
![image](https://user-images.githubusercontent.com/12383547/192565277-0a3d5533-c2b8-4a03-8cf6-6217187b3eab.png)
- Field:
![image](https://user-images.githubusercontent.com/12383547/192565432-fb96b738-490c-44e0-98ec-5fd6b34a42cf.png)
-toJson Method: 
![image](https://user-images.githubusercontent.com/12383547/192565977-5cf8b2ed-26d2-40bd-990b-cf8436fffc69.png)
- fromJson Method: 
![image](https://user-images.githubusercontent.com/12383547/192566522-d38aec37-470d-412d-85ff-cb4af17b8ec6.png)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela