### PR TITLE
(RFC) Csharp netcore generator supports UnityWebRequest library

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -100,6 +100,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
 
     protected boolean supportsRetry = Boolean.TRUE;
     protected boolean supportsAsync = Boolean.TRUE;
+    protected boolean supportsFileParameters = Boolean.TRUE;
     protected boolean netStandard = Boolean.FALSE;
 
     protected boolean validatable = Boolean.TRUE;
@@ -805,8 +806,12 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         } else if (UNITY.equals(getLibrary())) {
             setSupportsRetry(false);
             setSupportsAsync(true);
+            setSupportsFileParameters(false);
 
             addSupportingFiles(clientPackageDir, packageFolder, excludeTests, testPackageFolder, testPackageName, modelPackageDir, authPackageDir);
+
+            supportingFiles.add(new SupportingFile("ConnectionException.mustache", clientPackageDir, "ConnectionException.cs"));
+            supportingFiles.add(new SupportingFile("UnexpectedResponseException.mustache", clientPackageDir, "UnexpectedResponseException.cs"));
         } else { //restsharp
             addSupportingFiles(clientPackageDir, packageFolder, excludeTests, testPackageFolder, testPackageName, modelPackageDir, authPackageDir);
             additionalProperties.put("apiDocPath", apiDocPath);
@@ -1034,6 +1039,10 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
 
     public void setSupportsAsync(Boolean supportsAsync) {
         this.supportsAsync = supportsAsync;
+    }
+
+    public void setSupportsFileParameters(Boolean supportsFileParameters) {
+        this.supportsFileParameters = supportsFileParameters;
     }
 
     public void setSupportsRetry(Boolean supportsRetry) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -61,6 +61,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
     protected static final String RESTSHARP = "restsharp";
     protected static final String HTTPCLIENT = "httpclient";
     protected static final String GENERICHOST = "generichost";
+    protected static final String UNITY = "unity";
 
     // Project Variable, determined from target framework. Not intended to be user-settable.
     protected static final String TARGET_FRAMEWORK_IDENTIFIER = "targetFrameworkIdentifier";
@@ -324,6 +325,8 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         supportedLibraries.put(GENERICHOST, "HttpClient with Generic Host dependency injection (https://docs.microsoft.com/en-us/dotnet/core/extensions/generic-host) "
                 + "(Experimental. Subject to breaking changes without notice.)");
         supportedLibraries.put(HTTPCLIENT, "HttpClient (https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient) "
+                + "(Experimental. Subject to breaking changes without notice.)");
+        supportedLibraries.put(UNITY, "UnityWebRequest (...) "
                 + "(Experimental. Subject to breaking changes without notice.)");
         supportedLibraries.put(RESTSHARP, "RestSharp (https://github.com/restsharp/RestSharp)");
 
@@ -678,6 +681,11 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
             setLibrary(HTTPCLIENT);
             additionalProperties.put("useHttpClient", true);
             needsUriBuilder = true;
+        } else if (UNITY.equals(getLibrary())) {
+            setLibrary(UNITY);
+            additionalProperties.put("useUnityClient", true);
+            needsUriBuilder = true;
+
         } else {
             throw new RuntimeException("Invalid HTTP library " + getLibrary() + ". Only restsharp, httpclient, and generichost are supported.");
         }
@@ -794,6 +802,11 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
             addGenericHostSupportingFiles(clientPackageDir, packageFolder, excludeTests, testPackageFolder, testPackageName, modelPackageDir);
             additionalProperties.put("apiDocPath", apiDocPath + File.separatorChar + "apis");
             additionalProperties.put("modelDocPath", modelDocPath + File.separatorChar + "models");
