### PR TITLE
[PHP] Reverted extra blank lines accidentally added by #13012 commit

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -261,8 +261,8 @@ use {{invokerPackage}}\ObjectSerializer;
 
             switch($statusCode) {
             {{/-first}}
-            {{#dataType}}{{^isRange}}
-                {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
+            {{#dataType}}
+                {{^isRange}}{{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
                     if ('{{{dataType}}}' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
                     } else {
@@ -276,8 +276,8 @@ use {{invokerPackage}}\ObjectSerializer;
                         ObjectSerializer::deserialize($content, '{{{dataType}}}', []),
                         $response->getStatusCode(),
                         $response->getHeaders()
-                    ];
-            {{/isRange}}{{/dataType}}
+                    ];{{/isRange}}
+            {{/dataType}}
             {{#-last}}
             }
             {{/-last}}
@@ -307,16 +307,16 @@ use {{invokerPackage}}\ObjectSerializer;
         } catch (ApiException $e) {
             switch ($e->getCode()) {
         {{#responses}}
-            {{#dataType}}{{^isRange}}
-                {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
+            {{#dataType}}
+                {{^isRange}}{{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
                         '{{{dataType}}}',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);
-                    break;
-            {{/isRange}}{{/dataType}}
+                    break;{{/isRange}}
+            {{/dataType}}
         {{/responses}}
             }
             throw $e;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -183,7 +183,6 @@ class AnotherFakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Client' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -199,7 +198,6 @@ class AnotherFakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Client';
@@ -220,7 +218,6 @@ class AnotherFakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -229,7 +226,6 @@ class AnotherFakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -177,7 +177,6 @@ class DefaultApi
             }
 
             switch($statusCode) {
-            
                 default:
                     if ('\OpenAPI\Client\Model\FooGetDefaultResponse' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -193,7 +192,6 @@ class DefaultApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\FooGetDefaultResponse';
@@ -214,7 +212,6 @@ class DefaultApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 default:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -223,7 +220,6 @@ class DefaultApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -181,7 +181,6 @@ class FakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\HealthCheckResult' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -197,7 +196,6 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\HealthCheckResult';
@@ -218,7 +216,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -227,7 +224,6 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -455,7 +451,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -697,7 +692,6 @@ class FakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('bool' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -713,7 +707,6 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = 'bool';
@@ -734,7 +727,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -743,7 +735,6 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -967,7 +958,6 @@ class FakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\OuterComposite' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -983,7 +973,6 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\OuterComposite';
@@ -1004,7 +993,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1013,7 +1001,6 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -1237,7 +1224,6 @@ class FakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('float' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1253,7 +1239,6 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = 'float';
@@ -1274,7 +1259,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1283,7 +1267,6 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -1507,7 +1490,6 @@ class FakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('string' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1523,7 +1505,6 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = 'string';
@@ -1544,7 +1525,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1553,7 +1533,6 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -1777,7 +1756,6 @@ class FakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\OuterObjectWithEnumProperty' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1793,7 +1771,6 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\OuterObjectWithEnumProperty';
@@ -1814,7 +1791,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1823,7 +1799,6 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -2055,7 +2030,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -2274,7 +2248,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -2495,7 +2468,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -2735,7 +2707,6 @@ class FakeApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Client' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -2751,7 +2722,6 @@ class FakeApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Client';
@@ -2772,7 +2742,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -2781,7 +2750,6 @@ class FakeApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -3047,8 +3015,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }
@@ -3470,8 +3436,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }
@@ -3796,7 +3760,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -4110,7 +4073,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -4339,7 +4301,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -4586,7 +4547,6 @@ class FakeApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -183,7 +183,6 @@ class FakeClassnameTags123Api
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Client' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -199,7 +198,6 @@ class FakeClassnameTags123Api
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Client';
@@ -220,7 +218,6 @@ class FakeClassnameTags123Api
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -229,7 +226,6 @@ class FakeClassnameTags123Api
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -221,8 +221,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }
@@ -561,8 +559,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }
@@ -801,7 +797,6 @@ class PetApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Pet[]' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -817,8 +812,6 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Pet[]';
@@ -839,7 +832,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -848,8 +840,6 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
-            
             }
             throw $e;
         }
@@ -1096,7 +1086,6 @@ class PetApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Pet[]' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1112,8 +1101,6 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Pet[]';
@@ -1134,7 +1121,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1143,8 +1129,6 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
-            
             }
             throw $e;
         }
@@ -1393,7 +1377,6 @@ class PetApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Pet' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1409,9 +1392,6 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
-            
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Pet';
@@ -1432,7 +1412,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1441,9 +1420,6 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
-            
-            
             }
             throw $e;
         }
@@ -1726,10 +1702,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
-            
-            
             }
             throw $e;
         }
@@ -2070,8 +2042,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }
@@ -2322,7 +2292,6 @@ class PetApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\ApiResponse' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -2338,7 +2307,6 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\ApiResponse';
@@ -2359,7 +2327,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -2368,7 +2335,6 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -2640,7 +2606,6 @@ class PetApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\ApiResponse' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -2656,7 +2621,6 @@ class PetApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\ApiResponse';
@@ -2677,7 +2641,6 @@ class PetApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -2686,7 +2649,6 @@ class PetApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -185,8 +185,6 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }
@@ -411,7 +409,6 @@ class StoreApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('array<string,int>' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -427,7 +424,6 @@ class StoreApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
             }
 
             $returnType = 'array<string,int>';
@@ -448,7 +444,6 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -457,7 +452,6 @@ class StoreApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
             }
             throw $e;
         }
@@ -684,7 +678,6 @@ class StoreApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Order' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -700,9 +693,6 @@ class StoreApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
-            
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Order';
@@ -723,7 +713,6 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -732,9 +721,6 @@ class StoreApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
-            
-            
             }
             throw $e;
         }
@@ -981,7 +967,6 @@ class StoreApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\Order' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -997,8 +982,6 @@ class StoreApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\Order';
@@ -1019,7 +1002,6 @@ class StoreApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1028,8 +1010,6 @@ class StoreApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
-            
             }
             throw $e;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -185,7 +185,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -412,7 +411,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -639,7 +637,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -866,8 +863,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }
@@ -1094,7 +1089,6 @@ class UserApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('\OpenAPI\Client\Model\User' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1110,9 +1104,6 @@ class UserApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
-            
-            
             }
 
             $returnType = '\OpenAPI\Client\Model\User';
@@ -1133,7 +1124,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1142,9 +1132,6 @@ class UserApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
-            
-            
             }
             throw $e;
         }
@@ -1386,7 +1373,6 @@ class UserApi
             }
 
             switch($statusCode) {
-            
                 case 200:
                     if ('string' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
@@ -1402,8 +1388,6 @@ class UserApi
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
-            
-            
             }
 
             $returnType = 'string';
@@ -1424,7 +1408,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
@@ -1433,8 +1416,6 @@ class UserApi
                     );
                     $e->setResponseObject($data);
                     break;
-            
-            
             }
             throw $e;
         }
@@ -1694,7 +1675,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
             }
             throw $e;
         }
@@ -1907,8 +1887,6 @@ class UserApi
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {
-            
-            
             }
             throw $e;
         }


### PR DESCRIPTION
PR #13012 introduced some extra blank lines in the generated code. This PR fixes them.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee]
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon
