### PR TITLE
Rust: Remove unused serde_yaml

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -17,7 +17,6 @@ uuid = { version = "^1.0", features = ["serde"] }
 hyper = { version = "~0.14", features = ["full"] }
 hyper-tls = "~0.5"
 http = "~0.2"
-serde_yaml = "0.7"
 base64 = "~0.7.0"
 futures = "^0.3"
 {{/hyper}}

--- a/samples/client/petstore/rust/hyper/petstore/Cargo.toml
+++ b/samples/client/petstore/rust/hyper/petstore/Cargo.toml
@@ -14,7 +14,6 @@ uuid = { version = "^1.0", features = ["serde"] }
 hyper = { version = "~0.14", features = ["full"] }
 hyper-tls = "~0.5"
 http = "~0.2"
-serde_yaml = "0.7"
 base64 = "~0.7.0"
 futures = "^0.3"
 


### PR DESCRIPTION
This crate version has a security vuln
https://rustsec.org/advisories/RUSTSEC-2018-0005

ping @frol @farcaller @richardwhiuk @paladinzh @jacob-pro

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
