### PR TITLE
typescript-nestjs: queryParameters need to be a URLSearchParameter in order to work

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -96,7 +96,7 @@ export class {{classname}} {
             queryParameters['{{baseName}}'] = <any>{{paramName}}.toISOString();
         {{/isDateTime}}
         {{^isDateTime}}
-            queryParameters.append('{{baseName}}',{{paramName}}.toString());
+            queryParameters.append('{{baseName}}', String({{paramName}}));
         {{/isDateTime}}
         }
         {{/isArray}}

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -1,4 +1,4 @@
-                                                                                    {{>licenseInfo}}
+{{>licenseInfo}}
 /* tslint:disable:no-unused-variable member-ordering */
 
 {{#useAxiosHttpModule}}

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -1,4 +1,4 @@
-{{>licenseInfo}}
+                                                                                    {{>licenseInfo}}
 /* tslint:disable:no-unused-variable member-ordering */
 
 {{#useAxiosHttpModule}}
@@ -76,7 +76,7 @@ export class {{classname}} {
 {{/allParams}}
 
 {{#hasQueryParams}}
-        let queryParameters = {};
+        let queryParameters = new URLSearchParams();
 {{#queryParams}}
         {{#isArray}}
         if ({{paramName}}) {
@@ -96,7 +96,7 @@ export class {{classname}} {
             queryParameters['{{baseName}}'] = <any>{{paramName}}.toISOString();
         {{/isDateTime}}
         {{^isDateTime}}
-            queryParameters['{{baseName}}'] = <any>{{paramName}};
+            queryParameters.append('{{baseName}}',{{paramName}}.toString());
         {{/isDateTime}}
         }
         {{/isArray}}
@@ -179,7 +179,7 @@ export class {{classname}} {
 
         const canConsumeForm = this.canConsumeForm(consumes);
 
-        let formParams: { append(param: string, value: any): void; };
+        let formParams = new URLSearchParams();
         let useForm = false;
         let convertFormParamsToString = false;
 {{#formParams}}
@@ -191,7 +191,7 @@ export class {{classname}} {
 {{/isFile}}
 {{/formParams}}
         if (useForm) {
-            formParams = new FormData();
+            //formParams = new FormData();
         } else {
             // formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
         }


### PR DESCRIPTION

The generated *.service.ts files did not compile when query-parameters with isCollectionFormatMulti=true
It produced errors in the following way:
```
ERROR in ./generated_sources/finapi/access-service/api/transactions.service.ts 478:33-39
TS2339: Property 'append' does not exist on type '{}'.
    476 |         if (order) {
    477 |             order.forEach((element) => {
  > 478 |                 queryParameters.append('order', <any>element);
        |                                 ^^^^^^
    479 |             })
    480 |         }
    481 |
```

This was fixed, by making queryParameters an instance of URLSearchParam instead of a plain object.
Furthermore it turned out, that for regular (non-multi) parameters it is also necessary to append them to URLSearchParam, since the parameters were not sent otherwise
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