+        } else if (UNITY.equals(getLibrary())) {
+            setSupportsRetry(false);
+            setSupportsAsync(true);
+
+            addSupportingFiles(clientPackageDir, packageFolder, excludeTests, testPackageFolder, testPackageName, modelPackageDir, authPackageDir);
         } else { //restsharp
             addSupportingFiles(clientPackageDir, packageFolder, excludeTests, testPackageFolder, testPackageName, modelPackageDir, authPackageDir);
             additionalProperties.put("apiDocPath", apiDocPath);

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/RequestOptions.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/RequestOptions.mustache
@@ -35,10 +35,12 @@ namespace {{packageName}}.Client
         /// </summary>
         public Dictionary<string, string> FormParameters { get; set; }
 
+        {{#supportsFileParameters}}
         /// <summary>
         /// File parameters to be sent along with the request.
         /// </summary>
         public Multimap<string, Stream> FileParameters { get; set; }
+        {{/supportsFileParameters}}
 
         /// <summary>
         /// Cookies to be sent along with the request.
@@ -76,7 +78,9 @@ namespace {{packageName}}.Client
             QueryParameters = new Multimap<string, string>();
             HeaderParameters = new Multimap<string, string>();
             FormParameters = new Dictionary<string, string>();
+            {{#supportsFileParameters}}
             FileParameters = new Multimap<string, Stream>();
+            {{/supportsFileParameters}}
             Cookies = new List<Cookie>();
         }
     }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -361,13 +361,17 @@ namespace {{packageName}}.{{apiPackage}}
             {{#required}}
             {{#isFile}}
             {{#isArray}}
+            {{#supportsFileParameters}}
             foreach (var file in {{paramName}})
             {
                 localVarRequestOptions.FileParameters.Add("{{baseName}}", file);
             }
+            {{/supportsFileParameters}}
             {{/isArray}}
             {{^isArray}}
+            {{#supportsFileParameters}}
             localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+            {{/supportsFileParameters}}
             {{/isArray}}
             {{/isFile}}
             {{^isFile}}
@@ -379,13 +383,17 @@ namespace {{packageName}}.{{apiPackage}}
             {
                 {{#isFile}}
                 {{#isArray}}
+                {{#supportsFileParameters}}
                 foreach (var file in {{paramName}})
                 {
                     localVarRequestOptions.FileParameters.Add("{{baseName}}", file);
                 }
+                {{/supportsFileParameters}}
                 {{/isArray}}
                 {{^isArray}}
+                {{#supportsFileParameters}}
                 localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+                {{/supportsFileParameters}}
                 {{/isArray}}
                 {{/isFile}}
                 {{^isFile}}
@@ -602,13 +610,17 @@ namespace {{packageName}}.{{apiPackage}}
             {{#required}}
             {{#isFile}}
             {{#isArray}}
+            {{#supportsFileParameters}}
             foreach (var file in {{paramName}})
             {
                 localVarRequestOptions.FileParameters.Add("{{baseName}}", file);
             }
+            {{/supportsFileParameters}}
             {{/isArray}}
             {{^isArray}}
+            {{#supportsFileParameters}}
             localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+            {{/supportsFileParameters}}
             {{/isArray}}
             {{/isFile}}
             {{^isFile}}
@@ -620,13 +632,17 @@ namespace {{packageName}}.{{apiPackage}}
             {
                 {{#isFile}}
                 {{#isArray}}
+                {{#supportsFileParameters}}
                 foreach (var file in {{paramName}})
                 {
                     localVarRequestOptions.FileParameters.Add("{{baseName}}", file);
                 }
+                {{/supportsFileParameters}}
                 {{/isArray}}
                 {{^isArray}}
+                {{#supportsFileParameters}}
                 localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+                {{/supportsFileParameters}}
                 {{/isArray}}
                 {{/isFile}}
                 {{^isFile}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ApiClient.mustache
@@ -1,0 +1,701 @@
+{{>partial_header}}
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters;
+using System.Text;
+using System.Threading;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+{{^netStandard}}
+using System.Web;
+{{/netStandard}}
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using UnityEngine.Networking;
+using UnityEngine;
+{{#supportsRetry}}
+using Polly;
+{{/supportsRetry}}
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// To Serialize/Deserialize JSON using our custom logic, but only when ContentType is JSON.
+    /// </summary>
+    internal class CustomJsonCodec
+    {
+        private readonly IReadableConfiguration _configuration;
+        private static readonly string _contentType = "application/json";
+        private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = false
+                }
+            }
+        };
+
+        public CustomJsonCodec(IReadableConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public CustomJsonCodec(JsonSerializerSettings serializerSettings, IReadableConfiguration configuration)
+        {
+            _serializerSettings = serializerSettings;
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// Serialize the object into a JSON string.
+        /// </summary>
+        /// <param name="obj">Object to be serialized.</param>
+        /// <returns>A JSON string.</returns>
+        public string Serialize(object obj)
+        {
+            if (obj != null && obj is {{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema)
+            {
+                // the object to be serialized is an oneOf/anyOf schema
+                return (({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema)obj).ToJson();
+            }
+            else
+            {
+                return JsonConvert.SerializeObject(obj, _serializerSettings);
+            }
+        }
+
+        public T Deserialize<T>(UnityWebRequest request)
+        {
+            var result = (T) Deserialize(response, typeof(T));
+            return result;
+        }
+
+        /// <summary>
+        /// Deserialize the JSON string into a proper object.
+        /// </summary>
+        /// <param name="response">The HTTP response.</param>
+        /// <param name="type">Object type.</param>
+        /// <returns>Object representation of the JSON string.</returns>
+        internal object Deserialize(UnityWebRequest request, Type type)
+        {
+            IList<string> headers = response.Headers.Select(x => x.Key + "=" + x.Value).ToList();
+
+            if (type == typeof(byte[])) // return byte array
+            {
+                return request.downloadHandler.data;
+            }
+
+            // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
+            if (type == typeof(Stream))
+            {
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                // NOTE: Ignoring Content-Disposition filename support, since not all platforms
+                // have a location on disk to write arbitrary data (tvOS, consoles).
+                return new MemoryStream(request.downloadHandler.data);
+            }
+
+            if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
+            {
+                return DateTime.Parse(request.downloadHandler.text, null, System.Globalization.DateTimeStyles.RoundtripKind);
+            }
+
+            if (type == typeof(string) || type.Name.StartsWith("System.Nullable")) // return primitive type
+            {
+                return Convert.ChangeType(request.downloadHandler.text, type);
+            }
+
+            // at this point, it must be a model (json)
+            try
+            {
+                return JsonConvert.DeserializeObject(request.downloadHandler.text, type, _serializerSettings);
+            }
+            catch (Exception e)
+            {
+                throw new ApiException(500, e.Message);
+            }
+        }
+
+        public string RootElement { get; set; }
+        public string Namespace { get; set; }
+        public string DateFormat { get; set; }
+
+        public string ContentType
+        {
+            get { return _contentType; }
+            set { throw new InvalidOperationException("Not allowed to set content type."); }
+        }
+    }
+    /// <summary>
+    /// Provides a default implementation of an Api client (both synchronous and asynchronous implementations),
+    /// encapsulating general REST accessor use cases.
+    /// </summary>
+    /// <remarks>
+    /// The Dispose method will manage the HttpClient lifecycle when not passed by constructor.
+    /// </remarks>
+    {{>visibility}} partial class ApiClient : IDisposable, ISynchronousClient{{#supportsAsync}}, IAsynchronousClient{{/supportsAsync}}
+    {
+        private readonly string _baseUrl;
+
+        /// <summary>
+        /// Specifies the settings on a <see cref="JsonSerializer" /> object.
+        /// These settings can be adjusted to accommodate custom serialization rules.
+        /// </summary>
+        public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
+        {
+            // OpenAPI generated types generally hide default constructors.
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = false
+                }
+            }
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" />, defaulting to the global configurations' base url.
+        /// **IMPORTANT** This will also create an instance of HttpClient, which is less than ideal.
+        /// It's better to reuse the <see href="https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests#issues-with-the-original-httpclient-class-available-in-net">HttpClient and HttpClientHandler</see>.
+        /// </summary>
+        public ApiClient() :
+                 this({{packageName}}.Client.GlobalConfiguration.Instance.BasePath)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" />.
+        /// **IMPORTANT** This will also create an instance of HttpClient, which is less than ideal.
+        /// It's better to reuse the <see href="https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests#issues-with-the-original-httpclient-class-available-in-net">HttpClient and HttpClientHandler</see>.
+        /// </summary>
+        /// <param name="basePath">The target service's base path in URL format.</param>
+        /// <exception cref="ArgumentException"></exception>
+        public ApiClient(string basePath)
+        {
+            if (string.IsNullOrEmpty(basePath)) throw new ArgumentException("basePath cannot be empty");
+
+            _baseUrl = basePath;
+        }
+
+        /// <summary>
+        /// Disposes resources if they were created by us
+        /// </summary>
+        public void Dispose()
+        {
+        }
+
+        /// <summary>
+        /// Provides all logic for constructing a new HttpRequestMessage.
+        /// At this point, all information for querying the service is known. Here, it is simply
+        /// mapped into the a HttpRequestMessage.
+        /// </summary>
+        /// <param name="method">The http verb.</param>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>[private] A new HttpRequestMessage instance.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        private UnityWebRequest NewRequest(
+            string method,
+            string path,
+            RequestOptions options,
+            IReadableConfiguration configuration)
+        {
+            if (path == null) throw new ArgumentNullException("path");
+            if (options == null) throw new ArgumentNullException("options");
+            if (configuration == null) throw new ArgumentNullException("configuration");
+
+            WebRequestPathBuilder builder = new WebRequestPathBuilder(_baseUrl, path);
+
+            builder.AddPathParameters(options.PathParameters);
+
+            builder.AddQueryParameters(options.QueryParameters);
+
+            string contentType = null;
+            if (options.HeaderParameters != null && options.HeaderParameters.ContainsKey("Content-Type"))
+            {
+                var contentTypes = options.HeaderParameters["Content-Type"];
+                contentType = contentTypes.FirstOrDefault();
+            }
+
+            UnityWebRequest request = new UnityWebRequest(builder.GetFullUri(), method);
+            var setContentTypeHeader = false;
+
+            if (contentType == "multipart/form-data")
+            {
+                var formData = new List<IMultipartFormSection>();
+                foreach (var formParameter in options.FormParameters)
+                {
+                    formData.Add(new MultipartFormDataSection(formParameter.Key, formParameter.Value));
+                }
+
+                var boundary = UnityWebRequest.GenerateBoundary();
+                var data = UnityWebRequest.SerializeFormSections(formData, boundary);
+                request.uploadHandler = new UploadHandlerRaw(data);
+                request.uploadHandler.contentType = "multipart/form-data; boundary=" + System.Text.Encoding.UTF8.GetString(boundary, 0, boundary.Length);
+
+                setContentTypeHeader = true;
+            }
+            /*
+            else if (contentType == "application/x-www-form-urlencoded")
+            {
+                request.Content = new FormUrlEncodedContent(options.FormParameters);
+            }
+            else
+            {
+                if (options.Data != null)
+                {
+                    var serializer = new CustomJsonCodec(SerializerSettings, configuration);
+                    request.Content = new StringContent(serializer.Serialize(options.Data), new UTF8Encoding(),
+                        "application/json");
+                }
+            }
+
+            if (!string.IsNullOrEmpty(contentType) && !setContentTypeHeader)
+            {
+                request.SetRequestHeader("Content-Type", contentType);
+            }
+            
+
+            switch (method) {
+                case "GET":
+                {
+                    request = UnityWebRequest.Get(uri);
+                    break;
+                }
+
+                case "POST":
+                {
+                    if (contentType == "application/json") {
+                        // Making a post body application/json encoded is whack with UnityWebRequest.
+                        // See: https://stackoverflow.com/questions/68156230/unitywebrequest-post-not-sending-body
+                        request = UnityWebRequest.Put(uri, serializedJsonData);
+                        request.method = "POST";
+                    }
+                    else
+                    {
+                        request = UnityWeb
+                    }
+                    break;
+                }
+
+            }
+
+            if (configuration.UserAgent != null)
+            {
+                request.Headers.TryAddWithoutValidation("User-Agent", configuration.UserAgent);
+            }
+
+            if (configuration.DefaultHeaders != null)
+            {
+                foreach (var headerParam in configuration.DefaultHeaders)
+                {
+                    request.Headers.Add(headerParam.Key, headerParam.Value);
+                }
+            }
+
+            if (options.HeaderParameters != null)
+            {
+                foreach (var headerParam in options.HeaderParameters)
+                {
+                    foreach (var value in headerParam.Value)
+                    {
+                        // Todo make content headers actually content headers
+                        request.Headers.TryAddWithoutValidation(headerParam.Key, value);
+                    }
+                }
+            }
+
+            // TODO provide an alternative that allows cookies per request instead of per API client
+            if (options.Cookies != null && options.Cookies.Count > 0)
+            {
+                request.Properties["CookieContainer"] = options.Cookies;
+            }
+            */
+
+            return request;
+        }
+
+        partial void InterceptRequest(HttpRequestMessage req);
+        partial void InterceptResponse(HttpRequestMessage req, HttpResponseMessage response);
+
+        /*
+        private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
+        {
+            T result = (T) responseData;
+            string rawContent = await response.Content.ReadAsStringAsync();
+
+            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
+            {
+                ErrorText = response.ReasonPhrase,
+                Cookies = new List<Cookie>()
+            };
+
+            // process response headers, e.g. Access-Control-Allow-Methods
+            if (response.Headers != null)
+            {
+                foreach (var responseHeader in response.Headers)
+                {
+                    transformed.Headers.Add(responseHeader.Key, ClientUtils.ParameterToString(responseHeader.Value));
+                }
+            }
+
+            // process response content headers, e.g. Content-Type
+            if (response.Content.Headers != null)
+            {
+                foreach (var responseHeader in response.Content.Headers)
+                {
+                    transformed.Headers.Add(responseHeader.Key, ClientUtils.ParameterToString(responseHeader.Value));
+                }
+            }
+
+            if (_httpClientHandler != null && response != null)
+            {
+                try {
+                    foreach (Cookie cookie in _httpClientHandler.CookieContainer.GetCookies(uri))
+                    {
+                        transformed.Cookies.Add(cookie);
+                    }
+                }
+                catch (PlatformNotSupportedException) {}
+            }
+
+            return transformed;
+        }
+        */
+
+        private ApiResponse<T> Exec<T>(HttpRequestMessage req, IReadableConfiguration configuration)
+        {
+            return ExecAsync<T>(req, configuration).GetAwaiter().GetResult();
+        }
+
+        private async Task<ApiResponse<T>> ExecAsync<T>(HttpRequestMessage req,
+            IReadableConfiguration configuration,
+            System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            await Task.Delay(1000);
+            /*
+            CancellationTokenSource timeoutTokenSource = null;
+            CancellationTokenSource finalTokenSource = null;
+            var deserializer = new CustomJsonCodec(SerializerSettings, configuration);
+            var finalToken = cancellationToken;
+
+            try
+            {
+                if (configuration.Timeout > 0)
+                {
+                    timeoutTokenSource = new CancellationTokenSource(configuration.Timeout);
+                    finalTokenSource = CancellationTokenSource.CreateLinkedTokenSource(finalToken, timeoutTokenSource.Token);
+                    finalToken = finalTokenSource.Token;
+                }
+
+                if (configuration.Proxy != null)
+                {
+                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    _httpClientHandler.Proxy = configuration.Proxy;
+                }
+
+                if (configuration.ClientCertificates != null)
+                {
+                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
+                }
+
+                var cookieContainer = req.Properties.ContainsKey("CookieContainer") ? req.Properties["CookieContainer"] as List<Cookie> : null;
+
+                if (cookieContainer != null)
+                {
+                    if(_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    foreach (var cookie in cookieContainer)
+                    {
+                        _httpClientHandler.CookieContainer.Add(cookie);
+                    }
+                }
+
+                InterceptRequest(req);
+
+                HttpResponseMessage response;
+                {{#supportsRetry}}
+                if (RetryConfiguration.AsyncRetryPolicy != null)
+                {
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy
+                        .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
+                        .ConfigureAwait(false);
+                    response = (policyResult.Outcome == OutcomeType.Successful) ?
+                        policyResult.Result : new HttpResponseMessage()
+                        {
+                            ReasonPhrase = policyResult.FinalException.ToString(),
+                            RequestMessage = req
+                        };
+                }
+                else
+                {
+                {{/supportsRetry}}
+                    response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
+                {{#supportsRetry}}
+                }
+                {{/supportsRetry}}
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return await ToApiResponse<T>(response, default(T), req.RequestUri);
+                }
+
+                object responseData = await deserializer.Deserialize<T>(response);
+
+                // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+                if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+                {
+                    responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                }
+                else if (typeof(T).Name == "Stream") // for binary response
+                {
+                    responseData = (T) (object) await response.Content.ReadAsStreamAsync();
+                }
+
+                InterceptResponse(req, response);
+
+                return await ToApiResponse<T>(response, responseData, req.RequestUri);
+            }
+            finally
+            {
+                if (timeoutTokenSource != null)
+                {
+                    timeoutTokenSource.Dispose();
+                }
+
+                if (finalTokenSource != null)
+                {
+                    finalTokenSource.Dispose();
+                }
+            }
+            */
+        }
+
+        {{#supportsAsync}}
+        #region IAsynchronousClient
+        /// <summary>
+        /// Make a HTTP GET request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> GetAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest("GET", path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP POST request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PostAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest("POST", path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP PUT request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PutAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest("PUT", path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP DELETE request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> DeleteAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest("DELETE", path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP HEAD request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> HeadAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest("HEAD", path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP OPTION request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> OptionsAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest("OPTIONS", path, options, config), config, cancellationToken);
+        }
+
+        /// <summary>
+        /// Make a HTTP PATCH request (async).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public Task<ApiResponse<T>> PatchAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return ExecAsync<T>(NewRequest("PATCH", path, options, config), config, cancellationToken);
+        }
+        #endregion IAsynchronousClient
+        {{/supportsAsync}}
+
+        #region ISynchronousClient
+        /// <summary>
+        /// Make a HTTP GET request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Get<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest("GET", path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP POST request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Post<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest("POST", path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP PUT request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Put<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest("PUT", path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP DELETE request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Delete<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest("DELETE", path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP HEAD request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Head<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest("HEAD", path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP OPTION request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Options<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest("OPTIONS", path, options, config), config);
+        }
+
+        /// <summary>
+        /// Make a HTTP PATCH request (synchronous).
+        /// </summary>
+        /// <param name="path">The target path (or resource).</param>
+        /// <param name="options">The additional request options.</param>
+        /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
+        /// GlobalConfiguration has been done before calling this method.</param>
+        /// <returns>A Task containing ApiResponse</returns>
+        public ApiResponse<T> Patch<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
+        {
+            var config = configuration ?? GlobalConfiguration.Instance;
+            return Exec<T>(NewRequest("PATCH", path, options, config), config);
+        }
+        #endregion ISynchronousClient
+    }
+}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ApiClient.mustache
@@ -412,7 +412,7 @@ namespace {{packageName}}.Client
 
                 try
                 {
-                    await Task.WhenAny(tsc.Task, Task.Delay(Timeout.Infinite, finalToken)).ConfigureAwait(false);
+                    await Task.WhenAny(tsc.Task, Task.Delay(Timeout.Infinite, finalToken));
                 }
                 catch (OperationCanceledException)
                 {

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ApiClient.mustache
@@ -14,9 +14,6 @@ using System.Text;
 using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-{{^netStandard}}
-using System.Web;
-{{/netStandard}}
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
@@ -24,9 +21,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using UnityEngine.Networking;
 using UnityEngine;
-{{#supportsRetry}}
-using Polly;
-{{/supportsRetry}}
 
 namespace {{packageName}}.Client
 {
@@ -81,20 +75,18 @@ namespace {{packageName}}.Client
 
         public T Deserialize<T>(UnityWebRequest request)
         {
-            var result = (T) Deserialize(response, typeof(T));
+            var result = (T) Deserialize(request, typeof(T));
             return result;
         }
 
         /// <summary>
         /// Deserialize the JSON string into a proper object.
         /// </summary>
-        /// <param name="response">The HTTP response.</param>
+        /// <param name="response">The UnityWebRequest after it has a response.</param>
         /// <param name="type">Object type.</param>
         /// <returns>Object representation of the JSON string.</returns>
         internal object Deserialize(UnityWebRequest request, Type type)
         {
-            IList<string> headers = response.Headers.Select(x => x.Key + "=" + x.Value).ToList();
-
             if (type == typeof(byte[])) // return byte array
             {
                 return request.downloadHandler.data;
@@ -103,7 +95,6 @@ namespace {{packageName}}.Client
             // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
             if (type == typeof(Stream))
             {
-                var bytes = await response.Content.ReadAsByteArrayAsync();
                 // NOTE: Ignoring Content-Disposition filename support, since not all platforms
                 // have a location on disk to write arbitrary data (tvOS, consoles).
                 return new MemoryStream(request.downloadHandler.data);
@@ -119,15 +110,36 @@ namespace {{packageName}}.Client
                 return Convert.ChangeType(request.downloadHandler.text, type);
             }
 
-            // at this point, it must be a model (json)
-            try
+            var contentType = request.GetResponseHeader("Content-Type");
+
+            if (!string.IsNullOrEmpty(contentType) && contentType.Contains("application/json"))
             {
-                return JsonConvert.DeserializeObject(request.downloadHandler.text, type, _serializerSettings);
+                var text = request.downloadHandler?.text;
+
+                // Generated APIs that don't expect a return value provide System.Object as the type
+                if (type == typeof(System.Object) && (string.IsNullOrEmpty(text) || text.Trim() == "null"))
+                {
+                    return null;
+                }
+
+                // Deserialize as a model
+                try
+                {
+                    return JsonConvert.DeserializeObject(text, type, _serializerSettings);
+                }
+                catch (Exception e)
+                {
+                    throw new UnexpectedResponseException(request, type, e.ToString());
+                }
             }
-            catch (Exception e)
+
+            if (type != typeof(System.Object) && request.responseCode >= 200 && request.responseCode < 300)
             {
-                throw new ApiException(500, e.Message);
+                throw new UnexpectedResponseException(request, type);
             }
+
+            return null;
+
         }
 
         public string RootElement { get; set; }
@@ -200,18 +212,18 @@ namespace {{packageName}}.Client
         }
 
         /// <summary>
-        /// Provides all logic for constructing a new HttpRequestMessage.
+        /// Provides all logic for constructing a new UnityWebRequest.
         /// At this point, all information for querying the service is known. Here, it is simply
-        /// mapped into the a HttpRequestMessage.
+        /// mapped into the UnityWebRequest.
         /// </summary>
         /// <param name="method">The http verb.</param>
         /// <param name="path">The target path (or resource).</param>
         /// <param name="options">The additional request options.</param>
         /// <param name="configuration">A per-request configuration object. It is assumed that any merge with
         /// GlobalConfiguration has been done before calling this method.</param>
-        /// <returns>[private] A new HttpRequestMessage instance.</returns>
+        /// <returns>[private] A new UnityWebRequest instance.</returns>
         /// <exception cref="ArgumentNullException"></exception>
-        private UnityWebRequest NewRequest(
+        private UnityWebRequest NewRequest<T>(
             string method,
             string path,
             RequestOptions options,
@@ -234,8 +246,9 @@ namespace {{packageName}}.Client
                 contentType = contentTypes.FirstOrDefault();
             }
 
-            UnityWebRequest request = new UnityWebRequest(builder.GetFullUri(), method);
-            var setContentTypeHeader = false;
+            var uri = builder.GetFullUri();
+            UploadHandler uploadHandler = null;
+            UnityWebRequest request = null;
 
             if (contentType == "multipart/form-data")
             {
@@ -245,68 +258,51 @@ namespace {{packageName}}.Client
                     formData.Add(new MultipartFormDataSection(formParameter.Key, formParameter.Value));
                 }
 
-                var boundary = UnityWebRequest.GenerateBoundary();
-                var data = UnityWebRequest.SerializeFormSections(formData, boundary);
-                request.uploadHandler = new UploadHandlerRaw(data);
-                request.uploadHandler.contentType = "multipart/form-data; boundary=" + System.Text.Encoding.UTF8.GetString(boundary, 0, boundary.Length);
-
-                setContentTypeHeader = true;
+                request = UnityWebRequest.Post(uri, formData);
+                request.method = method;
             }
-            /*
             else if (contentType == "application/x-www-form-urlencoded")
             {
-                request.Content = new FormUrlEncodedContent(options.FormParameters);
+                var form = new WWWForm();
+                foreach (var kvp in options.FormParameters)
+                {
+                    form.AddField(kvp.Key, kvp.Value);
+                }
+
+                request = UnityWebRequest.Post(uri, form);
+                request.method = method;
+            }
+            else if (options.Data != null)
+            {
+                var serializer = new CustomJsonCodec(SerializerSettings, configuration);
+                var jsonData = serializer.Serialize(options.Data);
+
+                // Making a post body application/json encoded is whack with UnityWebRequest.
+                // See: https://stackoverflow.com/questions/68156230/unitywebrequest-post-not-sending-body
+                request = UnityWebRequest.Put(uri, jsonData);
+                request.method = method;
+                request.SetRequestHeader("Content-Type", "application/json");
             }
             else
             {
-                if (options.Data != null)
-                {
-                    var serializer = new CustomJsonCodec(SerializerSettings, configuration);
-                    request.Content = new StringContent(serializer.Serialize(options.Data), new UTF8Encoding(),
-                        "application/json");
-                }
+                request = new UnityWebRequest(builder.GetFullUri(), method);
             }
 
-            if (!string.IsNullOrEmpty(contentType) && !setContentTypeHeader)
+            if (request.downloadHandler == null && typeof(T) != typeof(System.Object))
             {
-                request.SetRequestHeader("Content-Type", contentType);
-            }
-            
-
-            switch (method) {
-                case "GET":
-                {
-                    request = UnityWebRequest.Get(uri);
-                    break;
-                }
-
-                case "POST":
-                {
-                    if (contentType == "application/json") {
-                        // Making a post body application/json encoded is whack with UnityWebRequest.
-                        // See: https://stackoverflow.com/questions/68156230/unitywebrequest-post-not-sending-body
-                        request = UnityWebRequest.Put(uri, serializedJsonData);
-                        request.method = "POST";
-                    }
-                    else
-                    {
-                        request = UnityWeb
-                    }
-                    break;
-                }
-
+                request.downloadHandler = new DownloadHandlerBuffer();
             }
 
             if (configuration.UserAgent != null)
             {
-                request.Headers.TryAddWithoutValidation("User-Agent", configuration.UserAgent);
+                request.SetRequestHeader("User-Agent", configuration.UserAgent);
             }
 
             if (configuration.DefaultHeaders != null)
             {
                 foreach (var headerParam in configuration.DefaultHeaders)
                 {
-                    request.Headers.Add(headerParam.Key, headerParam.Value);
+                    request.SetRequestHeader(headerParam.Key, headerParam.Value);
                 }
             }
 
@@ -317,85 +313,66 @@ namespace {{packageName}}.Client
                     foreach (var value in headerParam.Value)
                     {
                         // Todo make content headers actually content headers
-                        request.Headers.TryAddWithoutValidation(headerParam.Key, value);
+                        request.SetRequestHeader(headerParam.Key, value);
                     }
                 }
             }
 
-            // TODO provide an alternative that allows cookies per request instead of per API client
             if (options.Cookies != null && options.Cookies.Count > 0)
             {
-                request.Properties["CookieContainer"] = options.Cookies;
+                #if UNITY_WEBGL
+                throw new System.InvalidOperationException("UnityWebRequest does not support setting cookies in WebGL");
+                #else
+                if (options.Cookies.Count != 1)
+                {
+                    UnityEngine.Debug.LogError("Only one cookie supported, ignoring others");
+                }
+
+                request.SetRequestHeader("Cookie", options.Cookies[0].ToString());
+                #endif
             }
-            */
 
             return request;
+
         }
 
-        partial void InterceptRequest(HttpRequestMessage req);
-        partial void InterceptResponse(HttpRequestMessage req, HttpResponseMessage response);
+        partial void InterceptRequest(UnityWebRequest req);
+        partial void InterceptResponse(UnityWebRequest req);
 
-        /*
-        private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
+        private ApiResponse<T> ToApiResponse<T>(UnityWebRequest request, object responseData)
         {
             T result = (T) responseData;
-            string rawContent = await response.Content.ReadAsStringAsync();
 
-            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
+            var transformed = new ApiResponse<T>((HttpStatusCode)request.responseCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, request.downloadHandler?.text ?? "")
             {
-                ErrorText = response.ReasonPhrase,
+                ErrorText = request.error,
                 Cookies = new List<Cookie>()
             };
 
             // process response headers, e.g. Access-Control-Allow-Methods
-            if (response.Headers != null)
+            var responseHeaders = request.GetResponseHeaders();
+            if (responseHeaders != null)
             {
-                foreach (var responseHeader in response.Headers)
+                foreach (var responseHeader in request.GetResponseHeaders())
                 {
                     transformed.Headers.Add(responseHeader.Key, ClientUtils.ParameterToString(responseHeader.Value));
                 }
-            }
-
-            // process response content headers, e.g. Content-Type
-            if (response.Content.Headers != null)
-            {
-                foreach (var responseHeader in response.Content.Headers)
-                {
-                    transformed.Headers.Add(responseHeader.Key, ClientUtils.ParameterToString(responseHeader.Value));
-                }
-            }
-
-            if (_httpClientHandler != null && response != null)
-            {
-                try {
-                    foreach (Cookie cookie in _httpClientHandler.CookieContainer.GetCookies(uri))
-                    {
-                        transformed.Cookies.Add(cookie);
-                    }
-                }
-                catch (PlatformNotSupportedException) {}
             }
 
             return transformed;
         }
-        */
 
-        private ApiResponse<T> Exec<T>(HttpRequestMessage req, IReadableConfiguration configuration)
-        {
-            return ExecAsync<T>(req, configuration).GetAwaiter().GetResult();
-        }
-
-        private async Task<ApiResponse<T>> ExecAsync<T>(HttpRequestMessage req,
+        private async Task<ApiResponse<T>> ExecAsync<T>(
+            UnityWebRequest request,
             IReadableConfiguration configuration,
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            await Task.Delay(1000);
-            /*
             CancellationTokenSource timeoutTokenSource = null;
             CancellationTokenSource finalTokenSource = null;
             var deserializer = new CustomJsonCodec(SerializerSettings, configuration);
             var finalToken = cancellationToken;
 
+            using (request)
             try
             {
                 if (configuration.Timeout > 0)
@@ -407,72 +384,63 @@ namespace {{packageName}}.Client
 
                 if (configuration.Proxy != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
-                    _httpClientHandler.Proxy = configuration.Proxy;
+                    throw new InvalidOperationException("Configuration `Proxy` not supported by UnityWebRequest");
                 }
 
                 if (configuration.ClientCertificates != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
-                    _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
+                    // Only Android/iOS/tvOS/Standalone players can support certificates, and this
+                    // implementation is intended to work on all platforms.
+                    //
+                    // TODO: Could optionally allow support for this on these platforms.
+                    //
+                    // See: https://docs.unity3d.com/ScriptReference/Networking.CertificateHandler.html
+                    throw new InvalidOperationException("Configuration `ClientCertificates` not supported by UnityWebRequest on all platforms");
                 }
 
-                var cookieContainer = req.Properties.ContainsKey("CookieContainer") ? req.Properties["CookieContainer"] as List<Cookie> : null;
+                InterceptRequest(request);
 
-                if (cookieContainer != null)
+                var asyncOp = request.SendWebRequest();
+
+                TaskCompletionSource<UnityWebRequest.Result> tsc = new TaskCompletionSource<UnityWebRequest.Result>();
+                asyncOp.completed += (_) => tsc.TrySetResult(request.result);
+
+                if (asyncOp.isDone)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
-                    foreach (var cookie in cookieContainer)
-                    {
-                        _httpClientHandler.CookieContainer.Add(cookie);
-                    }
+                    tsc.TrySetResult(asyncOp.webRequest.result);
                 }
 
-                InterceptRequest(req);
-
-                HttpResponseMessage response;
-                {{#supportsRetry}}
-                if (RetryConfiguration.AsyncRetryPolicy != null)
+                try
                 {
-                    var policy = RetryConfiguration.AsyncRetryPolicy;
-                    var policyResult = await policy
-                        .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
-                        .ConfigureAwait(false);
-                    response = (policyResult.Outcome == OutcomeType.Successful) ?
-                        policyResult.Result : new HttpResponseMessage()
-                        {
-                            ReasonPhrase = policyResult.FinalException.ToString(),
-                            RequestMessage = req
-                        };
+                    await Task.WhenAny(tsc.Task, Task.Delay(Timeout.Infinite, finalToken)).ConfigureAwait(false);
                 }
-                else
+                catch (OperationCanceledException)
                 {
-                {{/supportsRetry}}
-                    response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
-                {{#supportsRetry}}
-                }
-                {{/supportsRetry}}
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    return await ToApiResponse<T>(response, default(T), req.RequestUri);
+                    request.Abort();
+                    throw;
                 }
 
-                object responseData = await deserializer.Deserialize<T>(response);
+                if (request.result == UnityWebRequest.Result.ConnectionError ||
+                    request.result == UnityWebRequest.Result.DataProcessingError)
+                {
+                    throw new ConnectionException(request);
+                }
+
+                object responseData = deserializer.Deserialize<T>(request);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
                 {
-                    responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                    responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { new ByteArrayContent(request.downloadHandler.data) });
                 }
                 else if (typeof(T).Name == "Stream") // for binary response
                 {
-                    responseData = (T) (object) await response.Content.ReadAsStreamAsync();
+                    responseData = (T) (object) new MemoryStream(request.downloadHandler.data);
                 }
 
-                InterceptResponse(req, response);
+                InterceptResponse(request);
 
-                return await ToApiResponse<T>(response, responseData, req.RequestUri);
+                return ToApiResponse<T>(request, responseData);
             }
             finally
             {
@@ -486,7 +454,6 @@ namespace {{packageName}}.Client
                     finalTokenSource.Dispose();
                 }
             }
-            */
         }
 
         {{#supportsAsync}}
@@ -503,7 +470,7 @@ namespace {{packageName}}.Client
         public Task<ApiResponse<T>> GetAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var config = configuration ?? GlobalConfiguration.Instance;
-            return ExecAsync<T>(NewRequest("GET", path, options, config), config, cancellationToken);
+            return ExecAsync<T>(NewRequest<T>("GET", path, options, config), config, cancellationToken);
         }
 
         /// <summary>
@@ -518,7 +485,7 @@ namespace {{packageName}}.Client
         public Task<ApiResponse<T>> PostAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var config = configuration ?? GlobalConfiguration.Instance;
-            return ExecAsync<T>(NewRequest("POST", path, options, config), config, cancellationToken);
+            return ExecAsync<T>(NewRequest<T>("POST", path, options, config), config, cancellationToken);
         }
 
         /// <summary>
@@ -533,7 +500,7 @@ namespace {{packageName}}.Client
         public Task<ApiResponse<T>> PutAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var config = configuration ?? GlobalConfiguration.Instance;
-            return ExecAsync<T>(NewRequest("PUT", path, options, config), config, cancellationToken);
+            return ExecAsync<T>(NewRequest<T>("PUT", path, options, config), config, cancellationToken);
         }
 
         /// <summary>
@@ -548,7 +515,7 @@ namespace {{packageName}}.Client
         public Task<ApiResponse<T>> DeleteAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var config = configuration ?? GlobalConfiguration.Instance;
-            return ExecAsync<T>(NewRequest("DELETE", path, options, config), config, cancellationToken);
+            return ExecAsync<T>(NewRequest<T>("DELETE", path, options, config), config, cancellationToken);
         }
 
         /// <summary>
@@ -563,7 +530,7 @@ namespace {{packageName}}.Client
         public Task<ApiResponse<T>> HeadAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var config = configuration ?? GlobalConfiguration.Instance;
-            return ExecAsync<T>(NewRequest("HEAD", path, options, config), config, cancellationToken);
+            return ExecAsync<T>(NewRequest<T>("HEAD", path, options, config), config, cancellationToken);
         }
 
         /// <summary>
@@ -578,7 +545,7 @@ namespace {{packageName}}.Client
         public Task<ApiResponse<T>> OptionsAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var config = configuration ?? GlobalConfiguration.Instance;
-            return ExecAsync<T>(NewRequest("OPTIONS", path, options, config), config, cancellationToken);
+            return ExecAsync<T>(NewRequest<T>("OPTIONS", path, options, config), config, cancellationToken);
         }
 
         /// <summary>
@@ -593,7 +560,7 @@ namespace {{packageName}}.Client
         public Task<ApiResponse<T>> PatchAsync<T>(string path, RequestOptions options, IReadableConfiguration configuration = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var config = configuration ?? GlobalConfiguration.Instance;
-            return ExecAsync<T>(NewRequest("PATCH", path, options, config), config, cancellationToken);
+            return ExecAsync<T>(NewRequest<T>("PATCH", path, options, config), config, cancellationToken);
         }
         #endregion IAsynchronousClient
         {{/supportsAsync}}
@@ -609,8 +576,7 @@ namespace {{packageName}}.Client
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Get<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
         {
-            var config = configuration ?? GlobalConfiguration.Instance;
-            return Exec<T>(NewRequest("GET", path, options, config), config);
+            throw new System.NotImplementedException("UnityWebRequest does not support synchronous operation");
         }
 
         /// <summary>
@@ -623,8 +589,7 @@ namespace {{packageName}}.Client
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Post<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
         {
-            var config = configuration ?? GlobalConfiguration.Instance;
-            return Exec<T>(NewRequest("POST", path, options, config), config);
+            throw new System.NotImplementedException("UnityWebRequest does not support synchronous operation");
         }
 
         /// <summary>
@@ -637,8 +602,7 @@ namespace {{packageName}}.Client
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Put<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
         {
-            var config = configuration ?? GlobalConfiguration.Instance;
-            return Exec<T>(NewRequest("PUT", path, options, config), config);
+            throw new System.NotImplementedException("UnityWebRequest does not support synchronous operation");
         }
 
         /// <summary>
@@ -651,8 +615,7 @@ namespace {{packageName}}.Client
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Delete<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
         {
-            var config = configuration ?? GlobalConfiguration.Instance;
-            return Exec<T>(NewRequest("DELETE", path, options, config), config);
+            throw new System.NotImplementedException("UnityWebRequest does not support synchronous operation");
         }
 
         /// <summary>
@@ -665,8 +628,7 @@ namespace {{packageName}}.Client
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Head<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
         {
-            var config = configuration ?? GlobalConfiguration.Instance;
-            return Exec<T>(NewRequest("HEAD", path, options, config), config);
+            throw new System.NotImplementedException("UnityWebRequest does not support synchronous operation");
         }
 
         /// <summary>
@@ -679,8 +641,7 @@ namespace {{packageName}}.Client
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Options<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
         {
-            var config = configuration ?? GlobalConfiguration.Instance;
-            return Exec<T>(NewRequest("OPTIONS", path, options, config), config);
+            throw new System.NotImplementedException("UnityWebRequest does not support synchronous operation");
         }
 
         /// <summary>
@@ -693,8 +654,7 @@ namespace {{packageName}}.Client
         /// <returns>A Task containing ApiResponse</returns>
         public ApiResponse<T> Patch<T>(string path, RequestOptions options, IReadableConfiguration configuration = null)
         {
-            var config = configuration ?? GlobalConfiguration.Instance;
-            return Exec<T>(NewRequest("PATCH", path, options, config), config);
+            throw new System.NotImplementedException("UnityWebRequest does not support synchronous operation");
         }
         #endregion ISynchronousClient
     }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ConnectionException.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/ConnectionException.mustache
@@ -1,0 +1,21 @@
+{{>partial_header}}
+
+using System;
+using UnityEngine.Networking;
+
+namespace {{packageName}}.Client
+{
+    public class ConnectionException : Exception
+    {
+        public UnityWebRequest.Result Result { get; private set; }
+        public string Error { get; private set; }
+
+        // NOTE: Cannot keep reference to the request since it will be disposed.
+        public ConnectionException(UnityWebRequest request)
+            : base($"result={request.result} error={request.error}")
+        {
+            Result = request.result;
+            Error = request.error ?? "";
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/RequestOptions.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/RequestOptions.mustache
@@ -1,0 +1,60 @@
+{{>partial_header}}
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// A container for generalized request inputs. This type allows consumers to extend the request functionality
+    /// by abstracting away from the default (built-in) request framework (e.g. RestSharp).
+    /// </summary>
+    public class RequestOptions
+    {
+        /// <summary>
+        /// Parameters to be bound to path parts of the Request's URL
+        /// </summary>
+        public Dictionary<string, string> PathParameters { get; set; }
+
+        /// <summary>
+        /// Query parameters to be applied to the request.
+        /// Keys may have 1 or more values associated.
+        /// </summary>
+        public Multimap<string, string> QueryParameters { get; set; }
+
+        /// <summary>
+        /// Header parameters to be applied to to the request.
+        /// Keys may have 1 or more values associated.
+        /// </summary>
+        public Multimap<string, string> HeaderParameters { get; set; }
+
+        /// <summary>
+        /// Form parameters to be sent along with the request.
+        /// </summary>
+        public Dictionary<string, string> FormParameters { get; set; }
+
+        /// <summary>
+        /// Cookies to be sent along with the request.
+        /// </summary>
+        public List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// Any data associated with a request body.
+        /// </summary>
+        public Object Data { get; set; }
+
+        /// <summary>
+        /// Constructs a new instance of <see cref="RequestOptions"/>
+        /// </summary>
+        public RequestOptions()
+        {
+            PathParameters = new Dictionary<string, string>();
+            QueryParameters = new Multimap<string, string>();
+            HeaderParameters = new Multimap<string, string>();
+            FormParameters = new Dictionary<string, string>();
+            Cookies = new List<Cookie>();
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/UnexpectedResponseException.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/UnexpectedResponseException.mustache
@@ -1,0 +1,26 @@
+{{>partial_header}}
+
+using System;
+using UnityEngine.Networking;
+
+namespace {{packageName}}.Client
+{
+    // Thrown when a backend doesn't return an expected response based on the expected type
+    // of the response data.
+    public class UnexpectedResponseException : Exception
+    {
+        public int ErrorCode { get; private set; }
+
+        // NOTE: Cannot keep reference to the request since it will be disposed.
+        public UnexpectedResponseException(UnityWebRequest request, System.Type type, string extra = "")
+            : base(CreateMessage(request, type, extra))
+        {
+            ErrorCode = (int)request.responseCode;
+        }
+
+        private static string CreateMessage(UnityWebRequest request, System.Type type, string extra)
+        {
+            return $"httpcode={request.responseCode}, expected {type.Name} but got data: {extra}";
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/api.mustache
@@ -368,7 +368,6 @@ namespace {{packageName}}.{{apiPackage}}
             {{#formParams}}
             {{#required}}
             {{#isFile}}
-            localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
             {{/isFile}}
             {{^isFile}}
             localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
@@ -378,7 +377,6 @@ namespace {{packageName}}.{{apiPackage}}
             if ({{paramName}} != null)
             {
                 {{#isFile}}
-                localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
                 {{/isFile}}
                 {{^isFile}}
                 localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
@@ -567,7 +565,6 @@ namespace {{packageName}}.{{apiPackage}}
             {{#formParams}}
             {{#required}}
             {{#isFile}}
-            localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
             {{/isFile}}
             {{^isFile}}
             localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
@@ -577,7 +574,6 @@ namespace {{packageName}}.{{apiPackage}}
             if ({{paramName}} != null)
             {
                 {{#isFile}}
-                localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
                 {{/isFile}}
                 {{^isFile}}
                 localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/api.mustache
@@ -1,0 +1,674 @@
+{{>partial_header}}
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using System.Net.Mime;
+using {{packageName}}.Client;
+{{#hasImport}}using {{packageName}}.{{modelPackage}};
+{{/hasImport}}
+
+namespace {{packageName}}.{{apiPackage}}
+{
+    {{#operations}}
+
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
+    {{>visibility}} interface {{interfacePrefix}}{{classname}}Sync : IApiAccessor
+    {
+        #region Synchronous Operations
+        {{#operation}}
+        /// <summary>
+        /// {{summary}}
+        /// </summary>
+        {{#notes}}
+        /// <remarks>
+        /// {{.}}
+        /// </remarks>
+        {{/notes}}
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}/// <returns>{{returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        {{{returnType}}}{{^returnType}}void{{/returnType}} {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}});
+
+        /// <summary>
+        /// {{summary}}
+        /// </summary>
+        /// <remarks>
+        /// {{notes}}
+        /// </remarks>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}/// <returns>ApiResponse of {{returnType}}{{^returnType}}Object(void){{/returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        ApiResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}});
+        {{/operation}}
+        #endregion Synchronous Operations
+    }
+
+    {{#supportsAsync}}
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
+    {{>visibility}} interface {{interfacePrefix}}{{classname}}Async : IApiAccessor
+    {
+        #region Asynchronous Operations
+        {{#operation}}
+        /// <summary>
+        /// {{summary}}
+        /// </summary>
+        /// <remarks>
+        /// {{notes}}
+        /// </remarks>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}
+        /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of {{returnType}}{{^returnType}}void{{/returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        {{#returnType}}System.Threading.Tasks.Task<{{{.}}}>{{/returnType}}{{^returnType}}System.Threading.Tasks.Task{{/returnType}} {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <summary>
+        /// {{summary}}
+        /// </summary>
+        /// <remarks>
+        /// {{notes}}
+        /// </remarks>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}
+        /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        System.Threading.Tasks.Task<ApiResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>> {{operationId}}WithHttpInfoAsync({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        {{/operation}}
+        #endregion Asynchronous Operations
+    }
+    {{/supportsAsync}}
+
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
+    {{>visibility}} interface {{interfacePrefix}}{{classname}} : {{interfacePrefix}}{{classname}}Sync{{#supportsAsync}}, {{interfacePrefix}}{{classname}}Async{{/supportsAsync}}
+    {
+
+    }
+
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
+    {{>visibility}} partial class {{classname}} : IDisposable, {{interfacePrefix}}{{classname}}
+    {
+        private {{packageName}}.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}"/> class.
+        /// **IMPORTANT** This will also create an instance of HttpClient, which is less than ideal.
+        /// It's better to reuse the <see href="https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests#issues-with-the-original-httpclient-class-available-in-net">HttpClient and HttpClientHandler</see>.
+        /// </summary>
+        /// <returns></returns>
+        public {{classname}}() : this((string)null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}"/> class.
+        /// **IMPORTANT** This will also create an instance of HttpClient, which is less than ideal.
+        /// It's better to reuse the <see href="https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests#issues-with-the-original-httpclient-class-available-in-net">HttpClient and HttpClientHandler</see>.
+        /// </summary>
+        /// <param name="basePath">The target service's base path in URL format.</param>
+        /// <exception cref="ArgumentException"></exception>
+        /// <returns></returns>
+        public {{classname}}(string basePath)
+        {
+            this.Configuration = {{packageName}}.Client.Configuration.MergeConfigurations(
+                {{packageName}}.Client.GlobalConfiguration.Instance,
+                new {{packageName}}.Client.Configuration { BasePath = basePath }
+            );
+            this.ApiClient = new {{packageName}}.Client.ApiClient(this.Configuration.BasePath);
+            this.Client =  this.ApiClient;
+            {{#supportsAsync}}
+            this.AsynchronousClient = this.ApiClient;
+            {{/supportsAsync}}
+            this.ExceptionFactory = {{packageName}}.Client.Configuration.DefaultExceptionFactory;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}"/> class using Configuration object.
+        /// **IMPORTANT** This will also create an instance of HttpClient, which is less than ideal.
+        /// It's better to reuse the <see href="https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests#issues-with-the-original-httpclient-class-available-in-net">HttpClient and HttpClientHandler</see>.
+        /// </summary>
+        /// <param name="configuration">An instance of Configuration.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <returns></returns>
+        public {{classname}}({{packageName}}.Client.Configuration configuration)
+        {
+            if (configuration == null) throw new ArgumentNullException("configuration");
+
+            this.Configuration = {{packageName}}.Client.Configuration.MergeConfigurations(
+                {{packageName}}.Client.GlobalConfiguration.Instance,
+                configuration
+            );
+            this.ApiClient = new {{packageName}}.Client.ApiClient(this.Configuration.BasePath);
+            this.Client = this.ApiClient;
+            {{#supportsAsync}}
+            this.AsynchronousClient = this.ApiClient;
+            {{/supportsAsync}}
+            ExceptionFactory = {{packageName}}.Client.Configuration.DefaultExceptionFactory;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}"/> class
+        /// using a Configuration object and client instance.
+        /// </summary>
+        /// <param name="client">The client interface for synchronous API access.</param>{{#supportsAsync}}
+        /// <param name="asyncClient">The client interface for asynchronous API access.</param>{{/supportsAsync}}
+        /// <param name="configuration">The configuration object.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public {{classname}}({{packageName}}.Client.ISynchronousClient client, {{#supportsAsync}}{{packageName}}.Client.IAsynchronousClient asyncClient, {{/supportsAsync}}{{packageName}}.Client.IReadableConfiguration configuration)
+        {
+            if (client == null) throw new ArgumentNullException("client");
+            {{#supportsAsync}}
+            if (asyncClient == null) throw new ArgumentNullException("asyncClient");
+            {{/supportsAsync}}
+            if (configuration == null) throw new ArgumentNullException("configuration");
+
+            this.Client = client;
+            {{#supportsAsync}}
+            this.AsynchronousClient = asyncClient;
+            {{/supportsAsync}}
+            this.Configuration = configuration;
+            this.ExceptionFactory = {{packageName}}.Client.Configuration.DefaultExceptionFactory;
+        }
+
+        /// <summary>
+        /// Disposes resources if they were created by us
+        /// </summary>
+        public void Dispose()
+        {
+            this.ApiClient?.Dispose();
+        }
+
+        /// <summary>
+        /// Holds the ApiClient if created
+        /// </summary>
+        public {{packageName}}.Client.ApiClient ApiClient { get; set; } = null;
+
+        {{#supportsAsync}}
+        /// <summary>
+        /// The client for accessing this underlying API asynchronously.
+        /// </summary>
+        public {{packageName}}.Client.IAsynchronousClient AsynchronousClient { get; set; }
+        {{/supportsAsync}}
+
+        /// <summary>
+        /// The client for accessing this underlying API synchronously.
+        /// </summary>
+        public {{packageName}}.Client.ISynchronousClient Client { get; set; }
+
+        /// <summary>
+        /// Gets the base path of the API client.
+        /// </summary>
+        /// <value>The base path</value>
+        public string GetBasePath()
+        {
+            return this.Configuration.BasePath;
+        }
+
+        /// <summary>
+        /// Gets or sets the configuration object
+        /// </summary>
+        /// <value>An instance of the Configuration</value>
+        public {{packageName}}.Client.IReadableConfiguration Configuration { get; set; }
+
+        /// <summary>
+        /// Provides a factory method hook for the creation of exceptions.
+        /// </summary>
+        public {{packageName}}.Client.ExceptionFactory ExceptionFactory
+        {
+            get
+            {
+                if (_exceptionFactory != null && _exceptionFactory.GetInvocationList().Length > 1)
+                {
+                    throw new InvalidOperationException("Multicast delegate for ExceptionFactory is unsupported.");
+                }
+                return _exceptionFactory;
+            }
+            set { _exceptionFactory = value; }
+        }
+
+        {{#operation}}
+        /// <summary>
+        /// {{summary}} {{notes}}
+        /// </summary>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}/// <returns>{{returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        public {{{returnType}}}{{^returnType}}void{{/returnType}} {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}})
+        {
+            {{#returnType}}{{packageName}}.Client.ApiResponse<{{{returnType}}}> localVarResponse = {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+            return localVarResponse.Data;{{/returnType}}{{^returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{/returnType}}
+        }
+
+        /// <summary>
+        /// {{summary}} {{notes}}
+        /// </summary>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}/// <returns>ApiResponse of {{returnType}}{{^returnType}}Object(void){{/returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        public {{packageName}}.Client.ApiResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}})
+        {
+            {{#allParams}}
+            {{#required}}
+            {{^vendorExtensions.x-csharp-value-type}}
+            // verify the required parameter '{{paramName}}' is set
+            if ({{paramName}} == null)
+                throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
+
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{/required}}
+            {{/allParams}}
+            {{packageName}}.Client.RequestOptions localVarRequestOptions = new {{packageName}}.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+                {{#consumes}}
+                "{{{mediaType}}}"{{^-last}},{{/-last}}
+                {{/consumes}}
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                {{#produces}}
+                "{{{mediaType}}}"{{^-last}},{{/-last}}
+                {{/produces}}
+            };
+
+            var localVarContentType = {{packageName}}.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = {{packageName}}.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+            {{#pathParams}}
+            {{#required}}
+            localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            }
+            {{/required}}
+            {{/pathParams}}
+            {{#queryParams}}
+            {{#required}}
+            {{#isDeepObject}}
+            {{#items.vars}}
+            localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}.{{name}}));
+            {{/items.vars}}
+            {{^items}}
+            localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
+            {{/items}}
+            {{/isDeepObject}}
+            {{^isDeepObject}}
+            localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
+            {{/isDeepObject}}
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                {{#isDeepObject}}
+                    {{#items.vars}}
+                if ({{paramName}}.{{name}} != null)
+                {
+                    localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}.{{name}}));
+                }
+                    {{/items.vars}}
+                {{^items}}
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
+                {{/items}}
+                {{/isDeepObject}}
+                {{^isDeepObject}}
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
+                {{/isDeepObject}}
+            }
+            {{/required}}
+            {{/queryParams}}
+            {{#headerParams}}
+            {{#required}}
+            localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            }
+            {{/required}}
+            {{/headerParams}}
+            {{#formParams}}
+            {{#required}}
+            {{#isFile}}
+            localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+            {{/isFile}}
+            {{^isFile}}
+            localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
+            {{/isFile}}
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                {{#isFile}}
+                localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+                {{/isFile}}
+                {{^isFile}}
+                localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
+                {{/isFile}}
+            }
+            {{/required}}
+            {{/formParams}}
+            {{#bodyParam}}
+            localVarRequestOptions.Data = {{paramName}};
+            {{/bodyParam}}
+
+            {{#authMethods}}
+            // authentication ({{name}}) required
+            {{#isApiKey}}
+            {{#isKeyInCookie}}
+            // cookie parameter support
+            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
+            {
+                localVarRequestOptions.Cookies.Add(new Cookie("{{keyParamName}}", this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")));
+            }
+            {{/isKeyInCookie}}
+            {{#isKeyInHeader}}
+            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
+            {
+                localVarRequestOptions.HeaderParameters.Add("{{keyParamName}}", this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}"));
+            }
+            {{/isKeyInHeader}}
+            {{#isKeyInQuery}}
+            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
+            {
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("", "{{keyParamName}}", this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")));
+            }
+            {{/isKeyInQuery}}
+            {{/isApiKey}}
+            {{#isBasicBasic}}
+            // http basic authentication required
+            if (!string.IsNullOrEmpty(this.Configuration.Username) || !string.IsNullOrEmpty(this.Configuration.Password) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
+            {
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Basic " + {{packageName}}.Client.ClientUtils.Base64Encode(this.Configuration.Username + ":" + this.Configuration.Password));
+            }
+            {{/isBasicBasic}}
+            {{#isBasicBearer}}
+            // bearer authentication required
+            if (!string.IsNullOrEmpty(this.Configuration.AccessToken) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
+            {
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Bearer " + this.Configuration.AccessToken);
+            }
+            {{/isBasicBearer}}
+            {{#isOAuth}}
+            // oauth required
+            if (!string.IsNullOrEmpty(this.Configuration.AccessToken) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
+            {
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Bearer " + this.Configuration.AccessToken);
+            }
+            {{/isOAuth}}
+            {{#isHttpSignature}}
+            if (this.Configuration.HttpSigningConfiguration != null)
+            {
+                var HttpSigningHeaders = this.Configuration.HttpSigningConfiguration.GetHttpSignedHeader(this.Configuration.BasePath, "{{{httpMethod}}}", "{{{path}}}", localVarRequestOptions);
+                foreach (var headerItem in HttpSigningHeaders)
+                {
+                    if (localVarRequestOptions.HeaderParameters.ContainsKey(headerItem.Key))
+                    {
+                        localVarRequestOptions.HeaderParameters[headerItem.Key] = new List<string>() { headerItem.Value };
+                    }
+                    else
+                    {
+                        localVarRequestOptions.HeaderParameters.Add(headerItem.Key, headerItem.Value);
+                    }
+                }
+            }
+            {{/isHttpSignature}}
+            {{/authMethods}}
+
+            // make the HTTP request
+            var localVarResponse = this.Client.{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}}<{{{returnType}}}{{^returnType}}Object{{/returnType}}>("{{{path}}}", localVarRequestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("{{operationId}}", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        {{#supportsAsync}}
+        /// <summary>
+        /// {{summary}} {{notes}}
+        /// </summary>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}
+        /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of {{returnType}}{{^returnType}}void{{/returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        {{#returnType}}public async System.Threading.Tasks.Task<{{{.}}}>{{/returnType}}{{^returnType}}public async System.Threading.Tasks.Task{{/returnType}} {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            {{#returnType}}{{packageName}}.Client.ApiResponse<{{{returnType}}}> localVarResponse = await {{operationId}}WithHttpInfoAsync({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;{{/returnType}}{{^returnType}}await {{operationId}}WithHttpInfoAsync({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}cancellationToken).ConfigureAwait(false);{{/returnType}}
+        }
+
+        /// <summary>
+        /// {{summary}} {{notes}}
+        /// </summary>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}
+        /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        {{/allParams}}
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
+        {{#isDeprecated}}
+        [Obsolete]
+        {{/isDeprecated}}
+        public async System.Threading.Tasks.Task<{{packageName}}.Client.ApiResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>> {{operationId}}WithHttpInfoAsync({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            {{#allParams}}
+            {{#required}}
+            {{^vendorExtensions.x-csharp-value-type}}
+            // verify the required parameter '{{paramName}}' is set
+            if ({{paramName}} == null)
+                throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
+
+            {{/vendorExtensions.x-csharp-value-type}}
+            {{/required}}
+            {{/allParams}}
+
+            {{packageName}}.Client.RequestOptions localVarRequestOptions = new {{packageName}}.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+                {{#consumes}}
+                "{{{mediaType}}}"{{^-last}}, {{/-last}}
+                {{/consumes}}
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                {{#produces}}
+                "{{{mediaType}}}"{{^-last}},{{/-last}}
+                {{/produces}}
+            };
+
+
+            var localVarContentType = {{packageName}}.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = {{packageName}}.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+            {{#pathParams}}
+            {{#required}}
+            localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
+            }
+            {{/required}}
+            {{/pathParams}}
+            {{#queryParams}}
+            {{#required}}
+            localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
+            }
+            {{/required}}
+            {{/queryParams}}
+            {{#headerParams}}
+            {{#required}}
+            localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter
+            }
+            {{/required}}
+            {{/headerParams}}
+            {{#formParams}}
+            {{#required}}
+            {{#isFile}}
+            localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+            {{/isFile}}
+            {{^isFile}}
+            localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
+            {{/isFile}}
+            {{/required}}
+            {{^required}}
+            if ({{paramName}} != null)
+            {
+                {{#isFile}}
+                localVarRequestOptions.FileParameters.Add("{{baseName}}", {{paramName}});
+                {{/isFile}}
+                {{^isFile}}
+                localVarRequestOptions.FormParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // form parameter
+                {{/isFile}}
+            }
+            {{/required}}
+            {{/formParams}}
+            {{#bodyParam}}
+            localVarRequestOptions.Data = {{paramName}};
+            {{/bodyParam}}
+
+            {{#authMethods}}
+            // authentication ({{name}}) required
+            {{#isApiKey}}
+            {{#isKeyInCookie}}
+            // cookie parameter support
+            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
+            {
+                localVarRequestOptions.Cookies.Add(new Cookie("{{keyParamName}}", this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")));
+            }
+            {{/isKeyInCookie}}
+            {{#isKeyInHeader}}
+            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
+            {
+                localVarRequestOptions.HeaderParameters.Add("{{keyParamName}}", this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}"));
+            }
+            {{/isKeyInHeader}}
+            {{#isKeyInQuery}}
+            if (!string.IsNullOrEmpty(this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
+            {
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("", "{{keyParamName}}", this.Configuration.GetApiKeyWithPrefix("{{keyParamName}}")));
+            }
+            {{/isKeyInQuery}}
+            {{/isApiKey}}
+            {{#isBasic}}
+            {{#isBasicBasic}}
+            // http basic authentication required
+            if (!string.IsNullOrEmpty(this.Configuration.Username) || !string.IsNullOrEmpty(this.Configuration.Password) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
+            {
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Basic " + {{packageName}}.Client.ClientUtils.Base64Encode(this.Configuration.Username + ":" + this.Configuration.Password));
+            }
+            {{/isBasicBasic}}
+            {{#isBasicBearer}}
+            // bearer authentication required
+            if (!string.IsNullOrEmpty(this.Configuration.AccessToken) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
+            {
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Bearer " + this.Configuration.AccessToken);
+            }
+            {{/isBasicBearer}}
+            {{/isBasic}}
+            {{#isOAuth}}
+            // oauth required
+            if (!string.IsNullOrEmpty(this.Configuration.AccessToken) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
+            {
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Bearer " + this.Configuration.AccessToken);
+            }
+            {{/isOAuth}}
+            {{#isHttpSignature}}
+            if (this.Configuration.HttpSigningConfiguration != null)
+            {
+                var HttpSigningHeaders = this.Configuration.HttpSigningConfiguration.GetHttpSignedHeader(this.Configuration.BasePath, "{{{httpMethod}}}", "{{{path}}}", localVarRequestOptions);
+                foreach (var headerItem in HttpSigningHeaders)
+                {
+                    if (localVarRequestOptions.HeaderParameters.ContainsKey(headerItem.Key))
+                    {
+                        localVarRequestOptions.HeaderParameters[headerItem.Key] = new List<string>() { headerItem.Value };
+                    }
+                    else
+                    {
+                        localVarRequestOptions.HeaderParameters.Add(headerItem.Key, headerItem.Value);
+                    }
+                }
+            }
+            {{/isHttpSignature}}
+            {{/authMethods}}
+
+            // make the HTTP request
+
+            var localVarResponse = await this.AsynchronousClient.{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}}Async<{{{returnType}}}{{^returnType}}Object{{/returnType}}>("{{{path}}}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("{{operationId}}", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        {{/supportsAsync}}
+        {{/operation}}
+    }
+    {{/operations}}
+}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/model.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/model.mustache
@@ -1,0 +1,51 @@
+{{>partial_header}}
+
+{{#models}}
+{{#model}}
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.IO;
+{{#vendorExtensions.x-com-visible}}
+using System.Runtime.InteropServices;
+{{/vendorExtensions.x-com-visible}}
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+{{#discriminator}}
+using JsonSubTypes;
+{{/discriminator}}
+{{/model}}
+{{/models}}
+{{#validatable}}
+using System.ComponentModel.DataAnnotations;
+{{/validatable}}
+using FileParameter = {{packageName}}.Client.FileParameter;
+using OpenAPIDateConverter = {{packageName}}.Client.OpenAPIDateConverter;
+{{#useCompareNetObjects}}
+using OpenAPIClientUtils = {{packageName}}.Client.ClientUtils;
+{{/useCompareNetObjects}}
+{{#models}}
+{{#model}}
+{{#oneOf}}
+{{#-first}}
+using System.Reflection;
+{{/-first}}
+{{/oneOf}}
+{{#anyOf}}
+{{#-first}}
+using System.Reflection;
+{{/-first}}
+{{/anyOf}}
+
+namespace {{packageName}}.{{modelPackage}}
+{
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{#anyOf}}{{#-first}}{{>modelAnyOf}}{{/-first}}{{/anyOf}}{{^oneOf}}{{^anyOf}}{{>modelGeneric}}{{/anyOf}}{{/oneOf}}{{/isEnum}}
+{{/model}}
+{{/models}}
+}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/model.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/unity/model.mustache
@@ -25,7 +25,6 @@ using JsonSubTypes;
 {{#validatable}}
 using System.ComponentModel.DataAnnotations;
 {{/validatable}}
-using FileParameter = {{packageName}}.Client.FileParameter;
 using OpenAPIDateConverter = {{packageName}}.Client.OpenAPIDateConverter;
 {{#useCompareNetObjects}}
 using OpenAPIClientUtils = {{packageName}}.Client.ClientUtils;


### PR DESCRIPTION
This PR is a working implementation of a library plugin for the csharp-netcore client generator that utilizes `UnityWebRequest` as the request backend.

Why, when RestSharp and HttpClient work in Unity? Cross-platform nightmares -- especially consoles.

Limitations (as specific as I can be due to NDA):

* Console A - Anything except UnityWebRequest doesn't support access to the platform's SSL certificate store. You have to embed certificates at build time and apply for a special waiver to use them. This then becomes a ticking time bomb because your root certs can expire while your game is in the wild.
* Console B - With no exception, requires you to use UnityWebRequest since it integrates natively with the platform's custom version of libcurl that all games must use.
* Console C - Use whatever you want! Villagers rejoice.
* File parameters cannot be supported everywhere. Some consoles and tvOS do not support either `Application.persistentDataPath` or will refuse to compile/link if you even reference `GetTempPath` as well.
* Setting cookies are not supported in WebGL platform
* UnityWebRequest also offers native performance with much less garbage usage. It's worth noting that the current Unity GC is still a very old one and even with incremental GC support it's still problematic on min-spec devices.

I am genuinely not sure how to proceed with this as a PR that could be considered for integration. First off, unit tests would require a Unity project, and secondly, I'm sure some of the changes I've made might be controversial.

The backend I've written also adds better result handling and provides additional exceptions that let you know when an API call failure is due to a connection error. The latter is a must-have distinction because console cert processes will fail you if your error messages are not exactly specific as to what happened (e.g. no "something went wrong" when you have no internet).

This backend only has one C# dependency that isn't default in Unity (or available via package manager like JSON.net): `System.ComponentModel.DataAnnotations.dll`.


