### PR TITLE
[PHP] Allow selecting Content-Type

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
+++ b/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
@@ -1,6 +1,6 @@
 <?php
 /**
- * ApiException
+ * HeaderSelector
  * PHP version 7.4
  *
  * @category Class
@@ -18,10 +18,8 @@
 
 namespace {{invokerPackage}};
 
-use \Exception;
-
 /**
- * ApiException Class Doc Comment
+ * HeaderSelector Class Doc Comment
  *
  * @category Class
  * @package  {{invokerPackage}}
@@ -32,10 +30,11 @@ class HeaderSelector
 {
     /**
      * @param string[] $accept
-     * @param string[] $contentTypes
-     * @return array
+     * @param string   $contentType
+     * @param bool     $isMultipart
+     * @return string[]
      */
-    public function selectHeaders($accept, $contentTypes)
+    public function selectHeaders(array $accept, string $contentType, bool $isMultipart): array
     {
         $headers = [];
 
@@ -43,20 +42,13 @@ class HeaderSelector
         if ($accept !== null) {
             $headers['Accept'] = $accept;
         }
+        if(!$isMultipart) {
+            if($contentType === '') {
+                $contentType = 'application/json';
+            }
+            $headers['Content-Type'] = $contentType;
+        }
 
-        $headers['Content-Type'] = $this->selectContentTypeHeader($contentTypes);
-        return $headers;
-    }
-
-    /**
-     * @param string[] $accept
-     * @return array
-     */
-    public function selectHeadersForMultipart($accept)
-    {
-        $headers = $this->selectHeaders($accept, []);
-
-        unset($headers['Content-Type']);
         return $headers;
     }
 
@@ -75,24 +67,6 @@ class HeaderSelector
             return implode(',', $jsonAccept);
         } else {
             return implode(',', $accept);
-        }
-    }
-
-    /**
-     * Return the content type based on an array of content-type provided
-     *
-     * @param string[] $contentType Array fo content-type
-     *
-     * @return string Content-Type (e.g. application/json)
-     */
-    private function selectContentTypeHeader($contentType)
-    {
-        if (count($contentType) === 0 || (count($contentType) === 1 && $contentType[0] === '')) {
-            return 'application/json';
-        } elseif (preg_grep("/application\/json/i", $contentType)) {
-            return 'application/json';
-        } else {
-            return implode(',', $contentType);
         }
     }
 }

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -595,9 +595,6 @@ use {{invokerPackage}}\ObjectSerializer;
         }
         {{/minItems}}
         {{/hasValidation}}{{/allParams}}
