### PR TITLE
[swift5] fix generation of multiple security definitions

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api.mustache
@@ -466,7 +466,7 @@ extension {{projectName}}API {
 
         let localVariableRequestBuilder: RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.{{#returnType}}getBuilder(){{/returnType}}{{^returnType}}getNonDecodableBuilder(){{/returnType}}
 
-        return localVariableRequestBuilder.init(method: "{{httpMethod}}", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: {{#authMethods}}true{{/authMethods}}{{^authMethods}}false{{/authMethods}})
+        return localVariableRequestBuilder.init(method: "{{httpMethod}}", URLString: (localVariableUrlComponents?.string ?? localVariableURLString), parameters: localVariableParameters, headers: localVariableHeaderParameters, requiresAuthentication: {{#hasAuthMethods}}true{{/hasAuthMethods}}{{^hasAuthMethods}}false{{/hasAuthMethods}})
     }
 {{/useVapor}}
 {{/operation}}

--- a/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -45,6 +45,7 @@ paths:
         - petstore_auth:
             - 'write:pets'
             - 'read:pets'
+        - api_key_query: []
     put:
       tags:
         - pet

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -34,6 +34,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/alamofireLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/alamofireLibrary/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -46,6 +46,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -45,6 +45,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/combineLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/combineLibrary/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -34,6 +34,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/frozenEnums/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/frozenEnums/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -34,6 +34,9 @@ internal class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/nonPublicApi/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/nonPublicApi/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -34,6 +34,9 @@ import AnyCodable
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/objcCompatible/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/objcCompatible/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -35,6 +35,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/promisekitLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/promisekitLibrary/docs/PetAPI.md
@@ -51,7 +51,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -34,6 +34,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/readonlyProperties/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/readonlyProperties/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -34,6 +34,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/resultLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/resultLibrary/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -41,6 +41,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/rxswiftLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/rxswiftLibrary/docs/PetAPI.md
@@ -44,7 +44,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -37,6 +37,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/urlsessionLibrary/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/urlsessionLibrary/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -34,6 +34,9 @@ open class PetAPI {
     /**
      Add a new pet to the store
      - POST /pet
+     - API Key:
+       - type: apiKey api_key_query (QUERY)
+       - name: api_key_query
      - OAuth:
        - type: oauth2
        - name: petstore_auth

--- a/samples/client/petstore/swift5/x-swift-hashable/docs/PetAPI.md
+++ b/samples/client/petstore/swift5/x-swift-hashable/docs/PetAPI.md
@@ -54,7 +54,7 @@ Void (empty response body)
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth)
+[api_key_query](../README.md#api_key_query), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR fixes #13613:
- Uses the correct mustache variable to check for the need for authentication of an endpoint
- updated samples to have one endpoint where multiple security schemes are being used  

Verification of the fix can be done either manually via provided swagger from bug report or via updated sample spec. Without the fix `truetrue` is being generated, with the fix just `true` as expected

## Workaround
Updated mustache file from this PR can be provided via the generator cli option `-t` to have it working for 6.2.0 for now

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. -> @4brunu 

### Declaration
The program was tested solely for our own use cases, which might differ from yours.

### Link to provider information
https://github.com/mercedes-benz