### PR TITLE
Revert "Fix #6899 - python-flask now uses the pre-existing getter/setter validators"

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-flask/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/model.mustache
@@ -58,7 +58,7 @@ class {{classname}}(Model):
         }
 {{#vars}}{{#-first}}
 {{/-first}}
-        self.{{name}} = {{name}}
+        self._{{name}} = {{name}}
 {{/vars}}
 
     @classmethod

--- a/samples/server/petstore/python-flask/openapi_server/models/api_response.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/api_response.py
@@ -37,9 +37,9 @@ class ApiResponse(Model):
             'message': 'message'
         }
 
-        self.code = code
-        self.type = type
-        self.message = message
+        self._code = code
+        self._type = type
+        self._message = message
 
     @classmethod
     def from_dict(cls, dikt) -> 'ApiResponse':

--- a/samples/server/petstore/python-flask/openapi_server/models/category.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/category.py
@@ -33,8 +33,8 @@ class Category(Model):
             'name': 'name'
         }
 
-        self.id = id
-        self.name = name
+        self._id = id
+        self._name = name
 
     @classmethod
     def from_dict(cls, dikt) -> 'Category':

--- a/samples/server/petstore/python-flask/openapi_server/models/order.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/order.py
@@ -49,12 +49,12 @@ class Order(Model):
             'complete': 'complete'
         }
 
-        self.id = id
-        self.pet_id = pet_id
-        self.quantity = quantity
-        self.ship_date = ship_date
-        self.status = status
-        self.complete = complete
+        self._id = id
+        self._pet_id = pet_id
+        self._quantity = quantity
+        self._ship_date = ship_date
+        self._status = status
+        self._complete = complete
 
     @classmethod
     def from_dict(cls, dikt) -> 'Order':

--- a/samples/server/petstore/python-flask/openapi_server/models/pet.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/pet.py
@@ -53,12 +53,12 @@ class Pet(Model):
             'status': 'status'
         }
 
-        self.id = id
-        self.category = category
-        self.name = name
-        self.photo_urls = photo_urls
-        self.tags = tags
-        self.status = status
+        self._id = id
+        self._category = category
+        self._name = name
+        self._photo_urls = photo_urls
+        self._tags = tags
+        self._status = status
 
     @classmethod
     def from_dict(cls, dikt) -> 'Pet':

--- a/samples/server/petstore/python-flask/openapi_server/models/tag.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/tag.py
@@ -33,8 +33,8 @@ class Tag(Model):
             'name': 'name'
         }
 
-        self.id = id
-        self.name = name
+        self._id = id
+        self._name = name
 
     @classmethod
     def from_dict(cls, dikt) -> 'Tag':

--- a/samples/server/petstore/python-flask/openapi_server/models/user.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/user.py
@@ -57,14 +57,14 @@ class User(Model):
             'user_status': 'userStatus'
         }
 
-        self.id = id
-        self.username = username
-        self.first_name = first_name
-        self.last_name = last_name
-        self.email = email
-        self.password = password
-        self.phone = phone
-        self.user_status = user_status
+        self._id = id
+        self._username = username
+        self._first_name = first_name
+        self._last_name = last_name
+        self._email = email
+        self._password = password
+        self._phone = phone
+        self._user_status = user_status
 
     @classmethod
     def from_dict(cls, dikt) -> 'User':


### PR DESCRIPTION
Reverts OpenAPITools/openapi-generator#6911

Because the source PR broke from_dict functionality
https://github.com/OpenAPITools/openapi-generator/pull/6911#issuecomment-667245941