### PR TITLE
[go][client] Import "time" package if property is oneOf and contains time.Time

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -647,6 +647,12 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 imports.add(createMapping("import", "fmt"));
             }
 
+            // if oneOf contains "time.Time" type
+            if (!addedTimeImport && model.oneOf != null && model.oneOf.contains("time.Time")) {
+                imports.add(createMapping("import", "time"));
+                addedTimeImport = true;
+            }
+
             // if oneOf contains "null" type
             if (model.oneOf != null && !model.oneOf.isEmpty() && model.oneOf.contains("nil")) {
                 model.isNullable = true;


### PR DESCRIPTION
Fix an issue with go client generator, where "time" import is missing if the time.Time type is wrapped in oneOf

```
    ObjectAttributeValue_value:
      oneOf:
      - type: string
      - format: date-time
        type: string
```
(via https://developer.atlassian.com/cloud/insight/swagger.v3.json)

```
openapi-codegen generate -i https://developer.atlassian.com/cloud/insight/swagger.v3.json -g go -o cloud-insight-test/
cd cloud-insight-test/ && go get && go build
```

Without fix:
```
# github.com/GIT_USER_ID/GIT_REPO_ID
./model_object_attribute_value_value.go:21:12: undefined: time
./model_object_attribute_value_value.go:32:45: undefined: time
./model_object_attribute_value_value.go:88:21: invalid operation: src.TimeTime != nil (operator != not defined on untyped nil)
./model_object_attribute_value_value.go:104:21: invalid operation: obj.TimeTime != nil (operator != not defined on untyped nil)
```

With fix the client builds without error.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d
