### PR TITLE
Add supporting test handling like models and API

### DIFF
--- a/docs/generators/groovy.md
+++ b/docs/generators/groovy.md
@@ -60,7 +60,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/groovy|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -85,7 +85,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|server title name or client service name| |OpenAPI Spring|
 |unhandledException|Declare operation methods to throw a generic exception and allow unhandled exceptions (useful for Spring `@ControllerAdvice` directives).| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -62,7 +62,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -73,7 +73,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |test|Specify which test tool to generate files for|<dl><dt>**junit**</dt><dd>Use JUnit as test tool</dd><dt>**spock**</dt><dd>Use Spock as test tool</dd></dl>|junit|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|Client service name| |null|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useOptional|Use Optional container for optional parameters| |false|

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -75,7 +75,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |test|Specify which test tool to generate files for|<dl><dt>**junit**</dt><dd>Use JUnit as test tool</dd><dt>**spock**</dt><dd>Use Spock as test tool</dd></dl>|junit|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|Client service name| |null|
 |useAuth|Whether to import authorization and to annotate controller methods accordingly| |true|
 |useBeanValidation|Use BeanValidation API annotations| |true|

--- a/docs/generators/java-msf4j.md
+++ b/docs/generators/java-msf4j.md
@@ -65,7 +65,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/docs/generators/java-pkmst.md
+++ b/docs/generators/java-pkmst.md
@@ -67,7 +67,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |springBootAdminUri|Spring-Boot URI| |null|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|server title name or client service name| |null|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 |zipkinUri|Zipkin URI| |null|

--- a/docs/generators/java-play-framework.md
+++ b/docs/generators/java-play-framework.md
@@ -67,7 +67,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |/app|
 |supportAsync|Support Async operations| |false|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|server title name or client service name| |openapi-java-playframework|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useInterfaces|Makes the controllerImp implements an interface to facilitate automatic completion when updating from version x to y of your spec| |true|

--- a/docs/generators/java-undertow-server.md
+++ b/docs/generators/java-undertow-server.md
@@ -62,7 +62,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-vertx-web.md
+++ b/docs/generators/java-vertx-web.md
@@ -62,7 +62,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## SUPPORTED VENDOR EXTENSIONS

--- a/docs/generators/java-vertx.md
+++ b/docs/generators/java-vertx.md
@@ -64,7 +64,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |vertxSwaggerRouterVersion|Specify the version of the swagger router library| |null|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -75,7 +75,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |supportStreaming|Support streaming endpoint (beta)| |false|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |useAbstractionForFiles|Use alternative types instead of java.io.File to allow passing bytes without a file on disk. Available on resttemplate, webclient, libraries| |false|
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useGzipFeature|Send gzip-encoded requests| |false|

--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -71,7 +71,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
 |supportAsync|Wrap responses in CompletionStage type, allowing asynchronous computation (requires JAX-RS 2.1).| |false|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -62,7 +62,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useGenericResponse|Use generic response| |false|
 |useGzipFeatureForTests|Use Gzip Feature for tests| |false|

--- a/docs/generators/jaxrs-cxf-extended.md
+++ b/docs/generators/jaxrs-cxf-extended.md
@@ -74,7 +74,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |supportMultipleSpringServices|Support generation of Spring services from multiple specifications| |false|
 |testDataControlFile|JSON file to control test data generation| |null|
 |testDataFile|JSON file to contain generated test data| |null|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useAnnotatedBasePath|Use @Path annotations for basePath| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|

--- a/docs/generators/jaxrs-cxf.md
+++ b/docs/generators/jaxrs-cxf.md
@@ -69,7 +69,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useAnnotatedBasePath|Use @Path annotations for basePath| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|

--- a/docs/generators/jaxrs-jersey.md
+++ b/docs/generators/jaxrs-jersey.md
@@ -66,7 +66,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
 |supportJava6|Whether to support Java6 with the Jersey1/2 library.| |false|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/docs/generators/jaxrs-resteasy-eap.md
