### PR TITLE
Clash of variable name when the body is just a string

### DIFF
--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -227,7 +227,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <aggregate>true</aggregate>
                 </configuration>
@@ -415,23 +415,23 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava-testlib</artifactId>
-            <version>28.2-jre</version>
+            <version>31.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.5.0</version>
+            <version>5.12.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>2.8.1</version>
+            <version>2.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
+            <version>3.23.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -354,9 +354,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-           <groupId>com.atlassian.commonmark</groupId>
+           <groupId>org.commonmark</groupId>
            <artifactId>commonmark</artifactId>
-           <version>0.11.0</version>
+           <version>0.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/bodyParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/bodyParams.mustache
@@ -1,4 +1,5 @@
 {{#isBodyParam}}
-        RequestParameter body = requestParameters.body();
-        {{{dataType}}} {{paramName}} = body != null ? DatabindCodec.mapper().convertValue(body.get(), new TypeReference<{{{dataType}}}>(){}) : null;
+  {{! Don't use body or requestBody as name, to avoid a name clash with the paramName }}
+  RequestParameter requestParameterBody = requestParameters.body();
+  {{{dataType}}} {{paramName}} = requestParameterBody != null ? DatabindCodec.mapper().convertValue(requestParameterBody.get(), new TypeReference<{{{dataType}}}>(){}) : null;
 {{/isBodyParam}}

--- a/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/deserializer.ex.mustache
@@ -19,13 +19,18 @@ defmodule {{moduleName}}.Deserializer do
   end
 
   def deserialize(model, field, :map, mod, options) do
-    model
-    |> Map.update!(
-      field,
-      &Map.new(&1, fn {key, val} ->
-        {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))}
-      end)
-    )
+    maybe_transform_map = fn
+      nil ->
+        nil
+
+      existing_value ->
+        Map.new(existing_value, fn
+          {key, val} ->
+            {key, Poison.Decode.decode(val, Keyword.merge(options, as: struct(mod)))}
+        end)
+    end
+
+    Map.update!(model, field, maybe_transform_map)
   end
 
   def deserialize(model, field, :date, _, _options) do

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -149,6 +149,49 @@ class ObjectSerializer
     }
 
     /**
+     * Checks if a value is empty, based on its OpenAPI type.
+     *
+     * @param mixed  $value
+     * @param string $openApiType
+     *
+     * @return bool true if $value is empty
+     */
+    private static function isEmptyValue($value, string $openApiType): bool
+    {
+        # If empty() returns false, it is not empty regardless of its type.
+        if (!empty($value)) {
+            return false;
+        }
+
+        # Null is always empty, as we cannot send a real "null" value in a query parameter.
+        if ($value === null) {
+            return true;
+        }
+
+        switch ($openApiType) {
+            # For numeric values, false and '' are considered empty.
+            # This comparison is safe for floating point values, since the previous call to empty() will
+            # filter out values that don't match 0.
+            case 'int':
+            case 'integer':
+                return $value !== 0;
+
+            case 'number':
+            case 'float':
+                return $value !== 0 && $value !== 0.0;
+
+            # For boolean values, '' is considered empty
+            case 'bool':
+            case 'boolean':
+                return !in_array($value, [false, 0], true);
+
+            # For all the other types, any value at this point can be considered empty.
+            default:
+                return true;
+        }
+    }
+
+    /**
      * Take query parameter properties and turn it into an array suitable for
      * native http_build_query or GuzzleHttp\Psr7\Query::build.
      *
@@ -169,10 +212,12 @@ class ObjectSerializer
         bool $explode = true,
         bool $required = true
     ): array {
-        if (
-            empty($value)
-            && ($value !== false || $openApiType !== 'boolean') // if $value === false and $openApiType ==='boolean' it isn't empty
-        ) {
+
+        # Check if we should omit this parameter from the query. This should only happen when:
+        #  - Parameter is NOT required; AND
+        #  - its value is set to a value that is equivalent to "empty", depending on its OpenAPI type. For
+        #    example, 0 as "int" or "boolean" is NOT an empty value.
+        if (self::isEmptyValue($value, $openApiType)) {
             if ($required) {
                 return ["{$paramName}" => ''];
             } else {

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -26,6 +26,8 @@
         end
       rescue Faraday::TimeoutError
         fail ApiError.new('Connection timed out')
+      rescue Faraday::ConnectionFailed
+        fail ApiError.new('Connection failed')
       end
 
       if opts[:return_type]

--- a/pom.xml
+++ b/pom.xml
@@ -1485,7 +1485,7 @@
 
         <archunit.version>0.23.1</archunit.version>
         <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
-        <commons-cli.version>1.4</commons-cli.version>
+        <commons-cli.version>1.5.0</commons-cli.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>3.12.0</commons-lang.version>
         <commons-text.version>1.10.0</commons-text.version>
@@ -1493,7 +1493,7 @@
         <generex.version>1.0.2</generex.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <groovy.version>3.0.9</groovy.version>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
         <handlebars-java.version>4.2.1</handlebars-java.version>
         <jackson-threetenbp.version>2.10.0</jackson-threetenbp.version>
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
@@ -1508,10 +1508,10 @@
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
-        <mockito.version>4.5.1</mockito.version>
+        <mockito.version>4.8.1</mockito.version>
         <pmd-plugin.version>3.12.0</pmd-plugin.version>
         <reflections.version>0.10</reflections.version>
-        <rxgen.version>1.3</rxgen.version>
+        <rxgen.version>1.4</rxgen.version>
         <scala-maven-plugin.version>4.6.1</scala-maven-plugin.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spotbugs-plugin.version>3.1.12.2</spotbugs-plugin.version>

--- a/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/deserializer.ex
@@ -21,13 +21,18 @@ defmodule OpenapiPetstore.Deserializer do
   end
 
   def deserialize(model, field, :map, mod, options) do
-    model
-    |> Map.update!(
-      field,
-      &Map.new(&1, fn {key, val} ->
-        {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))}
-      end)
-    )
+    maybe_transform_map = fn
+      nil ->
+        nil
+
+      existing_value ->
+        Map.new(existing_value, fn
+          {key, val} ->
+            {key, Poison.Decode.decode(val, Keyword.merge(options, as: struct(mod)))}
+        end)
+    end
+
+    Map.update!(model, field, maybe_transform_map)
   end
 
   def deserialize(model, field, :date, _, _options) do

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -158,6 +158,49 @@ class ObjectSerializer
     }
 
     /**
+     * Checks if a value is empty, based on its OpenAPI type.
+     *
+     * @param mixed  $value
+     * @param string $openApiType
+     *
+     * @return bool true if $value is empty
+     */
+    private static function isEmptyValue($value, string $openApiType): bool
+    {
+        # If empty() returns false, it is not empty regardless of its type.
+        if (!empty($value)) {
+            return false;
+        }
+
+        # Null is always empty, as we cannot send a real "null" value in a query parameter.
+        if ($value === null) {
+            return true;
+        }
+
+        switch ($openApiType) {
+            # For numeric values, false and '' are considered empty.
+            # This comparison is safe for floating point values, since the previous call to empty() will
+            # filter out values that don't match 0.
+            case 'int':
+            case 'integer':
+                return $value !== 0;
+
+            case 'number':
+            case 'float':
+                return $value !== 0 && $value !== 0.0;
+
+            # For boolean values, '' is considered empty
+            case 'bool':
+            case 'boolean':
+                return !in_array($value, [false, 0], true);
+
+            # For all the other types, any value at this point can be considered empty.
+            default:
+                return true;
+        }
+    }
+
+    /**
      * Take query parameter properties and turn it into an array suitable for
      * native http_build_query or GuzzleHttp\Psr7\Query::build.
      *
@@ -178,10 +221,12 @@ class ObjectSerializer
         bool $explode = true,
         bool $required = true
     ): array {
-        if (
-            empty($value)
-            && ($value !== false || $openApiType !== 'boolean') // if $value === false and $openApiType ==='boolean' it isn't empty
-        ) {
+
+        # Check if we should omit this parameter from the query. This should only happen when:
+        #  - Parameter is NOT required; AND
+        #  - its value is set to a value that is equivalent to "empty", depending on its OpenAPI type. For
+        #    example, 0 as "int" or "boolean" is NOT an empty value.
+        if (self::isEmptyValue($value, $openApiType)) {
             if ($required) {
                 return ["{$paramName}" => ''];
             } else {

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -336,6 +336,97 @@ class ObjectSerializerTest extends TestCase
             'form null DateTime object, explode on, required false' => [
                 null, 'dateTime', '\DateTime', 'form', true, false, '',
             ],
+            'form 1 int, explode on, required false' => [
+                1, 'field', 'int', 'form', true, false, 'field=1',
+            ],
+            'form 0 int, explode on, required false' => [
+                0, 'field', 'int', 'form', true, false, 'field=0',
+            ],
+            'form 0 int, explode on, required true' => [
+                0, 'field', 'int', 'form', true, true, 'field=0',
+            ],
+            'form null int, explode on, required false' => [
+                null, 'field', 'int', 'form', true, false, '',
+            ],
+            'form null int, explode on, required true' => [
+                null, 'field', 'int', 'form', true, true, 'field=',
+            ],
+            'form 1 integer, explode on, required false' => [
+                1, 'field', 'integer', 'form', true, false, 'field=1',
+            ],
+            'form 0 integer, explode on, required false' => [
+                0, 'field', 'integer', 'form', true, false, 'field=0',
+            ],
+            'form 0 integer, explode on, required true' => [
+                0, 'field', 'integer', 'form', true, true, 'field=0',
+            ],
+            'form null integer, explode on, required false' => [
+                null, 'field', 'integer', 'form', true, false, '',
+            ],
+            'form null integer, explode on, required true' => [
+                null, 'field', 'integer', 'form', true, true, 'field=',
+            ],
+            'form 1.1 float, explode on, required false' => [
+                1.1, 'field', 'float', 'form', true, false, 'field=1.1',
+            ],
+            'form 0 float, explode on, required false' => [
+                0, 'field', 'float', 'form', true, false, 'field=0',
+            ],
+            'form 0.0 float, explode on, required false' => [
+                0.0, 'field', 'float', 'form', true, false, 'field=0',
+            ],
+            'form 0 float, explode on, required true' => [
+                0, 'field', 'float', 'form', true, true, 'field=0',
+            ],
+            'form 0.0 float, explode on, required true' => [
+                0.0, 'field', 'float', 'form', true, true, 'field=0',
+            ],
+            'form null float, explode on, required false' => [
+                null, 'field', 'float', 'form', true, false, '',
+            ],
+            'form null float, explode on, required true' => [
+                null, 'field', 'float', 'form', true, true, 'field=',
+            ],
+            'form 1.1 number, explode on, required false' => [
+                1.1, 'field', 'number', 'form', true, false, 'field=1.1',
+            ],
+            'form 0 number, explode on, required false' => [
+                0, 'field', 'number', 'form', true, false, 'field=0',
+            ],
+            'form 0.0 number, explode on, required false' => [
+                0.0, 'field', 'number', 'form', true, false, 'field=0',
+            ],
+            'form 0 number, explode on, required true' => [
+                0, 'field', 'number', 'form', true, true, 'field=0',
+            ],
+            'form 0.0 number, explode on, required true' => [
+                0.0, 'field', 'number', 'form', true, true, 'field=0',
+            ],
+            'form null number, explode on, required false' => [
+                null, 'field', 'number', 'form', true, false, '',
+            ],
+            'form null number, explode on, required true' => [
+                null, 'field', 'number', 'form', true, true, 'field=',
+            ],
+            'form true bool, explode on, required false' => [
+                true, 'field', 'bool', 'form', true, false, 'field=1',
+            ],
+            'form false bool, explode on, required false' => [
+                false, 'field', 'bool', 'form', true, false, 'field=0',
+            ],
+            'form empty bool, explode on, required false' => [
+                null, 'field', 'bool', 'form', true, false, '',
+            ],
+            'form empty bool, explode on, required true' => [
+                null, 'field', 'bool', 'form', true, true, 'field=',
+            ],
+            # Entries for "boolean" type are already covered in the beginning of this provider
+            'form 1 bool, explode on, required false' => [
+                1, 'field', 'bool', 'form', true, false, 'field=1',
+            ],
+            'form 0 bool, explode on, required false' => [
+                0, 'field', 'bool', 'form', true, false, 'field=0',
+            ],
         ];
     }
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -71,6 +71,8 @@ module Petstore
         end
       rescue Faraday::TimeoutError
         fail ApiError.new('Connection timed out')
+      rescue Faraday::ConnectionFailed
+        fail ApiError.new('Connection failed')
       end
 
       if opts[:return_type]


### PR DESCRIPTION

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
If a `body` is just treated as a string, you would get a body clash name on `body` 

ie this is wrong
```java
RequestParameter body = requestParameters.body();
// body = body is not accepted by java
String body = body != null ? DatabindCodec.mapper().convertValue(body.get(), new TypeReference<String>(){}) : null;
```
with this change, you would get:
```java
RequestParameter requestParameterBody = requestParameters.body();
String body = requestParameterBody != null ? DatabindCodec.mapper().convertValue(requestParameterBody.get(), new TypeReference<String>(){}) : 
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)