### PR TITLE
Avoid duplicated generations when using multiple tags

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1150,42 +1150,59 @@ public class DefaultGenerator implements Generator {
 
         final Map<String, SecurityScheme> securitySchemes = openAPI.getComponents() != null ? openAPI.getComponents().getSecuritySchemes() : null;
         final List<SecurityRequirement> globalSecurities = openAPI.getSecurity();
-        for (Tag tag : tags) {
-            try {
-                CodegenOperation codegenOperation = config.fromOperation(resourcePath, httpMethod, operation, path.getServers());
-                codegenOperation.tags = new ArrayList<>(tags);
-                config.addOperationToGroup(config.sanitizeTag(tag.getName()), resourcePath, operation, codegenOperation, operations);
 
-                List<SecurityRequirement> securities = operation.getSecurity();
-                if (securities != null && securities.isEmpty()) {
-                    continue;
-                }
+        // Find the first possible tag
+        Tag tag = null;
+        for (Tag tmpTag : tags) {
+            List<SecurityRequirement> securities = operation.getSecurity();
+            if (securities != null && securities.isEmpty()) {
+                continue;
+            }
 
-                Map<String, SecurityScheme> authMethods = getAuthMethods(securities, securitySchemes);
+            tag = tmpTag;
+            break;
+        }
+
+        // Emit a warning for any ignored tag
+        for (Tag tmpTag : tags) {
+            if (tmpTag.equals(tag)) {
+                continue;
+            } else {
+                LOGGER.warn("Multiple tags detected for resource path '{}' ignoring '{}'", resourcePath, tmpTag.getName());
+            }
+        }
+
+        try {
+            CodegenOperation codegenOperation = config.fromOperation(resourcePath, httpMethod, operation, path.getServers());
+            codegenOperation.tags = new ArrayList<>(tags);
+            config.addOperationToGroup(config.sanitizeTag(tag.getName()), resourcePath, operation, codegenOperation, operations);
+
+            List<SecurityRequirement> securities = operation.getSecurity();
+
+            Map<String, SecurityScheme> authMethods = getAuthMethods(securities, securitySchemes);
+
+            if (authMethods != null && !authMethods.isEmpty()) {
+                List<CodegenSecurity> fullAuthMethods = config.fromSecurity(authMethods);
+                codegenOperation.authMethods = filterAuthMethods(fullAuthMethods, securities);
+                codegenOperation.hasAuthMethods = true;
+            } else {
+                authMethods = getAuthMethods(globalSecurities, securitySchemes);
 
                 if (authMethods != null && !authMethods.isEmpty()) {
                     List<CodegenSecurity> fullAuthMethods = config.fromSecurity(authMethods);
-                    codegenOperation.authMethods = filterAuthMethods(fullAuthMethods, securities);
+                    codegenOperation.authMethods = filterAuthMethods(fullAuthMethods, globalSecurities);
                     codegenOperation.hasAuthMethods = true;
-                } else {
-                    authMethods = getAuthMethods(globalSecurities, securitySchemes);
-
-                    if (authMethods != null && !authMethods.isEmpty()) {
-                        List<CodegenSecurity> fullAuthMethods = config.fromSecurity(authMethods);
-                        codegenOperation.authMethods = filterAuthMethods(fullAuthMethods, globalSecurities);
-                        codegenOperation.hasAuthMethods = true;
-                    }
                 }
-
-            } catch (Exception ex) {
-                String msg = "Could not process operation:\n" //
-                        + "  Tag: " + tag + "\n"//
-                        + "  Operation: " + operation.getOperationId() + "\n" //
-                        + "  Resource: " + httpMethod + " " + resourcePath + "\n"//
-                        + "  Schemas: " + openAPI.getComponents().getSchemas() + "\n"  //
-                        + "  Exception: " + ex.getMessage();
-                throw new RuntimeException(msg, ex);
             }
+
+        } catch (Exception ex) {
+            String msg = "Could not process operation:\n" //
+                    + "  Tag: " + tag + "\n"//
+                    + "  Operation: " + operation.getOperationId() + "\n" //
+                    + "  Resource: " + httpMethod + " " + resourcePath + "\n"//
+                    + "  Schemas: " + openAPI.getComponents().getSchemas() + "\n"  //
+                    + "  Exception: " + ex.getMessage();
+            throw new RuntimeException(msg, ex);
         }
 
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautAbstractCodegen.java
@@ -5,6 +5,7 @@ import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.tags.Tag;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
@@ -462,7 +463,13 @@ public abstract class JavaMicronautAbstractCodegen extends AbstractJavaCodegen i
             return;
         }
 
-        super.addOperationToGroup(super.sanitizeTag(tag), resourcePath, operation, co, operations);
+        if (!generateOperationOnlyForFirstTag) {
+            for (Tag tmpTag : co.tags) {
+                super.addOperationToGroup(super.sanitizeTag(tmpTag.getName()), resourcePath, operation, co, operations);
+            }
+        } else {
+            super.addOperationToGroup(super.sanitizeTag(tag), resourcePath, operation, co, operations);
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -394,6 +394,27 @@ public class DefaultGeneratorTest {
     }
 
     @Test
+    public void testNoDuplicatesOnTags() throws Exception {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.setPaths(new Paths());
+        List<String> tags = new ArrayList<>();
+        tags.add("foo");
+        tags.add("bar");
+        openAPI.getPaths().addPathItem("/path1", new PathItem().get(new Operation().tags(tags).operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+
+        ClientOptInput opts = new ClientOptInput();
+        opts.openAPI(openAPI);
+        opts.config(new DefaultCodegen());
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(opts);
+        Map<String, List<CodegenOperation>> result = generator.processPaths(openAPI.getPaths());
+        Assert.assertEquals(result.size(), 1);
+        List<CodegenOperation> fooList = result.get("Foo");
+        Assert.assertEquals(fooList.size(), 1);
+    }
+
+    @Test
     public void testRefModelValidationProperties() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/refAliasedPrimitiveWithValidation.yml");
         ClientOptInput opts = new ClientOptInput();


### PR DESCRIPTION
Resolves: #13615

Basically all of the generators, but Micronaut are generating duplicated routes in the presence of multiple tags.
I believe this is a bug and only the Micronaut implementation offered a workaround for this issue.
Here I propose to fix the actual bug while still preserving the original behavior of the Micronaut parameter.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc. @andriy-dmytruk as it's involved in the Micronaut implementation
