### PR TITLE
[swift][client] fix xcode warning

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Models.mustache
@@ -117,12 +117,6 @@ extension NullEncodable: Codable where Wrapped: Codable {
         self.request = request
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.request = requestTask.request
-    }
-
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func cancel() {
         lock.lock()
         defer { lock.unlock() }
@@ -137,12 +131,6 @@ extension NullEncodable: Codable where Wrapped: Codable {
         lock.lock()
         defer { lock.unlock() }
         self.task = task
-    }
-
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
     }
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func cancel() {

--- a/modules/openapi-generator/src/main/resources/swift5/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Models.mustache
@@ -106,15 +106,26 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} final class RequestTask {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} final class RequestTask{{#useAsyncAwait}}: @unchecked Sendable{{/useAsyncAwait}} {
+    private var lock = NSRecursiveLock()
 {{#useAlamofire}}
     private var request: Request?
 
     internal func set(request: Request) {
+        lock.lock()
+        defer { lock.unlock() }
         self.request = request
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.request = requestTask.request
+    }
+
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         request?.cancel()
         request = nil
     }
@@ -123,10 +134,20 @@ extension NullEncodable: Codable where Wrapped: Codable {
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/modules/openapi-generator/src/main/resources/swift5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api.mustache
@@ -211,7 +211,7 @@ extension {{projectName}}API {
     {{/isDeprecated}}
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) async throws{{#returnType}} -> {{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{/returnType}} {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -220,7 +220,7 @@ extension {{projectName}}API {
                   return
                 }
 
-                requestTask = {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}).execute { result in
+                let requestTask = {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}).execute { result in
                     switch result {
                     {{#returnType}}
                     case let .success(response):
@@ -234,9 +234,11 @@ extension {{projectName}}API {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 {{/useAsyncAwait}}

--- a/modules/openapi-generator/src/main/resources/swift5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api.mustache
@@ -211,7 +211,8 @@ extension {{projectName}}API {
     {{/isDeprecated}}
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) async throws{{#returnType}} -> {{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{/returnType}} {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -220,7 +221,7 @@ extension {{projectName}}API {
                   return
                 }
 
-                let requestTask = {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     {{#returnType}}
                     case let .success(response):
@@ -234,11 +235,9 @@ extension {{projectName}}API {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 {{/useAsyncAwait}}

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -116,12 +116,6 @@ public final class RequestTask {
         self.request = request
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.request = requestTask.request
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -107,13 +107,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var request: Request?
 
     internal func set(request: Request) {
+        lock.lock()
+        defer { lock.unlock() }
         self.request = request
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.request = requestTask.request
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         request?.cancel()
         request = nil
     }

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -20,7 +20,8 @@ open class AnotherFakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func call123testSpecialTags(body: Client) async throws -> Client {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = call123testSpecialTagsWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ open class AnotherFakeAPI {
                   return
                 }
 
-                let requestTask = call123testSpecialTagsWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -37,11 +38,9 @@ open class AnotherFakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -20,7 +20,7 @@ open class AnotherFakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func call123testSpecialTags(body: Client) async throws -> Client {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +29,7 @@ open class AnotherFakeAPI {
                   return
                 }
 
-                requestTask = call123testSpecialTagsWithRequestBuilder(body: body).execute { result in
+                let requestTask = call123testSpecialTagsWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -37,9 +37,11 @@ open class AnotherFakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -19,7 +19,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterBooleanSerialize(body: Bool? = nil) async throws -> Bool {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -28,7 +28,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { result in
+                let requestTask = fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -36,9 +36,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -73,7 +75,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil) async throws -> OuterComposite {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -82,7 +84,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = fakeOuterCompositeSerializeWithRequestBuilder(body: body).execute { result in
+                let requestTask = fakeOuterCompositeSerializeWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -90,9 +92,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -127,7 +131,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterNumberSerialize(body: Double? = nil) async throws -> Double {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -136,7 +140,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { result in
+                let requestTask = fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -144,9 +148,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -181,7 +187,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterStringSerialize(body: String? = nil) async throws -> String {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -190,7 +196,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = fakeOuterStringSerializeWithRequestBuilder(body: body).execute { result in
+                let requestTask = fakeOuterStringSerializeWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -198,9 +204,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -235,7 +243,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testBodyWithFileSchema(body: FileSchemaTestClass) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -244,7 +252,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testBodyWithFileSchemaWithRequestBuilder(body: body).execute { result in
+                let requestTask = testBodyWithFileSchemaWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -252,9 +260,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -290,7 +300,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testBodyWithQueryParams(query: String, body: User) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -299,7 +309,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body).execute { result in
+                let requestTask = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -307,9 +317,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -348,7 +360,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testClientModel(body: Client) async throws -> Client {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -357,7 +369,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testClientModelWithRequestBuilder(body: body).execute { result in
+                let requestTask = testClientModelWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -365,9 +377,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -417,7 +431,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -426,7 +440,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { result in
+                let requestTask = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -434,9 +448,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -581,7 +597,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -590,7 +606,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { result in
+                let requestTask = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -598,9 +614,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -663,7 +681,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -672,7 +690,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { result in
+                let requestTask = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -680,9 +698,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -731,7 +751,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testInlineAdditionalProperties(param: [String: String]) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -740,7 +760,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testInlineAdditionalPropertiesWithRequestBuilder(param: param).execute { result in
+                let requestTask = testInlineAdditionalPropertiesWithRequestBuilder(param: param).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -748,9 +768,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -787,7 +809,7 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testJsonFormData(param: String, param2: String) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -796,7 +818,7 @@ open class FakeAPI {
                   return
                 }
 
-                requestTask = testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { result in
+                let requestTask = testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -804,9 +826,11 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -19,7 +19,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterBooleanSerialize(body: Bool? = nil) async throws -> Bool {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = fakeOuterBooleanSerializeWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -28,7 +29,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -36,11 +37,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -75,7 +74,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil) async throws -> OuterComposite {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = fakeOuterCompositeSerializeWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -84,7 +84,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = fakeOuterCompositeSerializeWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -92,11 +92,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -131,7 +129,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterNumberSerialize(body: Double? = nil) async throws -> Double {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = fakeOuterNumberSerializeWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -140,7 +139,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -148,11 +147,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -187,7 +184,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func fakeOuterStringSerialize(body: String? = nil) async throws -> String {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = fakeOuterStringSerializeWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -196,7 +194,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = fakeOuterStringSerializeWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -204,11 +202,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -243,7 +239,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testBodyWithFileSchema(body: FileSchemaTestClass) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testBodyWithFileSchemaWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -252,7 +249,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testBodyWithFileSchemaWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -260,11 +257,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -300,7 +295,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testBodyWithQueryParams(query: String, body: User) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -309,7 +305,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -317,11 +313,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -360,7 +354,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testClientModel(body: Client) async throws -> Client {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testClientModelWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -369,7 +364,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testClientModelWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -377,11 +372,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -431,7 +424,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -440,7 +434,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -448,11 +442,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -597,7 +589,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -606,7 +599,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -614,11 +607,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -681,7 +672,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -690,7 +682,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -698,11 +690,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -751,7 +741,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testInlineAdditionalProperties(param: [String: String]) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testInlineAdditionalPropertiesWithRequestBuilder(param: param)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -760,7 +751,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testInlineAdditionalPropertiesWithRequestBuilder(param: param).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -768,11 +759,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -809,7 +798,8 @@ open class FakeAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testJsonFormData(param: String, param2: String) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testJsonFormDataWithRequestBuilder(param: param, param2: param2)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -818,7 +808,7 @@ open class FakeAPI {
                   return
                 }
 
-                let requestTask = testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -826,11 +816,9 @@ open class FakeAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -20,7 +20,7 @@ open class FakeClassnameTags123API {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testClassname(body: Client) async throws -> Client {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +29,7 @@ open class FakeClassnameTags123API {
                   return
                 }
 
-                requestTask = testClassnameWithRequestBuilder(body: body).execute { result in
+                let requestTask = testClassnameWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -37,9 +37,11 @@ open class FakeClassnameTags123API {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -20,7 +20,8 @@ open class FakeClassnameTags123API {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func testClassname(body: Client) async throws -> Client {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = testClassnameWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ open class FakeClassnameTags123API {
                   return
                 }
 
-                let requestTask = testClassnameWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -37,11 +38,9 @@ open class FakeClassnameTags123API {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -20,7 +20,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func addPet(body: Pet) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +29,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = addPetWithRequestBuilder(body: body).execute { result in
+                let requestTask = addPetWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -37,9 +37,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -82,7 +84,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deletePet(petId: Int64, apiKey: String? = nil) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -91,7 +93,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { result in
+                let requestTask = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -99,9 +101,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -153,7 +157,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func findPetsByStatus(status: [Status_findPetsByStatus]) async throws -> [Pet] {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -162,7 +166,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = findPetsByStatusWithRequestBuilder(status: status).execute { result in
+                let requestTask = findPetsByStatusWithRequestBuilder(status: status).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -170,9 +174,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -216,7 +222,7 @@ open class PetAPI {
     @available(*, deprecated, message: "This operation is deprecated.")
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func findPetsByTags(tags: [String]) async throws -> [Pet] {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -225,7 +231,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = findPetsByTagsWithRequestBuilder(tags: tags).execute { result in
+                let requestTask = findPetsByTagsWithRequestBuilder(tags: tags).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -233,9 +239,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -279,7 +287,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getPetById(petId: Int64) async throws -> Pet {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -288,7 +296,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = getPetByIdWithRequestBuilder(petId: petId).execute { result in
+                let requestTask = getPetByIdWithRequestBuilder(petId: petId).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -296,9 +304,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -341,7 +351,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updatePet(body: Pet) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -350,7 +360,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = updatePetWithRequestBuilder(body: body).execute { result in
+                let requestTask = updatePetWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -358,9 +368,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -401,7 +413,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -410,7 +422,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { result in
+                let requestTask = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -418,9 +430,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -472,7 +486,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) async throws -> ApiResponse {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -481,7 +495,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { result in
+                let requestTask = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -489,9 +503,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -543,7 +559,7 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) async throws -> ApiResponse {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -552,7 +568,7 @@ open class PetAPI {
                   return
                 }
 
-                requestTask = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { result in
+                let requestTask = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -560,9 +576,11 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -20,7 +20,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func addPet(body: Pet) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = addPetWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = addPetWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -37,11 +38,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -84,7 +83,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deletePet(petId: Int64, apiKey: String? = nil) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -93,7 +93,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -101,11 +101,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -157,7 +155,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func findPetsByStatus(status: [Status_findPetsByStatus]) async throws -> [Pet] {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = findPetsByStatusWithRequestBuilder(status: status)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -166,7 +165,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = findPetsByStatusWithRequestBuilder(status: status).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -174,11 +173,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -222,7 +219,8 @@ open class PetAPI {
     @available(*, deprecated, message: "This operation is deprecated.")
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func findPetsByTags(tags: [String]) async throws -> [Pet] {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = findPetsByTagsWithRequestBuilder(tags: tags)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -231,7 +229,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = findPetsByTagsWithRequestBuilder(tags: tags).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -239,11 +237,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -287,7 +283,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getPetById(petId: Int64) async throws -> Pet {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = getPetByIdWithRequestBuilder(petId: petId)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -296,7 +293,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = getPetByIdWithRequestBuilder(petId: petId).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -304,11 +301,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -351,7 +346,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updatePet(body: Pet) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = updatePetWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -360,7 +356,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = updatePetWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -368,11 +364,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -413,7 +407,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -422,7 +417,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -430,11 +425,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -486,7 +479,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) async throws -> ApiResponse {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -495,7 +489,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -503,11 +497,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -559,7 +551,8 @@ open class PetAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) async throws -> ApiResponse {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -568,7 +561,7 @@ open class PetAPI {
                   return
                 }
 
-                let requestTask = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -576,11 +569,9 @@ open class PetAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -20,7 +20,8 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deleteOrder(orderId: String) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = deleteOrderWithRequestBuilder(orderId: orderId)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ open class StoreAPI {
                   return
                 }
 
-                let requestTask = deleteOrderWithRequestBuilder(orderId: orderId).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -37,11 +38,9 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -80,7 +79,8 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getInventory() async throws -> [String: Int] {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = getInventoryWithRequestBuilder()
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -89,7 +89,7 @@ open class StoreAPI {
                   return
                 }
 
-                let requestTask = getInventoryWithRequestBuilder().execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -97,11 +97,9 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -140,7 +138,8 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getOrderById(orderId: Int64) async throws -> Order {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = getOrderByIdWithRequestBuilder(orderId: orderId)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -149,7 +148,7 @@ open class StoreAPI {
                   return
                 }
 
-                let requestTask = getOrderByIdWithRequestBuilder(orderId: orderId).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -157,11 +156,9 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -201,7 +198,8 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func placeOrder(body: Order) async throws -> Order {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = placeOrderWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -210,7 +208,7 @@ open class StoreAPI {
                   return
                 }
 
-                let requestTask = placeOrderWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -218,11 +216,9 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -20,7 +20,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deleteOrder(orderId: String) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +29,7 @@ open class StoreAPI {
                   return
                 }
 
-                requestTask = deleteOrderWithRequestBuilder(orderId: orderId).execute { result in
+                let requestTask = deleteOrderWithRequestBuilder(orderId: orderId).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -37,9 +37,11 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -78,7 +80,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getInventory() async throws -> [String: Int] {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -87,7 +89,7 @@ open class StoreAPI {
                   return
                 }
 
-                requestTask = getInventoryWithRequestBuilder().execute { result in
+                let requestTask = getInventoryWithRequestBuilder().execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -95,9 +97,11 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -136,7 +140,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getOrderById(orderId: Int64) async throws -> Order {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -145,7 +149,7 @@ open class StoreAPI {
                   return
                 }
 
-                requestTask = getOrderByIdWithRequestBuilder(orderId: orderId).execute { result in
+                let requestTask = getOrderByIdWithRequestBuilder(orderId: orderId).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -153,9 +157,11 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -195,7 +201,7 @@ open class StoreAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func placeOrder(body: Order) async throws -> Order {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -204,7 +210,7 @@ open class StoreAPI {
                   return
                 }
 
-                requestTask = placeOrderWithRequestBuilder(body: body).execute { result in
+                let requestTask = placeOrderWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -212,9 +218,11 @@ open class StoreAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -20,7 +20,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUser(body: User) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +29,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = createUserWithRequestBuilder(body: body).execute { result in
+                let requestTask = createUserWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -37,9 +37,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -76,7 +78,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUsersWithArrayInput(body: [User]) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -85,7 +87,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = createUsersWithArrayInputWithRequestBuilder(body: body).execute { result in
+                let requestTask = createUsersWithArrayInputWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -93,9 +95,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -131,7 +135,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUsersWithListInput(body: [User]) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -140,7 +144,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = createUsersWithListInputWithRequestBuilder(body: body).execute { result in
+                let requestTask = createUsersWithListInputWithRequestBuilder(body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -148,9 +152,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -186,7 +192,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deleteUser(username: String) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -195,7 +201,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = deleteUserWithRequestBuilder(username: username).execute { result in
+                let requestTask = deleteUserWithRequestBuilder(username: username).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -203,9 +209,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -245,7 +253,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getUserByName(username: String) async throws -> User {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -254,7 +262,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = getUserByNameWithRequestBuilder(username: username).execute { result in
+                let requestTask = getUserByNameWithRequestBuilder(username: username).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -262,9 +270,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -304,7 +314,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func loginUser(username: String, password: String) async throws -> String {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -313,7 +323,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = loginUserWithRequestBuilder(username: username, password: password).execute { result in
+                let requestTask = loginUserWithRequestBuilder(username: username, password: password).execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -321,9 +331,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -364,7 +376,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func logoutUser() async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -373,7 +385,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = logoutUserWithRequestBuilder().execute { result in
+                let requestTask = logoutUserWithRequestBuilder().execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -381,9 +393,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 
@@ -419,7 +433,7 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updateUser(username: String, body: User) async throws {
-        var requestTask: RequestTask?
+        let cancellableRequestTask = RequestTask()
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -428,7 +442,7 @@ open class UserAPI {
                   return
                 }
 
-                requestTask = updateUserWithRequestBuilder(username: username, body: body).execute { result in
+                let requestTask = updateUserWithRequestBuilder(username: username, body: body).execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -436,9 +450,11 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
+
+                cancellableRequestTask.set(requestTask: requestTask)
             }
-        } onCancel: { [requestTask] in
-            requestTask?.cancel()
+        } onCancel: {
+            cancellableRequestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -20,7 +20,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUser(body: User) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = createUserWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +30,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = createUserWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -37,11 +38,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -78,7 +77,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUsersWithArrayInput(body: [User]) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = createUsersWithArrayInputWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -87,7 +87,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = createUsersWithArrayInputWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -95,11 +95,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -135,7 +133,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func createUsersWithListInput(body: [User]) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = createUsersWithListInputWithRequestBuilder(body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -144,7 +143,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = createUsersWithListInputWithRequestBuilder(body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -152,11 +151,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -192,7 +189,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func deleteUser(username: String) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = deleteUserWithRequestBuilder(username: username)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -201,7 +199,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = deleteUserWithRequestBuilder(username: username).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -209,11 +207,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -253,7 +249,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func getUserByName(username: String) async throws -> User {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = getUserByNameWithRequestBuilder(username: username)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -262,7 +259,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = getUserByNameWithRequestBuilder(username: username).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -270,11 +267,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -314,7 +309,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func loginUser(username: String, password: String) async throws -> String {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = loginUserWithRequestBuilder(username: username, password: password)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -323,7 +319,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = loginUserWithRequestBuilder(username: username, password: password).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case let .success(response):
                         continuation.resume(returning: response.body)
@@ -331,11 +327,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -376,7 +370,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func logoutUser() async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = logoutUserWithRequestBuilder()
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -385,7 +380,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = logoutUserWithRequestBuilder().execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -393,11 +388,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 
@@ -433,7 +426,8 @@ open class UserAPI {
      */
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     open class func updateUser(username: String, body: User) async throws {
-        let cancellableRequestTask = RequestTask()
+        let requestBuilder = updateUserWithRequestBuilder(username: username, body: body)
+        let requestTask = requestBuilder.requestTask
         return try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return try await withCheckedThrowingContinuation { continuation in
@@ -442,7 +436,7 @@ open class UserAPI {
                   return
                 }
 
-                let requestTask = updateUserWithRequestBuilder(username: username, body: body).execute { result in
+                requestBuilder.execute { result in
                     switch result {
                     case .success:
                         continuation.resume(returning: ())
@@ -450,11 +444,9 @@ open class UserAPI {
                         continuation.resume(throwing: error)
                     }
                 }
-
-                cancellableRequestTask.set(requestTask: requestTask)
             }
         } onCancel: {
-            cancellableRequestTask.cancel()
+            requestTask.cancel()
         }
     }
 

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -105,14 +105,25 @@ open class Response<T> {
     }
 }
 
-public final class RequestTask {
+public final class RequestTask: @unchecked Sendable {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask: @unchecked Sendable {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ internal class Response<T> {
 }
 
 internal final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     internal func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ internal final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     internal func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -106,13 +106,24 @@ open class Response<T> {
 }
 
 public final class RequestTask {
+    private var lock = NSRecursiveLock()
     private var task: URLSessionTask?
 
     internal func set(task: URLSessionTask) {
+        lock.lock()
+        defer { lock.unlock() }
         self.task = task
     }
 
+    internal func set(requestTask: RequestTask) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.task = requestTask.task
+    }
+
     public func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
         task?.cancel()
         task = nil
     }

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -115,12 +115,6 @@ public final class RequestTask {
         self.task = task
     }
 
-    internal func set(requestTask: RequestTask) {
-        lock.lock()
-        defer { lock.unlock() }
-        self.task = requestTask.task
-    }
-
     public func cancel() {
         lock.lock()
         defer { lock.unlock() }


### PR DESCRIPTION
Fixes Xcode 14 warning: `Capture of with non-sendable type in a `@Sendable` closure withTaskCancellationHandler`

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)