### PR TITLE
fix #13150 Add uniqueModelMappings option

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -1080,6 +1080,45 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void testMappingSubtypesIssue13150() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/bugs/issue_13150.yaml", null, new ParseOptions()).getOpenAPI();
+
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setUniqueModelMappings(true);
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        codegen.setHateoas(true);
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
+
+        codegen.setUseOneOfInterfaces(true);
+        codegen.setLegacyDiscriminatorBehavior(false);
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+
+        generator.opts(input).generate();
+
+        String jsonSubType = "@JsonSubTypes({\n" +
+            "  @JsonSubTypes.Type(value = Foo.class, name = \"foo\")\n" +
+            "})";
+        assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Parent.java"), jsonSubType);
+    }
+
+    @Test
     public void testTypeMappings() {
         final SpringCodegen codegen = new SpringCodegen();
         codegen.processOpts();

--- a/modules/openapi-generator/src/test/resources/bugs/issue_13150.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_13150.yaml
@@ -1,0 +1,60 @@
+openapi: '3.0.0'
+info:
+  version: '1.0.0'
+  title: 'FooService'
+paths:
+  /parent:
+    put:
+      summary: put parent
+      operationId: putParent
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Name of the account being updated.
+          schema:
+            type: string
+      requestBody:
+        description: The updated account definition to save.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Parent'
+      responses:
+        '200':
+          $ref: '#/components/responses/Parent'
+components:
+  schemas:
+    Parent:
+      type: object
+      description: Defines an account by name.
+      properties:
+        name:
+          type: string
+          description: The account name.
+        type:
+          type: string
+          description: The account type discriminator.
+      required:
+        - name
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          foo: '#/components/schemas/Foo'
+
+    Foo:
+      allOf:
+        - $ref: "#/components/schemas/Parent"
+        - type: object
+          properties:
+            fooType:
+              type: string
+  responses:
+    Parent:
+      description: The saved account definition.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Parent'


### PR DESCRIPTION
Having multiple names for a model mapping can cause issues with clients that are expecting a particular types to always have the same model name. Refer https://github.com/OpenAPITools/openapi-generator/issues/13150. Since this potentially breaks system that rely on having the class names work as mappings alongside custom discriminator values, a new configuration option has been added - `uniqueModelMappings` (defaults to `false`). 

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
