### PR TITLE
[C][Client] Check cJSON_IsNull when the data type is datetime

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -669,7 +669,7 @@ fail:
     {{/isDate}}
     {{#isDateTime}}
     {{^required}}if ({{{name}}}) { {{/required}}
-    if(!cJSON_IsString({{{name}}}))
+    if(!cJSON_IsString({{{name}}}) && !cJSON_IsNull({{{name}}}))
     {
     goto end; //DateTime
     }
@@ -893,7 +893,7 @@ fail:
         {{^required}}{{{name}}} ? {{/required}}strdup({{{name}}}->valuestring){{^required}} : NULL{{/required}}{{^-last}},{{/-last}}
         {{/isDate}}
         {{#isDateTime}}
-        {{^required}}{{{name}}} ? {{/required}}strdup({{{name}}}->valuestring){{^required}} : NULL{{/required}}{{^-last}},{{/-last}}
+        {{^required}}{{{name}}} && !cJSON_IsNull({{{name}}}) ? {{/required}}strdup({{{name}}}->valuestring){{^required}} : NULL{{/required}}{{^-last}},{{/-last}}
         {{/isDateTime}}
         {{/isPrimitiveType}}
         {{/isContainer}}

--- a/samples/client/petstore/c/model/order.c
+++ b/samples/client/petstore/c/model/order.c
@@ -150,7 +150,7 @@ order_t *order_parseFromJSON(cJSON *orderJSON){
     // order->ship_date
     cJSON *ship_date = cJSON_GetObjectItemCaseSensitive(orderJSON, "shipDate");
     if (ship_date) { 
-    if(!cJSON_IsString(ship_date))
+    if(!cJSON_IsString(ship_date) && !cJSON_IsNull(ship_date))
     {
     goto end; //DateTime
     }
@@ -181,7 +181,7 @@ order_t *order_parseFromJSON(cJSON *orderJSON){
         id ? id->valuedouble : 0,
         pet_id ? pet_id->valuedouble : 0,
         quantity ? quantity->valuedouble : 0,
-        ship_date ? strdup(ship_date->valuestring) : NULL,
+        ship_date && !cJSON_IsNull(ship_date) ? strdup(ship_date->valuestring) : NULL,
         status ? statusVariable : -1,
         complete ? complete->valueint : 0
         );


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Sometimes, the value of `date-time` data type in the JSON/YAML string is `null`
e.g.
```yaml
- apiVersion: v1
  count: 1
  eventTime: null  <----- here !
  firstTimestamp: "2022-11-02T09:18:07Z"
  kind: Event
  lastTimestamp: "2022-11-02T09:18:07Z"
  ...
```
Currently openapi-generator/c-libcurl cannot handle this case when parsing JSON strings into cJSON objects. 

e.g. https://github.com/kubernetes-client/c/issues/144

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.