### PR TITLE
[elm] add function to allow more fine grained error handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/elm/Api.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/Api.mustache
@@ -3,6 +3,7 @@ module Api exposing
     , request
     , send
     , sendWithCustomError
+    , sendWithCustomExpect
     , task
     , map
     , withBasePath
@@ -55,13 +56,18 @@ send toMsg req =
 
 
 sendWithCustomError : (Http.Error -> e) -> (Result e a -> msg) -> Request a -> Cmd msg
-sendWithCustomError mapError toMsg (Request req) =
+sendWithCustomError mapError toMsg req =
+    sendWithCustomExpect (expectJson mapError toMsg) req
+
+
+sendWithCustomExpect : (Json.Decode.Decoder a -> Http.Expect msg) -> Request a -> Cmd msg
+sendWithCustomExpect expect (Request req) =
     Http.request
         { method = req.method
         , headers = req.headers
         , url = Url.Builder.crossOrigin req.basePath req.pathParams req.queryParams
         , body = req.body
-        , expect = expectJson mapError toMsg req.decoder
+        , expect = expect req.decoder
         , timeout = req.timeout
         , tracker = req.tracker
         }

--- a/samples/openapi3/client/elm/src/Api.elm
+++ b/samples/openapi3/client/elm/src/Api.elm
@@ -3,6 +3,7 @@ module Api exposing
     , request
     , send
     , sendWithCustomError
+    , sendWithCustomExpect
     , task
     , map
     , withBasePath
@@ -55,13 +56,18 @@ send toMsg req =
 
 
 sendWithCustomError : (Http.Error -> e) -> (Result e a -> msg) -> Request a -> Cmd msg
-sendWithCustomError mapError toMsg (Request req) =
+sendWithCustomError mapError toMsg req =
+    sendWithCustomExpect (expectJson mapError toMsg) req
+
+
+sendWithCustomExpect : (Json.Decode.Decoder a -> Http.Expect msg) -> Request a -> Cmd msg
+sendWithCustomExpect expect (Request req) =
     Http.request
         { method = req.method
         , headers = req.headers
         , url = Url.Builder.crossOrigin req.basePath req.pathParams req.queryParams
         , body = req.body
-        , expect = expectJson mapError toMsg req.decoder
+        , expect = expect req.decoder
         , timeout = req.timeout
         , tracker = req.tracker
         }


### PR DESCRIPTION
This is a backwards compatible change. It adds the additional function `sendWithCustomExpect` to the provided helper functions in `Api.elm` to make requests.

It can be used to implement a more fine grained error handling as described [here](https://package.elm-lang.org/packages/elm/http/latest/Http#expectStringResponse). Before it was e.g. not possible to access the response body if the server responded with an error like 404.

@eriktim

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
