### PR TITLE
Expose generateMetadata as global property

### DIFF
--- a/docs/global-properties.md
+++ b/docs/global-properties.md
@@ -21,6 +21,7 @@ title: Global Properties
 | modelDocs | Allows the user to define if model docs will be generated. Prefer using the more robust `.openapi-generator-ignore`. | `true` or `false` |
 | apiTests | Allows the user to define if api tests will be generated. Prefer using the more robust `.openapi-generator-ignore`. | `true` or `false` |
 | modelTests | Allows the user to define if model tests will be generated. Prefer using the more robust `.openapi-generator-ignore`. | `true` or `false` |
+| generateMetadata | Allows the user to define if metadata files will be generated. | `true` or `false` |
 | withXml | Allows the user to control support of XML generated constructs, where supported | none |
 
 

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -424,6 +424,15 @@ open class GenerateTask : DefaultTask() {
     val generateApiDocumentation = project.objects.property<Boolean>()
 
     /**
+     * Defines whether metadata files should be generated.
+     *
+     * This option enables/disables generation of VERSION, FILES and .openapi-generator-ignore files.
+     */
+    @Optional
+    @Input
+    val generateMetadata = project.objects.property<Boolean>()
+
+    /**
      * A special-case setting which configures some generators with XML support. In some cases,
      * this forces json OR xml, so the default here is false.
      */
@@ -546,6 +555,10 @@ open class GenerateTask : DefaultTask() {
 
             if (generateApiTests.isPresent) {
                 GlobalSettings.setProperty(CodegenConstants.API_TESTS, generateApiTests.get().toString())
+            }
+
+            if (generateMetadata.isPresent) {
+                GlobalSettings.setProperty(CodegenConstants.GENERATE_METADATA, generateMetadata.get().toString())
             }
 
             if (withXml.isPresent) {

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -406,6 +406,12 @@ public class CodeGenMojo extends AbstractMojo {
     private Boolean generateApiDocumentation = true;
 
     /**
+     * Generate the metadata files such as VERSION, FILES and .openapi-generator-ignore
+     */
+    @Parameter(name = "generateMetadata", property = "openapi.generator.maven.plugin.generateMetadata")
+    private Boolean generateMetadata = true;
+
+    /**
      * Generate the api documentation
      */
     @Parameter(name = "withXml", property = "openapi.generator.maven.plugin.withXml")
@@ -667,6 +673,7 @@ public class CodeGenMojo extends AbstractMojo {
             GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, generateModelDocumentation.toString());
             GlobalSettings.setProperty(CodegenConstants.API_TESTS, generateApiTests.toString());
             GlobalSettings.setProperty(CodegenConstants.API_DOCS, generateApiDocumentation.toString());
+            GlobalSettings.setProperty(CodegenConstants.GENERATE_METADATA, generateMetadata.toString());
             GlobalSettings.setProperty(CodegenConstants.WITH_XML, withXml.toString());
 
             if (configOptions != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -30,6 +30,7 @@ public class CodegenConstants {
     public static final String MODEL_DOCS = "modelDocs";
     public static final String API_TESTS = "apiTests";
     public static final String API_DOCS = "apiDocs";
+    public static final String GENERATE_METADATA = "generateMetadata";
 
     public static final String WITH_XML = "withXml";
     public static final String SKIP_FORM_MODEL = "skipFormModel";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -208,6 +208,7 @@ public class DefaultGenerator implements Generator {
         generateApis = GlobalSettings.getProperty(CodegenConstants.APIS) != null ? Boolean.TRUE : getGeneratorPropertyDefaultSwitch(CodegenConstants.APIS, null);
         generateModels = GlobalSettings.getProperty(CodegenConstants.MODELS) != null ? Boolean.TRUE : getGeneratorPropertyDefaultSwitch(CodegenConstants.MODELS, null);
         generateSupportingFiles = GlobalSettings.getProperty(CodegenConstants.SUPPORTING_FILES) != null ? Boolean.TRUE : getGeneratorPropertyDefaultSwitch(CodegenConstants.SUPPORTING_FILES, null);
+        generateMetadata = GlobalSettings.getProperty(CodegenConstants.GENERATE_METADATA) != null ? Boolean.TRUE : getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_METADATA, this.generateMetadata);
 
         if (generateApis == null && generateModels == null && generateSupportingFiles == null) {
             // no specifics are set, generate everything


### PR DESCRIPTION
Currently it is not possible to control whether metadata files are created even though there is already a flag for it. This PR exposes the flag as a global property. Currently this seems to be possible as a side-effect of disabling `generateSupportingFiles`, but I actually want the rest of the supporting files to be generated.
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
