### PR TITLE
[typescript-axios] / #12828: Add ESM support to typescript-axios client

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -266,6 +266,10 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("package.mustache", "", "package.json"));
         supportingFiles.add(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
+        // in case ECMAScript 6 is supported add another tsconfig for an ESM (ECMAScript Module)
+        if (supportsES6) {
+            supportingFiles.add(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
@@ -17,6 +17,10 @@
   "license": "Unlicense",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+{{#supportsES6}}
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
+{{/supportsES6}}
   "scripts": {
     "build": "tsc {{#supportsES6}}&& tsc -p tsconfig.esm.json{{/supportsES6}}",
     "prepare": "npm run build"

--- a/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
@@ -18,7 +18,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir dist/",
+    "build": "tsc {{#supportsES6}}&& tsc -p tsconfig.esm.json{{/supportsES6}}",
     "prepare": "npm run build"
   },
   "dependencies": {

--- a/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.esm.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.esm.mustache
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}ES5{{/supportsES6}}",
-    "module": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}CommonJS{{/supportsES6}}",
+    "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/axios/TypeScriptAxiosClientCodegenTest.java
@@ -1,11 +1,13 @@
 package org.openapitools.codegen.typescript.axios;
 
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.languages.TypeScriptAxiosClientCodegen;
 import org.openapitools.codegen.typescript.TypeScriptGroups;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(groups = {TypeScriptGroups.TYPESCRIPT, TypeScriptGroups.TYPESCRIPT_AXIOS})
 public class TypeScriptAxiosClientCodegenTest {
@@ -80,4 +82,33 @@ public class TypeScriptAxiosClientCodegenTest {
         assertEquals(codegen.toEnumVarName("b", "string"), "B");
     }
 
+    @Test
+    public void containsESMTSConfigFileInCaseOfES6AndNPM() {
+        TypeScriptAxiosClientCodegen codegen = new TypeScriptAxiosClientCodegen();
+
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-axios-petstore");
+        codegen.additionalProperties().put("snapshot", false);
+        codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
+        codegen.setSupportsES6(true);
+
+        codegen.processOpts();
+
+        assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
+        assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
+    }
+
+    @Test
+    public void doesNotContainESMTSConfigFileInCaseOfES5AndNPM() {
+        TypeScriptAxiosClientCodegen codegen = new TypeScriptAxiosClientCodegen();
+
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-axios-petstore");
+        codegen.additionalProperties().put("snapshot", false);
+        codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
+        codegen.setSupportsES6(false);
+
+        codegen.processOpts();
+
+        assertThat(codegen.supportingFiles()).contains(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
+        assertThat(codegen.supportingFiles()).doesNotContain(new SupportingFile("tsconfig.esm.mustache", "", "tsconfig.esm.json"));
+    }
 }

--- a/samples/client/petstore/typescript-axios/builds/es6-target/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/.openapi-generator/FILES
@@ -8,4 +8,5 @@ configuration.ts
 git_push.sh
 index.ts
 package.json
+tsconfig.esm.json
 tsconfig.json

--- a/samples/client/petstore/typescript-axios/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/package.json
@@ -17,6 +17,8 @@
   "license": "Unlicense",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "npm run build"

--- a/samples/client/petstore/typescript-axios/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/package.json
@@ -18,7 +18,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir dist/",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "npm run build"
   },
   "dependencies": {

--- a/samples/client/petstore/typescript-axios/builds/es6-target/tsconfig.esm.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/samples/client/petstore/typescript-axios/builds/es6-target/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "ES6",
-    "module": "ES6",
+    "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
@@ -18,7 +18,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir dist/",
+    "build": "tsc ",
     "prepare": "npm run build"
   },
   "dependencies": {

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "ES5",
-    "module": "CommonJS",
+    "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
@@ -18,7 +18,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir dist/",
+    "build": "tsc ",
     "prepare": "npm run build"
   },
   "dependencies": {

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "ES5",
-    "module": "CommonJS",
+    "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",


### PR DESCRIPTION
fix https://github.com/OpenAPITools/openapi-generator/issues/12828

An additional tsconfig.esm.json is added to every generated typescript-axios code having supportsES6 and npmName.
That will create an additional ECMAScript Module (ESM) to the npm build.

I used similar PR for `typescript-fetch` client as reference https://github.com/OpenAPITools/openapi-generator/pull/11720

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov  @davidgamero @mkusaka