### PR TITLE
Fix typescript codegen crash on extracting regular expression

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -1147,7 +1147,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
                     RxGen does not support our ECMA dialect https://github.com/curious-odd-man/RgxGen/issues/56
                     So strip off the leading / and trailing / and turn on ignore case if we have it
                      */
-                    Pattern valueExtractor = Pattern.compile("^/?(.+)?/?(.?)$");
+                    Pattern valueExtractor = Pattern.compile("^/(.+)?/(.?)$");
                     Matcher m = valueExtractor.matcher(pattern);
                     RgxGen rgxGen = null;
                     if (m.find()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -1147,7 +1147,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
                     RxGen does not support our ECMA dialect https://github.com/curious-odd-man/RgxGen/issues/56
                     So strip off the leading / and trailing / and turn on ignore case if we have it
                      */
-                    Pattern valueExtractor = Pattern.compile("^/?(.+?)/?(.?)$");
+                    Pattern valueExtractor = Pattern.compile("^/?(.+)?/?(.?)$");
                     Matcher m = valueExtractor.matcher(pattern);
                     RgxGen rgxGen = null;
                     if (m.find()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -177,4 +177,23 @@ public class TypeScriptClientCodegenTest {
             Assert.fail("Exception was thrown.");
         }
     }
+
+    @Test
+    public void compilePatternRegexOptionTest() {
+        final DefaultCodegen codegen = new TypeScriptClientCodegen();
+        final StringSchema prop = new StringSchema();
+        prop.setPattern("/[A-Z]{3,4}/i");
+        final Schema root = new ObjectSchema()
+                .addProperty("astring", prop);
+
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", root);
+        codegen.setOpenAPI(openAPI);
+
+        try {
+            CodegenModel model = codegen.fromModel("sample", root);
+            Assert.assertFalse(model.getVars().get(0).getExample().contains("/i"));
+        } catch (Exception e) {
+            Assert.fail("Exception was thrown.");
+        }
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -141,4 +141,40 @@ public class TypeScriptClientCodegenTest {
         Assert.assertEquals(tsImports.get(0).get("filename"), mappedName);
         Assert.assertEquals(tsImports.get(0).get("classname"), "ApiResponse");
     }
+
+    @Test
+    public void compilePatternTest() {
+        final DefaultCodegen codegen = new TypeScriptClientCodegen();
+        final StringSchema prop = new StringSchema();
+        prop.setPattern("[A-Z]{3}");
+        final Schema root = new ObjectSchema()
+                .addProperty("astring", prop);
+
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", root);
+        codegen.setOpenAPI(openAPI);
+
+        try {
+            codegen.fromModel("sample", root);
+        } catch (Exception e) {
+            Assert.fail("Exception was thrown.");
+        }
+    }
+
+    @Test
+    public void compilePatternMinMaxTest() {
+        final DefaultCodegen codegen = new TypeScriptClientCodegen();
+        final StringSchema prop = new StringSchema();
+        prop.setPattern("[A-Z]{3,4}");
+        final Schema root = new ObjectSchema()
+                .addProperty("astring", prop);
+
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", root);
+        codegen.setOpenAPI(openAPI);
+
+        try {
+            codegen.fromModel("sample", root);
+        } catch (Exception e) {
+            Assert.fail("Exception was thrown.");
+        }
+    }
 }


### PR DESCRIPTION
Fixes codegen returns error when schema has a pattern property:

```
Exception: Unbalanced '{' - missing '}' at
'z0-9]{3'
```

mention the technical committee members @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka

Fixes #13390 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
