### PR TITLE
CVE-2022-42889: Upgraded commons-text to version 1.10.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ packages/
 **/.vs
 .factorypath
 .metals/*
+nbproject/
+nbactions.xml
+nb-configuration.xml
 
 .settings
 

--- a/pom.xml
+++ b/pom.xml
@@ -1488,7 +1488,7 @@
         <commons-cli.version>1.4</commons-cli.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>3.12.0</commons-lang.version>
-        <commons-text.version>1.9</commons-text.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <diffutils.version>1.3.0</diffutils.version>
         <generex.version>1.0.2</generex.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>


### PR DESCRIPTION
Fixes a vulnerability in Apache Commons Text with CVE score 9.8 (CRITICAL).
Resolves #13851