### PR TITLE
Rust: Remove unused tokio in rust hyper client

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -35,8 +35,3 @@ version = "^0.11"
 features = ["json", "multipart"]
 {{/supportAsync}}
 {{/reqwest}}
-
-[dev-dependencies]
-{{#hyper}}
-tokio-core = "*"
-{{/hyper}}

--- a/samples/client/petstore/rust/hyper/petstore/Cargo.toml
+++ b/samples/client/petstore/rust/hyper/petstore/Cargo.toml
@@ -16,6 +16,3 @@ hyper-tls = "~0.5"
 http = "~0.2"
 base64 = "~0.7.0"
 futures = "^0.3"
-
-[dev-dependencies]
-tokio-core = "*"

--- a/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
@@ -14,5 +14,3 @@ uuid = { version = "^1.0", features = ["serde"] }
 [dependencies.reqwest]
 version = "^0.11"
 features = ["json", "multipart"]
-
-[dev-dependencies]

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
@@ -15,5 +15,3 @@ aws-sigv4 = "0.3.0"
 http = "0.2.5"
 secrecy = "0.8.0"
 reqwest = "~0.9"
-
-[dev-dependencies]

--- a/samples/client/petstore/rust/reqwest/petstore/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore/Cargo.toml
@@ -12,5 +12,3 @@ serde_json = "^1.0"
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde"] }
 reqwest = "~0.9"
-
-[dev-dependencies]


### PR DESCRIPTION
This crate version has an indirect security vuln,
as tokio-core 0.1.18 (latest) is two years old,
and uses tokio 0.1.5.
https://rustsec.org/advisories/RUSTSEC-2021-0124

ping @frol @farcaller @richardwhiuk @paladinzh @jacob-pro

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
