### PR TITLE
 [BUG][Kotlin/okhttp-gson] wrong handling of empty response #13718

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -247,10 +247,10 @@ import com.squareup.moshi.adapter
             }
             return tempFile as T
         }
-        val bodyContent = body.string()
-        if (bodyContent.isEmpty()) {
+        if (typeOf<T>() == typeOf<Unit?>()) {
             return null
         }
+        val bodyContent = body.string()
         return when {
             mediaType==null || (mediaType.startsWith("application/") && mediaType.endsWith("json")) ->
                 {{#moshi}}Serializer.moshi.adapter<T>().fromJson(bodyContent){{/moshi}}{{!


### PR DESCRIPTION
We use a legacy REST server that returns a non-empty response even if it the response type is Unit.
In this case the following exception is thrown:
java.lang.IllegalArgumentException: Platform class kotlin.Unit requires explicit JsonAdapter to be registered
at com.squareup.moshi.ClassJsonAdapter$1.create(ClassJsonAdapter.java:76)
at com.squareup.moshi.Moshi.adapter(Moshi.java:146)
at com.squareup.moshi.Moshi.adapter(Moshi.java:106)
at com.squareup.moshi.Moshi.adapter(Moshi.java:75)
at com.squareup.moshi._MoshiKotlinExtensionsKt.adapter(-MoshiKotlinExtensions.kt:40)
...

I checked another generator (Java/apache-httpclient) to see how it handles this case. There the Java class of the expected result is checked and the code doesn't call the JSON deserializer if no response is expected.
