### PR TITLE
[typescript-fetch] Fix response type to be Response or undefined

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -166,7 +166,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -177,7 +177,7 @@ export class BaseAPI {
                 }) || fetchParams;
             }
         }
-        let response = undefined;
+        let response: Response | undefined = undefined;
         try {
             response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
         } catch (e) {


### PR DESCRIPTION
Current generated code produces a `response` variable set to undefined, and TS does not like you changing the type of the variable later. Therefore, set the type of the variable to be `Response` or `undefined`

Solves OpenAPITools/openapi-generator#12007

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

_Very_ small change, simply fixing the type of the response variable so Typescript doesn't complain

<!-- Please check the completed items below -->
### PR checklist


- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov  @davidgamero  @mkusaka 
