### PR TITLE
Allow to specify the generated part (model, api...)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -288,14 +288,16 @@ public class CodegenConstants {
 
     // Not user-configurable. System provided for use in templates.
 
+    public static final String GENERATE_MODELS = "generateModels";
     public static final String GENERATE_APIS = "generateApis";
+
+    public static final String GENERATE_SUPPORTING_FILES = "generateSupportingFiles";
     public static final String GENERATE_API_DOCS = "generateApiDocs";
 
     public static final String GENERATE_API_TESTS = "generateApiTests";
     public static final String GENERATE_API_TESTS_DESC = "Specifies that api tests are to be generated.";
 
     // Not user-configurable. System provided for use in templates.
-    public static final String GENERATE_MODELS = "generateModels";
     public static final String GENERATE_MODEL_DOCS = "generateModelDocs";
 
     public static final String VIRTUAL_SERVICE = "virtualService";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
@@ -16,6 +16,7 @@
 
 package org.openapitools.codegen.config;
 
+import java.util.Optional;
 import java.util.Properties;
 
 /**
@@ -49,6 +50,10 @@ public class GlobalSettings {
         return properties.get().getProperty(key);
     }
 
+    public static Optional<String> getPropertyOpt(String key) {
+        return Optional.ofNullable(getProperty(key));
+    }
+
     public static void setProperty(String key, String value) {
         properties.get().setProperty(key, value);
     }
@@ -60,4 +65,5 @@ public class GlobalSettings {
     public static void reset() {
         properties.remove();
     }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -17,6 +17,8 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -26,6 +28,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultGeneratorTest {
 
@@ -340,7 +344,7 @@ public class DefaultGeneratorTest {
     }
 
     @Test
-    public void testNonStrictProcessPaths() throws Exception {
+    public void testNonStrictProcessPaths() {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         openAPI.setPaths(new Paths());
         openAPI.getPaths().addPathItem("path1/", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
@@ -365,7 +369,7 @@ public class DefaultGeneratorTest {
     }
 
     @Test
-    public void testProcessPaths() throws Exception {
+    public void testProcessPaths() {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         openAPI.setPaths(new Paths());
         openAPI.getPaths().addPathItem("/path1", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
@@ -664,7 +668,7 @@ public class DefaultGeneratorTest {
         Assert.assertEquals(servers.get(1).url, "http://trailingshlash.io:80/v1");
         Assert.assertEquals(servers.get(2).url, "http://notrailingslash.io:80/v2");
     }
-    
+
     @Test
     public void testHandlesRelativeUrlsInServers() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_10056.yaml");
@@ -765,5 +769,85 @@ public class DefaultGeneratorTest {
         // The bug causes a StackOverflowError when calling generateModels
         generator.generateModels(files, allModels, filteredSchemas);
         // all fine, we have passed
+    }
+
+    public class GenerationConfiguration {
+        @BeforeMethod
+        @AfterMethod
+        public void cleanup() {
+            System.clearProperty(CodegenConstants.APIS);
+            System.clearProperty(CodegenConstants.MODELS);
+            System.clearProperty(CodegenConstants.SUPPORTING_FILES);
+            System.clearProperty(CodegenConstants.GENERATE_APIS);
+            System.clearProperty(CodegenConstants.GENERATE_MODELS);
+            System.clearProperty(CodegenConstants.GENERATE_SUPPORTING_FILES);
+            GlobalSettings.reset();
+        }
+
+        @Test
+        public void nothingSetGenereateAll() {
+            testProperties(true, true, true);
+        }
+
+        @Test
+        public void specifyApiListGenerateOnlyApis() {
+            System.setProperty(CodegenConstants.APIS, "anApi,anotherApi");
+            testProperties(true, false, false);
+        }
+        @Test
+        public void specifyModelsListGenerateOnlyModels() {
+            System.setProperty(CodegenConstants.MODELS, "modelA");
+            testProperties(false, true, false);
+        }
+
+        @Test
+        public void specifySupportingFileListGenerateOnlySupportingFiles() {
+            System.setProperty(CodegenConstants.SUPPORTING_FILES, "pom");
+            testProperties(false, false, true);
+        }
+
+        @Test
+        public void specifyApiListWithForceModelsAndSupportingGenerateEverything() {
+            System.setProperty(CodegenConstants.APIS, "anApi,anotherApi");
+            System.setProperty(CodegenConstants.GENERATE_MODELS, "true");
+            System.setProperty(CodegenConstants.GENERATE_SUPPORTING_FILES, "true");
+            testProperties(true, true, true);
+        }
+
+        @Test
+        public void specifyModelsListWithForceApisGenerateApisAndModels() {
+            System.setProperty(CodegenConstants.GENERATE_APIS, "true");
+            System.setProperty(CodegenConstants.MODELS, "modelA");
+            testProperties(true, true, false);
+        }
+
+        @Test
+        public void generatePropertyBypassObjectList() {
+            System.setProperty(CodegenConstants.APIS, "anApi,anotherApi");
+            System.setProperty(CodegenConstants.MODELS, "modelA");
+            System.setProperty(CodegenConstants.SUPPORTING_FILES, "pom");
+            System.setProperty(CodegenConstants.GENERATE_APIS, "false");
+            System.setProperty(CodegenConstants.GENERATE_MODELS, "false");
+            System.setProperty(CodegenConstants.GENERATE_SUPPORTING_FILES, "false");
+            testProperties(false, false, false);
+        }
+
+        private void testProperties(boolean generateApis, boolean generateModels, boolean generateSupportingFiles) {
+            OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/bugs/recursion-bug-4650.yaml");
+            ClientOptInput opts = new ClientOptInput();
+            opts.openAPI(openAPI);
+            DefaultCodegen config = new DefaultCodegen();
+            config.setStrictSpecBehavior(false);
+            opts.config(config);
+            final DefaultGenerator generator = new DefaultGenerator();
+            generator.opts(opts);
+            // WHEN
+            generator.configureGeneratorProperties();
+            // THEN
+            assertThat(generator.config.additionalProperties())
+                    .containsEntry(CodegenConstants.GENERATE_APIS, generateApis)
+                    .containsEntry(CodegenConstants.GENERATE_MODELS, generateModels)
+                    .containsEntry(CodegenConstants.GENERATE_SUPPORTING_FILES, generateSupportingFiles);
+        }
     }
 }


### PR DESCRIPTION
This fix #13830

The idea behind the PR is to allow more control to the user for selecting the generation.
Currently, we can generate only some models by names. But here we can generate all the models without generating the API.

The code is quite weird because I've kept the initial behaviors. So the behavior changes only if the new properties are used.

If the change is OK I can try to update Gradle and maven plugins to use them.

Ping of the core team because it's a global behavior
@wing328 @jimschubert @cbornet @jmini @etherealjoy@spacether

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
