### PR TITLE
Java jersey OAuth2 add support for public client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -525,6 +525,22 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Helper method to set the credentials of a public client for the first OAuth2 authentication.
+   *
+   * @param clientId the client ID
+   * @return a {@link org.openapitools.client.ApiClient} object.
+   */
+  public ApiClient setOauthCredentialsForPublicClient(String clientId) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setCredentialsForPublicClient(clientId, isDebugging());
+        return this;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Helper method to set the password flow for the first OAuth2 authentication.
    *
    * @param username the user name

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/auth/OAuth.mustache
@@ -158,6 +158,19 @@ public class OAuth implements Authentication {
         return this;
     }
 
+    public OAuth setCredentialsForPublicClient(String clientId, Boolean debug) {
+        if (Boolean.TRUE.equals(debug)) {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe().debug()
+                .build(authApi);
+        } else {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe()
+                .build(authApi);
+        }
+        return this;
+    }
+
     public OAuth usePasswordFlow(String username, String password) {
         this.flow = OAuthFlow.PASSWORD;
         this.username = username;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -525,6 +525,22 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
+   * Helper method to set the credentials of a public client for the first OAuth2 authentication.
+   *
+   * @param clientId the client ID
+   * @return a {@link org.openapitools.client.ApiClient} object.
+   */
+  public ApiClient setOauthCredentialsForPublicClient(String clientId) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setCredentialsForPublicClient(clientId, isDebugging());
+        return this;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Helper method to set the password flow for the first OAuth2 authentication.
    *
    * @param username the user name

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/auth/OAuth.mustache
@@ -158,6 +158,19 @@ public class OAuth implements Authentication {
         return this;
     }
 
+    public OAuth setCredentialsForPublicClient(String clientId, Boolean debug) {
+        if (Boolean.TRUE.equals(debug)) {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe().debug()
+                .build(authApi);
+        } else {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe()
+                .build(authApi);
+        }
+        return this;
+    }
+
     public OAuth usePasswordFlow(String username, String password) {
         this.flow = OAuthFlow.PASSWORD;
         this.username = username;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -447,6 +447,22 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Helper method to set the credentials of a public client for the first OAuth2 authentication.
+   *
+   * @param clientId the client ID
+   * @return a {@link org.openapitools.client.ApiClient} object.
+   */
+  public ApiClient setOauthCredentialsForPublicClient(String clientId) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setCredentialsForPublicClient(clientId, isDebugging());
+        return this;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Helper method to set the password flow for the first OAuth2 authentication.
    *
    * @param username the user name

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -169,6 +169,19 @@ public class OAuth implements Authentication {
         return this;
     }
 
+    public OAuth setCredentialsForPublicClient(String clientId, Boolean debug) {
+        if (Boolean.TRUE.equals(debug)) {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe().debug()
+                .build(authApi);
+        } else {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe()
+                .build(authApi);
+        }
+        return this;
+    }
+
     public OAuth usePasswordFlow(String username, String password) {
         this.flow = OAuthFlow.PASSWORD;
         this.username = username;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -447,6 +447,22 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Helper method to set the credentials of a public client for the first OAuth2 authentication.
+   *
+   * @param clientId the client ID
+   * @return a {@link org.openapitools.client.ApiClient} object.
+   */
+  public ApiClient setOauthCredentialsForPublicClient(String clientId) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setCredentialsForPublicClient(clientId, isDebugging());
+        return this;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Helper method to set the password flow for the first OAuth2 authentication.
    *
    * @param username the user name

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -169,6 +169,19 @@ public class OAuth implements Authentication {
         return this;
     }
 
+    public OAuth setCredentialsForPublicClient(String clientId, Boolean debug) {
+        if (Boolean.TRUE.equals(debug)) {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe().debug()
+                .build(authApi);
+        } else {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe()
+                .build(authApi);
+        }
+        return this;
+    }
+
     public OAuth usePasswordFlow(String username, String password) {
         this.flow = OAuthFlow.PASSWORD;
         this.username = username;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
@@ -531,6 +531,22 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Helper method to set the credentials of a public client for the first OAuth2 authentication.
+   *
+   * @param clientId the client ID
+   * @return a {@link org.openapitools.client.ApiClient} object.
+   */
+  public ApiClient setOauthCredentialsForPublicClient(String clientId) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setCredentialsForPublicClient(clientId, isDebugging());
+        return this;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Helper method to set the password flow for the first OAuth2 authentication.
    *
    * @param username the user name

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -169,6 +169,19 @@ public class OAuth implements Authentication {
         return this;
     }
 
+    public OAuth setCredentialsForPublicClient(String clientId, Boolean debug) {
+        if (Boolean.TRUE.equals(debug)) {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe().debug()
+                .build(authApi);
+        } else {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe()
+                .build(authApi);
+        }
+        return this;
+    }
+
     public OAuth usePasswordFlow(String username, String password) {
         this.flow = OAuthFlow.PASSWORD;
         this.username = username;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -531,6 +531,22 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
+   * Helper method to set the credentials of a public client for the first OAuth2 authentication.
+   *
+   * @param clientId the client ID
+   * @return a {@link org.openapitools.client.ApiClient} object.
+   */
+  public ApiClient setOauthCredentialsForPublicClient(String clientId) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setCredentialsForPublicClient(clientId, isDebugging());
+        return this;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Helper method to set the password flow for the first OAuth2 authentication.
    *
    * @param username the user name

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -169,6 +169,19 @@ public class OAuth implements Authentication {
         return this;
     }
 
+    public OAuth setCredentialsForPublicClient(String clientId, Boolean debug) {
+        if (Boolean.TRUE.equals(debug)) {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe().debug()
+                .build(authApi);
+        } else {
+            service = new ServiceBuilder(clientId)
+                .apiSecretIsEmptyStringUnsafe()
+                .build(authApi);
+        }
+        return this;
+    }
+
     public OAuth usePasswordFlow(String username, String password) {
         this.flow = OAuthFlow.PASSWORD;
         this.username = username;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Java jersey OAuth2 add support for public client by a new method ApiClient.setOauthCredentialsForPublicClient(String clientId), which does not require the clientSecret as described in issue #13827 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)