### PR TITLE
Add flex wrap to website logo display in mobile devices

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -41,6 +41,7 @@ html[data-theme=''] .navbar__logo {
 
 .avatar__photo-link.bronze-sponsor {
     display: flex;
+    flex-wrap: wrap;
     margin-left: var(--button-margin);
 }
 


### PR DESCRIPTION
Add flex wrap to website logo display in mobile devices

![Screen Shot 2022-10-20 at 11 40 20 am](https://user-images.githubusercontent.com/934260/196851204-898a69e1-ada7-4a5c-b030-e1d34bd956da.png)



<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
