### PR TITLE
[WIP][kotlin-server] fix for wrongly html encoded backticks for reserved words

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
@@ -9,7 +9,7 @@ import java.io.Serializable
 /**
  * {{{description}}}
 {{#vars}}
- * @param {{name}} {{{description}}}
+ * @param {{&name}} {{{description}}}
 {{/vars}}
  */
 {{#parcelizeModels}}
@@ -37,7 +37,7 @@ data class {{classname}}(
     * {{{description}}}
     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
-    enum class {{nameInCamelCase}}(val value: {{dataType}}){
+    enum class {{&nameInCamelCase}}(val value: {{&dataType}}){
     {{#allowableValues}}
     {{#enumVars}}
         {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/data_class_opt_var.mustache
@@ -1,4 +1,4 @@
 {{#description}}
     /* {{{.}}} */
 {{/description}}
-    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}
+    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{{classname}}}.{{{nameInCamelCase}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/data_class_req_var.mustache
@@ -1,4 +1,4 @@
 {{#description}}
     /* {{{.}}} */
 {{/description}}
-    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}
+    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{{classname}}}.{{{nameInCamelCase}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}


### PR DESCRIPTION
I added fix for wrongly html encoded backticks for reserved words as shown in the example below.

## Example
```yaml
openapi: "3.0.3"

info:
  title: "Kotlin"
  version: "1"

paths:
  /users:
    get:
      responses:
        '200':
          description: test
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Response'

components:
  schemas:
    Response:
      type: object
      properties:
        class:
          type: string
        var:
          type: string
          enum:
            - contract
            - var
            - val
```

## Output

```kotlin
package org.openapitools.server.models


/**
 * 
 * @param propertyClass 
 * @param &#x60;var&#x60; 
 */
data class Response(
    val propertyClass: kotlin.String? = null,
    val `var`: Response.&#x60;Var&#x60;? = null
) 
{
    /**
    * 
    * Values: `contract`,`var`,`val`
    */
    enum class &#x60;Var&#x60;(val value: kotlin.String){
        `contract`("contract"),
        `var`("var"),
        `val`("val");
    }
}
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
