### PR TITLE
[csharp-netcore] Add missing ConfigureAwaits for csharp-netcore generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/auth/OAuthAuthenticator.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/auth/OAuthAuthenticator.mustache
@@ -63,7 +63,7 @@ namespace {{packageName}}.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -80,7 +80,7 @@ namespace {{packageName}}.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -79,7 +79,7 @@ namespace {{packageName}}.Client
 
         public async Task<T> Deserialize<T>(HttpResponseMessage response)
         {
-            var result = (T) await Deserialize(response, typeof(T));
+            var result = (T) await Deserialize(response, typeof(T)).ConfigureAwait(false);
             return result;
         }
 
@@ -95,17 +95,17 @@ namespace {{packageName}}.Client
 
             if (type == typeof(byte[])) // return byte array
             {
-                return await response.Content.ReadAsByteArrayAsync();
+                return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             }
             else if (type == typeof(FileParameter))
             {
-                return new FileParameter(await response.Content.ReadAsStreamAsync());
+                return new FileParameter(await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
             }
 
             // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
             if (type == typeof(Stream))
             {
-                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 if (headers != null)
                 {
                     var filePath = string.IsNullOrEmpty(_configuration.TempFolderPath)
@@ -129,18 +129,18 @@ namespace {{packageName}}.Client
 
             if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
             {
-                return DateTime.Parse(await response.Content.ReadAsStringAsync(), null, System.Globalization.DateTimeStyles.RoundtripKind);
+                return DateTime.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false), null, System.Globalization.DateTimeStyles.RoundtripKind);
             }
 
             if (type == typeof(string) || type.Name.StartsWith("System.Nullable")) // return primitive type
             {
-                return Convert.ChangeType(await response.Content.ReadAsStringAsync(), type);
+                return Convert.ChangeType(await response.Content.ReadAsStringAsync().ConfigureAwait(false), type);
             }
 
             // at this point, it must be a model (json)
             try
             {
-                return JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync(), type, _serializerSettings);
+                return JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false), type, _serializerSettings);
             }
             catch (Exception e)
             {
@@ -401,7 +401,7 @@ namespace {{packageName}}.Client
         private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
         {
             T result = (T) responseData;
-            string rawContent = await response.Content.ReadAsStringAsync();
+            string rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
             {
@@ -514,10 +514,10 @@ namespace {{packageName}}.Client
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    return await ToApiResponse<T>(response, default(T), req.RequestUri);
+                    return await ToApiResponse<T>(response, default(T), req.RequestUri).ConfigureAwait(false);
                 }
 
-                object responseData = await deserializer.Deserialize<T>(response);
+                object responseData = await deserializer.Deserialize<T>(response).ConfigureAwait(false);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -526,12 +526,12 @@ namespace {{packageName}}.Client
                 }
                 else if (typeof(T).Name == "Stream") // for binary response
                 {
-                    responseData = (T) (object) await response.Content.ReadAsStreamAsync();
+                    responseData = (T) (object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 }
 
                 InterceptResponse(req, response);
 
-                return await ToApiResponse<T>(response, responseData, req.RequestUri);
+                return await ToApiResponse<T>(response, responseData, req.RequestUri).ConfigureAwait(false);
             }
             finally
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Client
 
         public async Task<T> Deserialize<T>(HttpResponseMessage response)
         {
-            var result = (T) await Deserialize(response, typeof(T));
+            var result = (T) await Deserialize(response, typeof(T)).ConfigureAwait(false);
             return result;
         }
 
@@ -98,17 +98,17 @@ namespace Org.OpenAPITools.Client
 
             if (type == typeof(byte[])) // return byte array
             {
-                return await response.Content.ReadAsByteArrayAsync();
+                return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             }
             else if (type == typeof(FileParameter))
             {
-                return new FileParameter(await response.Content.ReadAsStreamAsync());
+                return new FileParameter(await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
             }
 
             // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
             if (type == typeof(Stream))
             {
-                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 if (headers != null)
                 {
                     var filePath = string.IsNullOrEmpty(_configuration.TempFolderPath)
@@ -132,18 +132,18 @@ namespace Org.OpenAPITools.Client
 
             if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
             {
-                return DateTime.Parse(await response.Content.ReadAsStringAsync(), null, System.Globalization.DateTimeStyles.RoundtripKind);
+                return DateTime.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false), null, System.Globalization.DateTimeStyles.RoundtripKind);
             }
 
             if (type == typeof(string) || type.Name.StartsWith("System.Nullable")) // return primitive type
             {
-                return Convert.ChangeType(await response.Content.ReadAsStringAsync(), type);
+                return Convert.ChangeType(await response.Content.ReadAsStringAsync().ConfigureAwait(false), type);
             }
 
             // at this point, it must be a model (json)
             try
             {
-                return JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync(), type, _serializerSettings);
+                return JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false), type, _serializerSettings);
             }
             catch (Exception e)
             {
@@ -402,7 +402,7 @@ namespace Org.OpenAPITools.Client
         private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
         {
             T result = (T) responseData;
-            string rawContent = await response.Content.ReadAsStringAsync();
+            string rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, rawContent)
             {
@@ -511,10 +511,10 @@ namespace Org.OpenAPITools.Client
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    return await ToApiResponse<T>(response, default(T), req.RequestUri);
+                    return await ToApiResponse<T>(response, default(T), req.RequestUri).ConfigureAwait(false);
                 }
 
-                object responseData = await deserializer.Deserialize<T>(response);
+                object responseData = await deserializer.Deserialize<T>(response).ConfigureAwait(false);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
@@ -523,12 +523,12 @@ namespace Org.OpenAPITools.Client
                 }
                 else if (typeof(T).Name == "Stream") // for binary response
                 {
-                    responseData = (T) (object) await response.Content.ReadAsStreamAsync();
+                    responseData = (T) (object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 }
 
                 InterceptResponse(req, response);
 
-                return await ToApiResponse<T>(response, responseData, req.RequestUri);
+                return await ToApiResponse<T>(response, responseData, req.RequestUri).ConfigureAwait(false);
             }
             finally
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net48/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/Auth/OAuthAuthenticator.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Client.Auth
         /// <returns>An authentication parameter.</returns>
         protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         {
-            var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+            var token = string.IsNullOrEmpty(Token) ? await GetToken().ConfigureAwait(false) : Token;
             return new HeaderParameter(KnownHeaders.Authorization, token);
         }
 
@@ -88,7 +88,7 @@ namespace Org.OpenAPITools.Client.Auth
                 .AddParameter("grant_type", _grantType)
                 .AddParameter("client_id", _clientId)
                 .AddParameter("client_secret", _clientSecret);
-            var response = await client.PostAsync<TokenResponse>(request);
+            var response = await client.PostAsync<TokenResponse>(request).ConfigureAwait(false);
             return $"{response.TokenType} {response.AccessToken}";
         }
     }


### PR DESCRIPTION
For the csharp-netcore generator, some `ConfigureAwait(false)` statements were missing in the async methods. This could cause a deadlock, mainly in .NET Framework UI code. The general guidance is to use ConfigureAwait(false) if you’re writing a general-purpose library.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