+++ b/docs/generators/jaxrs-resteasy-eap.md
@@ -65,7 +65,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerFeature|Use dynamic Swagger generator| |false|

--- a/docs/generators/jaxrs-resteasy.md
+++ b/docs/generators/jaxrs-resteasy.md
@@ -65,7 +65,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -71,7 +71,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
 |supportAsync|Wrap responses in CompletionStage type, allowing asynchronous computation (requires JAX-RS 2.1).| |false|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -78,7 +78,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
-|testOutput|Set output folder for models and APIs tests| |${project.build.directory}/generated-test-sources/openapi|
+|testOutput|Set output folder for models and APIs tests| |null|
 |title|server title name or client service name| |OpenAPI Spring|
 |unhandledException|Declare operation methods to throw a generic exception and allow unhandled exceptions (useful for Spring `@ControllerAdvice` directives).| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -135,6 +135,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     modelFilesConstrainedTo.set(generate.modelFilesConstrainedTo)
                     supportingFilesConstrainedTo.set(generate.supportingFilesConstrainedTo)
                     generateModelTests.set(generate.generateModelTests)
+                    generateSupportingFilesTests.set(generate.generateSupportingFilesTests)
                     generateModelDocumentation.set(generate.generateModelDocumentation)
                     generateApiTests.set(generate.generateApiTests)
                     generateApiDocumentation.set(generate.generateApiDocumentation)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -256,6 +256,16 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val supportingFilesConstrainedTo = project.objects.listProperty<String>()
 
     /**
+     * Defines whether supportingFiles-related _test_ files should be generated.
+     *
+     * This option enables/disables generation of ALL supportingFiles-related _test_ files.
+     *
+     * For more control over generation of individual files, configure an ignore file and
+     * refer to it via [ignoreFileOverride].
+     */
+    val generateSupportingFilesTests = project.objects.property<Boolean>()
+
+    /**
      * Defines whether model-related _test_ files should be generated.
      *
      * This option enables/disables generation of ALL model-related _test_ files.
@@ -346,6 +356,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
         modelNamePrefix.set("")
         modelNameSuffix.set("")
         apiNameSuffix.set("")
+        generateSupportingFilesTests.set(true)
         generateModelTests.set(true)
         generateModelDocumentation.set(true)
         generateApiTests.set(true)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -376,6 +376,18 @@ open class GenerateTask : DefaultTask() {
     val supportingFilesConstrainedTo = project.objects.listProperty<String>()
 
     /**
+     * Defines whether supporting-related _test_ files should be generated.
+     *
+     * This option enables/disables generation of ALL supporting-related _test_ files.
+     *
+     * For more control over generation of individual files, configure an ignore file and
+     * refer to it via [ignoreFileOverride].
+     */
+    @Optional
+    @Input
+    val generateSupportingFilesTests = project.objects.property<Boolean>()
+
+    /**
      * Defines whether model-related _test_ files should be generated.
      *
      * This option enables/disables generation of ALL model-related _test_ files.
@@ -538,6 +550,10 @@ open class GenerateTask : DefaultTask() {
 
             if (generateModelDocumentation.isPresent) {
                 GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, generateModelDocumentation.get().toString())
+            }
+
+            if (generateSupportingFilesTests.isPresent) {
+                GlobalSettings.setProperty(CodegenConstants.SUPPORTING_TESTS, generateSupportingFilesTests.get().toString())
             }
 
             if (generateModelTests.isPresent) {

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -376,6 +376,12 @@ public class CodeGenMojo extends AbstractMojo {
     private Boolean generateSupportingFiles = true;
 
     /**
+     * Generate the supporting files tests
+     */
+    @Parameter(name = "generateSupportingFilesTests", property = "openapi.generator.maven.plugin.generateSupportingFilesTests")
+    private Boolean generateSupportingFilesTests = true;
+
+    /**
      * A comma separated list of models to generate. All models is the default.
      */
     @Parameter(name = "supportingFilesToGenerate", property = "openapi.generator.maven.plugin.supportingFilesToGenerate")
