### PR TITLE
Fix AbstractJavaCodegen ability to customize container types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1319,16 +1319,16 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         if (!fullJavaUtil) {
             if ("array".equals(property.containerType)) {
-                model.imports.add("ArrayList");
+                model.imports.add(instantiationTypes.get("array"));
             } else if ("set".equals(property.containerType)) {
-                model.imports.add("LinkedHashSet");
+                model.imports.add(instantiationTypes.get("set"));
                 boolean canNotBeWrappedToNullable = !openApiNullable || !property.isNullable;
                 if (canNotBeWrappedToNullable) {
                     model.imports.add("JsonDeserialize");
-                    property.vendorExtensions.put("x-setter-extra-annotation", "@JsonDeserialize(as = LinkedHashSet.class)");
+                    property.vendorExtensions.put("x-setter-extra-annotation", "@JsonDeserialize(as = " + instantiationTypes.get("set") + ".class)");
                 }
             } else if ("map".equals(property.containerType)) {
-                model.imports.add("HashMap");
+                model.imports.add(instantiationTypes.get("map"));
             }
         }
 


### PR DESCRIPTION
After https://github.com/OpenAPITools/openapi-generator/pull/5466 java codegen emits Set for array with uniqueItems=true which has its downsides
- easy to lose track of element order (it can be important)
- easy to lose ordering by switching between java Set flavors (HashSet vs LinkedHashSet) somewhere down the line
- bigger divergence from original json types (either array or object)

Luckily types can be customized/overriden by extending the generator:
- extend JavaClientCodegen for example
- in constructor do
```java
    super();
    // import/interface type
    typeMapping().put("set", typeMapping().get("array"));
    // concrete type
    instantiationTypes().put("set", instantiationTypes().get("array"));
```

But sometimes it won't work because of missing ArrayList import, can be fixed by also doing
```java
    // workaround for https://github.com/OpenAPITools/openapi-generator/issues/13549
    importMapping().put("LinkedHashSet", importMapping().get("ArrayList"));
```

Looks like a bug of assuming "set" fields are instantiated with LinkedHashSet,
let's fix it by using type mappings.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
