### PR TITLE
fix: null exception error with addImport(composed, refSchema, m, modelName).

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5494,7 +5494,7 @@ public class DefaultCodegen implements CodegenConfig {
      */
     protected void addImport(ComposedSchema composed, Schema childSchema, CodegenModel model, String modelName ) {
         // import only if it's not allOf composition schema (without discriminator)
-        if (!(composed.getAllOf() != null && childSchema.getDiscriminator() == null)) {
+        if (!(composed.getAllOf() != null && childSchema != null &&childSchema.getDiscriminator() == null)) {
             addImport(model, modelName);
         } else {
             LOGGER.debug("Skipped import for allOf composition schema {}", modelName);


### PR DESCRIPTION
Closes https://github.com/OpenAPITools/openapi-generator/issues/13588

Hi team.

The following error occurred while generating a k6 scenario from oas using openapi-generator-cli version 6.2.0.

```log
Exception in thread "main" java.lang.RuntimeException: Could not process model 'CommonSiteLink'.Please make sure that your schema is correct!
        at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:518)
        at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:912)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:465)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
Caused by: java.lang.NullPointerException: Cannot invoke "io.swagger.v3.oas.models.media.Schema.getDiscriminator()" because "childSchema" is null
        at org.openapitools.codegen.DefaultCodegen.addImport(DefaultCodegen.java:5497)
        at org.openapitools.codegen.DefaultCodegen.updateModelForComposedSchema(DefaultCodegen.java:2633)
        at org.openapitools.codegen.DefaultCodegen.fromModel(DefaultCodegen.java:2963)
        at org.openapitools.codegen.DefaultGenerator.processModels(DefaultGenerator.java:1291)
        at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:513)
        ... 4 more
```

This error is occurred if [allDefinitions](https://github.com/OpenAPITools/openapi-generator/blob/085e1e58e5efbe7f259cf6689819ed0fa357dd56/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L2627) is null or
[allDefinitions.get(ref)](https://github.com/OpenAPITools/openapi-generator/blob/085e1e58e5efbe7f259cf6689819ed0fa357dd56/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L2628) returned null.

Therefore i added null check of the childSchema to the if statement.

This error was generated by https://github.com/OpenAPITools/openapi-generator/pull/12798.

The release that incorporates this PR appears to be 6.1.0, so versions above 6.1.0 may have the above error.

Signed-off-by: mugioka <okamugi0722@gmail.com>

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
