### PR TITLE
[swift5] [alamofire] adds ability to inject custom response serializers

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Configuration.mustache
@@ -25,11 +25,11 @@ extension {{projectName}}API {
     /// ResponseSerializer that will be used by the generator for `Data` responses
     ///
     /// If unchanged, Alamofires default `DataResponseSerializer` will be used. 
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer.data())
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer())
     /// ResponseSerializer that will be used by the generator for `String` responses
     ///
     /// If unchanged, Alamofires default `StringResponseSerializer` will be used. 
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer.string()){{/useAlamofire}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer()){{/useAlamofire}}
 }
 {{#useAlamofire}}
 

--- a/modules/openapi-generator/src/main/resources/swift5/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Configuration.mustache
@@ -5,7 +5,8 @@
 //
 
 import Foundation{{#useVapor}}
-import Vapor{{/useVapor}}
+import Vapor{{/useVapor}}{{#useAlamofire}}
+import Alamofire{{/useAlamofire}}
 
 {{#swiftUseApiNamespace}}
 @available(*, deprecated, renamed: "{{projectName}}API.Configuration")
@@ -20,9 +21,32 @@ extension {{projectName}}API {
     // This value is used to configure the date formatter that is used to serialize dates into JSON format.
     // You must set it prior to encoding any dates, and it will only be read once.
     @available(*, unavailable, message: "To set a different date format, use CodableHelper.dateFormatter instead.")
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"{{/useVapor}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"{{/useVapor}}{{#useAlamofire}}
+    /// ResponseSerializer that will be used by the generator for `Data` responses
+    ///
+    /// If unchanged, Alamofires default `DataResponseSerializer` will be used. 
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer.data())
+    /// ResponseSerializer that will be used by the generator for `String` responses
+    ///
+    /// If unchanged, Alamofires default `StringResponseSerializer` will be used. 
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static var stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer.string()){{/useAlamofire}}
 }
-{{#swiftUseApiNamespace}}
-}
+{{#useAlamofire}}
+
+/// Type-erased response serializer
+///
+/// This is needed in order to use `ResponseSerializer` as a Type in `Configuration`. Obsolete with `any` keyword in Swift >= 5.7
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} struct AnyResponseSerializer<T>: ResponseSerializer {
+    
+    let _serialize: (URLRequest?, HTTPURLResponse?, Data?, Error?) throws -> T
+    
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init<V: ResponseSerializer>(_ delegatee: V) where V.SerializedObject == T {
+        _serialize = delegatee.serialize
+    }
+    
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> T {
+        try _serialize(request, response, data, error)
+    }
+}{{/useAlamofire}}{{#swiftUseApiNamespace}}}
 
 {{/swiftUseApiNamespace}}

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/alamofire/AlamofireImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/alamofire/AlamofireImplementations.mustache
@@ -169,7 +169,9 @@ private var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 
         switch T.self {
         case is Void.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { voidResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { voidResponse in
                 cleanupRequest()
 
                 switch voidResponse.result {
@@ -261,7 +263,9 @@ private var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 
         switch T.self {
         case is String.Type:
-            validatedRequest.responseString(queue: apiResponseQueue, completionHandler: { stringResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.stringResponseSerializer,
+                          completionHandler: { stringResponse in
                 cleanupRequest()
 
                 switch stringResponse.result {
@@ -273,7 +277,9 @@ private var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 
             })
         case is URL.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { dataResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { dataResponse in
                 cleanupRequest()
 
                 do {
@@ -319,7 +325,9 @@ private var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
                 return
             })
         case is Void.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { voidResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { voidResponse in
                 cleanupRequest()
 
                 switch voidResponse.result {
@@ -331,7 +339,9 @@ private var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 
             })
         case is Data.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { dataResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { dataResponse in
                 cleanupRequest()
 
                 switch dataResponse.result {
@@ -343,7 +353,9 @@ private var managerStore = SynchronizedDictionary<String, Alamofire.Session>()
 
             })
         default:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { dataResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { dataResponse in
                 cleanupRequest()
 
                 if case let .failure(error) = dataResponse.result {

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/AlamofireImplementations.swift
@@ -169,7 +169,9 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
 
         switch T.self {
         case is Void.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { voidResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { voidResponse in
                 cleanupRequest()
 
                 switch voidResponse.result {
@@ -261,7 +263,9 @@ open class AlamofireDecodableRequestBuilder<T: Decodable>: AlamofireRequestBuild
 
         switch T.self {
         case is String.Type:
-            validatedRequest.responseString(queue: apiResponseQueue, completionHandler: { stringResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.stringResponseSerializer,
+                          completionHandler: { stringResponse in
                 cleanupRequest()
 
                 switch stringResponse.result {
@@ -273,7 +277,9 @@ open class AlamofireDecodableRequestBuilder<T: Decodable>: AlamofireRequestBuild
 
             })
         case is URL.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { dataResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { dataResponse in
                 cleanupRequest()
 
                 do {
@@ -319,7 +325,9 @@ open class AlamofireDecodableRequestBuilder<T: Decodable>: AlamofireRequestBuild
                 return
             })
         case is Void.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { voidResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { voidResponse in
                 cleanupRequest()
 
                 switch voidResponse.result {
@@ -331,7 +339,9 @@ open class AlamofireDecodableRequestBuilder<T: Decodable>: AlamofireRequestBuild
 
             })
         case is Data.Type:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { dataResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { dataResponse in
                 cleanupRequest()
 
                 switch dataResponse.result {
@@ -343,7 +353,9 @@ open class AlamofireDecodableRequestBuilder<T: Decodable>: AlamofireRequestBuild
 
             })
         default:
-            validatedRequest.responseData(queue: apiResponseQueue, completionHandler: { dataResponse in
+            validatedRequest.response(queue: apiResponseQueue,
+                          responseSerializer: Configuration.dataResponseSerializer,
+                          completionHandler: { dataResponse in
                 cleanupRequest()
 
                 if case let .failure(error) = dataResponse.result {

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -16,11 +16,11 @@ open class Configuration {
     /// ResponseSerializer that will be used by the generator for `Data` responses
     ///
     /// If unchanged, Alamofires default `DataResponseSerializer` will be used. 
-    public static var dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer.data())
+    public static var dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer())
     /// ResponseSerializer that will be used by the generator for `String` responses
     ///
     /// If unchanged, Alamofires default `StringResponseSerializer` will be used. 
-    public static var stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer.string())
+    public static var stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer())
 }
 
 /// Type-erased response serializer

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import Alamofire
 
 open class Configuration {
     
@@ -12,4 +13,28 @@ open class Configuration {
     // You must set it prior to encoding any dates, and it will only be read once.
     @available(*, unavailable, message: "To set a different date format, use CodableHelper.dateFormatter instead.")
     public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    /// ResponseSerializer that will be used by the generator for `Data` responses
+    ///
+    /// If unchanged, Alamofires default `DataResponseSerializer` will be used. 
+    public static var dataResponseSerializer: AnyResponseSerializer<Data> = AnyResponseSerializer(DataResponseSerializer.data())
+    /// ResponseSerializer that will be used by the generator for `String` responses
+    ///
+    /// If unchanged, Alamofires default `StringResponseSerializer` will be used. 
+    public static var stringResponseSerializer: AnyResponseSerializer<String> = AnyResponseSerializer(StringResponseSerializer.string())
+}
+
+/// Type-erased response serializer
+///
+/// This is needed in order to use `ResponseSerializer` as a Type in `Configuration`. Obsolete with `any` keyword in Swift >= 5.7
+public struct AnyResponseSerializer<T>: ResponseSerializer {
+    
+    let _serialize: (URLRequest?, HTTPURLResponse?, Data?, Error?) throws -> T
+    
+    public init<V: ResponseSerializer>(_ delegatee: V) where V.SerializedObject == T {
+        _serialize = delegatee.serialize
+    }
+    
+    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> T {
+        try _serialize(request, response, data, error)
+    }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This is a solution for the problem described in #11629 

Adds ability for injection of custom ResponseSerializers into Alamofire library version of the generator. This is useful for many use cases like adjusting the empty response codes which default to [204, 205] otherwise. 

If Configuration remains unchanged, behavior of the generated code is the same as before. 
Because we can't make use of Swift 5.7 language feature [`any`](https://www.donnywals.com/what-is-the-any-keyword-in-swift/), unfortunately we have to use type erasure in order to use `ResponseSerializer` as a type in the `Configuration`

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. -> @4brunu 

### Declaration
The program was tested solely for our own use cases, which might differ from yours.

### Link to provider information
https://github.com/mercedes-benz