### PR TITLE
Fix issue9444

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -763,6 +763,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         // sanitize name
         name = sanitizeName(name, "\\W-[\\$]"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
+        // name is not just equal to "_" which translates to "_u" corner case.
+        boolean beginsWithUnderScore = name.length()!=1 && name.startsWith("_");
+
         if (name.toLowerCase(Locale.ROOT).matches("^_*class$")) {
             return "propertyClass";
         }
@@ -795,7 +798,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         // camelize (lower first character) the variable name
         // pet_id => petId
-        boolean beginsWithUnderScore = name.startsWith("_");
         name = camelize(name, true);
 
         // for reserved word or word starting with number, append _
@@ -1988,7 +1990,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (name == null || name.length() == 0) {
             return name;
         }
-        boolean beginsWithUnderScore = name.startsWith("_");
+        boolean beginsWithUnderScore = name.length()!=1 && name.startsWith("_");
         name = toVarName(name);
         //
         // Let the property name capitalized

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -764,7 +764,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         name = sanitizeName(name, "\\W-[\\$]"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
         // name is not just equal to "_" which translates to "_u" corner case.
-        boolean beginsWithUnderScore = name.length()!=1 && name.startsWith("_");
+        boolean prependUnderscore = prependUnderscore(name);
 
         if (name.toLowerCase(Locale.ROOT).matches("^_*class$")) {
             return "propertyClass";
@@ -802,7 +802,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         // for reserved word or word starting with number, append _
         // for _ in start of word, put it back in, as camelize removes it totally.
-        if (isReservedWord(name) || name.matches("^\\d.*") || beginsWithUnderScore ) {
+        if (isReservedWord(name) || name.matches("^\\d.*") || prependUnderscore ) {
             name = escapeReservedWord(name);
         }
 
@@ -1990,7 +1990,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (name == null || name.length() == 0) {
             return name;
         }
-        boolean beginsWithUnderScore = name.length()!=1 && name.startsWith("_");
+        boolean prependUnderscore = prependUnderscore(name);
         name = toVarName(name);
         //
         // Let the property name capitalized
@@ -2002,10 +2002,16 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             lowercaseFirstLetter = true;
         }
         name = camelize(name, lowercaseFirstLetter);
-        if ( beginsWithUnderScore ) {
+        if ( prependUnderscore ) {
             name = "_" + name;
         }
         return name;
+    }
+
+    private boolean prependUnderscore(String name) {
+        boolean beginsWithUnderScore = name.length()!=1 && name.startsWith("_")
+                && ( name.equals("class") || name.equals("_class") || name.equals("__class") );
+        return beginsWithUnderScore;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1988,6 +1988,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (name == null || name.length() == 0) {
             return name;
         }
+        boolean beginsWithUnderScore = name.startsWith("_");
         name = toVarName(name);
         //
         // Let the property name capitalized
@@ -1995,12 +1996,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         // Refer to section 8.8: Capitalization of inferred names of the JavaBeans API specification
         // http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf)
         //
-        boolean beginsWithUnderScore = name.startsWith("_");
-        int indexToCheck = 0;
-        if (beginsWithUnderScore) {
-            indexToCheck = 1;
-        }
-        if (name.length() > 1 && Character.isLowerCase(name.charAt(indexToCheck)) && Character.isUpperCase(name.charAt(indexToCheck+1))) {
+        if (name.length() > 1 && Character.isLowerCase(name.charAt(0)) && Character.isUpperCase(name.charAt(1))) {
             lowercaseFirstLetter = true;
         }
         name = camelize(name, lowercaseFirstLetter);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2010,7 +2010,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     private boolean prependUnderscore(String name) {
         boolean beginsWithUnderScore = name.length()!=1 && name.startsWith("_")
-                && ( name.equals("class") || name.equals("_class") || name.equals("__class") );
+                && !( name.equals("class") || name.equals("_class") || name.equals("__class") );
         return beginsWithUnderScore;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -795,10 +795,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         // camelize (lower first character) the variable name
         // pet_id => petId
+        boolean beginsWithUnderScore = name.startsWith("_");
         name = camelize(name, true);
 
         // for reserved word or word starting with number, append _
-        if (isReservedWord(name) || name.matches("^\\d.*")) {
+        // for _ in start of word, put it back in, as camelize removes it totally.
+        if (isReservedWord(name) || name.matches("^\\d.*") || beginsWithUnderScore ) {
             name = escapeReservedWord(name);
         }
 
@@ -1993,10 +1995,19 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         // Refer to section 8.8: Capitalization of inferred names of the JavaBeans API specification
         // http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf)
         //
-        if (name.length() > 1 && Character.isLowerCase(name.charAt(0)) && Character.isUpperCase(name.charAt(1))) {
+        boolean beginsWithUnderScore = name.startsWith("_");
+        int indexToCheck = 0;
+        if (beginsWithUnderScore) {
+            indexToCheck = 1;
+        }
+        if (name.length() > 1 && Character.isLowerCase(name.charAt(indexToCheck)) && Character.isUpperCase(name.charAt(indexToCheck+1))) {
             lowercaseFirstLetter = true;
         }
-        return camelize(name, lowercaseFirstLetter);
+        name = camelize(name, lowercaseFirstLetter);
+        if ( beginsWithUnderScore ) {
+            name = "_" + name;
+        }
+        return name;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -763,8 +763,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         // sanitize name
         name = sanitizeName(name, "\\W-[\\$]"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
+        // We need to rePrepend the "_" if it appears as first character of a series of characters in a name.
         // name is not just equal to "_" which translates to "_u" corner case.
-        boolean prependUnderscore = prependUnderscore(name);
+        boolean prependUnderscore = name.length()!=1 && name.startsWith("_");
 
         if (name.toLowerCase(Locale.ROOT).matches("^_*class$")) {
             return "propertyClass";
@@ -1990,7 +1991,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (name == null || name.length() == 0) {
             return name;
         }
-        boolean prependUnderscore = prependUnderscore(name);
+        boolean prependUnderscore = name.length()!=1 && name.startsWith("_");
         name = toVarName(name);
         //
         // Let the property name capitalized
@@ -2002,16 +2003,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             lowercaseFirstLetter = true;
         }
         name = camelize(name, lowercaseFirstLetter);
-        if ( prependUnderscore ) {
+        // Note capitalizing "P" initial letter since camelize capitalizes it
+        if ( prependUnderscore && !name.equals("PropertyClass")) {
             name = "_" + name;
         }
         return name;
-    }
-
-    private boolean prependUnderscore(String name) {
-        boolean beginsWithUnderScore = name.length()!=1 && name.startsWith("_")
-                && !( name.equals("class") || name.equals("_class") || name.equals("__class") );
-        return beginsWithUnderScore;
     }
 
     @Override


### PR DESCRIPTION
**This is for issue# 9444**

@bbdouglas, @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)

### Need feedback

So I analyzed the problem as following:

`org.openapitools.codegen.utils.StringUtils.camelize(final String inputWord, boolean lowercaseFirstLetter)`

removes all underscores characters using this matcher:

`m = camelizeUnderscorePattern.matcher(word);`

If we let camelize do what it does and say that even removing the first underscore is part of its job, then one can do a more local fix in class "AbstractJavaCodegen" just for the java generators.

So toVarName()  and getterAndSetterCapitalize() could be changed with something as simple as the line below at start of methods:  
`        boolean beginsWithUnderScore = name.startsWith("_");`

And when the methods are ready to return, re-add back the underscore at the beginning. For example the toVarName could change as follows towards the end.

And getterAndSetterCapitalize is just a little bit complicated, but doable as follows:
```
    public String getterAndSetterCapitalize(String name) {
        boolean lowercaseFirstLetter = false;
        if (name == null || name.length() == 0) {
            return name;
        }
        boolean prependUnderscore = name.length()!=1 && name.startsWith("_");
        name = toVarName(name);
        //
        // Let the property name capitalized
        // except when the first letter of the property name is lowercase and the second letter is uppercase
        // Refer to section 8.8: Capitalization of inferred names of the JavaBeans API specification
        // http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf)
        //
        if (name.length() > 1 && Character.isLowerCase(name.charAt(0)) && Character.isUpperCase(name.charAt(1))) {
            lowercaseFirstLetter = true;
        }
        name = camelize(name, lowercaseFirstLetter);
        // Note capitalizing "P" initial letter since camelize capitalizes it
        if ( prependUnderscore && !name.equals("PropertyClass")) {
            name = "_" + name;
        }
        return name;
    }
```

Can some one see a problem for these changes. Any other suggestions ?

We could make this a configurable option as well.

### Open Part still

Also the last open part is the moustache templates.

For this schema with props type, _type and subtype:

```yaml
components:
  schemas:
    Message:
      required:
      - _type
      - text
      type: object
      properties:
        type:
          type: string
          description: Type of this message.
          enum:
          - STATUS
          - TEXT
          - ERROR
          - PROGRESS
        subType:
          type: string
          description: Sub-type of this message.
          enum:
          - STATUS
          - LOCK
          - UNKNOWN
        _type:
          type: string
      discriminator:
        propertyName: _type


```
I should get this generated in the annotations


```java
@JsonPropertyOrder({
  Message.JSON_PROPERTY_TYPE,
  Message.JSON_PROPERTY_SUB_TYPE,
  Message.JSON_PROPERTY__TYPE
})
```
but the double "__" in third property above is not generated:


I looked at the moustache templates. No expert here, but maybe the "nameInSnakeCase" is the culprit in pojo.moustasche. I just searched the string "JSON_PROPERTY_" and the following lines poped up:

  {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}

Must be other places also as variable is wrong at a couple of places.

Any suggestions


Regards, 


PR TEMPLATE Leave alone for now.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