@@ -662,7 +668,7 @@ public class CodeGenMojo extends AbstractMojo {
             } else {
                 GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES);
             }
-
+            GlobalSettings.setProperty(CodegenConstants.SUPPORTING_TESTS, generateSupportingFilesTests.toString());
             GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, generateModelTests.toString());
             GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, generateModelDocumentation.toString());
             GlobalSettings.setProperty(CodegenConstants.API_TESTS, generateApiTests.toString());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -77,6 +77,8 @@ public interface CodegenConfig {
 
     String modelTestFileFolder();
 
+    String supportingTestFileFolder();
+
     String modelDocFileFolder();
 
     String modelPackage();
@@ -114,6 +116,8 @@ public interface CodegenConfig {
     Set<String> reservedWords();
 
     List<SupportingFile> supportingFiles();
+
+    List<SupportingFile> supportingTestFiles();
 
     String getInputSpec();
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -29,6 +29,8 @@ public class CodegenConstants {
     public static final String MODEL_TESTS = "modelTests";
     public static final String MODEL_DOCS = "modelDocs";
     public static final String API_TESTS = "apiTests";
+
+    public static final String SUPPORTING_TESTS = "supportingTest";
     public static final String API_DOCS = "apiDocs";
 
     public static final String WITH_XML = "withXml";
@@ -297,6 +299,8 @@ public class CodegenConstants {
     // Not user-configurable. System provided for use in templates.
     public static final String GENERATE_MODELS = "generateModels";
     public static final String GENERATE_MODEL_DOCS = "generateModelDocs";
+
+    public static final String GENERATE_SUPPORTING_TESTS = "generateSupportingTests";
 
     public static final String VIRTUAL_SERVICE = "virtualService";
     public static final String VIRTUAL_SERVICE_DESC = "Generate Spring boot rest service as virtual service with Virtualan";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -195,6 +195,7 @@ public class DefaultCodegen implements CodegenConfig {
     See also 'apiTemplateFiles'.
     */
     protected List<SupportingFile> supportingFiles = new ArrayList<>();
+    protected List<SupportingFile> supportingTestFiles = new ArrayList<>();
     protected List<CliOption> cliOptions = new ArrayList<>();
     protected boolean skipOverwrite;
     protected boolean removeOperationIdPrefix;
@@ -1209,6 +1210,11 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     @Override
+    public String supportingTestFileFolder() {
+        return outputFolder + File.separator + testPackage().replace('.', File.separatorChar);
+    }
+
+    @Override
     public String apiDocFileFolder() {
         return outputFolder;
     }
@@ -1236,6 +1242,11 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public List<SupportingFile> supportingFiles() {
         return supportingFiles;
+    }
+
+    @Override
+    public List<SupportingFile> supportingTestFiles() {
+        return supportingTestFiles;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -81,8 +81,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String IMPLICIT_HEADERS = "implicitHeaders";
     public static final String IMPLICIT_HEADERS_REGEX = "implicitHeadersRegex";
 
-    public static final String DEFAULT_TEST_FOLDER = "${project.build.directory}/generated-test-sources/openapi";
-
     protected String dateLibrary = "java8";
     protected boolean supportAsync = false;
     protected boolean withXml = false;
@@ -272,7 +270,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         snapShotVersionOptions.put("false", "Use a Release Version");
         snapShotVersion.setEnum(snapShotVersionOptions);
         cliOptions.add(snapShotVersion);
-        cliOptions.add(CliOption.newString(TEST_OUTPUT, "Set output folder for models and APIs tests").defaultValue(DEFAULT_TEST_FOLDER));
+        cliOptions.add(CliOption.newString(TEST_OUTPUT, "Set output folder for models and APIs tests"));
 
         if (null != defaultDocumentationProvider()) {
             CliOption documentationProviderCliOption = new CliOption(DOCUMENTATION_PROVIDER,
@@ -710,12 +708,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String apiTestFileFolder() {
-        return (outputTestFolder + File.separator + testFolder + File.separator + apiPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);
+        return (getOutputTestFolder() + File.separator + testFolder + File.separator + apiPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);
     }
 
     @Override
     public String modelTestFileFolder() {
-        return (outputTestFolder + File.separator + testFolder + File.separator + modelPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);
+        return (getOutputTestFolder() + File.separator + testFolder + File.separator + modelPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);
     }
 
     @Override
@@ -731,6 +729,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     @Override
     public String modelDocFileFolder() {
         return (outputFolder + File.separator + modelDocPath).replace('/', File.separatorChar);
+    }
+
+    @Override
+    public String supportingTestFileFolder() {
+        return (getOutputTestFolder() + File.separator + testFolder).replace('/', File.separatorChar);
     }
 
     @Override
@@ -1853,17 +1856,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         this.openApiNullable = openApiNullable;
     }
 
-    @Override
-    public void setOutputDir(String dir) {
-        super.setOutputDir(dir);
-        if (this.outputTestFolder.isEmpty()) {
-            setOutputTestFolder(dir);
-        }
-    }
-
     public String getOutputTestFolder() {
         if (outputTestFolder.isEmpty()) {
-            return DEFAULT_TEST_FOLDER;
+            LOGGER.info("Default output folder for test files, can be configured with {} option", TEST_OUTPUT);
+            return outputFolder;
         }
         return outputTestFolder;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -474,8 +474,8 @@ public class SpringCodegen extends AbstractJavaCodegen
                 supportingFiles.add(new SupportingFile("openapi2SpringBoot.mustache",
                         (sourceFolder + File.separator + basePackage).replace(".", java.io.File.separator),
                         "OpenApiGeneratorApplication.java"));
-                supportingFiles.add(new SupportingFile("SpringBootTest.mustache",
-                    (testFolder + File.separator + basePackage).replace(".", java.io.File.separator),
+                supportingTestFiles.add(new SupportingFile("SpringBootTest.mustache",
+                    basePackage.replace(".", java.io.File.separator),
                     "OpenApiGeneratorApplicationTests.java"));
                 supportingFiles.add(new SupportingFile("RFC3339DateFormat.mustache",
                         (sourceFolder + File.separator + basePackage).replace(".", java.io.File.separator),

--- a/samples/server/petstore/java-camel/.openapi-generator/FILES
+++ b/samples/server/petstore/java-camel/.openapi-generator/FILES
@@ -20,3 +20,4 @@ src/main/java/org/openapitools/model/Pet.java
 src/main/java/org/openapitools/model/Tag.java
 src/main/java/org/openapitools/model/User.java
 src/main/resources/application.properties
+src/test/java/org/openapitools/OpenApiGeneratorApplicationTests.java

--- a/samples/server/petstore/java-camel/src/test/java/org/openapitools/OpenApiGeneratorApplicationTests.java
+++ b/samples/server/petstore/java-camel/src/test/java/org/openapitools/OpenApiGeneratorApplicationTests.java
@@ -1,0 +1,13 @@
+package org.openapitools;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OpenApiGeneratorApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
This PR should fix #13677
The idea is to allow the handling of supporting files test like it is done for models and API.

With the PR we can do this for spring and have the tests well generated in the right folder:
```xml
<configuration>
    <inputSpec>${project.basedir}/src/main/resources/openapi.yaml</inputSpec>
    <generatorName>spring</generatorName>
    <library>spring-boot</library>
    <generateSupportingFilesTests>true</generateSupportingFilesTests>
    <configOptions>
        <testOutput>${project.basedir}/target/generated-test-sources</testOutput>
    </configOptions>
</configuration>
```

The only impact seen so far is with spring-camel but I don't get why the test was not generated before.

No impact is expected on other generators than java-spring because I've migrated nothing else for now. But I think if the PR is merged the same fix can be done for other generators (like kotlin-spring)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


ping : @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02)