### PR TITLE
[Elixir] Fixes issue with maps/dictionary not present in payload

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
@@ -19,13 +19,18 @@ defmodule {{moduleName}}.Deserializer do
   end
 
   def deserialize(model, field, :map, mod, options) do
-    model
-    |> Map.update!(
-      field,
-      &Map.new(&1, fn {key, val} ->
-        {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))}
-      end)
-    )
+    maybe_transform_map = fn
+      nil ->
+        nil
+
+      existing_value ->
+        Map.new(existing_value, fn
+          {key, val} ->
+            {key, Poison.Decode.decode(val, Keyword.merge(options, as: struct(mod)))}
+        end)
+    end
+
+    Map.update!(model, field, maybe_transform_map)
   end
 
   def deserialize(model, field, :date, _, _options) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
@@ -21,13 +21,18 @@ defmodule OpenapiPetstore.Deserializer do
   end
 
   def deserialize(model, field, :map, mod, options) do
-    model
-    |> Map.update!(
-      field,
-      &Map.new(&1, fn {key, val} ->
-        {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))}
-      end)
-    )
+    maybe_transform_map = fn
+      nil ->
+        nil
+
+      existing_value ->
+        Map.new(existing_value, fn
+          {key, val} ->
+            {key, Poison.Decode.decode(val, Keyword.merge(options, as: struct(mod)))}
+        end)
+    end
+
+    Map.update!(model, field, maybe_transform_map)
   end
 
   def deserialize(model, field, :date, _, _options) do


### PR DESCRIPTION
Currently, there is an issue with the deserializations of maps, which are null.

As an example, the given payload is the following
```json
{
  "ID": "2b892741-1853-3ddd-382f-fc12e93b5174",
  "CreateTime": 1666707394061348343,
  "ModifyTime": 1666707394064897549
}
```

the schema definitions looks something like this
```yaml
components:
  schemas:
    Evaluation:
      properties:
        CreateTime:
          format: int64
          type: integer
        FailedTGAllocs:
          additionalProperties:
            $ref: '#/components/schemas/AllocationMetric'
          type: object
        ID:
          type: string
        ModifyTime:
          format: int64
          type: integer
      type: object
    AllocationMetric:
      properties:
        AllocationTime:
          format: int64
          type: integer
      type: object
```

As you can see, `FailedTGAllocs` is a simple dictionary with the value type of `AllocationMetric`. The generator will produce something like this (which is correct):
```elixir
defimpl Poison.Decoder, for: Example.Model.Evaluation do
  import Example.Deserializer

  def decode(value, options) do
    value
    |> deserialize(:FailedTGAllocs, :map, Example.Model.AllocationMetric, options)
  end
end
```

The main issue is now, since payload doesn't have the field `FailedTGAllocs`, the `Map.new(...)` call will receive `nil` as the first parameter, which results in a pattern match error. To prevent this, I've added the `maybe_transform_map` function, which simply returns `ni`l for `nil`, and the decoded/transformed model for everything else.

Since I'm the only one in the technical committee, @wing328, could you take a look?

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