-        if(!in_array($contentType, self::contentTypes['{{{operationId}}}'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling {{classname}}.{{operationId}}, must be one of [".implode(',', self::contentTypes['{{{operationId}}}'])."].");
-        }
 
         $resourcePath = '{{{path}}}';
         $formParams = [];

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -60,7 +60,16 @@ use {{invokerPackage}}\ObjectSerializer;
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [{{#operation}}
+        '{{{operationId}}}' => [{{#consumes}}
+            '{{{mediaType}}}',{{/consumes}}
+        {{^consumes}}
+            'application/json',
+{{/consumes}}        ],{{/operation}}
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -151,6 +160,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
 {{/-first}}
 {{/servers}}
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -159,9 +169,9 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}?int $hostIndex = null, array $variables = []{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
-        {{#returnType}}list($response) = {{/returnType}}$this->{{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}$hostIndex, $variables{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});{{#returnType}}
+        {{#returnType}}list($response) = {{/returnType}}$this->{{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});{{#returnType}}
         return $response;{{/returnType}}
     }
 
@@ -209,6 +219,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
 {{/-first}}
 {{/servers}}
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -217,9 +228,9 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}?int $hostIndex = null, array $variables = []{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
-        $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}$hostIndex, $variables{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
+        $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
 
         try {
             $options = $this->createHttpClientOption();
@@ -367,6 +378,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
 {{/-first}}
 {{/servers}}
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -374,9 +386,9 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}Async({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}?int $hostIndex = null, array $variables = []{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}Async({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
-        return $this->{{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}$hostIndex, $variables{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+        return $this->{{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
             ->then(
                 function ($response) {
                     return $response[0];
@@ -428,6 +440,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
 {{/-first}}
 {{/servers}}
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -435,10 +448,10 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}?int $hostIndex = null, array $variables = []{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
         $returnType = '{{{returnType}}}';
-        $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}$hostIndex, $variables{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
+        $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -517,6 +530,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
 {{/-first}}
 {{/servers}}
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
@@ -524,7 +538,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#servers}}{{#-first}}{{#allParams}}{{#-first}}, {{/-first}}{{/allParams}}?int $hostIndex = null, array $variables = []{{/-first}}{{/servers}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
         {{#vendorExtensions.x-group-parameters}}
         // unbox the parameters from the associative array
@@ -533,7 +547,9 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/allParams}}{{#servers.0}}
         $hostIndex = $associative_array['hostIndex'];
         $variables = array_key_exists('variables', $associative_array) ? $associative_array['variables'] : [];
-{{/servers.0}}{{/vendorExtensions.x-group-parameters}}{{#allParams}}
+{{/servers.0}}
+        $contentType = $associative_array['contentType'] ?? self::contentTypes['{{{operationId}}}'][0];
+        {{/vendorExtensions.x-group-parameters}}{{#allParams}}
         {{#required}}
         // verify the required parameter '{{paramName}}' is set
         if (${{paramName}} === null || (is_array(${{paramName}}) && count(${{paramName}}) === 0)) {
@@ -578,9 +594,10 @@ use {{invokerPackage}}\ObjectSerializer;
             throw new \InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
         }
         {{/minItems}}
-
-        {{/hasValidation}}
-        {{/allParams}}
+        {{/hasValidation}}{{/allParams}}
+        if(!in_array($contentType, self::contentTypes['{{{operationId}}}'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling {{classname}}.{{operationId}}, must be one of [".implode(',', self::contentTypes['{{{operationId}}}'])."].");
+        }
 
         $resourcePath = '{{{path}}}';
         $formParams = [];
@@ -649,21 +666,17 @@ use {{invokerPackage}}\ObjectSerializer;
         }
         {{/formParams}}
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                [{{#produces}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/produces}}]
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [{{#produces}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/produces}}],
-                [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}]
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [{{#produces}}'{{{mediaType}}}', {{/produces}}],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         {{#bodyParams}}
         if (isset(${{paramName}})) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization(${{paramName}}));
             } else {
                 $httpBody = ${{paramName}};
@@ -687,9 +700,9 @@ use {{invokerPackage}}\ObjectSerializer;
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -332,9 +332,6 @@ class AnotherFakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['call123TestSpecialTags'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling AnotherFakeApi.call123TestSpecialTags, must be one of [".implode(',', self::contentTypes['call123TestSpecialTags'])."].");
-        }
 
         $resourcePath = '/another-fake/dummy';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -69,7 +69,14 @@ class AnotherFakeApi
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [
+        'call123TestSpecialTags' => [
+            'application/json',
+        ],
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -121,14 +128,15 @@ class AnotherFakeApi
      * To test special tags
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function call123TestSpecialTags($client)
+    public function call123TestSpecialTags($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
     {
-        list($response) = $this->call123TestSpecialTagsWithHttpInfo($client);
+        list($response) = $this->call123TestSpecialTagsWithHttpInfo($client, $contentType);
         return $response;
     }
 
@@ -138,14 +146,15 @@ class AnotherFakeApi
      * To test special tags
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function call123TestSpecialTagsWithHttpInfo($client)
+    public function call123TestSpecialTagsWithHttpInfo($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
     {
-        $request = $this->call123TestSpecialTagsRequest($client);
+        $request = $this->call123TestSpecialTagsRequest($client, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -237,13 +246,14 @@ class AnotherFakeApi
      * To test special tags
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function call123TestSpecialTagsAsync($client)
+    public function call123TestSpecialTagsAsync($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
     {
-        return $this->call123TestSpecialTagsAsyncWithHttpInfo($client)
+        return $this->call123TestSpecialTagsAsyncWithHttpInfo($client, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -257,14 +267,15 @@ class AnotherFakeApi
      * To test special tags
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function call123TestSpecialTagsAsyncWithHttpInfo($client)
+    public function call123TestSpecialTagsAsyncWithHttpInfo($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Client';
-        $request = $this->call123TestSpecialTagsRequest($client);
+        $request = $this->call123TestSpecialTagsRequest($client, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -306,11 +317,12 @@ class AnotherFakeApi
      * Create request for operation 'call123TestSpecialTags'
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function call123TestSpecialTagsRequest($client)
+    public function call123TestSpecialTagsRequest($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
     {
 
         // verify the required parameter 'client' is set
@@ -318,6 +330,10 @@ class AnotherFakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $client when calling call123TestSpecialTags'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['call123TestSpecialTags'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling AnotherFakeApi.call123TestSpecialTags, must be one of [".implode(',', self::contentTypes['call123TestSpecialTags'])."].");
         }
 
         $resourcePath = '/another-fake/dummy';
@@ -331,20 +347,16 @@ class AnotherFakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -364,9 +376,9 @@ class AnotherFakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -312,9 +312,6 @@ class DefaultApi
     public function fooGetRequest(string $contentType = self::contentTypes['fooGet'][0])
     {
 
-        if(!in_array($contentType, self::contentTypes['fooGet'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling DefaultApi.fooGet, must be one of [".implode(',', self::contentTypes['fooGet'])."].");
-        }
 
         $resourcePath = '/foo';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -69,7 +69,14 @@ class DefaultApi
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [
+        'fooGet' => [
+            'application/json',
+        ],
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -118,28 +125,30 @@ class DefaultApi
     /**
      * Operation fooGet
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\FooGetDefaultResponse
      */
-    public function fooGet()
+    public function fooGet(string $contentType = self::contentTypes['fooGet'][0])
     {
-        list($response) = $this->fooGetWithHttpInfo();
+        list($response) = $this->fooGetWithHttpInfo($contentType);
         return $response;
     }
 
     /**
      * Operation fooGetWithHttpInfo
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\FooGetDefaultResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fooGetWithHttpInfo()
+    public function fooGetWithHttpInfo(string $contentType = self::contentTypes['fooGet'][0])
     {
-        $request = $this->fooGetRequest();
+        $request = $this->fooGetRequest($contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -228,13 +237,14 @@ class DefaultApi
     /**
      * Operation fooGetAsync
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fooGetAsync()
+    public function fooGetAsync(string $contentType = self::contentTypes['fooGet'][0])
     {
-        return $this->fooGetAsyncWithHttpInfo()
+        return $this->fooGetAsyncWithHttpInfo($contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -245,14 +255,15 @@ class DefaultApi
     /**
      * Operation fooGetAsyncWithHttpInfo
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fooGetAsyncWithHttpInfo()
+    public function fooGetAsyncWithHttpInfo(string $contentType = self::contentTypes['fooGet'][0])
     {
         $returnType = '\OpenAPI\Client\Model\FooGetDefaultResponse';
-        $request = $this->fooGetRequest();
+        $request = $this->fooGetRequest($contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -293,12 +304,17 @@ class DefaultApi
     /**
      * Create request for operation 'fooGet'
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fooGetRequest()
+    public function fooGetRequest(string $contentType = self::contentTypes['fooGet'][0])
     {
+
+        if(!in_array($contentType, self::contentTypes['fooGet'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling DefaultApi.fooGet, must be one of [".implode(',', self::contentTypes['fooGet'])."].");
+        }
 
         $resourcePath = '/foo';
         $formParams = [];
@@ -311,16 +327,11 @@ class DefaultApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -338,9 +349,9 @@ class DefaultApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -69,7 +69,63 @@ class FakeApi
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [
+        'fakeHealthGet' => [
+            'application/json',
+        ],
+        'fakeHttpSignatureTest' => [
+            'application/json',
+            'application/xml',
+        ],
+        'fakeOuterBooleanSerialize' => [
+            'application/json',
+        ],
+        'fakeOuterCompositeSerialize' => [
+            'application/json',
+        ],
+        'fakeOuterNumberSerialize' => [
+            'application/json',
+        ],
+        'fakeOuterStringSerialize' => [
+            'application/json',
+        ],
+        'fakePropertyEnumIntegerSerialize' => [
+            'application/json',
+        ],
+        'testBodyWithBinary' => [
+            'image/png',
+        ],
+        'testBodyWithFileSchema' => [
+            'application/json',
+        ],
+        'testBodyWithQueryParams' => [
+            'application/json',
+        ],
+        'testClientModel' => [
+            'application/json',
+        ],
+        'testEndpointParameters' => [
+            'application/x-www-form-urlencoded',
+        ],
+        'testEnumParameters' => [
+            'application/x-www-form-urlencoded',
+        ],
+        'testGroupParameters' => [
+            'application/json',
+        ],
+        'testInlineAdditionalProperties' => [
+            'application/json',
+        ],
+        'testJsonFormData' => [
+            'application/x-www-form-urlencoded',
+        ],
+        'testQueryParameterCollectionFormat' => [
+            'application/json',
+        ],
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -120,14 +176,15 @@ class FakeApi
      *
      * Health check endpoint
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\HealthCheckResult
      */
-    public function fakeHealthGet()
+    public function fakeHealthGet(string $contentType = self::contentTypes['fakeHealthGet'][0])
     {
-        list($response) = $this->fakeHealthGetWithHttpInfo();
+        list($response) = $this->fakeHealthGetWithHttpInfo($contentType);
         return $response;
     }
 
@@ -136,14 +193,15 @@ class FakeApi
      *
      * Health check endpoint
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\HealthCheckResult, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeHealthGetWithHttpInfo()
+    public function fakeHealthGetWithHttpInfo(string $contentType = self::contentTypes['fakeHealthGet'][0])
     {
-        $request = $this->fakeHealthGetRequest();
+        $request = $this->fakeHealthGetRequest($contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -234,13 +292,14 @@ class FakeApi
      *
      * Health check endpoint
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHealthGetAsync()
+    public function fakeHealthGetAsync(string $contentType = self::contentTypes['fakeHealthGet'][0])
     {
-        return $this->fakeHealthGetAsyncWithHttpInfo()
+        return $this->fakeHealthGetAsyncWithHttpInfo($contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -253,14 +312,15 @@ class FakeApi
      *
      * Health check endpoint
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHealthGetAsyncWithHttpInfo()
+    public function fakeHealthGetAsyncWithHttpInfo(string $contentType = self::contentTypes['fakeHealthGet'][0])
     {
         $returnType = '\OpenAPI\Client\Model\HealthCheckResult';
-        $request = $this->fakeHealthGetRequest();
+        $request = $this->fakeHealthGetRequest($contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -301,12 +361,17 @@ class FakeApi
     /**
      * Create request for operation 'fakeHealthGet'
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeHealthGetRequest()
+    public function fakeHealthGetRequest(string $contentType = self::contentTypes['fakeHealthGet'][0])
     {
+
+        if(!in_array($contentType, self::contentTypes['fakeHealthGet'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeHealthGet, must be one of [".implode(',', self::contentTypes['fakeHealthGet'])."].");
+        }
 
         $resourcePath = '/fake/health';
         $formParams = [];
@@ -319,16 +384,11 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -346,9 +406,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -385,14 +445,15 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  string $query_1 query parameter (optional)
      * @param  string $header_1 header parameter (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function fakeHttpSignatureTest($pet, $query_1 = null, $header_1 = null)
+    public function fakeHttpSignatureTest($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
     {
-        $this->fakeHttpSignatureTestWithHttpInfo($pet, $query_1, $header_1);
+        $this->fakeHttpSignatureTestWithHttpInfo($pet, $query_1, $header_1, $contentType);
     }
 
     /**
@@ -403,14 +464,15 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  string $query_1 query parameter (optional)
      * @param  string $header_1 header parameter (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeHttpSignatureTestWithHttpInfo($pet, $query_1 = null, $header_1 = null)
+    public function fakeHttpSignatureTestWithHttpInfo($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
     {
-        $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1);
+        $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -464,13 +526,14 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  string $query_1 query parameter (optional)
      * @param  string $header_1 header parameter (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHttpSignatureTestAsync($pet, $query_1 = null, $header_1 = null)
+    public function fakeHttpSignatureTestAsync($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
     {
-        return $this->fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1, $header_1)
+        return $this->fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1, $header_1, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -486,14 +549,15 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  string $query_1 query parameter (optional)
      * @param  string $header_1 header parameter (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1 = null, $header_1 = null)
+    public function fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
     {
         $returnType = '';
-        $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1);
+        $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -524,11 +588,12 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  string $query_1 query parameter (optional)
      * @param  string $header_1 header parameter (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeHttpSignatureTestRequest($pet, $query_1 = null, $header_1 = null)
+    public function fakeHttpSignatureTestRequest($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
     {
 
         // verify the required parameter 'pet' is set
@@ -539,6 +604,10 @@ class FakeApi
         }
 
 
+
+        if(!in_array($contentType, self::contentTypes['fakeHttpSignatureTest'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeHttpSignatureTest, must be one of [".implode(',', self::contentTypes['fakeHttpSignatureTest'])."].");
+        }
 
         $resourcePath = '/fake/http-signature-test';
         $formParams = [];
@@ -564,20 +633,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json', 'application/xml']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -597,9 +662,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -632,14 +697,15 @@ class FakeApi
      * Operation fakeOuterBooleanSerialize
      *
      * @param  bool $body Input boolean as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return bool
      */
-    public function fakeOuterBooleanSerialize($body = null)
+    public function fakeOuterBooleanSerialize($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
     {
-        list($response) = $this->fakeOuterBooleanSerializeWithHttpInfo($body);
+        list($response) = $this->fakeOuterBooleanSerializeWithHttpInfo($body, $contentType);
         return $response;
     }
 
@@ -647,14 +713,15 @@ class FakeApi
      * Operation fakeOuterBooleanSerializeWithHttpInfo
      *
      * @param  bool $body Input boolean as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of bool, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterBooleanSerializeWithHttpInfo($body = null)
+    public function fakeOuterBooleanSerializeWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
     {
-        $request = $this->fakeOuterBooleanSerializeRequest($body);
+        $request = $this->fakeOuterBooleanSerializeRequest($body, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -744,13 +811,14 @@ class FakeApi
      * Operation fakeOuterBooleanSerializeAsync
      *
      * @param  bool $body Input boolean as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterBooleanSerializeAsync($body = null)
+    public function fakeOuterBooleanSerializeAsync($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
     {
-        return $this->fakeOuterBooleanSerializeAsyncWithHttpInfo($body)
+        return $this->fakeOuterBooleanSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -762,14 +830,15 @@ class FakeApi
      * Operation fakeOuterBooleanSerializeAsyncWithHttpInfo
      *
      * @param  bool $body Input boolean as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterBooleanSerializeAsyncWithHttpInfo($body = null)
+    public function fakeOuterBooleanSerializeAsyncWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
     {
         $returnType = 'bool';
-        $request = $this->fakeOuterBooleanSerializeRequest($body);
+        $request = $this->fakeOuterBooleanSerializeRequest($body, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -811,13 +880,18 @@ class FakeApi
      * Create request for operation 'fakeOuterBooleanSerialize'
      *
      * @param  bool $body Input boolean as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterBooleanSerializeRequest($body = null)
+    public function fakeOuterBooleanSerializeRequest($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
     {
 
+
+        if(!in_array($contentType, self::contentTypes['fakeOuterBooleanSerialize'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterBooleanSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterBooleanSerialize'])."].");
+        }
 
         $resourcePath = '/fake/outer/boolean';
         $formParams = [];
@@ -830,20 +904,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['*/*']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['*/*'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['*/*', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -863,9 +933,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -898,14 +968,15 @@ class FakeApi
      * Operation fakeOuterCompositeSerialize
      *
      * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\OuterComposite
      */
-    public function fakeOuterCompositeSerialize($outer_composite = null)
+    public function fakeOuterCompositeSerialize($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
     {
-        list($response) = $this->fakeOuterCompositeSerializeWithHttpInfo($outer_composite);
+        list($response) = $this->fakeOuterCompositeSerializeWithHttpInfo($outer_composite, $contentType);
         return $response;
     }
 
@@ -913,14 +984,15 @@ class FakeApi
      * Operation fakeOuterCompositeSerializeWithHttpInfo
      *
      * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\OuterComposite, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterCompositeSerializeWithHttpInfo($outer_composite = null)
+    public function fakeOuterCompositeSerializeWithHttpInfo($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
     {
-        $request = $this->fakeOuterCompositeSerializeRequest($outer_composite);
+        $request = $this->fakeOuterCompositeSerializeRequest($outer_composite, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1010,13 +1082,14 @@ class FakeApi
      * Operation fakeOuterCompositeSerializeAsync
      *
      * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterCompositeSerializeAsync($outer_composite = null)
+    public function fakeOuterCompositeSerializeAsync($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
     {
-        return $this->fakeOuterCompositeSerializeAsyncWithHttpInfo($outer_composite)
+        return $this->fakeOuterCompositeSerializeAsyncWithHttpInfo($outer_composite, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1028,14 +1101,15 @@ class FakeApi
      * Operation fakeOuterCompositeSerializeAsyncWithHttpInfo
      *
      * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterCompositeSerializeAsyncWithHttpInfo($outer_composite = null)
+    public function fakeOuterCompositeSerializeAsyncWithHttpInfo($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
     {
         $returnType = '\OpenAPI\Client\Model\OuterComposite';
-        $request = $this->fakeOuterCompositeSerializeRequest($outer_composite);
+        $request = $this->fakeOuterCompositeSerializeRequest($outer_composite, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1077,13 +1151,18 @@ class FakeApi
      * Create request for operation 'fakeOuterCompositeSerialize'
      *
      * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterCompositeSerializeRequest($outer_composite = null)
+    public function fakeOuterCompositeSerializeRequest($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
     {
 
+
+        if(!in_array($contentType, self::contentTypes['fakeOuterCompositeSerialize'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterCompositeSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterCompositeSerialize'])."].");
+        }
 
         $resourcePath = '/fake/outer/composite';
         $formParams = [];
@@ -1096,20 +1175,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['*/*']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['*/*'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['*/*', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($outer_composite)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($outer_composite));
             } else {
                 $httpBody = $outer_composite;
@@ -1129,9 +1204,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1164,14 +1239,15 @@ class FakeApi
      * Operation fakeOuterNumberSerialize
      *
      * @param  float $body Input number as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return float
      */
-    public function fakeOuterNumberSerialize($body = null)
+    public function fakeOuterNumberSerialize($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
     {
-        list($response) = $this->fakeOuterNumberSerializeWithHttpInfo($body);
+        list($response) = $this->fakeOuterNumberSerializeWithHttpInfo($body, $contentType);
         return $response;
     }
 
@@ -1179,14 +1255,15 @@ class FakeApi
      * Operation fakeOuterNumberSerializeWithHttpInfo
      *
      * @param  float $body Input number as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of float, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterNumberSerializeWithHttpInfo($body = null)
+    public function fakeOuterNumberSerializeWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
     {
-        $request = $this->fakeOuterNumberSerializeRequest($body);
+        $request = $this->fakeOuterNumberSerializeRequest($body, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1276,13 +1353,14 @@ class FakeApi
      * Operation fakeOuterNumberSerializeAsync
      *
      * @param  float $body Input number as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterNumberSerializeAsync($body = null)
+    public function fakeOuterNumberSerializeAsync($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
     {
-        return $this->fakeOuterNumberSerializeAsyncWithHttpInfo($body)
+        return $this->fakeOuterNumberSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1294,14 +1372,15 @@ class FakeApi
      * Operation fakeOuterNumberSerializeAsyncWithHttpInfo
      *
      * @param  float $body Input number as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterNumberSerializeAsyncWithHttpInfo($body = null)
+    public function fakeOuterNumberSerializeAsyncWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
     {
         $returnType = 'float';
-        $request = $this->fakeOuterNumberSerializeRequest($body);
+        $request = $this->fakeOuterNumberSerializeRequest($body, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1343,13 +1422,18 @@ class FakeApi
      * Create request for operation 'fakeOuterNumberSerialize'
      *
      * @param  float $body Input number as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterNumberSerializeRequest($body = null)
+    public function fakeOuterNumberSerializeRequest($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
     {
 
+
+        if(!in_array($contentType, self::contentTypes['fakeOuterNumberSerialize'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterNumberSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterNumberSerialize'])."].");
+        }
 
         $resourcePath = '/fake/outer/number';
         $formParams = [];
@@ -1362,20 +1446,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['*/*']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['*/*'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['*/*', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1395,9 +1475,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1430,14 +1510,15 @@ class FakeApi
      * Operation fakeOuterStringSerialize
      *
      * @param  string $body Input string as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function fakeOuterStringSerialize($body = null)
+    public function fakeOuterStringSerialize($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
     {
-        list($response) = $this->fakeOuterStringSerializeWithHttpInfo($body);
+        list($response) = $this->fakeOuterStringSerializeWithHttpInfo($body, $contentType);
         return $response;
     }
 
@@ -1445,14 +1526,15 @@ class FakeApi
      * Operation fakeOuterStringSerializeWithHttpInfo
      *
      * @param  string $body Input string as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterStringSerializeWithHttpInfo($body = null)
+    public function fakeOuterStringSerializeWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
     {
-        $request = $this->fakeOuterStringSerializeRequest($body);
+        $request = $this->fakeOuterStringSerializeRequest($body, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1542,13 +1624,14 @@ class FakeApi
      * Operation fakeOuterStringSerializeAsync
      *
      * @param  string $body Input string as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterStringSerializeAsync($body = null)
+    public function fakeOuterStringSerializeAsync($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
     {
-        return $this->fakeOuterStringSerializeAsyncWithHttpInfo($body)
+        return $this->fakeOuterStringSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1560,14 +1643,15 @@ class FakeApi
      * Operation fakeOuterStringSerializeAsyncWithHttpInfo
      *
      * @param  string $body Input string as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterStringSerializeAsyncWithHttpInfo($body = null)
+    public function fakeOuterStringSerializeAsyncWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
     {
         $returnType = 'string';
-        $request = $this->fakeOuterStringSerializeRequest($body);
+        $request = $this->fakeOuterStringSerializeRequest($body, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1609,13 +1693,18 @@ class FakeApi
      * Create request for operation 'fakeOuterStringSerialize'
      *
      * @param  string $body Input string as post body (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterStringSerializeRequest($body = null)
+    public function fakeOuterStringSerializeRequest($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
     {
 
+
+        if(!in_array($contentType, self::contentTypes['fakeOuterStringSerialize'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterStringSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterStringSerialize'])."].");
+        }
 
         $resourcePath = '/fake/outer/string';
         $formParams = [];
@@ -1628,20 +1717,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['*/*']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['*/*'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['*/*', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -1661,9 +1746,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1696,14 +1781,15 @@ class FakeApi
      * Operation fakePropertyEnumIntegerSerialize
      *
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\OuterObjectWithEnumProperty
      */
-    public function fakePropertyEnumIntegerSerialize($outer_object_with_enum_property)
+    public function fakePropertyEnumIntegerSerialize($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
     {
-        list($response) = $this->fakePropertyEnumIntegerSerializeWithHttpInfo($outer_object_with_enum_property);
+        list($response) = $this->fakePropertyEnumIntegerSerializeWithHttpInfo($outer_object_with_enum_property, $contentType);
         return $response;
     }
 
@@ -1711,14 +1797,15 @@ class FakeApi
      * Operation fakePropertyEnumIntegerSerializeWithHttpInfo
      *
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\OuterObjectWithEnumProperty, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakePropertyEnumIntegerSerializeWithHttpInfo($outer_object_with_enum_property)
+    public function fakePropertyEnumIntegerSerializeWithHttpInfo($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
     {
-        $request = $this->fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property);
+        $request = $this->fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1808,13 +1895,14 @@ class FakeApi
      * Operation fakePropertyEnumIntegerSerializeAsync
      *
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakePropertyEnumIntegerSerializeAsync($outer_object_with_enum_property)
+    public function fakePropertyEnumIntegerSerializeAsync($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
     {
-        return $this->fakePropertyEnumIntegerSerializeAsyncWithHttpInfo($outer_object_with_enum_property)
+        return $this->fakePropertyEnumIntegerSerializeAsyncWithHttpInfo($outer_object_with_enum_property, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1826,14 +1914,15 @@ class FakeApi
      * Operation fakePropertyEnumIntegerSerializeAsyncWithHttpInfo
      *
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakePropertyEnumIntegerSerializeAsyncWithHttpInfo($outer_object_with_enum_property)
+    public function fakePropertyEnumIntegerSerializeAsyncWithHttpInfo($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
     {
         $returnType = '\OpenAPI\Client\Model\OuterObjectWithEnumProperty';
-        $request = $this->fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property);
+        $request = $this->fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1875,11 +1964,12 @@ class FakeApi
      * Create request for operation 'fakePropertyEnumIntegerSerialize'
      *
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property)
+    public function fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
     {
 
         // verify the required parameter 'outer_object_with_enum_property' is set
@@ -1887,6 +1977,10 @@ class FakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $outer_object_with_enum_property when calling fakePropertyEnumIntegerSerialize'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['fakePropertyEnumIntegerSerialize'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakePropertyEnumIntegerSerialize, must be one of [".implode(',', self::contentTypes['fakePropertyEnumIntegerSerialize'])."].");
         }
 
         $resourcePath = '/fake/property/enum-int';
@@ -1900,20 +1994,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['*/*']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['*/*'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['*/*', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($outer_object_with_enum_property)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($outer_object_with_enum_property));
             } else {
                 $httpBody = $outer_object_with_enum_property;
@@ -1933,9 +2023,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1968,28 +2058,30 @@ class FakeApi
      * Operation testBodyWithBinary
      *
      * @param  \SplFileObject $body image to upload (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testBodyWithBinary($body)
+    public function testBodyWithBinary($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
     {
-        $this->testBodyWithBinaryWithHttpInfo($body);
+        $this->testBodyWithBinaryWithHttpInfo($body, $contentType);
     }
 
     /**
      * Operation testBodyWithBinaryWithHttpInfo
      *
      * @param  \SplFileObject $body image to upload (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testBodyWithBinaryWithHttpInfo($body)
+    public function testBodyWithBinaryWithHttpInfo($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
     {
-        $request = $this->testBodyWithBinaryRequest($body);
+        $request = $this->testBodyWithBinaryRequest($body, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2039,13 +2131,14 @@ class FakeApi
      * Operation testBodyWithBinaryAsync
      *
      * @param  \SplFileObject $body image to upload (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithBinaryAsync($body)
+    public function testBodyWithBinaryAsync($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
     {
-        return $this->testBodyWithBinaryAsyncWithHttpInfo($body)
+        return $this->testBodyWithBinaryAsyncWithHttpInfo($body, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2057,14 +2150,15 @@ class FakeApi
      * Operation testBodyWithBinaryAsyncWithHttpInfo
      *
      * @param  \SplFileObject $body image to upload (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithBinaryAsyncWithHttpInfo($body)
+    public function testBodyWithBinaryAsyncWithHttpInfo($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
     {
         $returnType = '';
-        $request = $this->testBodyWithBinaryRequest($body);
+        $request = $this->testBodyWithBinaryRequest($body, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2093,11 +2187,12 @@ class FakeApi
      * Create request for operation 'testBodyWithBinary'
      *
      * @param  \SplFileObject $body image to upload (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testBodyWithBinaryRequest($body)
+    public function testBodyWithBinaryRequest($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
     {
 
         // verify the required parameter 'body' is set
@@ -2105,6 +2200,10 @@ class FakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling testBodyWithBinary'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['testBodyWithBinary'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testBodyWithBinary, must be one of [".implode(',', self::contentTypes['testBodyWithBinary'])."].");
         }
 
         $resourcePath = '/fake/body-with-binary';
@@ -2118,20 +2217,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['image/png']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($body));
             } else {
                 $httpBody = $body;
@@ -2151,9 +2246,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2186,28 +2281,30 @@ class FakeApi
      * Operation testBodyWithFileSchema
      *
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class file_schema_test_class (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testBodyWithFileSchema($file_schema_test_class)
+    public function testBodyWithFileSchema($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
     {
-        $this->testBodyWithFileSchemaWithHttpInfo($file_schema_test_class);
+        $this->testBodyWithFileSchemaWithHttpInfo($file_schema_test_class, $contentType);
     }
 
     /**
      * Operation testBodyWithFileSchemaWithHttpInfo
      *
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testBodyWithFileSchemaWithHttpInfo($file_schema_test_class)
+    public function testBodyWithFileSchemaWithHttpInfo($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
     {
-        $request = $this->testBodyWithFileSchemaRequest($file_schema_test_class);
+        $request = $this->testBodyWithFileSchemaRequest($file_schema_test_class, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2257,13 +2354,14 @@ class FakeApi
      * Operation testBodyWithFileSchemaAsync
      *
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithFileSchemaAsync($file_schema_test_class)
+    public function testBodyWithFileSchemaAsync($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
     {
-        return $this->testBodyWithFileSchemaAsyncWithHttpInfo($file_schema_test_class)
+        return $this->testBodyWithFileSchemaAsyncWithHttpInfo($file_schema_test_class, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2275,14 +2373,15 @@ class FakeApi
      * Operation testBodyWithFileSchemaAsyncWithHttpInfo
      *
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithFileSchemaAsyncWithHttpInfo($file_schema_test_class)
+    public function testBodyWithFileSchemaAsyncWithHttpInfo($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
     {
         $returnType = '';
-        $request = $this->testBodyWithFileSchemaRequest($file_schema_test_class);
+        $request = $this->testBodyWithFileSchemaRequest($file_schema_test_class, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2311,11 +2410,12 @@ class FakeApi
      * Create request for operation 'testBodyWithFileSchema'
      *
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testBodyWithFileSchemaRequest($file_schema_test_class)
+    public function testBodyWithFileSchemaRequest($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
     {
 
         // verify the required parameter 'file_schema_test_class' is set
@@ -2323,6 +2423,10 @@ class FakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $file_schema_test_class when calling testBodyWithFileSchema'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['testBodyWithFileSchema'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testBodyWithFileSchema, must be one of [".implode(',', self::contentTypes['testBodyWithFileSchema'])."].");
         }
 
         $resourcePath = '/fake/body-with-file-schema';
@@ -2336,20 +2440,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($file_schema_test_class)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($file_schema_test_class));
             } else {
                 $httpBody = $file_schema_test_class;
@@ -2369,9 +2469,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2405,14 +2505,15 @@ class FakeApi
      *
      * @param  string $query query (required)
      * @param  \OpenAPI\Client\Model\User $user user (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testBodyWithQueryParams($query, $user)
+    public function testBodyWithQueryParams($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
     {
-        $this->testBodyWithQueryParamsWithHttpInfo($query, $user);
+        $this->testBodyWithQueryParamsWithHttpInfo($query, $user, $contentType);
     }
 
     /**
@@ -2420,14 +2521,15 @@ class FakeApi
      *
      * @param  string $query (required)
      * @param  \OpenAPI\Client\Model\User $user (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testBodyWithQueryParamsWithHttpInfo($query, $user)
+    public function testBodyWithQueryParamsWithHttpInfo($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
     {
-        $request = $this->testBodyWithQueryParamsRequest($query, $user);
+        $request = $this->testBodyWithQueryParamsRequest($query, $user, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2478,13 +2580,14 @@ class FakeApi
      *
      * @param  string $query (required)
      * @param  \OpenAPI\Client\Model\User $user (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithQueryParamsAsync($query, $user)
+    public function testBodyWithQueryParamsAsync($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
     {
-        return $this->testBodyWithQueryParamsAsyncWithHttpInfo($query, $user)
+        return $this->testBodyWithQueryParamsAsyncWithHttpInfo($query, $user, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2497,14 +2600,15 @@ class FakeApi
      *
      * @param  string $query (required)
      * @param  \OpenAPI\Client\Model\User $user (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithQueryParamsAsyncWithHttpInfo($query, $user)
+    public function testBodyWithQueryParamsAsyncWithHttpInfo($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
     {
         $returnType = '';
-        $request = $this->testBodyWithQueryParamsRequest($query, $user);
+        $request = $this->testBodyWithQueryParamsRequest($query, $user, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2534,11 +2638,12 @@ class FakeApi
      *
      * @param  string $query (required)
      * @param  \OpenAPI\Client\Model\User $user (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testBodyWithQueryParamsRequest($query, $user)
+    public function testBodyWithQueryParamsRequest($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
     {
 
         // verify the required parameter 'query' is set
@@ -2553,6 +2658,10 @@ class FakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $user when calling testBodyWithQueryParams'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['testBodyWithQueryParams'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testBodyWithQueryParams, must be one of [".implode(',', self::contentTypes['testBodyWithQueryParams'])."].");
         }
 
         $resourcePath = '/fake/body-with-query-params';
@@ -2575,20 +2684,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -2608,9 +2713,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2645,14 +2750,15 @@ class FakeApi
      * To test \&quot;client\&quot; model
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function testClientModel($client)
+    public function testClientModel($client, string $contentType = self::contentTypes['testClientModel'][0])
     {
-        list($response) = $this->testClientModelWithHttpInfo($client);
+        list($response) = $this->testClientModelWithHttpInfo($client, $contentType);
         return $response;
     }
 
@@ -2662,14 +2768,15 @@ class FakeApi
      * To test \&quot;client\&quot; model
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testClientModelWithHttpInfo($client)
+    public function testClientModelWithHttpInfo($client, string $contentType = self::contentTypes['testClientModel'][0])
     {
-        $request = $this->testClientModelRequest($client);
+        $request = $this->testClientModelRequest($client, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2761,13 +2868,14 @@ class FakeApi
      * To test \&quot;client\&quot; model
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClientModelAsync($client)
+    public function testClientModelAsync($client, string $contentType = self::contentTypes['testClientModel'][0])
     {
-        return $this->testClientModelAsyncWithHttpInfo($client)
+        return $this->testClientModelAsyncWithHttpInfo($client, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2781,14 +2889,15 @@ class FakeApi
      * To test \&quot;client\&quot; model
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClientModelAsyncWithHttpInfo($client)
+    public function testClientModelAsyncWithHttpInfo($client, string $contentType = self::contentTypes['testClientModel'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Client';
-        $request = $this->testClientModelRequest($client);
+        $request = $this->testClientModelRequest($client, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2830,11 +2939,12 @@ class FakeApi
      * Create request for operation 'testClientModel'
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testClientModelRequest($client)
+    public function testClientModelRequest($client, string $contentType = self::contentTypes['testClientModel'][0])
     {
 
         // verify the required parameter 'client' is set
@@ -2842,6 +2952,10 @@ class FakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $client when calling testClientModel'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['testClientModel'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testClientModel, must be one of [".implode(',', self::contentTypes['testClientModel'])."].");
         }
 
         $resourcePath = '/fake';
@@ -2855,20 +2969,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -2888,9 +2998,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2938,14 +3048,15 @@ class FakeApi
      * @param  \DateTime $date_time None (optional)
      * @param  string $password None (optional)
      * @param  string $callback None (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testEndpointParameters($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null)
+    public function testEndpointParameters($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
     {
-        $this->testEndpointParametersWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback);
+        $this->testEndpointParametersWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType);
     }
 
     /**
@@ -2967,14 +3078,15 @@ class FakeApi
      * @param  \DateTime $date_time None (optional)
      * @param  string $password None (optional)
      * @param  string $callback None (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testEndpointParametersWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null)
+    public function testEndpointParametersWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
     {
-        $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback);
+        $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -3039,13 +3151,14 @@ class FakeApi
      * @param  \DateTime $date_time None (optional)
      * @param  string $password None (optional)
      * @param  string $callback None (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEndpointParametersAsync($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null)
+    public function testEndpointParametersAsync($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
     {
-        return $this->testEndpointParametersAsyncWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback)
+        return $this->testEndpointParametersAsyncWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -3072,14 +3185,15 @@ class FakeApi
      * @param  \DateTime $date_time None (optional)
      * @param  string $password None (optional)
      * @param  string $callback None (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEndpointParametersAsyncWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null)
+    public function testEndpointParametersAsyncWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
     {
         $returnType = '';
-        $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback);
+        $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -3121,11 +3235,12 @@ class FakeApi
      * @param  \DateTime $date_time None (optional)
      * @param  string $password None (optional)
      * @param  string $callback None (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null)
+    public function testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
     {
 
         // verify the required parameter 'number' is set
@@ -3140,8 +3255,7 @@ class FakeApi
         if ($number < 32.1) {
             throw new \InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 32.1.');
         }
-
-
+        
         // verify the required parameter 'double' is set
         if ($double === null || (is_array($double) && count($double) === 0)) {
             throw new \InvalidArgumentException(
@@ -3154,8 +3268,7 @@ class FakeApi
         if ($double < 67.8) {
             throw new \InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 67.8.');
         }
-
-
+        
         // verify the required parameter 'pattern_without_delimiter' is set
         if ($pattern_without_delimiter === null || (is_array($pattern_without_delimiter) && count($pattern_without_delimiter) === 0)) {
             throw new \InvalidArgumentException(
@@ -3165,8 +3278,7 @@ class FakeApi
         if (!preg_match("/^[A-Z].*/", $pattern_without_delimiter)) {
             throw new \InvalidArgumentException("invalid value for \"pattern_without_delimiter\" when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.");
         }
-
-
+        
         // verify the required parameter 'byte' is set
         if ($byte === null || (is_array($byte) && count($byte) === 0)) {
             throw new \InvalidArgumentException(
@@ -3180,27 +3292,23 @@ class FakeApi
         if ($integer !== null && $integer < 10) {
             throw new \InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
-
-
+        
         if ($int32 !== null && $int32 > 200) {
             throw new \InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 200.');
         }
         if ($int32 !== null && $int32 < 20) {
             throw new \InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 20.');
         }
-
-
+        
 
         if ($float !== null && $float > 987.6) {
             throw new \InvalidArgumentException('invalid value for "$float" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 987.6.');
         }
-
-
+        
         if ($string !== null && !preg_match("/[a-z]/i", $string)) {
             throw new \InvalidArgumentException("invalid value for \"string\" when calling FakeApi.testEndpointParameters, must conform to the pattern /[a-z]/i.");
         }
-
-
+        
 
 
 
@@ -3210,8 +3318,11 @@ class FakeApi
         if ($password !== null && strlen($password) < 10) {
             throw new \InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
+        
 
-
+        if(!in_array($contentType, self::contentTypes['testEndpointParameters'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testEndpointParameters, must be one of [".implode(',', self::contentTypes['testEndpointParameters'])."].");
+        }
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -3288,16 +3399,11 @@ class FakeApi
             $formParams['callback'] = ObjectSerializer::toFormValue($callback);
         }
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/x-www-form-urlencoded']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -3315,9 +3421,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -3364,14 +3470,15 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testEnumParameters($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg')
+    public function testEnumParameters($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
     {
-        $this->testEnumParametersWithHttpInfo($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string);
+        $this->testEnumParametersWithHttpInfo($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType);
     }
 
     /**
@@ -3388,14 +3495,15 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testEnumParametersWithHttpInfo($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg')
+    public function testEnumParametersWithHttpInfo($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
     {
-        $request = $this->testEnumParametersRequest($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string);
+        $request = $this->testEnumParametersRequest($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -3455,13 +3563,14 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEnumParametersAsync($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg')
+    public function testEnumParametersAsync($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
     {
-        return $this->testEnumParametersAsyncWithHttpInfo($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string)
+        return $this->testEnumParametersAsyncWithHttpInfo($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -3483,14 +3592,15 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEnumParametersAsyncWithHttpInfo($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg')
+    public function testEnumParametersAsyncWithHttpInfo($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
     {
         $returnType = '';
-        $request = $this->testEnumParametersRequest($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string);
+        $request = $this->testEnumParametersRequest($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -3527,11 +3637,12 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
      * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
      * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testEnumParametersRequest($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg')
+    public function testEnumParametersRequest($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
     {
 
 
@@ -3542,6 +3653,10 @@ class FakeApi
 
 
 
+
+        if(!in_array($contentType, self::contentTypes['testEnumParameters'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testEnumParameters, must be one of [".implode(',', self::contentTypes['testEnumParameters'])."].");
+        }
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -3618,16 +3733,11 @@ class FakeApi
             $formParams['enum_form_string'] = ObjectSerializer::toFormValue($enum_form_string);
         }
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/x-www-form-urlencoded']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -3645,9 +3755,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -3689,6 +3799,7 @@ class FakeApi
      * @param  int $string_group String in group parameters (optional)
      * @param  bool $boolean_group Boolean in group parameters (optional)
      * @param  int $int64_group Integer in group parameters (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -3712,6 +3823,7 @@ class FakeApi
      * @param  int $string_group String in group parameters (optional)
      * @param  bool $boolean_group Boolean in group parameters (optional)
      * @param  int $int64_group Integer in group parameters (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -3778,6 +3890,7 @@ class FakeApi
      * @param  int $string_group String in group parameters (optional)
      * @param  bool $boolean_group Boolean in group parameters (optional)
      * @param  int $int64_group Integer in group parameters (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -3805,6 +3918,7 @@ class FakeApi
      * @param  int $string_group String in group parameters (optional)
      * @param  bool $boolean_group Boolean in group parameters (optional)
      * @param  int $int64_group Integer in group parameters (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -3848,6 +3962,7 @@ class FakeApi
      * @param  int $string_group String in group parameters (optional)
      * @param  bool $boolean_group Boolean in group parameters (optional)
      * @param  int $int64_group Integer in group parameters (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
@@ -3861,7 +3976,8 @@ class FakeApi
         $string_group = array_key_exists('string_group', $associative_array) ? $associative_array['string_group'] : null;
         $boolean_group = array_key_exists('boolean_group', $associative_array) ? $associative_array['boolean_group'] : null;
         $int64_group = array_key_exists('int64_group', $associative_array) ? $associative_array['int64_group'] : null;
-
+        $contentType = $associative_array['contentType'] ?? self::contentTypes['testGroupParameters'][0];
+        
         // verify the required parameter 'required_string_group' is set
         if ($required_string_group === null || (is_array($required_string_group) && count($required_string_group) === 0)) {
             throw new \InvalidArgumentException(
@@ -3885,6 +4001,10 @@ class FakeApi
 
 
 
+
+        if(!in_array($contentType, self::contentTypes['testGroupParameters'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testGroupParameters, must be one of [".implode(',', self::contentTypes['testGroupParameters'])."].");
+        }
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -3941,16 +4061,11 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -3968,9 +4083,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -4009,14 +4124,15 @@ class FakeApi
      * test inline additionalProperties
      *
      * @param  array<string,string> $request_body request body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testInlineAdditionalProperties($request_body)
+    public function testInlineAdditionalProperties($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
     {
-        $this->testInlineAdditionalPropertiesWithHttpInfo($request_body);
+        $this->testInlineAdditionalPropertiesWithHttpInfo($request_body, $contentType);
     }
 
     /**
@@ -4025,14 +4141,15 @@ class FakeApi
      * test inline additionalProperties
      *
      * @param  array<string,string> $request_body request body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testInlineAdditionalPropertiesWithHttpInfo($request_body)
+    public function testInlineAdditionalPropertiesWithHttpInfo($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
     {
-        $request = $this->testInlineAdditionalPropertiesRequest($request_body);
+        $request = $this->testInlineAdditionalPropertiesRequest($request_body, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -4084,13 +4201,14 @@ class FakeApi
      * test inline additionalProperties
      *
      * @param  array<string,string> $request_body request body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testInlineAdditionalPropertiesAsync($request_body)
+    public function testInlineAdditionalPropertiesAsync($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
     {
-        return $this->testInlineAdditionalPropertiesAsyncWithHttpInfo($request_body)
+        return $this->testInlineAdditionalPropertiesAsyncWithHttpInfo($request_body, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -4104,14 +4222,15 @@ class FakeApi
      * test inline additionalProperties
      *
      * @param  array<string,string> $request_body request body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testInlineAdditionalPropertiesAsyncWithHttpInfo($request_body)
+    public function testInlineAdditionalPropertiesAsyncWithHttpInfo($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
     {
         $returnType = '';
-        $request = $this->testInlineAdditionalPropertiesRequest($request_body);
+        $request = $this->testInlineAdditionalPropertiesRequest($request_body, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -4140,11 +4259,12 @@ class FakeApi
      * Create request for operation 'testInlineAdditionalProperties'
      *
      * @param  array<string,string> $request_body request body (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testInlineAdditionalPropertiesRequest($request_body)
+    public function testInlineAdditionalPropertiesRequest($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
     {
 
         // verify the required parameter 'request_body' is set
@@ -4152,6 +4272,10 @@ class FakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $request_body when calling testInlineAdditionalProperties'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['testInlineAdditionalProperties'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testInlineAdditionalProperties, must be one of [".implode(',', self::contentTypes['testInlineAdditionalProperties'])."].");
         }
 
         $resourcePath = '/fake/inline-additionalProperties';
@@ -4165,20 +4289,16 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($request_body)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($request_body));
             } else {
                 $httpBody = $request_body;
@@ -4198,9 +4318,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -4236,14 +4356,15 @@ class FakeApi
      *
      * @param  string $param field1 (required)
      * @param  string $param2 field2 (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testJsonFormData($param, $param2)
+    public function testJsonFormData($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
     {
-        $this->testJsonFormDataWithHttpInfo($param, $param2);
+        $this->testJsonFormDataWithHttpInfo($param, $param2, $contentType);
     }
 
     /**
@@ -4253,14 +4374,15 @@ class FakeApi
      *
      * @param  string $param field1 (required)
      * @param  string $param2 field2 (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testJsonFormDataWithHttpInfo($param, $param2)
+    public function testJsonFormDataWithHttpInfo($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
     {
-        $request = $this->testJsonFormDataRequest($param, $param2);
+        $request = $this->testJsonFormDataRequest($param, $param2, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -4313,13 +4435,14 @@ class FakeApi
      *
      * @param  string $param field1 (required)
      * @param  string $param2 field2 (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testJsonFormDataAsync($param, $param2)
+    public function testJsonFormDataAsync($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
     {
-        return $this->testJsonFormDataAsyncWithHttpInfo($param, $param2)
+        return $this->testJsonFormDataAsyncWithHttpInfo($param, $param2, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -4334,14 +4457,15 @@ class FakeApi
      *
      * @param  string $param field1 (required)
      * @param  string $param2 field2 (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testJsonFormDataAsyncWithHttpInfo($param, $param2)
+    public function testJsonFormDataAsyncWithHttpInfo($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
     {
         $returnType = '';
-        $request = $this->testJsonFormDataRequest($param, $param2);
+        $request = $this->testJsonFormDataRequest($param, $param2, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -4371,11 +4495,12 @@ class FakeApi
      *
      * @param  string $param field1 (required)
      * @param  string $param2 field2 (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testJsonFormDataRequest($param, $param2)
+    public function testJsonFormDataRequest($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
     {
 
         // verify the required parameter 'param' is set
@@ -4390,6 +4515,10 @@ class FakeApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $param2 when calling testJsonFormData'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['testJsonFormData'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testJsonFormData, must be one of [".implode(',', self::contentTypes['testJsonFormData'])."].");
         }
 
         $resourcePath = '/fake/jsonFormData';
@@ -4411,16 +4540,11 @@ class FakeApi
             $formParams['param2'] = ObjectSerializer::toFormValue($param2);
         }
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/x-www-form-urlencoded']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -4438,9 +4562,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -4479,14 +4603,15 @@ class FakeApi
      * @param  string[] $context context (required)
      * @param  string $allow_empty allow_empty (required)
      * @param  array<string,string> $language language (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
+    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
     {
-        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
+        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType);
     }
 
     /**
@@ -4499,14 +4624,15 @@ class FakeApi
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
+    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
     {
-        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -4562,13 +4688,14 @@ class FakeApi
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
+    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
     {
-        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language)
+        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -4586,14 +4713,15 @@ class FakeApi
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
+    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
     {
         $returnType = '';
-        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -4628,11 +4756,12 @@ class FakeApi
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
+    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
     {
 
         // verify the required parameter 'pipe' is set
@@ -4677,6 +4806,10 @@ class FakeApi
             );
         }
 
+
+        if(!in_array($contentType, self::contentTypes['testQueryParameterCollectionFormat'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testQueryParameterCollectionFormat, must be one of [".implode(',', self::contentTypes['testQueryParameterCollectionFormat'])."].");
+        }
 
         $resourcePath = '/fake/test-query-parameters';
         $formParams = [];
@@ -4752,16 +4885,11 @@ class FakeApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -4779,9 +4907,9 @@ class FakeApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -369,9 +369,6 @@ class FakeApi
     public function fakeHealthGetRequest(string $contentType = self::contentTypes['fakeHealthGet'][0])
     {
 
-        if(!in_array($contentType, self::contentTypes['fakeHealthGet'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeHealthGet, must be one of [".implode(',', self::contentTypes['fakeHealthGet'])."].");
-        }
 
         $resourcePath = '/fake/health';
         $formParams = [];
@@ -605,9 +602,6 @@ class FakeApi
 
 
 
-        if(!in_array($contentType, self::contentTypes['fakeHttpSignatureTest'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeHttpSignatureTest, must be one of [".implode(',', self::contentTypes['fakeHttpSignatureTest'])."].");
-        }
 
         $resourcePath = '/fake/http-signature-test';
         $formParams = [];
@@ -889,9 +883,6 @@ class FakeApi
     {
 
 
-        if(!in_array($contentType, self::contentTypes['fakeOuterBooleanSerialize'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterBooleanSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterBooleanSerialize'])."].");
-        }
 
         $resourcePath = '/fake/outer/boolean';
         $formParams = [];
@@ -1160,9 +1151,6 @@ class FakeApi
     {
 
 
-        if(!in_array($contentType, self::contentTypes['fakeOuterCompositeSerialize'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterCompositeSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterCompositeSerialize'])."].");
-        }
 
         $resourcePath = '/fake/outer/composite';
         $formParams = [];
@@ -1431,9 +1419,6 @@ class FakeApi
     {
 
 
-        if(!in_array($contentType, self::contentTypes['fakeOuterNumberSerialize'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterNumberSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterNumberSerialize'])."].");
-        }
 
         $resourcePath = '/fake/outer/number';
         $formParams = [];
@@ -1702,9 +1687,6 @@ class FakeApi
     {
 
 
-        if(!in_array($contentType, self::contentTypes['fakeOuterStringSerialize'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakeOuterStringSerialize, must be one of [".implode(',', self::contentTypes['fakeOuterStringSerialize'])."].");
-        }
 
         $resourcePath = '/fake/outer/string';
         $formParams = [];
@@ -1979,9 +1961,6 @@ class FakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['fakePropertyEnumIntegerSerialize'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.fakePropertyEnumIntegerSerialize, must be one of [".implode(',', self::contentTypes['fakePropertyEnumIntegerSerialize'])."].");
-        }
 
         $resourcePath = '/fake/property/enum-int';
         $formParams = [];
@@ -2202,9 +2181,6 @@ class FakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['testBodyWithBinary'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testBodyWithBinary, must be one of [".implode(',', self::contentTypes['testBodyWithBinary'])."].");
-        }
 
         $resourcePath = '/fake/body-with-binary';
         $formParams = [];
@@ -2425,9 +2401,6 @@ class FakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['testBodyWithFileSchema'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testBodyWithFileSchema, must be one of [".implode(',', self::contentTypes['testBodyWithFileSchema'])."].");
-        }
 
         $resourcePath = '/fake/body-with-file-schema';
         $formParams = [];
@@ -2660,9 +2633,6 @@ class FakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['testBodyWithQueryParams'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testBodyWithQueryParams, must be one of [".implode(',', self::contentTypes['testBodyWithQueryParams'])."].");
-        }
 
         $resourcePath = '/fake/body-with-query-params';
         $formParams = [];
@@ -2954,9 +2924,6 @@ class FakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['testClientModel'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testClientModel, must be one of [".implode(',', self::contentTypes['testClientModel'])."].");
-        }
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -3320,9 +3287,6 @@ class FakeApi
         }
         
 
-        if(!in_array($contentType, self::contentTypes['testEndpointParameters'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testEndpointParameters, must be one of [".implode(',', self::contentTypes['testEndpointParameters'])."].");
-        }
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -3654,9 +3618,6 @@ class FakeApi
 
 
 
-        if(!in_array($contentType, self::contentTypes['testEnumParameters'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testEnumParameters, must be one of [".implode(',', self::contentTypes['testEnumParameters'])."].");
-        }
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -4002,9 +3963,6 @@ class FakeApi
 
 
 
-        if(!in_array($contentType, self::contentTypes['testGroupParameters'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testGroupParameters, must be one of [".implode(',', self::contentTypes['testGroupParameters'])."].");
-        }
 
         $resourcePath = '/fake';
         $formParams = [];
@@ -4274,9 +4232,6 @@ class FakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['testInlineAdditionalProperties'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testInlineAdditionalProperties, must be one of [".implode(',', self::contentTypes['testInlineAdditionalProperties'])."].");
-        }
 
         $resourcePath = '/fake/inline-additionalProperties';
         $formParams = [];
@@ -4517,9 +4472,6 @@ class FakeApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['testJsonFormData'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testJsonFormData, must be one of [".implode(',', self::contentTypes['testJsonFormData'])."].");
-        }
 
         $resourcePath = '/fake/jsonFormData';
         $formParams = [];
@@ -4807,9 +4759,6 @@ class FakeApi
         }
 
 
-        if(!in_array($contentType, self::contentTypes['testQueryParameterCollectionFormat'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeApi.testQueryParameterCollectionFormat, must be one of [".implode(',', self::contentTypes['testQueryParameterCollectionFormat'])."].");
-        }
 
         $resourcePath = '/fake/test-query-parameters';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -332,9 +332,6 @@ class FakeClassnameTags123Api
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['testClassname'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeClassnameTags123Api.testClassname, must be one of [".implode(',', self::contentTypes['testClassname'])."].");
-        }
 
         $resourcePath = '/fake_classname_test';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -69,7 +69,14 @@ class FakeClassnameTags123Api
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [
+        'testClassname' => [
+            'application/json',
+        ],
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -121,14 +128,15 @@ class FakeClassnameTags123Api
      * To test class name in snake case
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function testClassname($client)
+    public function testClassname($client, string $contentType = self::contentTypes['testClassname'][0])
     {
-        list($response) = $this->testClassnameWithHttpInfo($client);
+        list($response) = $this->testClassnameWithHttpInfo($client, $contentType);
         return $response;
     }
 
@@ -138,14 +146,15 @@ class FakeClassnameTags123Api
      * To test class name in snake case
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testClassnameWithHttpInfo($client)
+    public function testClassnameWithHttpInfo($client, string $contentType = self::contentTypes['testClassname'][0])
     {
-        $request = $this->testClassnameRequest($client);
+        $request = $this->testClassnameRequest($client, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -237,13 +246,14 @@ class FakeClassnameTags123Api
      * To test class name in snake case
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClassnameAsync($client)
+    public function testClassnameAsync($client, string $contentType = self::contentTypes['testClassname'][0])
     {
-        return $this->testClassnameAsyncWithHttpInfo($client)
+        return $this->testClassnameAsyncWithHttpInfo($client, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -257,14 +267,15 @@ class FakeClassnameTags123Api
      * To test class name in snake case
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClassnameAsyncWithHttpInfo($client)
+    public function testClassnameAsyncWithHttpInfo($client, string $contentType = self::contentTypes['testClassname'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Client';
-        $request = $this->testClassnameRequest($client);
+        $request = $this->testClassnameRequest($client, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -306,11 +317,12 @@ class FakeClassnameTags123Api
      * Create request for operation 'testClassname'
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testClassnameRequest($client)
+    public function testClassnameRequest($client, string $contentType = self::contentTypes['testClassname'][0])
     {
 
         // verify the required parameter 'client' is set
@@ -318,6 +330,10 @@ class FakeClassnameTags123Api
             throw new \InvalidArgumentException(
                 'Missing the required parameter $client when calling testClassname'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['testClassname'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling FakeClassnameTags123Api.testClassname, must be one of [".implode(',', self::contentTypes['testClassname'])."].");
         }
 
         $resourcePath = '/fake_classname_test';
@@ -331,20 +347,16 @@ class FakeClassnameTags123Api
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($client)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($client));
             } else {
                 $httpBody = $client;
@@ -364,9 +376,9 @@ class FakeClassnameTags123Api
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -69,7 +69,40 @@ class PetApi
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [
+        'addPet' => [
+            'application/json',
+            'application/xml',
+        ],
+        'deletePet' => [
+            'application/json',
+        ],
+        'findPetsByStatus' => [
+            'application/json',
+        ],
+        'findPetsByTags' => [
+            'application/json',
+        ],
+        'getPetById' => [
+            'application/json',
+        ],
+        'updatePet' => [
+            'application/json',
+            'application/xml',
+        ],
+        'updatePetWithForm' => [
+            'application/x-www-form-urlencoded',
+        ],
+        'uploadFile' => [
+            'multipart/form-data',
+        ],
+        'uploadFileWithRequiredFile' => [
+            'multipart/form-data',
+        ],
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -139,14 +172,15 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function addPet($pet, ?int $hostIndex = null, array $variables = [])
+    public function addPet($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
     {
-        $this->addPetWithHttpInfo($pet, $hostIndex, $variables);
+        $this->addPetWithHttpInfo($pet, $hostIndex, $variables, $contentType);
     }
 
     /**
@@ -173,14 +207,15 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function addPetWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [])
+    public function addPetWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
     {
-        $request = $this->addPetRequest($pet, $hostIndex, $variables);
+        $request = $this->addPetRequest($pet, $hostIndex, $variables, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -250,13 +285,14 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function addPetAsync($pet, ?int $hostIndex = null, array $variables = [])
+    public function addPetAsync($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
     {
-        return $this->addPetAsyncWithHttpInfo($pet, $hostIndex, $variables)
+        return $this->addPetAsyncWithHttpInfo($pet, $hostIndex, $variables, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -288,14 +324,15 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function addPetAsyncWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [])
+    public function addPetAsyncWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
     {
         $returnType = '';
-        $request = $this->addPetRequest($pet, $hostIndex, $variables);
+        $request = $this->addPetRequest($pet, $hostIndex, $variables, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -342,11 +379,12 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function addPetRequest($pet, ?int $hostIndex = null, array $variables = [])
+    public function addPetRequest($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
     {
 
         // verify the required parameter 'pet' is set
@@ -354,6 +392,10 @@ class PetApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pet when calling addPet'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['addPet'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.addPet, must be one of [".implode(',', self::contentTypes['addPet'])."].");
         }
 
         $resourcePath = '/pet';
@@ -367,20 +409,16 @@ class PetApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json', 'application/xml']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -400,9 +438,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -494,14 +532,15 @@ class PetApi
      *
      * @param  int $pet_id Pet id to delete (required)
      * @param  string $api_key api_key (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deletePet($pet_id, $api_key = null)
+    public function deletePet($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
     {
-        $this->deletePetWithHttpInfo($pet_id, $api_key);
+        $this->deletePetWithHttpInfo($pet_id, $api_key, $contentType);
     }
 
     /**
@@ -511,14 +550,15 @@ class PetApi
      *
      * @param  int $pet_id Pet id to delete (required)
      * @param  string $api_key (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deletePetWithHttpInfo($pet_id, $api_key = null)
+    public function deletePetWithHttpInfo($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
     {
-        $request = $this->deletePetRequest($pet_id, $api_key);
+        $request = $this->deletePetRequest($pet_id, $api_key, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -571,13 +611,14 @@ class PetApi
      *
      * @param  int $pet_id Pet id to delete (required)
      * @param  string $api_key (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deletePetAsync($pet_id, $api_key = null)
+    public function deletePetAsync($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
     {
-        return $this->deletePetAsyncWithHttpInfo($pet_id, $api_key)
+        return $this->deletePetAsyncWithHttpInfo($pet_id, $api_key, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -592,14 +633,15 @@ class PetApi
      *
      * @param  int $pet_id Pet id to delete (required)
      * @param  string $api_key (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deletePetAsyncWithHttpInfo($pet_id, $api_key = null)
+    public function deletePetAsyncWithHttpInfo($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
     {
         $returnType = '';
-        $request = $this->deletePetRequest($pet_id, $api_key);
+        $request = $this->deletePetRequest($pet_id, $api_key, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -629,11 +671,12 @@ class PetApi
      *
      * @param  int $pet_id Pet id to delete (required)
      * @param  string $api_key (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function deletePetRequest($pet_id, $api_key = null)
+    public function deletePetRequest($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
     {
 
         // verify the required parameter 'pet_id' is set
@@ -643,6 +686,10 @@ class PetApi
             );
         }
 
+
+        if(!in_array($contentType, self::contentTypes['deletePet'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.deletePet, must be one of [".implode(',', self::contentTypes['deletePet'])."].");
+        }
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -667,16 +714,11 @@ class PetApi
         }
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -694,9 +736,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -735,14 +777,15 @@ class PetApi
      * Finds Pets by status
      *
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet[]
      */
-    public function findPetsByStatus($status)
+    public function findPetsByStatus($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
     {
-        list($response) = $this->findPetsByStatusWithHttpInfo($status);
+        list($response) = $this->findPetsByStatusWithHttpInfo($status, $contentType);
         return $response;
     }
 
@@ -752,14 +795,15 @@ class PetApi
      * Finds Pets by status
      *
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet[], HTTP status code, HTTP response headers (array of strings)
      */
-    public function findPetsByStatusWithHttpInfo($status)
+    public function findPetsByStatusWithHttpInfo($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
     {
-        $request = $this->findPetsByStatusRequest($status);
+        $request = $this->findPetsByStatusRequest($status, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -851,13 +895,14 @@ class PetApi
      * Finds Pets by status
      *
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function findPetsByStatusAsync($status)
+    public function findPetsByStatusAsync($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
     {
-        return $this->findPetsByStatusAsyncWithHttpInfo($status)
+        return $this->findPetsByStatusAsyncWithHttpInfo($status, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -871,14 +916,15 @@ class PetApi
      * Finds Pets by status
      *
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function findPetsByStatusAsyncWithHttpInfo($status)
+    public function findPetsByStatusAsyncWithHttpInfo($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Pet[]';
-        $request = $this->findPetsByStatusRequest($status);
+        $request = $this->findPetsByStatusRequest($status, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -920,11 +966,12 @@ class PetApi
      * Create request for operation 'findPetsByStatus'
      *
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function findPetsByStatusRequest($status)
+    public function findPetsByStatusRequest($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
     {
 
         // verify the required parameter 'status' is set
@@ -932,6 +979,10 @@ class PetApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $status when calling findPetsByStatus'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['findPetsByStatus'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.findPetsByStatus, must be one of [".implode(',', self::contentTypes['findPetsByStatus'])."].");
         }
 
         $resourcePath = '/pet/findByStatus';
@@ -954,16 +1005,11 @@ class PetApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/xml', 'application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/xml', 'application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/xml', 'application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -981,9 +1027,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1022,15 +1068,16 @@ class PetApi
      * Finds Pets by tags
      *
      * @param  string[] $tags Tags to filter by (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet[]
      * @deprecated
      */
-    public function findPetsByTags($tags)
+    public function findPetsByTags($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
     {
-        list($response) = $this->findPetsByTagsWithHttpInfo($tags);
+        list($response) = $this->findPetsByTagsWithHttpInfo($tags, $contentType);
         return $response;
     }
 
@@ -1040,15 +1087,16 @@ class PetApi
      * Finds Pets by tags
      *
      * @param  string[] $tags Tags to filter by (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet[], HTTP status code, HTTP response headers (array of strings)
      * @deprecated
      */
-    public function findPetsByTagsWithHttpInfo($tags)
+    public function findPetsByTagsWithHttpInfo($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
     {
-        $request = $this->findPetsByTagsRequest($tags);
+        $request = $this->findPetsByTagsRequest($tags, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1140,14 +1188,15 @@ class PetApi
      * Finds Pets by tags
      *
      * @param  string[] $tags Tags to filter by (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      * @deprecated
      */
-    public function findPetsByTagsAsync($tags)
+    public function findPetsByTagsAsync($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
     {
-        return $this->findPetsByTagsAsyncWithHttpInfo($tags)
+        return $this->findPetsByTagsAsyncWithHttpInfo($tags, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1161,15 +1210,16 @@ class PetApi
      * Finds Pets by tags
      *
      * @param  string[] $tags Tags to filter by (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      * @deprecated
      */
-    public function findPetsByTagsAsyncWithHttpInfo($tags)
+    public function findPetsByTagsAsyncWithHttpInfo($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Pet[]';
-        $request = $this->findPetsByTagsRequest($tags);
+        $request = $this->findPetsByTagsRequest($tags, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1211,12 +1261,13 @@ class PetApi
      * Create request for operation 'findPetsByTags'
      *
      * @param  string[] $tags Tags to filter by (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      * @deprecated
      */
-    public function findPetsByTagsRequest($tags)
+    public function findPetsByTagsRequest($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
     {
 
         // verify the required parameter 'tags' is set
@@ -1225,7 +1276,10 @@ class PetApi
                 'Missing the required parameter $tags when calling findPetsByTags'
             );
         }
-
+        
+        if(!in_array($contentType, self::contentTypes['findPetsByTags'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.findPetsByTags, must be one of [".implode(',', self::contentTypes['findPetsByTags'])."].");
+        }
 
         $resourcePath = '/pet/findByTags';
         $formParams = [];
@@ -1247,16 +1301,11 @@ class PetApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/xml', 'application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/xml', 'application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/xml', 'application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -1274,9 +1323,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1315,14 +1364,15 @@ class PetApi
      * Find pet by ID
      *
      * @param  int $pet_id ID of pet to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet
      */
-    public function getPetById($pet_id)
+    public function getPetById($pet_id, string $contentType = self::contentTypes['getPetById'][0])
     {
-        list($response) = $this->getPetByIdWithHttpInfo($pet_id);
+        list($response) = $this->getPetByIdWithHttpInfo($pet_id, $contentType);
         return $response;
     }
 
@@ -1332,14 +1382,15 @@ class PetApi
      * Find pet by ID
      *
      * @param  int $pet_id ID of pet to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getPetByIdWithHttpInfo($pet_id)
+    public function getPetByIdWithHttpInfo($pet_id, string $contentType = self::contentTypes['getPetById'][0])
     {
-        $request = $this->getPetByIdRequest($pet_id);
+        $request = $this->getPetByIdRequest($pet_id, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1431,13 +1482,14 @@ class PetApi
      * Find pet by ID
      *
      * @param  int $pet_id ID of pet to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getPetByIdAsync($pet_id)
+    public function getPetByIdAsync($pet_id, string $contentType = self::contentTypes['getPetById'][0])
     {
-        return $this->getPetByIdAsyncWithHttpInfo($pet_id)
+        return $this->getPetByIdAsyncWithHttpInfo($pet_id, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1451,14 +1503,15 @@ class PetApi
      * Find pet by ID
      *
      * @param  int $pet_id ID of pet to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getPetByIdAsyncWithHttpInfo($pet_id)
+    public function getPetByIdAsyncWithHttpInfo($pet_id, string $contentType = self::contentTypes['getPetById'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Pet';
-        $request = $this->getPetByIdRequest($pet_id);
+        $request = $this->getPetByIdRequest($pet_id, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1500,11 +1553,12 @@ class PetApi
      * Create request for operation 'getPetById'
      *
      * @param  int $pet_id ID of pet to return (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getPetByIdRequest($pet_id)
+    public function getPetByIdRequest($pet_id, string $contentType = self::contentTypes['getPetById'][0])
     {
 
         // verify the required parameter 'pet_id' is set
@@ -1512,6 +1566,10 @@ class PetApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling getPetById'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['getPetById'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.getPetById, must be one of [".implode(',', self::contentTypes['getPetById'])."].");
         }
 
         $resourcePath = '/pet/{petId}';
@@ -1533,16 +1591,11 @@ class PetApi
         }
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/xml', 'application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/xml', 'application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/xml', 'application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -1560,9 +1613,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1620,14 +1673,15 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function updatePet($pet, ?int $hostIndex = null, array $variables = [])
+    public function updatePet($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
     {
-        $this->updatePetWithHttpInfo($pet, $hostIndex, $variables);
+        $this->updatePetWithHttpInfo($pet, $hostIndex, $variables, $contentType);
     }
 
     /**
@@ -1654,14 +1708,15 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updatePetWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [])
+    public function updatePetWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
     {
-        $request = $this->updatePetRequest($pet, $hostIndex, $variables);
+        $request = $this->updatePetRequest($pet, $hostIndex, $variables, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1731,13 +1786,14 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetAsync($pet, ?int $hostIndex = null, array $variables = [])
+    public function updatePetAsync($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
     {
-        return $this->updatePetAsyncWithHttpInfo($pet, $hostIndex, $variables)
+        return $this->updatePetAsyncWithHttpInfo($pet, $hostIndex, $variables, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1769,14 +1825,15 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetAsyncWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [])
+    public function updatePetAsyncWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
     {
         $returnType = '';
-        $request = $this->updatePetRequest($pet, $hostIndex, $variables);
+        $request = $this->updatePetRequest($pet, $hostIndex, $variables, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1823,11 +1880,12 @@ class PetApi
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
      * @param  null|int $hostIndex Host index. Defaults to null. If null, then the library will use $this->hostIndex instead
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function updatePetRequest($pet, ?int $hostIndex = null, array $variables = [])
+    public function updatePetRequest($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
     {
 
         // verify the required parameter 'pet' is set
@@ -1835,6 +1893,10 @@ class PetApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pet when calling updatePet'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['updatePet'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.updatePet, must be one of [".implode(',', self::contentTypes['updatePet'])."].");
         }
 
         $resourcePath = '/pet';
@@ -1848,20 +1910,16 @@ class PetApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json', 'application/xml']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($pet)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
@@ -1881,9 +1939,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1976,14 +2034,15 @@ class PetApi
      * @param  int $pet_id ID of pet that needs to be updated (required)
      * @param  string $name Updated name of the pet (optional)
      * @param  string $status Updated status of the pet (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function updatePetWithForm($pet_id, $name = null, $status = null)
+    public function updatePetWithForm($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
     {
-        $this->updatePetWithFormWithHttpInfo($pet_id, $name, $status);
+        $this->updatePetWithFormWithHttpInfo($pet_id, $name, $status, $contentType);
     }
 
     /**
@@ -1994,14 +2053,15 @@ class PetApi
      * @param  int $pet_id ID of pet that needs to be updated (required)
      * @param  string $name Updated name of the pet (optional)
      * @param  string $status Updated status of the pet (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updatePetWithFormWithHttpInfo($pet_id, $name = null, $status = null)
+    public function updatePetWithFormWithHttpInfo($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
     {
-        $request = $this->updatePetWithFormRequest($pet_id, $name, $status);
+        $request = $this->updatePetWithFormRequest($pet_id, $name, $status, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2055,13 +2115,14 @@ class PetApi
      * @param  int $pet_id ID of pet that needs to be updated (required)
      * @param  string $name Updated name of the pet (optional)
      * @param  string $status Updated status of the pet (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetWithFormAsync($pet_id, $name = null, $status = null)
+    public function updatePetWithFormAsync($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
     {
-        return $this->updatePetWithFormAsyncWithHttpInfo($pet_id, $name, $status)
+        return $this->updatePetWithFormAsyncWithHttpInfo($pet_id, $name, $status, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2077,14 +2138,15 @@ class PetApi
      * @param  int $pet_id ID of pet that needs to be updated (required)
      * @param  string $name Updated name of the pet (optional)
      * @param  string $status Updated status of the pet (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetWithFormAsyncWithHttpInfo($pet_id, $name = null, $status = null)
+    public function updatePetWithFormAsyncWithHttpInfo($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
     {
         $returnType = '';
-        $request = $this->updatePetWithFormRequest($pet_id, $name, $status);
+        $request = $this->updatePetWithFormRequest($pet_id, $name, $status, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2115,11 +2177,12 @@ class PetApi
      * @param  int $pet_id ID of pet that needs to be updated (required)
      * @param  string $name Updated name of the pet (optional)
      * @param  string $status Updated status of the pet (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function updatePetWithFormRequest($pet_id, $name = null, $status = null)
+    public function updatePetWithFormRequest($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
     {
 
         // verify the required parameter 'pet_id' is set
@@ -2130,6 +2193,10 @@ class PetApi
         }
 
 
+
+        if(!in_array($contentType, self::contentTypes['updatePetWithForm'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.updatePetWithForm, must be one of [".implode(',', self::contentTypes['updatePetWithForm'])."].");
+        }
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -2158,16 +2225,11 @@ class PetApi
             $formParams['status'] = ObjectSerializer::toFormValue($status);
         }
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/x-www-form-urlencoded']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -2185,9 +2247,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2228,14 +2290,15 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
      * @param  \SplFileObject $file file to upload (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\ApiResponse
      */
-    public function uploadFile($pet_id, $additional_metadata = null, $file = null)
+    public function uploadFile($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
     {
-        list($response) = $this->uploadFileWithHttpInfo($pet_id, $additional_metadata, $file);
+        list($response) = $this->uploadFileWithHttpInfo($pet_id, $additional_metadata, $file, $contentType);
         return $response;
     }
 
@@ -2247,14 +2310,15 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
      * @param  \SplFileObject $file file to upload (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\ApiResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function uploadFileWithHttpInfo($pet_id, $additional_metadata = null, $file = null)
+    public function uploadFileWithHttpInfo($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
     {
-        $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file);
+        $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2348,13 +2412,14 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
      * @param  \SplFileObject $file file to upload (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileAsync($pet_id, $additional_metadata = null, $file = null)
+    public function uploadFileAsync($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
     {
-        return $this->uploadFileAsyncWithHttpInfo($pet_id, $additional_metadata, $file)
+        return $this->uploadFileAsyncWithHttpInfo($pet_id, $additional_metadata, $file, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2370,14 +2435,15 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
      * @param  \SplFileObject $file file to upload (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileAsyncWithHttpInfo($pet_id, $additional_metadata = null, $file = null)
+    public function uploadFileAsyncWithHttpInfo($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
     {
         $returnType = '\OpenAPI\Client\Model\ApiResponse';
-        $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file);
+        $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2421,11 +2487,12 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
      * @param  \SplFileObject $file file to upload (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function uploadFileRequest($pet_id, $additional_metadata = null, $file = null)
+    public function uploadFileRequest($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
     {
 
         // verify the required parameter 'pet_id' is set
@@ -2436,6 +2503,10 @@ class PetApi
         }
 
 
+
+        if(!in_array($contentType, self::contentTypes['uploadFile'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.uploadFile, must be one of [".implode(',', self::contentTypes['uploadFile'])."].");
+        }
 
         $resourcePath = '/pet/{petId}/uploadImage';
         $formParams = [];
@@ -2472,16 +2543,11 @@ class PetApi
             }
         }
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                ['multipart/form-data']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -2499,9 +2565,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -2542,14 +2608,15 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\ApiResponse
      */
-    public function uploadFileWithRequiredFile($pet_id, $required_file, $additional_metadata = null)
+    public function uploadFileWithRequiredFile($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
     {
-        list($response) = $this->uploadFileWithRequiredFileWithHttpInfo($pet_id, $required_file, $additional_metadata);
+        list($response) = $this->uploadFileWithRequiredFileWithHttpInfo($pet_id, $required_file, $additional_metadata, $contentType);
         return $response;
     }
 
@@ -2561,14 +2628,15 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\ApiResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function uploadFileWithRequiredFileWithHttpInfo($pet_id, $required_file, $additional_metadata = null)
+    public function uploadFileWithRequiredFileWithHttpInfo($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
     {
-        $request = $this->uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata);
+        $request = $this->uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2662,13 +2730,14 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileWithRequiredFileAsync($pet_id, $required_file, $additional_metadata = null)
+    public function uploadFileWithRequiredFileAsync($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
     {
-        return $this->uploadFileWithRequiredFileAsyncWithHttpInfo($pet_id, $required_file, $additional_metadata)
+        return $this->uploadFileWithRequiredFileAsyncWithHttpInfo($pet_id, $required_file, $additional_metadata, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2684,14 +2753,15 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileWithRequiredFileAsyncWithHttpInfo($pet_id, $required_file, $additional_metadata = null)
+    public function uploadFileWithRequiredFileAsyncWithHttpInfo($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
     {
         $returnType = '\OpenAPI\Client\Model\ApiResponse';
-        $request = $this->uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata);
+        $request = $this->uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2735,11 +2805,12 @@ class PetApi
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
      * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata = null)
+    public function uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
     {
 
         // verify the required parameter 'pet_id' is set
@@ -2756,6 +2827,10 @@ class PetApi
             );
         }
 
+
+        if(!in_array($contentType, self::contentTypes['uploadFileWithRequiredFile'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.uploadFileWithRequiredFile, must be one of [".implode(',', self::contentTypes['uploadFileWithRequiredFile'])."].");
+        }
 
         $resourcePath = '/fake/{petId}/uploadImageWithRequiredFile';
         $formParams = [];
@@ -2792,16 +2867,11 @@ class PetApi
             }
         }
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                ['multipart/form-data']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -2819,9 +2889,9 @@ class PetApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -394,9 +394,6 @@ class PetApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['addPet'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.addPet, must be one of [".implode(',', self::contentTypes['addPet'])."].");
-        }
 
         $resourcePath = '/pet';
         $formParams = [];
@@ -687,9 +684,6 @@ class PetApi
         }
 
 
-        if(!in_array($contentType, self::contentTypes['deletePet'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.deletePet, must be one of [".implode(',', self::contentTypes['deletePet'])."].");
-        }
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -981,9 +975,6 @@ class PetApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['findPetsByStatus'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.findPetsByStatus, must be one of [".implode(',', self::contentTypes['findPetsByStatus'])."].");
-        }
 
         $resourcePath = '/pet/findByStatus';
         $formParams = [];
@@ -1277,9 +1268,6 @@ class PetApi
             );
         }
         
-        if(!in_array($contentType, self::contentTypes['findPetsByTags'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.findPetsByTags, must be one of [".implode(',', self::contentTypes['findPetsByTags'])."].");
-        }
 
         $resourcePath = '/pet/findByTags';
         $formParams = [];
@@ -1568,9 +1556,6 @@ class PetApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['getPetById'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.getPetById, must be one of [".implode(',', self::contentTypes['getPetById'])."].");
-        }
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -1895,9 +1880,6 @@ class PetApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['updatePet'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.updatePet, must be one of [".implode(',', self::contentTypes['updatePet'])."].");
-        }
 
         $resourcePath = '/pet';
         $formParams = [];
@@ -2194,9 +2176,6 @@ class PetApi
 
 
 
-        if(!in_array($contentType, self::contentTypes['updatePetWithForm'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.updatePetWithForm, must be one of [".implode(',', self::contentTypes['updatePetWithForm'])."].");
-        }
 
         $resourcePath = '/pet/{petId}';
         $formParams = [];
@@ -2504,9 +2483,6 @@ class PetApi
 
 
 
-        if(!in_array($contentType, self::contentTypes['uploadFile'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.uploadFile, must be one of [".implode(',', self::contentTypes['uploadFile'])."].");
-        }
 
         $resourcePath = '/pet/{petId}/uploadImage';
         $formParams = [];
@@ -2828,9 +2804,6 @@ class PetApi
         }
 
 
-        if(!in_array($contentType, self::contentTypes['uploadFileWithRequiredFile'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling PetApi.uploadFileWithRequiredFile, must be one of [".implode(',', self::contentTypes['uploadFileWithRequiredFile'])."].");
-        }
 
         $resourcePath = '/fake/{petId}/uploadImageWithRequiredFile';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -69,7 +69,23 @@ class StoreApi
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [
+        'deleteOrder' => [
+            'application/json',
+        ],
+        'getInventory' => [
+            'application/json',
+        ],
+        'getOrderById' => [
+            'application/json',
+        ],
+        'placeOrder' => [
+            'application/json',
+        ],
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -121,14 +137,15 @@ class StoreApi
      * Delete purchase order by ID
      *
      * @param  string $order_id ID of the order that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deleteOrder($order_id)
+    public function deleteOrder($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
     {
-        $this->deleteOrderWithHttpInfo($order_id);
+        $this->deleteOrderWithHttpInfo($order_id, $contentType);
     }
 
     /**
@@ -137,14 +154,15 @@ class StoreApi
      * Delete purchase order by ID
      *
      * @param  string $order_id ID of the order that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deleteOrderWithHttpInfo($order_id)
+    public function deleteOrderWithHttpInfo($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
     {
-        $request = $this->deleteOrderRequest($order_id);
+        $request = $this->deleteOrderRequest($order_id, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -196,13 +214,14 @@ class StoreApi
      * Delete purchase order by ID
      *
      * @param  string $order_id ID of the order that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteOrderAsync($order_id)
+    public function deleteOrderAsync($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
     {
-        return $this->deleteOrderAsyncWithHttpInfo($order_id)
+        return $this->deleteOrderAsyncWithHttpInfo($order_id, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -216,14 +235,15 @@ class StoreApi
      * Delete purchase order by ID
      *
      * @param  string $order_id ID of the order that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteOrderAsyncWithHttpInfo($order_id)
+    public function deleteOrderAsyncWithHttpInfo($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
     {
         $returnType = '';
-        $request = $this->deleteOrderRequest($order_id);
+        $request = $this->deleteOrderRequest($order_id, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -252,11 +272,12 @@ class StoreApi
      * Create request for operation 'deleteOrder'
      *
      * @param  string $order_id ID of the order that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function deleteOrderRequest($order_id)
+    public function deleteOrderRequest($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
     {
 
         // verify the required parameter 'order_id' is set
@@ -264,6 +285,10 @@ class StoreApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $order_id when calling deleteOrder'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['deleteOrder'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.deleteOrder, must be one of [".implode(',', self::contentTypes['deleteOrder'])."].");
         }
 
         $resourcePath = '/store/order/{order_id}';
@@ -285,16 +310,11 @@ class StoreApi
         }
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -312,9 +332,9 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -348,14 +368,15 @@ class StoreApi
      *
      * Returns pet inventories by status
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array<string,int>
      */
-    public function getInventory()
+    public function getInventory(string $contentType = self::contentTypes['getInventory'][0])
     {
-        list($response) = $this->getInventoryWithHttpInfo();
+        list($response) = $this->getInventoryWithHttpInfo($contentType);
         return $response;
     }
 
@@ -364,14 +385,15 @@ class StoreApi
      *
      * Returns pet inventories by status
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of array<string,int>, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getInventoryWithHttpInfo()
+    public function getInventoryWithHttpInfo(string $contentType = self::contentTypes['getInventory'][0])
     {
-        $request = $this->getInventoryRequest();
+        $request = $this->getInventoryRequest($contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -462,13 +484,14 @@ class StoreApi
      *
      * Returns pet inventories by status
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getInventoryAsync()
+    public function getInventoryAsync(string $contentType = self::contentTypes['getInventory'][0])
     {
-        return $this->getInventoryAsyncWithHttpInfo()
+        return $this->getInventoryAsyncWithHttpInfo($contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -481,14 +504,15 @@ class StoreApi
      *
      * Returns pet inventories by status
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getInventoryAsyncWithHttpInfo()
+    public function getInventoryAsyncWithHttpInfo(string $contentType = self::contentTypes['getInventory'][0])
     {
         $returnType = 'array<string,int>';
-        $request = $this->getInventoryRequest();
+        $request = $this->getInventoryRequest($contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -529,12 +553,17 @@ class StoreApi
     /**
      * Create request for operation 'getInventory'
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getInventoryRequest()
+    public function getInventoryRequest(string $contentType = self::contentTypes['getInventory'][0])
     {
+
+        if(!in_array($contentType, self::contentTypes['getInventory'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.getInventory, must be one of [".implode(',', self::contentTypes['getInventory'])."].");
+        }
 
         $resourcePath = '/store/inventory';
         $formParams = [];
@@ -547,16 +576,11 @@ class StoreApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -574,9 +598,9 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -616,14 +640,15 @@ class StoreApi
      * Find purchase order by ID
      *
      * @param  int $order_id ID of pet that needs to be fetched (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Order
      */
-    public function getOrderById($order_id)
+    public function getOrderById($order_id, string $contentType = self::contentTypes['getOrderById'][0])
     {
-        list($response) = $this->getOrderByIdWithHttpInfo($order_id);
+        list($response) = $this->getOrderByIdWithHttpInfo($order_id, $contentType);
         return $response;
     }
 
@@ -633,14 +658,15 @@ class StoreApi
      * Find purchase order by ID
      *
      * @param  int $order_id ID of pet that needs to be fetched (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Order, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getOrderByIdWithHttpInfo($order_id)
+    public function getOrderByIdWithHttpInfo($order_id, string $contentType = self::contentTypes['getOrderById'][0])
     {
-        $request = $this->getOrderByIdRequest($order_id);
+        $request = $this->getOrderByIdRequest($order_id, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -732,13 +758,14 @@ class StoreApi
      * Find purchase order by ID
      *
      * @param  int $order_id ID of pet that needs to be fetched (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getOrderByIdAsync($order_id)
+    public function getOrderByIdAsync($order_id, string $contentType = self::contentTypes['getOrderById'][0])
     {
-        return $this->getOrderByIdAsyncWithHttpInfo($order_id)
+        return $this->getOrderByIdAsyncWithHttpInfo($order_id, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -752,14 +779,15 @@ class StoreApi
      * Find purchase order by ID
      *
      * @param  int $order_id ID of pet that needs to be fetched (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getOrderByIdAsyncWithHttpInfo($order_id)
+    public function getOrderByIdAsyncWithHttpInfo($order_id, string $contentType = self::contentTypes['getOrderById'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Order';
-        $request = $this->getOrderByIdRequest($order_id);
+        $request = $this->getOrderByIdRequest($order_id, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -801,11 +829,12 @@ class StoreApi
      * Create request for operation 'getOrderById'
      *
      * @param  int $order_id ID of pet that needs to be fetched (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getOrderByIdRequest($order_id)
+    public function getOrderByIdRequest($order_id, string $contentType = self::contentTypes['getOrderById'][0])
     {
 
         // verify the required parameter 'order_id' is set
@@ -820,7 +849,10 @@ class StoreApi
         if ($order_id < 1) {
             throw new \InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
         }
-
+        
+        if(!in_array($contentType, self::contentTypes['getOrderById'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.getOrderById, must be one of [".implode(',', self::contentTypes['getOrderById'])."].");
+        }
 
         $resourcePath = '/store/order/{order_id}';
         $formParams = [];
@@ -841,16 +873,11 @@ class StoreApi
         }
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/xml', 'application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/xml', 'application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/xml', 'application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -868,9 +895,9 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -905,14 +932,15 @@ class StoreApi
      * Place an order for a pet
      *
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Order
      */
-    public function placeOrder($order)
+    public function placeOrder($order, string $contentType = self::contentTypes['placeOrder'][0])
     {
-        list($response) = $this->placeOrderWithHttpInfo($order);
+        list($response) = $this->placeOrderWithHttpInfo($order, $contentType);
         return $response;
     }
 
@@ -922,14 +950,15 @@ class StoreApi
      * Place an order for a pet
      *
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Order, HTTP status code, HTTP response headers (array of strings)
      */
-    public function placeOrderWithHttpInfo($order)
+    public function placeOrderWithHttpInfo($order, string $contentType = self::contentTypes['placeOrder'][0])
     {
-        $request = $this->placeOrderRequest($order);
+        $request = $this->placeOrderRequest($order, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1021,13 +1050,14 @@ class StoreApi
      * Place an order for a pet
      *
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function placeOrderAsync($order)
+    public function placeOrderAsync($order, string $contentType = self::contentTypes['placeOrder'][0])
     {
-        return $this->placeOrderAsyncWithHttpInfo($order)
+        return $this->placeOrderAsyncWithHttpInfo($order, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1041,14 +1071,15 @@ class StoreApi
      * Place an order for a pet
      *
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function placeOrderAsyncWithHttpInfo($order)
+    public function placeOrderAsyncWithHttpInfo($order, string $contentType = self::contentTypes['placeOrder'][0])
     {
         $returnType = '\OpenAPI\Client\Model\Order';
-        $request = $this->placeOrderRequest($order);
+        $request = $this->placeOrderRequest($order, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1090,11 +1121,12 @@ class StoreApi
      * Create request for operation 'placeOrder'
      *
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function placeOrderRequest($order)
+    public function placeOrderRequest($order, string $contentType = self::contentTypes['placeOrder'][0])
     {
 
         // verify the required parameter 'order' is set
@@ -1102,6 +1134,10 @@ class StoreApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $order when calling placeOrder'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['placeOrder'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.placeOrder, must be one of [".implode(',', self::contentTypes['placeOrder'])."].");
         }
 
         $resourcePath = '/store/order';
@@ -1115,20 +1151,16 @@ class StoreApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/xml', 'application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/xml', 'application/json'],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/xml', 'application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($order)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($order));
             } else {
                 $httpBody = $order;
@@ -1148,9 +1180,9 @@ class StoreApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -287,9 +287,6 @@ class StoreApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['deleteOrder'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.deleteOrder, must be one of [".implode(',', self::contentTypes['deleteOrder'])."].");
-        }
 
         $resourcePath = '/store/order/{order_id}';
         $formParams = [];
@@ -561,9 +558,6 @@ class StoreApi
     public function getInventoryRequest(string $contentType = self::contentTypes['getInventory'][0])
     {
 
-        if(!in_array($contentType, self::contentTypes['getInventory'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.getInventory, must be one of [".implode(',', self::contentTypes['getInventory'])."].");
-        }
 
         $resourcePath = '/store/inventory';
         $formParams = [];
@@ -850,9 +844,6 @@ class StoreApi
             throw new \InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
         }
         
-        if(!in_array($contentType, self::contentTypes['getOrderById'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.getOrderById, must be one of [".implode(',', self::contentTypes['getOrderById'])."].");
-        }
 
         $resourcePath = '/store/order/{order_id}';
         $formParams = [];
@@ -1136,9 +1127,6 @@ class StoreApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['placeOrder'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling StoreApi.placeOrder, must be one of [".implode(',', self::contentTypes['placeOrder'])."].");
-        }
 
         $resourcePath = '/store/order';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -69,7 +69,35 @@ class UserApi
      */
     protected $hostIndex;
 
-    /**
+    /** @var string[] $contentTypes **/
+    public const contentTypes = [
+        'createUser' => [
+            'application/json',
+        ],
+        'createUsersWithArrayInput' => [
+            'application/json',
+        ],
+        'createUsersWithListInput' => [
+            'application/json',
+        ],
+        'deleteUser' => [
+            'application/json',
+        ],
+        'getUserByName' => [
+            'application/json',
+        ],
+        'loginUser' => [
+            'application/json',
+        ],
+        'logoutUser' => [
+            'application/json',
+        ],
+        'updateUser' => [
+            'application/json',
+        ],
+    ];
+
+/**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -121,14 +149,15 @@ class UserApi
      * Create user
      *
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function createUser($user)
+    public function createUser($user, string $contentType = self::contentTypes['createUser'][0])
     {
-        $this->createUserWithHttpInfo($user);
+        $this->createUserWithHttpInfo($user, $contentType);
     }
 
     /**
@@ -137,14 +166,15 @@ class UserApi
      * Create user
      *
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function createUserWithHttpInfo($user)
+    public function createUserWithHttpInfo($user, string $contentType = self::contentTypes['createUser'][0])
     {
-        $request = $this->createUserRequest($user);
+        $request = $this->createUserRequest($user, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -196,13 +226,14 @@ class UserApi
      * Create user
      *
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUserAsync($user)
+    public function createUserAsync($user, string $contentType = self::contentTypes['createUser'][0])
     {
-        return $this->createUserAsyncWithHttpInfo($user)
+        return $this->createUserAsyncWithHttpInfo($user, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -216,14 +247,15 @@ class UserApi
      * Create user
      *
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUserAsyncWithHttpInfo($user)
+    public function createUserAsyncWithHttpInfo($user, string $contentType = self::contentTypes['createUser'][0])
     {
         $returnType = '';
-        $request = $this->createUserRequest($user);
+        $request = $this->createUserRequest($user, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -252,11 +284,12 @@ class UserApi
      * Create request for operation 'createUser'
      *
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function createUserRequest($user)
+    public function createUserRequest($user, string $contentType = self::contentTypes['createUser'][0])
     {
 
         // verify the required parameter 'user' is set
@@ -264,6 +297,10 @@ class UserApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $user when calling createUser'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['createUser'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.createUser, must be one of [".implode(',', self::contentTypes['createUser'])."].");
         }
 
         $resourcePath = '/user';
@@ -277,20 +314,16 @@ class UserApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -310,9 +343,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -347,14 +380,15 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function createUsersWithArrayInput($user)
+    public function createUsersWithArrayInput($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
     {
-        $this->createUsersWithArrayInputWithHttpInfo($user);
+        $this->createUsersWithArrayInputWithHttpInfo($user, $contentType);
     }
 
     /**
@@ -363,14 +397,15 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function createUsersWithArrayInputWithHttpInfo($user)
+    public function createUsersWithArrayInputWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
     {
-        $request = $this->createUsersWithArrayInputRequest($user);
+        $request = $this->createUsersWithArrayInputRequest($user, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -422,13 +457,14 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithArrayInputAsync($user)
+    public function createUsersWithArrayInputAsync($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
     {
-        return $this->createUsersWithArrayInputAsyncWithHttpInfo($user)
+        return $this->createUsersWithArrayInputAsyncWithHttpInfo($user, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -442,14 +478,15 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithArrayInputAsyncWithHttpInfo($user)
+    public function createUsersWithArrayInputAsyncWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
     {
         $returnType = '';
-        $request = $this->createUsersWithArrayInputRequest($user);
+        $request = $this->createUsersWithArrayInputRequest($user, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -478,11 +515,12 @@ class UserApi
      * Create request for operation 'createUsersWithArrayInput'
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function createUsersWithArrayInputRequest($user)
+    public function createUsersWithArrayInputRequest($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
     {
 
         // verify the required parameter 'user' is set
@@ -490,6 +528,10 @@ class UserApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $user when calling createUsersWithArrayInput'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['createUsersWithArrayInput'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.createUsersWithArrayInput, must be one of [".implode(',', self::contentTypes['createUsersWithArrayInput'])."].");
         }
 
         $resourcePath = '/user/createWithArray';
@@ -503,20 +545,16 @@ class UserApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -536,9 +574,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -573,14 +611,15 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function createUsersWithListInput($user)
+    public function createUsersWithListInput($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
     {
-        $this->createUsersWithListInputWithHttpInfo($user);
+        $this->createUsersWithListInputWithHttpInfo($user, $contentType);
     }
 
     /**
@@ -589,14 +628,15 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function createUsersWithListInputWithHttpInfo($user)
+    public function createUsersWithListInputWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
     {
-        $request = $this->createUsersWithListInputRequest($user);
+        $request = $this->createUsersWithListInputRequest($user, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -648,13 +688,14 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithListInputAsync($user)
+    public function createUsersWithListInputAsync($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
     {
-        return $this->createUsersWithListInputAsyncWithHttpInfo($user)
+        return $this->createUsersWithListInputAsyncWithHttpInfo($user, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -668,14 +709,15 @@ class UserApi
      * Creates list of users with given input array
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithListInputAsyncWithHttpInfo($user)
+    public function createUsersWithListInputAsyncWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
     {
         $returnType = '';
-        $request = $this->createUsersWithListInputRequest($user);
+        $request = $this->createUsersWithListInputRequest($user, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -704,11 +746,12 @@ class UserApi
      * Create request for operation 'createUsersWithListInput'
      *
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function createUsersWithListInputRequest($user)
+    public function createUsersWithListInputRequest($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
     {
 
         // verify the required parameter 'user' is set
@@ -716,6 +759,10 @@ class UserApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $user when calling createUsersWithListInput'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['createUsersWithListInput'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.createUsersWithListInput, must be one of [".implode(',', self::contentTypes['createUsersWithListInput'])."].");
         }
 
         $resourcePath = '/user/createWithList';
@@ -729,20 +776,16 @@ class UserApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -762,9 +805,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -799,14 +842,15 @@ class UserApi
      * Delete user
      *
      * @param  string $username The name that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deleteUser($username)
+    public function deleteUser($username, string $contentType = self::contentTypes['deleteUser'][0])
     {
-        $this->deleteUserWithHttpInfo($username);
+        $this->deleteUserWithHttpInfo($username, $contentType);
     }
 
     /**
@@ -815,14 +859,15 @@ class UserApi
      * Delete user
      *
      * @param  string $username The name that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deleteUserWithHttpInfo($username)
+    public function deleteUserWithHttpInfo($username, string $contentType = self::contentTypes['deleteUser'][0])
     {
-        $request = $this->deleteUserRequest($username);
+        $request = $this->deleteUserRequest($username, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -874,13 +919,14 @@ class UserApi
      * Delete user
      *
      * @param  string $username The name that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteUserAsync($username)
+    public function deleteUserAsync($username, string $contentType = self::contentTypes['deleteUser'][0])
     {
-        return $this->deleteUserAsyncWithHttpInfo($username)
+        return $this->deleteUserAsyncWithHttpInfo($username, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -894,14 +940,15 @@ class UserApi
      * Delete user
      *
      * @param  string $username The name that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteUserAsyncWithHttpInfo($username)
+    public function deleteUserAsyncWithHttpInfo($username, string $contentType = self::contentTypes['deleteUser'][0])
     {
         $returnType = '';
-        $request = $this->deleteUserRequest($username);
+        $request = $this->deleteUserRequest($username, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -930,11 +977,12 @@ class UserApi
      * Create request for operation 'deleteUser'
      *
      * @param  string $username The name that needs to be deleted (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function deleteUserRequest($username)
+    public function deleteUserRequest($username, string $contentType = self::contentTypes['deleteUser'][0])
     {
 
         // verify the required parameter 'username' is set
@@ -942,6 +990,10 @@ class UserApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $username when calling deleteUser'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['deleteUser'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.deleteUser, must be one of [".implode(',', self::contentTypes['deleteUser'])."].");
         }
 
         $resourcePath = '/user/{username}';
@@ -963,16 +1015,11 @@ class UserApi
         }
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -990,9 +1037,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1027,14 +1074,15 @@ class UserApi
      * Get user by user name
      *
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\User
      */
-    public function getUserByName($username)
+    public function getUserByName($username, string $contentType = self::contentTypes['getUserByName'][0])
     {
-        list($response) = $this->getUserByNameWithHttpInfo($username);
+        list($response) = $this->getUserByNameWithHttpInfo($username, $contentType);
         return $response;
     }
 
@@ -1044,14 +1092,15 @@ class UserApi
      * Get user by user name
      *
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\User, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getUserByNameWithHttpInfo($username)
+    public function getUserByNameWithHttpInfo($username, string $contentType = self::contentTypes['getUserByName'][0])
     {
-        $request = $this->getUserByNameRequest($username);
+        $request = $this->getUserByNameRequest($username, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1143,13 +1192,14 @@ class UserApi
      * Get user by user name
      *
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getUserByNameAsync($username)
+    public function getUserByNameAsync($username, string $contentType = self::contentTypes['getUserByName'][0])
     {
-        return $this->getUserByNameAsyncWithHttpInfo($username)
+        return $this->getUserByNameAsyncWithHttpInfo($username, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1163,14 +1213,15 @@ class UserApi
      * Get user by user name
      *
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getUserByNameAsyncWithHttpInfo($username)
+    public function getUserByNameAsyncWithHttpInfo($username, string $contentType = self::contentTypes['getUserByName'][0])
     {
         $returnType = '\OpenAPI\Client\Model\User';
-        $request = $this->getUserByNameRequest($username);
+        $request = $this->getUserByNameRequest($username, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1212,11 +1263,12 @@ class UserApi
      * Create request for operation 'getUserByName'
      *
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getUserByNameRequest($username)
+    public function getUserByNameRequest($username, string $contentType = self::contentTypes['getUserByName'][0])
     {
 
         // verify the required parameter 'username' is set
@@ -1224,6 +1276,10 @@ class UserApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $username when calling getUserByName'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['getUserByName'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.getUserByName, must be one of [".implode(',', self::contentTypes['getUserByName'])."].");
         }
 
         $resourcePath = '/user/{username}';
@@ -1245,16 +1301,11 @@ class UserApi
         }
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/xml', 'application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/xml', 'application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/xml', 'application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -1272,9 +1323,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1310,14 +1361,15 @@ class UserApi
      *
      * @param  string $username The user name for login (required)
      * @param  string $password The password for login in clear text (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function loginUser($username, $password)
+    public function loginUser($username, $password, string $contentType = self::contentTypes['loginUser'][0])
     {
-        list($response) = $this->loginUserWithHttpInfo($username, $password);
+        list($response) = $this->loginUserWithHttpInfo($username, $password, $contentType);
         return $response;
     }
 
@@ -1328,14 +1380,15 @@ class UserApi
      *
      * @param  string $username The user name for login (required)
      * @param  string $password The password for login in clear text (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function loginUserWithHttpInfo($username, $password)
+    public function loginUserWithHttpInfo($username, $password, string $contentType = self::contentTypes['loginUser'][0])
     {
-        $request = $this->loginUserRequest($username, $password);
+        $request = $this->loginUserRequest($username, $password, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1428,13 +1481,14 @@ class UserApi
      *
      * @param  string $username The user name for login (required)
      * @param  string $password The password for login in clear text (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function loginUserAsync($username, $password)
+    public function loginUserAsync($username, $password, string $contentType = self::contentTypes['loginUser'][0])
     {
-        return $this->loginUserAsyncWithHttpInfo($username, $password)
+        return $this->loginUserAsyncWithHttpInfo($username, $password, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1449,14 +1503,15 @@ class UserApi
      *
      * @param  string $username The user name for login (required)
      * @param  string $password The password for login in clear text (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function loginUserAsyncWithHttpInfo($username, $password)
+    public function loginUserAsyncWithHttpInfo($username, $password, string $contentType = self::contentTypes['loginUser'][0])
     {
         $returnType = 'string';
-        $request = $this->loginUserRequest($username, $password);
+        $request = $this->loginUserRequest($username, $password, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1499,11 +1554,12 @@ class UserApi
      *
      * @param  string $username The user name for login (required)
      * @param  string $password The password for login in clear text (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function loginUserRequest($username, $password)
+    public function loginUserRequest($username, $password, string $contentType = self::contentTypes['loginUser'][0])
     {
 
         // verify the required parameter 'username' is set
@@ -1518,6 +1574,10 @@ class UserApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $password when calling loginUser'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['loginUser'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.loginUser, must be one of [".implode(',', self::contentTypes['loginUser'])."].");
         }
 
         $resourcePath = '/user/login';
@@ -1549,16 +1609,11 @@ class UserApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                ['application/xml', 'application/json']
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                ['application/xml', 'application/json'],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/xml', 'application/json', ],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -1576,9 +1631,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1612,14 +1667,15 @@ class UserApi
      *
      * Logs out current logged in user session
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function logoutUser()
+    public function logoutUser(string $contentType = self::contentTypes['logoutUser'][0])
     {
-        $this->logoutUserWithHttpInfo();
+        $this->logoutUserWithHttpInfo($contentType);
     }
 
     /**
@@ -1627,14 +1683,15 @@ class UserApi
      *
      * Logs out current logged in user session
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function logoutUserWithHttpInfo()
+    public function logoutUserWithHttpInfo(string $contentType = self::contentTypes['logoutUser'][0])
     {
-        $request = $this->logoutUserRequest();
+        $request = $this->logoutUserRequest($contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1685,13 +1742,14 @@ class UserApi
      *
      * Logs out current logged in user session
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function logoutUserAsync()
+    public function logoutUserAsync(string $contentType = self::contentTypes['logoutUser'][0])
     {
-        return $this->logoutUserAsyncWithHttpInfo()
+        return $this->logoutUserAsyncWithHttpInfo($contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1704,14 +1762,15 @@ class UserApi
      *
      * Logs out current logged in user session
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function logoutUserAsyncWithHttpInfo()
+    public function logoutUserAsyncWithHttpInfo(string $contentType = self::contentTypes['logoutUser'][0])
     {
         $returnType = '';
-        $request = $this->logoutUserRequest();
+        $request = $this->logoutUserRequest($contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1739,12 +1798,17 @@ class UserApi
     /**
      * Create request for operation 'logoutUser'
      *
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function logoutUserRequest()
+    public function logoutUserRequest(string $contentType = self::contentTypes['logoutUser'][0])
     {
+
+        if(!in_array($contentType, self::contentTypes['logoutUser'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.logoutUser, must be one of [".implode(',', self::contentTypes['logoutUser'])."].");
+        }
 
         $resourcePath = '/user/logout';
         $formParams = [];
@@ -1757,16 +1821,11 @@ class UserApi
 
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                []
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (count($formParams) > 0) {
@@ -1784,9 +1843,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);
@@ -1822,14 +1881,15 @@ class UserApi
      *
      * @param  string $username name that need to be deleted (required)
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function updateUser($username, $user)
+    public function updateUser($username, $user, string $contentType = self::contentTypes['updateUser'][0])
     {
-        $this->updateUserWithHttpInfo($username, $user);
+        $this->updateUserWithHttpInfo($username, $user, $contentType);
     }
 
     /**
@@ -1839,14 +1899,15 @@ class UserApi
      *
      * @param  string $username name that need to be deleted (required)
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updateUserWithHttpInfo($username, $user)
+    public function updateUserWithHttpInfo($username, $user, string $contentType = self::contentTypes['updateUser'][0])
     {
-        $request = $this->updateUserRequest($username, $user);
+        $request = $this->updateUserRequest($username, $user, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1899,13 +1960,14 @@ class UserApi
      *
      * @param  string $username name that need to be deleted (required)
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updateUserAsync($username, $user)
+    public function updateUserAsync($username, $user, string $contentType = self::contentTypes['updateUser'][0])
     {
-        return $this->updateUserAsyncWithHttpInfo($username, $user)
+        return $this->updateUserAsyncWithHttpInfo($username, $user, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1920,14 +1982,15 @@ class UserApi
      *
      * @param  string $username name that need to be deleted (required)
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updateUserAsyncWithHttpInfo($username, $user)
+    public function updateUserAsyncWithHttpInfo($username, $user, string $contentType = self::contentTypes['updateUser'][0])
     {
         $returnType = '';
-        $request = $this->updateUserRequest($username, $user);
+        $request = $this->updateUserRequest($username, $user, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1957,11 +2020,12 @@ class UserApi
      *
      * @param  string $username name that need to be deleted (required)
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function updateUserRequest($username, $user)
+    public function updateUserRequest($username, $user, string $contentType = self::contentTypes['updateUser'][0])
     {
 
         // verify the required parameter 'username' is set
@@ -1976,6 +2040,10 @@ class UserApi
             throw new \InvalidArgumentException(
                 'Missing the required parameter $user when calling updateUser'
             );
+        }
+
+        if(!in_array($contentType, self::contentTypes['updateUser'], true)) {
+            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.updateUser, must be one of [".implode(',', self::contentTypes['updateUser'])."].");
         }
 
         $resourcePath = '/user/{username}';
@@ -1997,20 +2065,16 @@ class UserApi
         }
 
 
-        if ($multipart) {
-            $headers = $this->headerSelector->selectHeadersForMultipart(
-                []
-            );
-        } else {
-            $headers = $this->headerSelector->selectHeaders(
-                [],
-                ['application/json']
-            );
-        }
+        $headers = $this->headerSelector->selectHeaders(
+            [],
+            $contentType,
+            $multipart
+        );
 
         // for model (json/xml)
         if (isset($user)) {
-            if ($headers['Content-Type'] === 'application/json') {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($user));
             } else {
                 $httpBody = $user;
@@ -2030,9 +2094,9 @@ class UserApi
                 // for HTTP post (form)
                 $httpBody = new MultipartStream($multipartContents);
 
-            } elseif ($headers['Content-Type'] === 'application/json') {
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
                 $httpBody = \GuzzleHttp\json_encode($formParams);
-
             } else {
                 // for HTTP post (form)
                 $httpBody = ObjectSerializer::buildQuery($formParams);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -299,9 +299,6 @@ class UserApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['createUser'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.createUser, must be one of [".implode(',', self::contentTypes['createUser'])."].");
-        }
 
         $resourcePath = '/user';
         $formParams = [];
@@ -530,9 +527,6 @@ class UserApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['createUsersWithArrayInput'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.createUsersWithArrayInput, must be one of [".implode(',', self::contentTypes['createUsersWithArrayInput'])."].");
-        }
 
         $resourcePath = '/user/createWithArray';
         $formParams = [];
@@ -761,9 +755,6 @@ class UserApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['createUsersWithListInput'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.createUsersWithListInput, must be one of [".implode(',', self::contentTypes['createUsersWithListInput'])."].");
-        }
 
         $resourcePath = '/user/createWithList';
         $formParams = [];
@@ -992,9 +983,6 @@ class UserApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['deleteUser'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.deleteUser, must be one of [".implode(',', self::contentTypes['deleteUser'])."].");
-        }
 
         $resourcePath = '/user/{username}';
         $formParams = [];
@@ -1278,9 +1266,6 @@ class UserApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['getUserByName'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.getUserByName, must be one of [".implode(',', self::contentTypes['getUserByName'])."].");
-        }
 
         $resourcePath = '/user/{username}';
         $formParams = [];
@@ -1576,9 +1561,6 @@ class UserApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['loginUser'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.loginUser, must be one of [".implode(',', self::contentTypes['loginUser'])."].");
-        }
 
         $resourcePath = '/user/login';
         $formParams = [];
@@ -1806,9 +1788,6 @@ class UserApi
     public function logoutUserRequest(string $contentType = self::contentTypes['logoutUser'][0])
     {
 
-        if(!in_array($contentType, self::contentTypes['logoutUser'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.logoutUser, must be one of [".implode(',', self::contentTypes['logoutUser'])."].");
-        }
 
         $resourcePath = '/user/logout';
         $formParams = [];
@@ -2042,9 +2021,6 @@ class UserApi
             );
         }
 
-        if(!in_array($contentType, self::contentTypes['updateUser'], true)) {
-            throw new \InvalidArgumentException("invalid value for \"contentType\" when calling UserApi.updateUser, must be one of [".implode(',', self::contentTypes['updateUser'])."].");
-        }
 
         $resourcePath = '/user/{username}';
         $formParams = [];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/HeaderSelector.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/HeaderSelector.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ApiException
+ * HeaderSelector
  * PHP version 7.4
  *
  * @category Class
@@ -27,10 +27,8 @@
 
 namespace OpenAPI\Client;
 
-use \Exception;
-
 /**
- * ApiException Class Doc Comment
+ * HeaderSelector Class Doc Comment
  *
  * @category Class
  * @package  OpenAPI\Client
@@ -41,10 +39,11 @@ class HeaderSelector
 {
     /**
      * @param string[] $accept
-     * @param string[] $contentTypes
-     * @return array
+     * @param string   $contentType
+     * @param bool     $isMultipart
+     * @return string[]
      */
-    public function selectHeaders($accept, $contentTypes)
+    public function selectHeaders(array $accept, string $contentType, bool $isMultipart): array
     {
         $headers = [];
 
@@ -52,20 +51,13 @@ class HeaderSelector
         if ($accept !== null) {
             $headers['Accept'] = $accept;
         }
+        if(!$isMultipart) {
+            if($contentType === '') {
+                $contentType = 'application/json';
+            }
+            $headers['Content-Type'] = $contentType;
+        }
 
-        $headers['Content-Type'] = $this->selectContentTypeHeader($contentTypes);
-        return $headers;
-    }
-
-    /**
-     * @param string[] $accept
-     * @return array
-     */
-    public function selectHeadersForMultipart($accept)
-    {
-        $headers = $this->selectHeaders($accept, []);
-
-        unset($headers['Content-Type']);
         return $headers;
     }
 
@@ -84,24 +76,6 @@ class HeaderSelector
             return implode(',', $jsonAccept);
         } else {
             return implode(',', $accept);
-        }
-    }
-
-    /**
-     * Return the content type based on an array of content-type provided
-     *
-     * @param string[] $contentType Array fo content-type
-     *
-     * @return string Content-Type (e.g. application/json)
-     */
-    private function selectContentTypeHeader($contentType)
-    {
-        if (count($contentType) === 0 || (count($contentType) === 1 && $contentType[0] === '')) {
-            return 'application/json';
-        } elseif (preg_grep("/application\/json/i", $contentType)) {
-            return 'application/json';
-        } else {
-            return implode(',', $contentType);
         }
     }
 }


### PR DESCRIPTION
The current HeaderSelector class is handling Content-Type incorrectly:
1. When there are multiple Content types in the OpenAPI Definition and none are of type application/json, it is concatenating them. This is explicitly described as incorrect in IETF RFC9110, section 8.3, last paragraph:
> Although Content-Type is defined as a singleton field, it is sometimes incorrectly generated multiple times, resulting in a combined field value that appears to be a list. Recipients often attempt to handle this error by using the last syntactically valid member of the list, leading to potential interoperability and security issues if different implementations have different error handling behaviors.
2. If any of the multiple content types contains "application/json", then it will always set the Content Type as "application/json" - potentially ignoring parameters given to that content type. Many services expect to receive parameters in the Content-Type header: they can be used, for example to define the charset, restrict the amount of data to be received or define the standard to be used when reading floating-point fields. Consider the following examples:
```
Content-Type: application/json; IEEE754Compatible=true
Content-Type: application/json; charset=ISO-8859-4
Content-Type: application/json; odata.metadata=minimal
```
The first one is critical when sending data to Microsoft Business Central: without it, sending a numeric (floating point) field through POST will result in 500 error.

3. Third-party OpenAPI definitions may offer multiple content-types for application/json, each one with different parameters. Right now, it is not possible to choose between them.

In order to solve this issues, and after discussing them with @wing328, I'm presenting this PR to add the Content-Type as an extra parameter to the operation calls.

I thought about creating constants for the Content-Types, but normalizing them in order to create the constant names (like we do for field names and enum constants, for example) would require changes to the PhpClientCodegen. To avoid that, I chose to create a constant array to hold the possible Content-Types for each operation. In this way, we can provide a list of possible values for the $contentType parameter, and also validate it.

I've also discussed changes to the Accept header. They will come in a separate PR, to keep it small.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon
