### PR TITLE
[kotlin] Fix empty body with POST/etc in OkHttp client

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -343,7 +343,7 @@ import com.squareup.moshi.adapter
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -351,16 +351,16 @@ import com.squareup.moshi.adapter
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -158,7 +158,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -166,16 +166,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -156,7 +156,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -164,16 +164,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -158,7 +158,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -166,16 +166,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -158,7 +158,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -166,16 +166,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -156,7 +156,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -164,16 +164,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -158,7 +158,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -166,16 +166,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -158,7 +158,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -166,16 +166,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -176,7 +176,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -184,16 +184,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -176,7 +176,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -184,16 +184,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -182,7 +182,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -190,16 +190,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -179,7 +179,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -187,16 +187,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -177,7 +177,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -185,16 +185,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -177,7 +177,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -185,16 +185,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -177,7 +177,7 @@ internal open class ApiClient(val baseUrl: String, val client: OkHttpClient = de
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -185,16 +185,16 @@ internal open class ApiClient(val baseUrl: String, val client: OkHttpClient = de
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -177,7 +177,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -185,16 +185,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -175,7 +175,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -183,16 +183,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -177,7 +177,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -185,16 +185,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -177,7 +177,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -185,16 +185,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -158,7 +158,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -166,16 +166,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -177,7 +177,7 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -185,16 +185,16 @@ open class ApiClient(val baseUrl: String, val client: OkHttpClient = defaultClie
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Don't pass `Content-Type: application/json` when passing a `null` body for `POST`/etc request in Kotlin.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m