### PR TITLE
[swift5] fixes a bug encoding/decoding decimal

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
@@ -147,6 +147,17 @@ extension KeyedEncodingContainerProtocol {
         }
     }
 
+	{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} mutating func encode(_ value: Decimal, forKey key: Self.Key) throws {
+        var mutableValue = value
+        let stringValue = NSDecimalString(&mutableValue, Locale(identifier: "en_US"))
+        try encode(stringValue, forKey: key)
+    }
+
+	{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} mutating func encodeIfPresent(_ value: Decimal?, forKey key: Self.Key) throws {
+        if let value = value {
+            try encode(value, forKey: key)
+        }
+    }
 }
 
 extension KeyedDecodingContainerProtocol {
@@ -184,6 +195,28 @@ extension KeyedDecodingContainerProtocol {
         }
 
         return map
+    }
+
+	{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func decode(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal {
+        let stringValue = try decode(String.self, forKey: key)
+        guard let decimalValue = Decimal(string: stringValue) else {
+            let context = DecodingError.Context(codingPath: [key], debugDescription: "The key \(key) couldn't be converted to a Decimal value")
+            throw DecodingError.typeMismatch(type, context)
+        }
+
+        return decimalValue
+    }
+
+	{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func decodeIfPresent(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal? {
+        guard let stringValue = try decodeIfPresent(String.self, forKey: key) else {
+            return nil
+        }
+        guard let decimalValue = Decimal(string: stringValue) else {
+            let context = DecodingError.Context(codingPath: [key], debugDescription: "The key \(key) couldn't be converted to a Decimal value")
+            throw DecodingError.typeMismatch(type, context)
+        }
+
+        return decimalValue
     }
 
 }{{/generateModelAdditionalProperties}}{{^useVapor}}


### PR DESCRIPTION
@jgavris @ehyche @Edubits @jaz-ah @4brunu

Fixes the bug described in https://github.com/OpenAPITools/openapi-generator/issues/13410
Tested with OpenAPI generator 6.2.1-snapshot and a Swift Client on iOS 14.7
All 3 commands (mvnw clean package, generate-samples.sh, export_docs_generators.sh) ran successfully.