### PR TITLE
Single inheritance alias 13784

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -242,7 +242,7 @@ public class DefaultCodegen implements CodegenConfig {
     // Then translated back during JSON encoding and decoding
     protected Map<String, String> specialCharReplacements = new LinkedHashMap<>();
     // When a model is an alias for a simple type
-    protected Map<String, String> typeAliases = null;
+    protected Map<String, String> typeAliases = Collections.emptyMap();
     protected Boolean prependFormOrBodyParameters = false;
     // The extension of the generated documentation files (defaults to markdown .md)
     protected String docExtension;
@@ -844,6 +844,9 @@ public class DefaultCodegen implements CodegenConfig {
         // Set global settings such that helper functions in ModelUtils can lookup the value
         // of the CLI option.
         ModelUtils.setDisallowAdditionalPropertiesIfNotPresent(getDisallowAdditionalPropertiesIfNotPresent());
+
+        // Multiple operations rely on proper type aliases, so we should always update them
+        typeAliases = getAllAliases(ModelUtils.getSchemas(openAPI));
     }
 
     // override with any message to be shown right before the process finishes
@@ -2861,10 +2864,6 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public CodegenModel fromModel(String name, Schema schema) {
         Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
-        if (typeAliases == null) {
-            // Only do this once during first call
-            typeAliases = getAllAliases(allDefinitions);
-        }
 
         CodegenModel m = CodegenModelFactory.newInstance(CodegenModelType.MODEL);
         if (schema.equals(trueSchema)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5708,6 +5708,28 @@ public class DefaultCodegen implements CodegenConfig {
 
         }
 
+		boolean foundNewAlias;
+		do {
+			foundNewAlias = false;
+			for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
+				if (aliases.containsKey(entry.getKey())) {
+					continue;
+				}
+				Schema schema = entry.getValue();
+				if(!(schema instanceof ComposedSchema)) {
+					continue;
+				}
+				List<Schema> subTypes = ModelUtils.getInterfaces((ComposedSchema)schema);
+				if (subTypes.size() == 1) {
+					String aliasType = ModelUtils.getSimpleRef(subTypes.get(0).get$ref());
+					if (aliases.containsKey(aliasType)) {
+						aliases.put(entry.getKey(), aliases.get(aliasType));
+						foundNewAlias = true;
+					}
+				}
+			}
+		} while (foundNewAlias);
+
         return aliases;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -242,7 +242,7 @@ public class DefaultCodegen implements CodegenConfig {
     // Then translated back during JSON encoding and decoding
     protected Map<String, String> specialCharReplacements = new LinkedHashMap<>();
     // When a model is an alias for a simple type
-    protected Map<String, String> typeAliases = Collections.emptyMap();
+    protected Map<String, Schema> typeAliases = Collections.emptyMap();
     protected Boolean prependFormOrBodyParameters = false;
     // The extension of the generated documentation files (defaults to markdown .md)
     protected String docExtension;
@@ -2245,6 +2245,13 @@ public class DefaultCodegen implements CodegenConfig {
 
     @Override
     public Schema unaliasSchema(Schema schema) {
+        if(schema != null && schema.get$ref() != null) {
+            String schemaName = ModelUtils.getSimpleRef(schema.get$ref());
+            // Explicit schema mapping wins, otherwise we use the primitive type alias
+            if(!schemaMapping.containsKey(schemaName) && typeAliases.containsKey(schemaName)) {
+                return typeAliases.get(schemaName);
+            }
+        }
         return ModelUtils.unaliasSchema(this.openAPI, schema, schemaMapping);
     }
 
@@ -2423,8 +2430,8 @@ public class DefaultCodegen implements CodegenConfig {
      * for this type, then returns the input type name.
      */
     public String getAlias(String name) {
-        if (typeAliases != null && typeAliases.containsKey(name)) {
-            return typeAliases.get(name);
+        if (typeAliases.containsKey(name)) {
+            return getPrimitiveType(typeAliases.get(name));
         }
         return name;
     }
@@ -5691,18 +5698,17 @@ public class DefaultCodegen implements CodegenConfig {
      * @param schemas The complete set of model definitions (schemas).
      * @return A mapping from model name to type alias
      */
-    Map<String, String> getAllAliases(Map<String, Schema> schemas) {
+    Map<String, Schema> getAllAliases(Map<String, Schema> schemas) {
         if (schemas == null || schemas.isEmpty()) {
             return new HashMap<>();
         }
 
-        Map<String, String> aliases = new HashMap<>();
+        Map<String, Schema> aliases = new HashMap<>();
         for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
             Schema schema = entry.getValue();
             if (isAliasOfSimpleTypes(schema)) {
                 String oasName = entry.getKey();
-                String schemaType = getPrimitiveType(schema);
-                aliases.put(oasName, schemaType);
+                aliases.put(oasName, schema);
             }
 
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
@@ -209,14 +209,6 @@ public abstract class AbstractApexCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public String getAlias(String name) {
-        if (typeAliases != null && typeAliases.containsKey(name)) {
-            return typeAliases.get(name);
-        }
-        return name;
-    }
-
-    @Override
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isArraySchema(p)) {
             final ArraySchema ap = (ArraySchema) p;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -905,14 +905,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public String getAlias(String name) {
-        if (typeAliases != null && typeAliases.containsKey(name)) {
-            return typeAliases.get(name);
-        }
-        return name;
-    }
-
-    @Override
     public String toDefaultValue(Schema schema) {
         schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
         if (ModelUtils.isArraySchema(schema)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -236,6 +236,25 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testSingleInheritanceAliasesGetResolved() throws Exception {
+        // See Issue #13784
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/anyOf-allOf-oneOf-single-inheritance-alias.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        Map<String, String> allAliases = codegen.getAllAliases(openAPI.getComponents().getSchemas());
+
+        Assert.assertEquals(allAliases.size(), 8);
+        Assert.assertEquals(allAliases.get("Id"), "string");
+        Assert.assertEquals(allAliases.get("IdReference"), "string");
+        Assert.assertEquals(allAliases.get("EntityWithId_idReference"), "string");
+        Assert.assertEquals(allAliases.get("EntityWithId_idAnyOfDeepReference"), "string");
+        Assert.assertEquals(allAliases.get("EntityWithId_idAllOfDeepReference"), "string");
+        Assert.assertEquals(allAliases.get("EntityWithId_idOneOfDeepReference"), "string");
+        Assert.assertEquals(allAliases.get("UuidAlias"), "UUID");
+        Assert.assertEquals(allAliases.get("EntityWithId_uuidReference"), "UUID");
+    }
+
+    @Test
     public void testFormParameterHasDefaultValue() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1782,6 +1782,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/component-deprecated.yml");
         new InlineModelResolver().flatten(openAPI);
         final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
 
         CodegenModel codegenPetModel = codegen.fromModel("Pet", openAPI.getComponents().getSchemas().get("Pet"));
         Assert.assertTrue(codegenPetModel.isDeprecated);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -859,6 +859,7 @@ public class AbstractJavaCodegenTest {
     public void testOneOfModelImports() throws Exception {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/oneOf_nonPrimitive.yaml");
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+        codegen.setOpenAPI(openAPI);
         codegen.preprocessOpenAPI(openAPI);
 
         Schema<?> schema = openAPI.getComponents().getSchemas().get("Example");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1644,25 +1644,62 @@ public class JavaClientCodegenTest {
         Map<String, Object> additionalProperties = new HashMap<>();
         additionalProperties.put(BeanValidationFeatures.USE_BEANVALIDATION, "true");
         final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("java")
-                .setAdditionalProperties(additionalProperties)
-                .setInputSpec("src/test/resources/3_0/issue-11340.yaml")
-                .setOutputDir(output.getAbsolutePath()
-                        .replace("\\", "/"));
+            .setAdditionalProperties(additionalProperties)
+            .setInputSpec("src/test/resources/3_0/issue-11340.yaml")
+            .setOutputDir(output.getAbsolutePath()
+                .replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
 
         Map<String, File> files = generator.opts(clientOptInput).generate().stream()
-                .collect(Collectors.toMap(File::getName, Function.identity()));
+            .collect(Collectors.toMap(File::getName, Function.identity()));
 
         JavaFileAssert.assertThat(files.get("DefaultApi.java"))
-                .assertMethod("operationWithHttpInfo")
-                    .hasParameter("requestBody")
-                    .assertParameterAnnotations()
-                    .containsWithName("NotNull")
-                .toParameter().toMethod()
-                    .hasParameter("xNonNullHeaderParameter")
-                    .assertParameterAnnotations()
-                    .containsWithName("NotNull");
+            .assertMethod("operationWithHttpInfo")
+            .hasParameter("requestBody")
+            .assertParameterAnnotations()
+            .containsWithName("NotNull")
+            .toParameter().toMethod()
+            .hasParameter("xNonNullHeaderParameter")
+            .assertParameterAnnotations()
+            .containsWithName("NotNull");
+    }
+
+    /**
+     * See https://github.com/OpenAPITools/openapi-generator/issues/13784
+     */
+    @Test
+    public void testSingleInheritanceAliasesGetResolved() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("java")
+            .setInputSpec("src/test/resources/3_0/anyOf-allOf-oneOf-single-inheritance-alias.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+
+        Map<String, File> files = generator.opts(clientOptInput).generate().stream()
+            .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+            .assertMethod("getId")
+            .hasReturnType("String");
+        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+            .assertMethod("getIdReference")
+            .hasReturnType("String");
+        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+            .assertMethod("getIdAnyOfDeepReference")
+            .hasReturnType("String");
+        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+            .assertMethod("getIdAllOfDeepReference")
+            .hasReturnType("String");
+        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+            .assertMethod("getIdOneOfDeepReference")
+            .hasReturnType("String");
+        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+            .assertMethod("getUuidReference")
+            .hasReturnType("UUID");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1675,6 +1675,8 @@ public class JavaClientCodegenTest {
         output.deleteOnExit();
         final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("java")
             .setInputSpec("src/test/resources/3_0/anyOf-allOf-oneOf-single-inheritance-alias.yaml")
+            // Adding a suffix allows us to detect confusion between String and StringApiDto
+            .setModelNameSuffix("ApiDto")
             .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -1683,23 +1685,35 @@ public class JavaClientCodegenTest {
         Map<String, File> files = generator.opts(clientOptInput).generate().stream()
             .collect(Collectors.toMap(File::getName, Function.identity()));
 
-        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+        // Assert Model
+        File entityFile = files.get("EntityWithIdApiDto.java");
+        JavaFileAssert.assertThat(entityFile)
             .assertMethod("getId")
             .hasReturnType("String");
-        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+        JavaFileAssert.assertThat(entityFile)
             .assertMethod("getIdReference")
             .hasReturnType("String");
-        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+        JavaFileAssert.assertThat(entityFile)
             .assertMethod("getIdAnyOfDeepReference")
             .hasReturnType("String");
-        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+        JavaFileAssert.assertThat(entityFile)
             .assertMethod("getIdAllOfDeepReference")
             .hasReturnType("String");
-        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+        JavaFileAssert.assertThat(entityFile)
             .assertMethod("getIdOneOfDeepReference")
             .hasReturnType("String");
-        JavaFileAssert.assertThat(files.get("EntityWithId.java"))
+        JavaFileAssert.assertThat(entityFile)
             .assertMethod("getUuidReference")
             .hasReturnType("UUID");
+
+        // Assert API
+        File apiFile = files.get("DefaultApi.java");
+        JavaFileAssert.assertThat(apiFile)
+            .assertMethod("aliasedParameterAndReturnTypeGet")
+            .hasParameter("id")
+            .withType("String");
+        JavaFileAssert.assertThat(apiFile)
+            .assertMethod("aliasedParameterAndReturnTypeGet")
+            .hasReturnType("String");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -263,6 +263,7 @@ public class AbstractKotlinCodegenTest {
     public void testEnumPropertyWithDefaultValue() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/kotlin/issue10591-enum-defaultValue.yaml");
         final AbstractKotlinCodegen codegen = new P_AbstractKotlinCodegen();
+        codegen.setOpenAPI(openAPI);
 
         Schema test1 = openAPI.getComponents().getSchemas().get("ModelWithEnumPropertyHavingDefault");
         CodegenModel cm1 = codegen.fromModel("ModelWithEnumPropertyHavingDefault", test1);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
@@ -132,6 +132,7 @@ public class AbstractPhpCodegenTest {
     public void testArrayOfArrays() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_8945.yaml");
         final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.setOpenAPI(openAPI);
 
         Schema test1 = openAPI.getComponents().getSchemas().get("MyResponse");
         CodegenModel cm1 = codegen.fromModel("MyResponse", test1);
@@ -150,6 +151,7 @@ public class AbstractPhpCodegenTest {
     public void testEnumPropertyWithDefaultValue() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/php/issue_10244.yaml");
         final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.setOpenAPI(openAPI);
 
         Schema test1 = openAPI.getComponents().getSchemas().get("ModelWithEnumPropertyHavingDefault");
         CodegenModel cm1 = codegen.fromModel("ModelWithEnumPropertyHavingDefault", test1);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -180,6 +180,7 @@ public class TypeScriptNodeClientCodegenTest {
             .addSchemas("Child", childSchema);
 
         final TypeScriptNodeClientCodegen codegen = new TypeScriptNodeClientCodegen();
+        codegen.setOpenAPI(openAPI);
         codegen.setModelNameSuffix("Suffix");
 
         final HashMap<String, ModelsMap> allModels = createParameterForPostProcessAllModels(
@@ -209,6 +210,7 @@ public class TypeScriptNodeClientCodegenTest {
             .addSchemas("Child", childSchema);
 
         final TypeScriptNodeClientCodegen codegen = new TypeScriptNodeClientCodegen();
+        codegen.setOpenAPI(openAPI);
         codegen.setModelNamePrefix("Prefix");
 
         final HashMap<String, ModelsMap> allModels = createParameterForPostProcessAllModels(

--- a/modules/openapi-generator/src/test/resources/3_0/anyOf-allOf-oneOf-single-inheritance-alias.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/anyOf-allOf-oneOf-single-inheritance-alias.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.2
+info:
+  title: Test that single-inheritance (allOf/anyOf/oneOf with a single subtype) act as aliases to primitive types
+  version: 1.0.0
+  description: todo
+paths:
+  /entity:
+    description: Query for Entity
+    get:
+      parameters:
+        - name: id
+          in: path
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/IdReference'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityWithId'
+          description: Entity
+components:
+  schemas:
+    Id:
+      description: An id.
+      type: string
+      minLength: 16
+      maxLength: 128
+      example: 9d158f59-80b7-4c11-9c0c-8a2b4d936b2d
+    IdReference:
+      description: An id that is used for Entities
+      anyOf:
+          - $ref: '#/components/schemas/Id'
+    UuidAlias:
+      type: string
+      format: uuid
+    EntityWithId:
+      description: Entity with id
+      type: object
+      properties:
+        id:
+          # Here we can't add a description to this property
+          $ref: '#/components/schemas/Id'
+
+        # This should be equivalent, and we can add a description.
+        idReference:
+          description: id, populated only when the third party system provided it
+          anyOf:
+            - $ref: '#/components/schemas/Id'
+
+        # Same, but more than one indirection
+        idAnyOfDeepReference:
+          anyOf:
+            - $ref: '#/components/schemas/IdReference'
+
+        # Same for allOf
+        idAllOfDeepReference:
+          allOf:
+            - $ref: '#/components/schemas/IdReference'
+
+        # Same for oneOf
+        idOneOfDeepReference:
+          oneOf:
+            - $ref: '#/components/schemas/IdReference'
+
+        # same, but for UUIDs
+        uuidReference:
+          anyOf:
+            - $ref: '#/components/schemas/UuidAlias'

--- a/modules/openapi-generator/src/test/resources/3_0/anyOf-allOf-oneOf-single-inheritance-alias.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/anyOf-allOf-oneOf-single-inheritance-alias.yaml
@@ -4,21 +4,22 @@ info:
   version: 1.0.0
   description: todo
 paths:
-  /entity:
+  /aliasedParameterAndReturnType:
     description: Query for Entity
     get:
       parameters:
         - name: id
           in: path
           schema:
-            allOf:
+            anyOf:
               - $ref: '#/components/schemas/IdReference'
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EntityWithId'
+                anyOf:
+                  - $ref: '#/components/schemas/IdReference'
           description: Entity
 components:
   schemas:


### PR DESCRIPTION
The current aliasing mechanism makes sure, that aliases for primitve types are resolved to that basic type. It doesn't take into account, that an alias to an alias is still an alias. This PR changes that. 

The problem appeared in a 3rd party openapi spec that I had to use (https://github.com/astm-utm/Protocol/blob/cb7cf962d3a0c01b5ab12502f5f54789624977bf/utm.yaml), where they used `anyOf` with a single subtype to achieve that.

Here is the issue https://github.com/OpenAPITools/openapi-generator/issues/13784.

Basically, two methods needed to change: `DefaultCodegen.getAlias(String name)` and `DefaultCodegen.unaliasSchema(Schema schema)`. This is achieved in two ways:

1. The `typeAliases` now holds the Schema, that a type is an alias for, not just the `String`. This is necessary since `unaliasSchema` needs to return a `Schema`.
2. The `typeAliases` need to be initialized properly and include the recursion for "alias to alias" resolution. This is contained in `getAllAliases(Map<String, Schema> schemas)`.

Cleanup work: Some Tests didn't call `setOpenAPI` on the generator, which I added. The initialization of the aliases was done in `fromModel`, which I moved to `setOpenAPI`.

This merge request comes with a unit test in `DefaultCodegenTest` and a integration Test in `AbstractJavaCodegenTest`.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
