### PR TITLE
fix for issue #13722: send body for application/x-www-form-urlencoded data

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.handlebars
+++ b/modules/openapi-generator/src/main/resources/python/api_client.handlebars
@@ -293,7 +293,7 @@ class StyleFormSerializer(ParameterSerializerBase):
         prefix_separator_iterator: typing.Optional[PrefixSeparatorIterator] = None
     ) -> str:
         if prefix_separator_iterator is None:
-            prefix_separator_iterator = PrefixSeparatorIterator('?', '&')
+            prefix_separator_iterator = PrefixSeparatorIterator('', '&')
         return self._ref6570_expansion(
             variable_name=name,
             in_data=in_data,

--- a/modules/openapi-generator/src/main/resources/python/rest.handlebars
+++ b/modules/openapi-generator/src/main/resources/python/rest.handlebars
@@ -139,6 +139,7 @@ class RESTClientObject(object):
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':  # noqa: E501
                     r = self.pool_manager.request(
                         method, url,
+                        body=body,
                         fields=fields,
                         encode_multipart=False,
                         preload_content=not stream,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/api_client.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/api_client.py
@@ -297,7 +297,7 @@ class StyleFormSerializer(ParameterSerializerBase):
         prefix_separator_iterator: typing.Optional[PrefixSeparatorIterator] = None
     ) -> str:
         if prefix_separator_iterator is None:
-            prefix_separator_iterator = PrefixSeparatorIterator('?', '&')
+            prefix_separator_iterator = PrefixSeparatorIterator('', '&')
         return self._ref6570_expansion(
             variable_name=name,
             in_data=in_data,

--- a/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/rest.py
+++ b/samples/openapi3/client/3_0_3_unit_test/python/unit_test_api/rest.py
@@ -146,6 +146,7 @@ class RESTClientObject(object):
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':  # noqa: E501
                     r = self.pool_manager.request(
                         method, url,
+                        body=body,
                         fields=fields,
                         encode_multipart=False,
                         preload_content=not stream,

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
@@ -297,7 +297,7 @@ class StyleFormSerializer(ParameterSerializerBase):
         prefix_separator_iterator: typing.Optional[PrefixSeparatorIterator] = None
     ) -> str:
         if prefix_separator_iterator is None:
-            prefix_separator_iterator = PrefixSeparatorIterator('?', '&')
+            prefix_separator_iterator = PrefixSeparatorIterator('', '&')
         return self._ref6570_expansion(
             variable_name=name,
             in_data=in_data,

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
@@ -146,6 +146,7 @@ class RESTClientObject(object):
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':  # noqa: E501
                     r = self.pool_manager.request(
                         method, url,
+                        body=body,
                         fields=fields,
                         encode_multipart=False,
                         preload_content=not stream,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -297,7 +297,7 @@ class StyleFormSerializer(ParameterSerializerBase):
         prefix_separator_iterator: typing.Optional[PrefixSeparatorIterator] = None
     ) -> str:
         if prefix_separator_iterator is None:
-            prefix_separator_iterator = PrefixSeparatorIterator('?', '&')
+            prefix_separator_iterator = PrefixSeparatorIterator('', '&')
         return self._ref6570_expansion(
             variable_name=name,
             in_data=in_data,

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -146,6 +146,7 @@ class RESTClientObject(object):
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':  # noqa: E501
                     r = self.pool_manager.request(
                         method, url,
+                        body=body,
                         fields=fields,
                         encode_multipart=False,
                         preload_content=not stream,


### PR DESCRIPTION
Fix for issue #13722: verified with successful calls to /v5/oauth/token endpoints for https://github.com/pinterest/api-description

@spacether

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
