### PR TITLE
[Kotlin]Reducing code smells

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -90,7 +90,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     // A cache of sanitized words. The sanitizeName() method is invoked many times with the same
     // arguments, this cache is used to optimized performance.
-    private static Cache<SanitizeNameOptions, String> sanitizedNameCache;
+    private static final Cache<SanitizeNameOptions, String> sanitizedNameCache;
     private static final String xSchemaTestExamplesKey = "x-schema-test-examples";
     private static final String xSchemaTestExamplesRefPrefix = "#/components/x-schema-test-examples/";
     protected static Schema falseSchema;
@@ -161,9 +161,9 @@ public class DefaultCodegen implements CodegenConfig {
     protected Set<String> reservedWords;
     protected Set<String> languageSpecificPrimitives = new HashSet<>();
     protected Map<String, String> importMapping = new HashMap<>();
-    // a map to store the mappping between a schema and the new one
+    // a map to store the mapping between a schema and the new one
     protected Map<String, String> schemaMapping = new HashMap<>();
-    // a map to store the mappping between inline schema and the name provided by the user
+    // a map to store the mapping between inline schema and the name provided by the user
     protected Map<String, String> inlineSchemaNameMapping = new HashMap<>();
     // a map to store the inline schema naming conventions
     protected Map<String, String> inlineSchemaNameDefault = new HashMap<>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -131,7 +131,7 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
 
         cliOptions.add(CliOption.newBoolean(INTERFACE_ONLY, "Whether to generate only API interface stubs without the server files. This option is currently supported only when using jaxrs-spec library.").defaultValue(String.valueOf(interfaceOnly)));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations. This option is currently supported only when using jaxrs-spec library.", useBeanValidation));
-        cliOptions.add(CliOption.newBoolean(USE_COROUTINES, "Whether to use the Coroutines. This option is currently supported only when using jaxrs-spec library."));
+        cliOptions.add(CliOption.newBoolean(USE_COROUTINES, "Whether to use the Coroutines. This option is currently supported only when using jaxrs-spec library.", useCoroutines));
         cliOptions.add(CliOption.newBoolean(RETURN_RESPONSE, "Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true. This option is currently supported only when using jaxrs-spec library.").defaultValue(String.valueOf(returnResponse)));
     }
 
@@ -293,7 +293,6 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
 
         boolean generateApis = additionalProperties.containsKey(CodegenConstants.GENERATE_APIS) && (Boolean) additionalProperties.get(CodegenConstants.GENERATE_APIS);
         String packageFolder = (sourceFolder + File.separator + packageName).replace(".", File.separator);
-        String resourcesFolder = "src/main/resources"; // not sure this can be user configurable.
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerDeprecatedCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerDeprecatedCodegen.java
@@ -214,7 +214,6 @@ public class KotlinServerDeprecatedCodegen extends AbstractKotlinCodegen {
 
         boolean generateApis = additionalProperties.containsKey(CodegenConstants.GENERATE_APIS) && (Boolean) additionalProperties.get(CodegenConstants.GENERATE_APIS);
         String packageFolder = (sourceFolder + File.separator + packageName).replace(".", File.separator);
-        String resourcesFolder = "src/main/resources"; // not sure this can be user configurable.
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("Dockerfile.mustache", "", "Dockerfile"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -75,7 +75,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     private String invokerPackage;
     private String serverPort = "8080";
     private String title = "OpenAPI Kotlin Spring";
-    private String resourceFolder = "src/main/resources";
     private boolean useBeanValidation = true;
     private boolean exceptionHandler = true;
     private boolean gradleBuildFile = true;
@@ -234,14 +233,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 getDocumentationProvider().equals(DocumentationProvider.SOURCE);
     }
 
-    public String getResourceFolder() {
-        return this.resourceFolder;
-    }
-
-    public void setResourceFolder(String resourceFolder) {
-        this.resourceFolder = resourceFolder;
-    }
-
     public String getBasePackage() {
         return this.basePackage;
     }
@@ -334,10 +325,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
 
     public void setReactive(boolean reactive) {
         this.reactive = reactive;
-    }
-
-    public boolean isBeanQualifiers() {
-        return beanQualifiers;
     }
 
     public void setBeanQualifiers(boolean beanQualifiers) {
@@ -569,16 +556,16 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                             (sourceFolder + File.separator + basePackage).replace(".", java.io.File.separator),
                             "HomeController.kt"));
                     supportingFiles.add(new SupportingFile("openapi.mustache",
-                            ("src/main/resources").replace("/", java.io.File.separator), "openapi.yaml"));
+                            resourcesFolder.replace("/", java.io.File.separator), "openapi.yaml"));
                 }
 
-                supportingFiles.add(new SupportingFile("application.mustache", resourceFolder, "application.yaml"));
+                supportingFiles.add(new SupportingFile("application.mustache", resourcesFolder, "application.yaml"));
                 supportingFiles.add(new SupportingFile("springBootApplication.mustache",
                         sanitizeDirectory(sourceFolder + File.separator + basePackage), "Application.kt"));
 
                 if (useSwaggerUI && selectedDocumentationProviderRequiresSwaggerUiBootstrap()) {
                     supportingFiles.add(new SupportingFile("swagger-ui.mustache",
-                            "src/main/resources/static", "swagger-ui.html"));
+                            resourcesFolder + "/static", "swagger-ui.html"));
                 }
             }
         }


### PR DESCRIPTION
A first try to reduce code smells. I've take a reduce scope with only kotlin generators.

@jimschubert (2017/09) heart, @dr4ke616 (2018/08) @karismann (2019/03) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
