### PR TITLE
[GO] fix identation for model_simple.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -195,12 +195,12 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 {{/deprecated}}
 func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
 	if o == nil{{^isNullable}} || isNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || isNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
-    {{^isFreeFormObject}}
-    return nil, false
-    {{/isFreeFormObject}}
-    {{#isFreeFormObject}}
-    return {{vendorExtensions.x-go-base-type}}{}, false
-    {{/isFreeFormObject}}
+	{{^isFreeFormObject}}
+		return nil, false
+	{{/isFreeFormObject}}
+	{{#isFreeFormObject}}
+		return {{vendorExtensions.x-go-base-type}}{}, false
+	{{/isFreeFormObject}}
 	}
 {{#isNullable}}
 {{#vendorExtensions.x-golang-is-container}}

--- a/samples/client/petstore/go/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go/go-petstore/model_200_response.go
@@ -50,7 +50,7 @@ func (o *Model200Response) GetName() int32 {
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetNameOk() (*int32, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }
@@ -82,7 +82,7 @@ func (o *Model200Response) GetClass() string {
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetClassOk() (*string, bool) {
 	if o == nil || isNil(o.Class) {
-    return nil, false
+		return nil, false
 	}
 	return o.Class, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
@@ -49,7 +49,7 @@ func (o *AdditionalPropertiesAnyType) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesAnyType) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
@@ -49,7 +49,7 @@ func (o *AdditionalPropertiesArray) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesArray) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
@@ -49,7 +49,7 @@ func (o *AdditionalPropertiesBoolean) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesBoolean) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_class.go
@@ -59,7 +59,7 @@ func (o *AdditionalPropertiesClass) GetMapString() map[string]string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapStringOk() (*map[string]string, bool) {
 	if o == nil || isNil(o.MapString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapString, true
 }
@@ -91,7 +91,7 @@ func (o *AdditionalPropertiesClass) GetMapNumber() map[string]float32 {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapNumberOk() (*map[string]float32, bool) {
 	if o == nil || isNil(o.MapNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapNumber, true
 }
@@ -123,7 +123,7 @@ func (o *AdditionalPropertiesClass) GetMapInteger() map[string]int32 {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapIntegerOk() (*map[string]int32, bool) {
 	if o == nil || isNil(o.MapInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapInteger, true
 }
@@ -155,7 +155,7 @@ func (o *AdditionalPropertiesClass) GetMapBoolean() map[string]bool {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapBooleanOk() (*map[string]bool, bool) {
 	if o == nil || isNil(o.MapBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapBoolean, true
 }
@@ -187,7 +187,7 @@ func (o *AdditionalPropertiesClass) GetMapArrayInteger() map[string][]int32 {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapArrayIntegerOk() (*map[string][]int32, bool) {
 	if o == nil || isNil(o.MapArrayInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapArrayInteger, true
 }
@@ -219,7 +219,7 @@ func (o *AdditionalPropertiesClass) GetMapArrayAnytype() map[string][]map[string
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapArrayAnytypeOk() (*map[string][]map[string]interface{}, bool) {
 	if o == nil || isNil(o.MapArrayAnytype) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapArrayAnytype, true
 }
@@ -251,7 +251,7 @@ func (o *AdditionalPropertiesClass) GetMapMapString() map[string]map[string]stri
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapMapStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || isNil(o.MapMapString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapMapString, true
 }
@@ -283,7 +283,7 @@ func (o *AdditionalPropertiesClass) GetMapMapAnytype() map[string]map[string]map
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapMapAnytypeOk() (*map[string]map[string]map[string]interface{}, bool) {
 	if o == nil || isNil(o.MapMapAnytype) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapMapAnytype, true
 }
@@ -315,7 +315,7 @@ func (o *AdditionalPropertiesClass) GetAnytype1() map[string]interface{} {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetAnytype1Ok() (map[string]interface{}, bool) {
 	if o == nil || isNil(o.Anytype1) {
-    return map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.Anytype1, true
 }
@@ -347,7 +347,7 @@ func (o *AdditionalPropertiesClass) GetAnytype2() map[string]interface{} {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetAnytype2Ok() (map[string]interface{}, bool) {
 	if o == nil || isNil(o.Anytype2) {
-    return map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.Anytype2, true
 }
@@ -379,7 +379,7 @@ func (o *AdditionalPropertiesClass) GetAnytype3() map[string]interface{} {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetAnytype3Ok() (map[string]interface{}, bool) {
 	if o == nil || isNil(o.Anytype3) {
-    return map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.Anytype3, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
@@ -49,7 +49,7 @@ func (o *AdditionalPropertiesInteger) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesInteger) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
@@ -49,7 +49,7 @@ func (o *AdditionalPropertiesNumber) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesNumber) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
@@ -49,7 +49,7 @@ func (o *AdditionalPropertiesObject) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesObject) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
@@ -49,7 +49,7 @@ func (o *AdditionalPropertiesString) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesString) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/client/petstore/go/go-petstore/model_animal.go
@@ -79,7 +79,7 @@ func (o *Animal) GetColor() string {
 // and a boolean to check if the value has been set.
 func (o *Animal) GetColorOk() (*string, bool) {
 	if o == nil || isNil(o.Color) {
-    return nil, false
+		return nil, false
 	}
 	return o.Color, true
 }

--- a/samples/client/petstore/go/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go/go-petstore/model_api_response.go
@@ -51,7 +51,7 @@ func (o *ApiResponse) GetCode() int32 {
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 	if o == nil || isNil(o.Code) {
-    return nil, false
+		return nil, false
 	}
 	return o.Code, true
 }
@@ -83,7 +83,7 @@ func (o *ApiResponse) GetType() string {
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetTypeOk() (*string, bool) {
 	if o == nil || isNil(o.Type) {
-    return nil, false
+		return nil, false
 	}
 	return o.Type, true
 }
@@ -115,7 +115,7 @@ func (o *ApiResponse) GetMessage() string {
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetMessageOk() (*string, bool) {
 	if o == nil || isNil(o.Message) {
-    return nil, false
+		return nil, false
 	}
 	return o.Message, true
 }

--- a/samples/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
@@ -49,7 +49,7 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 // and a boolean to check if the value has been set.
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 	if o == nil || isNil(o.ArrayArrayNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayArrayNumber, true
 }

--- a/samples/client/petstore/go/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go/go-petstore/model_array_of_number_only.go
@@ -49,7 +49,7 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 // and a boolean to check if the value has been set.
 func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 	if o == nil || isNil(o.ArrayNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayNumber, true
 }

--- a/samples/client/petstore/go/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_array_test_.go
@@ -51,7 +51,7 @@ func (o *ArrayTest) GetArrayOfString() []string {
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 	if o == nil || isNil(o.ArrayOfString) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayOfString, true
 }
@@ -83,7 +83,7 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 	if o == nil || isNil(o.ArrayArrayOfInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayArrayOfInteger, true
 }
@@ -115,7 +115,7 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 	if o == nil || isNil(o.ArrayArrayOfModel) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayArrayOfModel, true
 }

--- a/samples/client/petstore/go/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat.go
@@ -53,7 +53,7 @@ func (o *BigCat) GetKind() string {
 // and a boolean to check if the value has been set.
 func (o *BigCat) GetKindOk() (*string, bool) {
 	if o == nil || isNil(o.Kind) {
-    return nil, false
+		return nil, false
 	}
 	return o.Kind, true
 }

--- a/samples/client/petstore/go/go-petstore/model_big_cat_all_of.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat_all_of.go
@@ -49,7 +49,7 @@ func (o *BigCatAllOf) GetKind() string {
 // and a boolean to check if the value has been set.
 func (o *BigCatAllOf) GetKindOk() (*string, bool) {
 	if o == nil || isNil(o.Kind) {
-    return nil, false
+		return nil, false
 	}
 	return o.Kind, true
 }

--- a/samples/client/petstore/go/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go/go-petstore/model_capitalization.go
@@ -55,7 +55,7 @@ func (o *Capitalization) GetSmallCamel() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 	if o == nil || isNil(o.SmallCamel) {
-    return nil, false
+		return nil, false
 	}
 	return o.SmallCamel, true
 }
@@ -87,7 +87,7 @@ func (o *Capitalization) GetCapitalCamel() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 	if o == nil || isNil(o.CapitalCamel) {
-    return nil, false
+		return nil, false
 	}
 	return o.CapitalCamel, true
 }
@@ -119,7 +119,7 @@ func (o *Capitalization) GetSmallSnake() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 	if o == nil || isNil(o.SmallSnake) {
-    return nil, false
+		return nil, false
 	}
 	return o.SmallSnake, true
 }
@@ -151,7 +151,7 @@ func (o *Capitalization) GetCapitalSnake() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 	if o == nil || isNil(o.CapitalSnake) {
-    return nil, false
+		return nil, false
 	}
 	return o.CapitalSnake, true
 }
@@ -183,7 +183,7 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 	if o == nil || isNil(o.SCAETHFlowPoints) {
-    return nil, false
+		return nil, false
 	}
 	return o.SCAETHFlowPoints, true
 }
@@ -215,7 +215,7 @@ func (o *Capitalization) GetATT_NAME() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 	if o == nil || isNil(o.ATT_NAME) {
-    return nil, false
+		return nil, false
 	}
 	return o.ATT_NAME, true
 }

--- a/samples/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_cat.go
@@ -53,7 +53,7 @@ func (o *Cat) GetDeclawed() bool {
 // and a boolean to check if the value has been set.
 func (o *Cat) GetDeclawedOk() (*bool, bool) {
 	if o == nil || isNil(o.Declawed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Declawed, true
 }

--- a/samples/client/petstore/go/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go/go-petstore/model_cat_all_of.go
@@ -49,7 +49,7 @@ func (o *CatAllOf) GetDeclawed() bool {
 // and a boolean to check if the value has been set.
 func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 	if o == nil || isNil(o.Declawed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Declawed, true
 }

--- a/samples/client/petstore/go/go-petstore/model_category.go
+++ b/samples/client/petstore/go/go-petstore/model_category.go
@@ -53,7 +53,7 @@ func (o *Category) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Category) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }

--- a/samples/client/petstore/go/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go/go-petstore/model_class_model.go
@@ -49,7 +49,7 @@ func (o *ClassModel) GetClass() string {
 // and a boolean to check if the value has been set.
 func (o *ClassModel) GetClassOk() (*string, bool) {
 	if o == nil || isNil(o.Class) {
-    return nil, false
+		return nil, false
 	}
 	return o.Class, true
 }

--- a/samples/client/petstore/go/go-petstore/model_client.go
+++ b/samples/client/petstore/go/go-petstore/model_client.go
@@ -49,7 +49,7 @@ func (o *Client) GetClient() string {
 // and a boolean to check if the value has been set.
 func (o *Client) GetClientOk() (*string, bool) {
 	if o == nil || isNil(o.Client) {
-    return nil, false
+		return nil, false
 	}
 	return o.Client, true
 }

--- a/samples/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/client/petstore/go/go-petstore/model_dog.go
@@ -53,7 +53,7 @@ func (o *Dog) GetBreed() string {
 // and a boolean to check if the value has been set.
 func (o *Dog) GetBreedOk() (*string, bool) {
 	if o == nil || isNil(o.Breed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Breed, true
 }

--- a/samples/client/petstore/go/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go/go-petstore/model_dog_all_of.go
@@ -49,7 +49,7 @@ func (o *DogAllOf) GetBreed() string {
 // and a boolean to check if the value has been set.
 func (o *DogAllOf) GetBreedOk() (*string, bool) {
 	if o == nil || isNil(o.Breed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Breed, true
 }

--- a/samples/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -50,7 +50,7 @@ func (o *EnumArrays) GetJustSymbol() string {
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 	if o == nil || isNil(o.JustSymbol) {
-    return nil, false
+		return nil, false
 	}
 	return o.JustSymbol, true
 }
@@ -82,7 +82,7 @@ func (o *EnumArrays) GetArrayEnum() []string {
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 	if o == nil || isNil(o.ArrayEnum) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayEnum, true
 }

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -54,7 +54,7 @@ func (o *EnumTest) GetEnumString() string {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 	if o == nil || isNil(o.EnumString) {
-    return nil, false
+		return nil, false
 	}
 	return o.EnumString, true
 }
@@ -110,7 +110,7 @@ func (o *EnumTest) GetEnumInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.EnumInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.EnumInteger, true
 }
@@ -142,7 +142,7 @@ func (o *EnumTest) GetEnumNumber() float64 {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 	if o == nil || isNil(o.EnumNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.EnumNumber, true
 }
@@ -174,7 +174,7 @@ func (o *EnumTest) GetOuterEnum() OuterEnum {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool) {
 	if o == nil || isNil(o.OuterEnum) {
-    return nil, false
+		return nil, false
 	}
 	return o.OuterEnum, true
 }

--- a/samples/client/petstore/go/go-petstore/model_file.go
+++ b/samples/client/petstore/go/go-petstore/model_file.go
@@ -50,7 +50,7 @@ func (o *File) GetSourceURI() string {
 // and a boolean to check if the value has been set.
 func (o *File) GetSourceURIOk() (*string, bool) {
 	if o == nil || isNil(o.SourceURI) {
-    return nil, false
+		return nil, false
 	}
 	return o.SourceURI, true
 }

--- a/samples/client/petstore/go/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go/go-petstore/model_file_schema_test_class.go
@@ -50,7 +50,7 @@ func (o *FileSchemaTestClass) GetFile() File {
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 	if o == nil || isNil(o.File) {
-    return nil, false
+		return nil, false
 	}
 	return o.File, true
 }
@@ -82,7 +82,7 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 	if o == nil || isNil(o.Files) {
-    return nil, false
+		return nil, false
 	}
 	return o.Files, true
 }

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -68,7 +68,7 @@ func (o *FormatTest) GetInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.Integer) {
-    return nil, false
+		return nil, false
 	}
 	return o.Integer, true
 }
@@ -100,7 +100,7 @@ func (o *FormatTest) GetInt32() int32 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 	if o == nil || isNil(o.Int32) {
-    return nil, false
+		return nil, false
 	}
 	return o.Int32, true
 }
@@ -132,7 +132,7 @@ func (o *FormatTest) GetInt64() int64 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 	if o == nil || isNil(o.Int64) {
-    return nil, false
+		return nil, false
 	}
 	return o.Int64, true
 }
@@ -188,7 +188,7 @@ func (o *FormatTest) GetFloat() float32 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetFloatOk() (*float32, bool) {
 	if o == nil || isNil(o.Float) {
-    return nil, false
+		return nil, false
 	}
 	return o.Float, true
 }
@@ -220,7 +220,7 @@ func (o *FormatTest) GetDouble() float64 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 	if o == nil || isNil(o.Double) {
-    return nil, false
+		return nil, false
 	}
 	return o.Double, true
 }
@@ -252,7 +252,7 @@ func (o *FormatTest) GetString() string {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetStringOk() (*string, bool) {
 	if o == nil || isNil(o.String) {
-    return nil, false
+		return nil, false
 	}
 	return o.String, true
 }
@@ -308,7 +308,7 @@ func (o *FormatTest) GetBinary() *os.File {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || isNil(o.Binary) {
-    return nil, false
+		return nil, false
 	}
 	return o.Binary, true
 }
@@ -364,7 +364,7 @@ func (o *FormatTest) GetDateTime() time.Time {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || isNil(o.DateTime) {
-    return nil, false
+		return nil, false
 	}
 	return o.DateTime, true
 }
@@ -396,7 +396,7 @@ func (o *FormatTest) GetUuid() string {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetUuidOk() (*string, bool) {
 	if o == nil || isNil(o.Uuid) {
-    return nil, false
+		return nil, false
 	}
 	return o.Uuid, true
 }
@@ -452,7 +452,7 @@ func (o *FormatTest) GetBigDecimal() float64 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetBigDecimalOk() (*float64, bool) {
 	if o == nil || isNil(o.BigDecimal) {
-    return nil, false
+		return nil, false
 	}
 	return o.BigDecimal, true
 }

--- a/samples/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -50,7 +50,7 @@ func (o *HasOnlyReadOnly) GetBar() string {
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 	if o == nil || isNil(o.Bar) {
-    return nil, false
+		return nil, false
 	}
 	return o.Bar, true
 }
@@ -82,7 +82,7 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 	if o == nil || isNil(o.Foo) {
-    return nil, false
+		return nil, false
 	}
 	return o.Foo, true
 }

--- a/samples/client/petstore/go/go-petstore/model_list.go
+++ b/samples/client/petstore/go/go-petstore/model_list.go
@@ -49,7 +49,7 @@ func (o *List) GetVar123List() string {
 // and a boolean to check if the value has been set.
 func (o *List) GetVar123ListOk() (*string, bool) {
 	if o == nil || isNil(o.Var123List) {
-    return nil, false
+		return nil, false
 	}
 	return o.Var123List, true
 }

--- a/samples/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_map_test_.go
@@ -52,7 +52,7 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || isNil(o.MapMapOfString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapMapOfString, true
 }
@@ -84,7 +84,7 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 	if o == nil || isNil(o.MapOfEnumString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapOfEnumString, true
 }
@@ -116,7 +116,7 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 	if o == nil || isNil(o.DirectMap) {
-    return nil, false
+		return nil, false
 	}
 	return o.DirectMap, true
 }
@@ -148,7 +148,7 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 	if o == nil || isNil(o.IndirectMap) {
-    return nil, false
+		return nil, false
 	}
 	return o.IndirectMap, true
 }

--- a/samples/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -52,7 +52,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
 	if o == nil || isNil(o.Uuid) {
-    return nil, false
+		return nil, false
 	}
 	return o.Uuid, true
 }
@@ -84,7 +84,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || isNil(o.DateTime) {
-    return nil, false
+		return nil, false
 	}
 	return o.DateTime, true
 }
@@ -116,7 +116,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
 	if o == nil || isNil(o.Map) {
-    return nil, false
+		return nil, false
 	}
 	return o.Map, true
 }

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -77,7 +77,7 @@ func (o *Name) GetSnakeCase() int32 {
 // and a boolean to check if the value has been set.
 func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 	if o == nil || isNil(o.SnakeCase) {
-    return nil, false
+		return nil, false
 	}
 	return o.SnakeCase, true
 }
@@ -109,7 +109,7 @@ func (o *Name) GetProperty() string {
 // and a boolean to check if the value has been set.
 func (o *Name) GetPropertyOk() (*string, bool) {
 	if o == nil || isNil(o.Property) {
-    return nil, false
+		return nil, false
 	}
 	return o.Property, true
 }
@@ -141,7 +141,7 @@ func (o *Name) GetVar123Number() int32 {
 // and a boolean to check if the value has been set.
 func (o *Name) GetVar123NumberOk() (*int32, bool) {
 	if o == nil || isNil(o.Var123Number) {
-    return nil, false
+		return nil, false
 	}
 	return o.Var123Number, true
 }

--- a/samples/client/petstore/go/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go/go-petstore/model_number_only.go
@@ -49,7 +49,7 @@ func (o *NumberOnly) GetJustNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.JustNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.JustNumber, true
 }

--- a/samples/client/petstore/go/go-petstore/model_order.go
+++ b/samples/client/petstore/go/go-petstore/model_order.go
@@ -60,7 +60,7 @@ func (o *Order) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Order) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -92,7 +92,7 @@ func (o *Order) GetPetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Order) GetPetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.PetId) {
-    return nil, false
+		return nil, false
 	}
 	return o.PetId, true
 }
@@ -124,7 +124,7 @@ func (o *Order) GetQuantity() int32 {
 // and a boolean to check if the value has been set.
 func (o *Order) GetQuantityOk() (*int32, bool) {
 	if o == nil || isNil(o.Quantity) {
-    return nil, false
+		return nil, false
 	}
 	return o.Quantity, true
 }
@@ -156,7 +156,7 @@ func (o *Order) GetShipDate() time.Time {
 // and a boolean to check if the value has been set.
 func (o *Order) GetShipDateOk() (*time.Time, bool) {
 	if o == nil || isNil(o.ShipDate) {
-    return nil, false
+		return nil, false
 	}
 	return o.ShipDate, true
 }
@@ -188,7 +188,7 @@ func (o *Order) GetStatus() string {
 // and a boolean to check if the value has been set.
 func (o *Order) GetStatusOk() (*string, bool) {
 	if o == nil || isNil(o.Status) {
-    return nil, false
+		return nil, false
 	}
 	return o.Status, true
 }
@@ -220,7 +220,7 @@ func (o *Order) GetComplete() bool {
 // and a boolean to check if the value has been set.
 func (o *Order) GetCompleteOk() (*bool, bool) {
 	if o == nil || isNil(o.Complete) {
-    return nil, false
+		return nil, false
 	}
 	return o.Complete, true
 }

--- a/samples/client/petstore/go/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go/go-petstore/model_outer_composite.go
@@ -51,7 +51,7 @@ func (o *OuterComposite) GetMyNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.MyNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.MyNumber, true
 }
@@ -83,7 +83,7 @@ func (o *OuterComposite) GetMyString() string {
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 	if o == nil || isNil(o.MyString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MyString, true
 }
@@ -115,7 +115,7 @@ func (o *OuterComposite) GetMyBoolean() bool {
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 	if o == nil || isNil(o.MyBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.MyBoolean, true
 }

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -57,7 +57,7 @@ func (o *Pet) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Pet) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -89,7 +89,7 @@ func (o *Pet) GetCategory() Category {
 // and a boolean to check if the value has been set.
 func (o *Pet) GetCategoryOk() (*Category, bool) {
 	if o == nil || isNil(o.Category) {
-    return nil, false
+		return nil, false
 	}
 	return o.Category, true
 }
@@ -169,7 +169,7 @@ func (o *Pet) GetTags() []Tag {
 // and a boolean to check if the value has been set.
 func (o *Pet) GetTagsOk() ([]Tag, bool) {
 	if o == nil || isNil(o.Tags) {
-    return nil, false
+		return nil, false
 	}
 	return o.Tags, true
 }
@@ -201,7 +201,7 @@ func (o *Pet) GetStatus() string {
 // and a boolean to check if the value has been set.
 func (o *Pet) GetStatusOk() (*string, bool) {
 	if o == nil || isNil(o.Status) {
-    return nil, false
+		return nil, false
 	}
 	return o.Status, true
 }

--- a/samples/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go/go-petstore/model_read_only_first.go
@@ -50,7 +50,7 @@ func (o *ReadOnlyFirst) GetBar() string {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 	if o == nil || isNil(o.Bar) {
-    return nil, false
+		return nil, false
 	}
 	return o.Bar, true
 }
@@ -82,7 +82,7 @@ func (o *ReadOnlyFirst) GetBaz() string {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 	if o == nil || isNil(o.Baz) {
-    return nil, false
+		return nil, false
 	}
 	return o.Baz, true
 }

--- a/samples/client/petstore/go/go-petstore/model_return.go
+++ b/samples/client/petstore/go/go-petstore/model_return.go
@@ -49,7 +49,7 @@ func (o *Return) GetReturn() int32 {
 // and a boolean to check if the value has been set.
 func (o *Return) GetReturnOk() (*int32, bool) {
 	if o == nil || isNil(o.Return) {
-    return nil, false
+		return nil, false
 	}
 	return o.Return, true
 }

--- a/samples/client/petstore/go/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_special_model_name.go
@@ -49,7 +49,7 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 // and a boolean to check if the value has been set.
 func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 	if o == nil || isNil(o.SpecialPropertyName) {
-    return nil, false
+		return nil, false
 	}
 	return o.SpecialPropertyName, true
 }

--- a/samples/client/petstore/go/go-petstore/model_tag.go
+++ b/samples/client/petstore/go/go-petstore/model_tag.go
@@ -50,7 +50,7 @@ func (o *Tag) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Tag) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -82,7 +82,7 @@ func (o *Tag) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *Tag) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/client/petstore/go/go-petstore/model_user.go
+++ b/samples/client/petstore/go/go-petstore/model_user.go
@@ -57,7 +57,7 @@ func (o *User) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *User) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -89,7 +89,7 @@ func (o *User) GetUsername() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetUsernameOk() (*string, bool) {
 	if o == nil || isNil(o.Username) {
-    return nil, false
+		return nil, false
 	}
 	return o.Username, true
 }
@@ -121,7 +121,7 @@ func (o *User) GetFirstName() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetFirstNameOk() (*string, bool) {
 	if o == nil || isNil(o.FirstName) {
-    return nil, false
+		return nil, false
 	}
 	return o.FirstName, true
 }
@@ -153,7 +153,7 @@ func (o *User) GetLastName() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetLastNameOk() (*string, bool) {
 	if o == nil || isNil(o.LastName) {
-    return nil, false
+		return nil, false
 	}
 	return o.LastName, true
 }
@@ -185,7 +185,7 @@ func (o *User) GetEmail() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetEmailOk() (*string, bool) {
 	if o == nil || isNil(o.Email) {
-    return nil, false
+		return nil, false
 	}
 	return o.Email, true
 }
@@ -217,7 +217,7 @@ func (o *User) GetPassword() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetPasswordOk() (*string, bool) {
 	if o == nil || isNil(o.Password) {
-    return nil, false
+		return nil, false
 	}
 	return o.Password, true
 }
@@ -249,7 +249,7 @@ func (o *User) GetPhone() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetPhoneOk() (*string, bool) {
 	if o == nil || isNil(o.Phone) {
-    return nil, false
+		return nil, false
 	}
 	return o.Phone, true
 }
@@ -281,7 +281,7 @@ func (o *User) GetUserStatus() int32 {
 // and a boolean to check if the value has been set.
 func (o *User) GetUserStatusOk() (*int32, bool) {
 	if o == nil || isNil(o.UserStatus) {
-    return nil, false
+		return nil, false
 	}
 	return o.UserStatus, true
 }

--- a/samples/client/petstore/go/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go/go-petstore/model_xml_item.go
@@ -77,7 +77,7 @@ func (o *XmlItem) GetAttributeString() string {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeStringOk() (*string, bool) {
 	if o == nil || isNil(o.AttributeString) {
-    return nil, false
+		return nil, false
 	}
 	return o.AttributeString, true
 }
@@ -109,7 +109,7 @@ func (o *XmlItem) GetAttributeNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.AttributeNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.AttributeNumber, true
 }
@@ -141,7 +141,7 @@ func (o *XmlItem) GetAttributeInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.AttributeInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.AttributeInteger, true
 }
@@ -173,7 +173,7 @@ func (o *XmlItem) GetAttributeBoolean() bool {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetAttributeBooleanOk() (*bool, bool) {
 	if o == nil || isNil(o.AttributeBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.AttributeBoolean, true
 }
@@ -205,7 +205,7 @@ func (o *XmlItem) GetWrappedArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetWrappedArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.WrappedArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.WrappedArray, true
 }
@@ -237,7 +237,7 @@ func (o *XmlItem) GetNameString() string {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameStringOk() (*string, bool) {
 	if o == nil || isNil(o.NameString) {
-    return nil, false
+		return nil, false
 	}
 	return o.NameString, true
 }
@@ -269,7 +269,7 @@ func (o *XmlItem) GetNameNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.NameNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.NameNumber, true
 }
@@ -301,7 +301,7 @@ func (o *XmlItem) GetNameInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.NameInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.NameInteger, true
 }
@@ -333,7 +333,7 @@ func (o *XmlItem) GetNameBoolean() bool {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameBooleanOk() (*bool, bool) {
 	if o == nil || isNil(o.NameBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.NameBoolean, true
 }
@@ -365,7 +365,7 @@ func (o *XmlItem) GetNameArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.NameArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.NameArray, true
 }
@@ -397,7 +397,7 @@ func (o *XmlItem) GetNameWrappedArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNameWrappedArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.NameWrappedArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.NameWrappedArray, true
 }
@@ -429,7 +429,7 @@ func (o *XmlItem) GetPrefixString() string {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixStringOk() (*string, bool) {
 	if o == nil || isNil(o.PrefixString) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixString, true
 }
@@ -461,7 +461,7 @@ func (o *XmlItem) GetPrefixNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.PrefixNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixNumber, true
 }
@@ -493,7 +493,7 @@ func (o *XmlItem) GetPrefixInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.PrefixInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixInteger, true
 }
@@ -525,7 +525,7 @@ func (o *XmlItem) GetPrefixBoolean() bool {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixBooleanOk() (*bool, bool) {
 	if o == nil || isNil(o.PrefixBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixBoolean, true
 }
@@ -557,7 +557,7 @@ func (o *XmlItem) GetPrefixArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.PrefixArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixArray, true
 }
@@ -589,7 +589,7 @@ func (o *XmlItem) GetPrefixWrappedArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixWrappedArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.PrefixWrappedArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixWrappedArray, true
 }
@@ -621,7 +621,7 @@ func (o *XmlItem) GetNamespaceString() string {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceStringOk() (*string, bool) {
 	if o == nil || isNil(o.NamespaceString) {
-    return nil, false
+		return nil, false
 	}
 	return o.NamespaceString, true
 }
@@ -653,7 +653,7 @@ func (o *XmlItem) GetNamespaceNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.NamespaceNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.NamespaceNumber, true
 }
@@ -685,7 +685,7 @@ func (o *XmlItem) GetNamespaceInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.NamespaceInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.NamespaceInteger, true
 }
@@ -717,7 +717,7 @@ func (o *XmlItem) GetNamespaceBoolean() bool {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceBooleanOk() (*bool, bool) {
 	if o == nil || isNil(o.NamespaceBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.NamespaceBoolean, true
 }
@@ -749,7 +749,7 @@ func (o *XmlItem) GetNamespaceArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.NamespaceArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.NamespaceArray, true
 }
@@ -781,7 +781,7 @@ func (o *XmlItem) GetNamespaceWrappedArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetNamespaceWrappedArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.NamespaceWrappedArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.NamespaceWrappedArray, true
 }
@@ -813,7 +813,7 @@ func (o *XmlItem) GetPrefixNsString() string {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsStringOk() (*string, bool) {
 	if o == nil || isNil(o.PrefixNsString) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixNsString, true
 }
@@ -845,7 +845,7 @@ func (o *XmlItem) GetPrefixNsNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.PrefixNsNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixNsNumber, true
 }
@@ -877,7 +877,7 @@ func (o *XmlItem) GetPrefixNsInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.PrefixNsInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixNsInteger, true
 }
@@ -909,7 +909,7 @@ func (o *XmlItem) GetPrefixNsBoolean() bool {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsBooleanOk() (*bool, bool) {
 	if o == nil || isNil(o.PrefixNsBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixNsBoolean, true
 }
@@ -941,7 +941,7 @@ func (o *XmlItem) GetPrefixNsArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.PrefixNsArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixNsArray, true
 }
@@ -973,7 +973,7 @@ func (o *XmlItem) GetPrefixNsWrappedArray() []int32 {
 // and a boolean to check if the value has been set.
 func (o *XmlItem) GetPrefixNsWrappedArrayOk() ([]int32, bool) {
 	if o == nil || isNil(o.PrefixNsWrappedArray) {
-    return nil, false
+		return nil, false
 	}
 	return o.PrefixNsWrappedArray, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
@@ -53,7 +53,7 @@ func (o *Model200Response) GetName() int32 {
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetNameOk() (*int32, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }
@@ -85,7 +85,7 @@ func (o *Model200Response) GetClass() string {
 // and a boolean to check if the value has been set.
 func (o *Model200Response) GetClassOk() (*string, bool) {
 	if o == nil || isNil(o.Class) {
-    return nil, false
+		return nil, false
 	}
 	return o.Class, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
@@ -52,7 +52,7 @@ func (o *FooGetDefaultResponse) GetString() Foo {
 // and a boolean to check if the value has been set.
 func (o *FooGetDefaultResponse) GetStringOk() (*Foo, bool) {
 	if o == nil || isNil(o.String) {
-    return nil, false
+		return nil, false
 	}
 	return o.String, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
@@ -52,7 +52,7 @@ func (o *SpecialModelName) GetSpecialPropertyName() int64 {
 // and a boolean to check if the value has been set.
 func (o *SpecialModelName) GetSpecialPropertyNameOk() (*int64, bool) {
 	if o == nil || isNil(o.SpecialPropertyName) {
-    return nil, false
+		return nil, false
 	}
 	return o.SpecialPropertyName, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
@@ -53,7 +53,7 @@ func (o *AdditionalPropertiesClass) GetMapProperty() map[string]string {
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapPropertyOk() (*map[string]string, bool) {
 	if o == nil || isNil(o.MapProperty) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapProperty, true
 }
@@ -85,7 +85,7 @@ func (o *AdditionalPropertiesClass) GetMapOfMapProperty() map[string]map[string]
 // and a boolean to check if the value has been set.
 func (o *AdditionalPropertiesClass) GetMapOfMapPropertyOk() (*map[string]map[string]string, bool) {
 	if o == nil || isNil(o.MapOfMapProperty) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapOfMapProperty, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
@@ -82,7 +82,7 @@ func (o *Animal) GetColor() string {
 // and a boolean to check if the value has been set.
 func (o *Animal) GetColorOk() (*string, bool) {
 	if o == nil || isNil(o.Color) {
-    return nil, false
+		return nil, false
 	}
 	return o.Color, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
@@ -54,7 +54,7 @@ func (o *ApiResponse) GetCode() int32 {
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetCodeOk() (*int32, bool) {
 	if o == nil || isNil(o.Code) {
-    return nil, false
+		return nil, false
 	}
 	return o.Code, true
 }
@@ -86,7 +86,7 @@ func (o *ApiResponse) GetType() string {
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetTypeOk() (*string, bool) {
 	if o == nil || isNil(o.Type) {
-    return nil, false
+		return nil, false
 	}
 	return o.Type, true
 }
@@ -118,7 +118,7 @@ func (o *ApiResponse) GetMessage() string {
 // and a boolean to check if the value has been set.
 func (o *ApiResponse) GetMessageOk() (*string, bool) {
 	if o == nil || isNil(o.Message) {
-    return nil, false
+		return nil, false
 	}
 	return o.Message, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
@@ -52,7 +52,7 @@ func (o *Apple) GetCultivar() string {
 // and a boolean to check if the value has been set.
 func (o *Apple) GetCultivarOk() (*string, bool) {
 	if o == nil || isNil(o.Cultivar) {
-    return nil, false
+		return nil, false
 	}
 	return o.Cultivar, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
@@ -78,7 +78,7 @@ func (o *AppleReq) GetMealy() bool {
 // and a boolean to check if the value has been set.
 func (o *AppleReq) GetMealyOk() (*bool, bool) {
 	if o == nil || isNil(o.Mealy) {
-    return nil, false
+		return nil, false
 	}
 	return o.Mealy, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
@@ -52,7 +52,7 @@ func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumber() [][]float32 {
 // and a boolean to check if the value has been set.
 func (o *ArrayOfArrayOfNumberOnly) GetArrayArrayNumberOk() ([][]float32, bool) {
 	if o == nil || isNil(o.ArrayArrayNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayArrayNumber, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
@@ -52,7 +52,7 @@ func (o *ArrayOfNumberOnly) GetArrayNumber() []float32 {
 // and a boolean to check if the value has been set.
 func (o *ArrayOfNumberOnly) GetArrayNumberOk() ([]float32, bool) {
 	if o == nil || isNil(o.ArrayNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayNumber, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
@@ -54,7 +54,7 @@ func (o *ArrayTest) GetArrayOfString() []string {
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayOfStringOk() ([]string, bool) {
 	if o == nil || isNil(o.ArrayOfString) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayOfString, true
 }
@@ -86,7 +86,7 @@ func (o *ArrayTest) GetArrayArrayOfInteger() [][]int64 {
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfIntegerOk() ([][]int64, bool) {
 	if o == nil || isNil(o.ArrayArrayOfInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayArrayOfInteger, true
 }
@@ -118,7 +118,7 @@ func (o *ArrayTest) GetArrayArrayOfModel() [][]ReadOnlyFirst {
 // and a boolean to check if the value has been set.
 func (o *ArrayTest) GetArrayArrayOfModelOk() ([][]ReadOnlyFirst, bool) {
 	if o == nil || isNil(o.ArrayArrayOfModel) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayArrayOfModel, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
@@ -52,7 +52,7 @@ func (o *Banana) GetLengthCm() float32 {
 // and a boolean to check if the value has been set.
 func (o *Banana) GetLengthCmOk() (*float32, bool) {
 	if o == nil || isNil(o.LengthCm) {
-    return nil, false
+		return nil, false
 	}
 	return o.LengthCm, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
@@ -78,7 +78,7 @@ func (o *BananaReq) GetSweet() bool {
 // and a boolean to check if the value has been set.
 func (o *BananaReq) GetSweetOk() (*bool, bool) {
 	if o == nil || isNil(o.Sweet) {
-    return nil, false
+		return nil, false
 	}
 	return o.Sweet, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
@@ -58,7 +58,7 @@ func (o *Capitalization) GetSmallCamel() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallCamelOk() (*string, bool) {
 	if o == nil || isNil(o.SmallCamel) {
-    return nil, false
+		return nil, false
 	}
 	return o.SmallCamel, true
 }
@@ -90,7 +90,7 @@ func (o *Capitalization) GetCapitalCamel() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalCamelOk() (*string, bool) {
 	if o == nil || isNil(o.CapitalCamel) {
-    return nil, false
+		return nil, false
 	}
 	return o.CapitalCamel, true
 }
@@ -122,7 +122,7 @@ func (o *Capitalization) GetSmallSnake() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSmallSnakeOk() (*string, bool) {
 	if o == nil || isNil(o.SmallSnake) {
-    return nil, false
+		return nil, false
 	}
 	return o.SmallSnake, true
 }
@@ -154,7 +154,7 @@ func (o *Capitalization) GetCapitalSnake() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetCapitalSnakeOk() (*string, bool) {
 	if o == nil || isNil(o.CapitalSnake) {
-    return nil, false
+		return nil, false
 	}
 	return o.CapitalSnake, true
 }
@@ -186,7 +186,7 @@ func (o *Capitalization) GetSCAETHFlowPoints() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetSCAETHFlowPointsOk() (*string, bool) {
 	if o == nil || isNil(o.SCAETHFlowPoints) {
-    return nil, false
+		return nil, false
 	}
 	return o.SCAETHFlowPoints, true
 }
@@ -218,7 +218,7 @@ func (o *Capitalization) GetATT_NAME() string {
 // and a boolean to check if the value has been set.
 func (o *Capitalization) GetATT_NAMEOk() (*string, bool) {
 	if o == nil || isNil(o.ATT_NAME) {
-    return nil, false
+		return nil, false
 	}
 	return o.ATT_NAME, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
@@ -58,7 +58,7 @@ func (o *Cat) GetDeclawed() bool {
 // and a boolean to check if the value has been set.
 func (o *Cat) GetDeclawedOk() (*bool, bool) {
 	if o == nil || isNil(o.Declawed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Declawed, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat_all_of.go
@@ -52,7 +52,7 @@ func (o *CatAllOf) GetDeclawed() bool {
 // and a boolean to check if the value has been set.
 func (o *CatAllOf) GetDeclawedOk() (*bool, bool) {
 	if o == nil || isNil(o.Declawed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Declawed, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_category.go
@@ -56,7 +56,7 @@ func (o *Category) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Category) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
@@ -52,7 +52,7 @@ func (o *ClassModel) GetClass() string {
 // and a boolean to check if the value has been set.
 func (o *ClassModel) GetClassOk() (*string, bool) {
 	if o == nil || isNil(o.Class) {
-    return nil, false
+		return nil, false
 	}
 	return o.Class, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_client.go
@@ -52,7 +52,7 @@ func (o *Client) GetClient() string {
 // and a boolean to check if the value has been set.
 func (o *Client) GetClientOk() (*string, bool) {
 	if o == nil || isNil(o.Client) {
-    return nil, false
+		return nil, false
 	}
 	return o.Client, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
@@ -58,7 +58,7 @@ func (o *Dog) GetBreed() string {
 // and a boolean to check if the value has been set.
 func (o *Dog) GetBreedOk() (*string, bool) {
 	if o == nil || isNil(o.Breed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Breed, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog_all_of.go
@@ -52,7 +52,7 @@ func (o *DogAllOf) GetBreed() string {
 // and a boolean to check if the value has been set.
 func (o *DogAllOf) GetBreedOk() (*string, bool) {
 	if o == nil || isNil(o.Breed) {
-    return nil, false
+		return nil, false
 	}
 	return o.Breed, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child.go
@@ -56,7 +56,7 @@ func (o *DuplicatedPropChild) GetDupProp() string {
 // and a boolean to check if the value has been set.
 func (o *DuplicatedPropChild) GetDupPropOk() (*string, bool) {
 	if o == nil || isNil(o.DupProp) {
-    return nil, false
+		return nil, false
 	}
 	return o.DupProp, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child_all_of.go
@@ -53,7 +53,7 @@ func (o *DuplicatedPropChildAllOf) GetDupProp() string {
 // and a boolean to check if the value has been set.
 func (o *DuplicatedPropChildAllOf) GetDupPropOk() (*string, bool) {
 	if o == nil || isNil(o.DupProp) {
-    return nil, false
+		return nil, false
 	}
 	return o.DupProp, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -53,7 +53,7 @@ func (o *EnumArrays) GetJustSymbol() string {
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetJustSymbolOk() (*string, bool) {
 	if o == nil || isNil(o.JustSymbol) {
-    return nil, false
+		return nil, false
 	}
 	return o.JustSymbol, true
 }
@@ -85,7 +85,7 @@ func (o *EnumArrays) GetArrayEnum() []string {
 // and a boolean to check if the value has been set.
 func (o *EnumArrays) GetArrayEnumOk() ([]string, bool) {
 	if o == nil || isNil(o.ArrayEnum) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayEnum, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
@@ -68,7 +68,7 @@ func (o *EnumTest) GetEnumString() string {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumStringOk() (*string, bool) {
 	if o == nil || isNil(o.EnumString) {
-    return nil, false
+		return nil, false
 	}
 	return o.EnumString, true
 }
@@ -124,7 +124,7 @@ func (o *EnumTest) GetEnumInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.EnumInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.EnumInteger, true
 }
@@ -156,7 +156,7 @@ func (o *EnumTest) GetEnumNumber() float64 {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetEnumNumberOk() (*float64, bool) {
 	if o == nil || isNil(o.EnumNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.EnumNumber, true
 }
@@ -189,7 +189,7 @@ func (o *EnumTest) GetOuterEnum() OuterEnum {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *EnumTest) GetOuterEnumOk() (*OuterEnum, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.OuterEnum.Get(), o.OuterEnum.IsSet()
 }
@@ -230,7 +230,7 @@ func (o *EnumTest) GetOuterEnumInteger() OuterEnumInteger {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumIntegerOk() (*OuterEnumInteger, bool) {
 	if o == nil || isNil(o.OuterEnumInteger) {
-    return nil, false
+		return nil, false
 	}
 	return o.OuterEnumInteger, true
 }
@@ -262,7 +262,7 @@ func (o *EnumTest) GetOuterEnumDefaultValue() OuterEnumDefaultValue {
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumDefaultValueOk() (*OuterEnumDefaultValue, bool) {
 	if o == nil || isNil(o.OuterEnumDefaultValue) {
-    return nil, false
+		return nil, false
 	}
 	return o.OuterEnumDefaultValue, true
 }
@@ -294,7 +294,7 @@ func (o *EnumTest) GetOuterEnumIntegerDefaultValue() OuterEnumIntegerDefaultValu
 // and a boolean to check if the value has been set.
 func (o *EnumTest) GetOuterEnumIntegerDefaultValueOk() (*OuterEnumIntegerDefaultValue, bool) {
 	if o == nil || isNil(o.OuterEnumIntegerDefaultValue) {
-    return nil, false
+		return nil, false
 	}
 	return o.OuterEnumIntegerDefaultValue, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file.go
@@ -53,7 +53,7 @@ func (o *File) GetSourceURI() string {
 // and a boolean to check if the value has been set.
 func (o *File) GetSourceURIOk() (*string, bool) {
 	if o == nil || isNil(o.SourceURI) {
-    return nil, false
+		return nil, false
 	}
 	return o.SourceURI, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
@@ -53,7 +53,7 @@ func (o *FileSchemaTestClass) GetFile() File {
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFileOk() (*File, bool) {
 	if o == nil || isNil(o.File) {
-    return nil, false
+		return nil, false
 	}
 	return o.File, true
 }
@@ -85,7 +85,7 @@ func (o *FileSchemaTestClass) GetFiles() []File {
 // and a boolean to check if the value has been set.
 func (o *FileSchemaTestClass) GetFilesOk() ([]File, bool) {
 	if o == nil || isNil(o.Files) {
-    return nil, false
+		return nil, false
 	}
 	return o.Files, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
@@ -56,7 +56,7 @@ func (o *Foo) GetBar() string {
 // and a boolean to check if the value has been set.
 func (o *Foo) GetBarOk() (*string, bool) {
 	if o == nil || isNil(o.Bar) {
-    return nil, false
+		return nil, false
 	}
 	return o.Bar, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -74,7 +74,7 @@ func (o *FormatTest) GetInteger() int32 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetIntegerOk() (*int32, bool) {
 	if o == nil || isNil(o.Integer) {
-    return nil, false
+		return nil, false
 	}
 	return o.Integer, true
 }
@@ -106,7 +106,7 @@ func (o *FormatTest) GetInt32() int32 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt32Ok() (*int32, bool) {
 	if o == nil || isNil(o.Int32) {
-    return nil, false
+		return nil, false
 	}
 	return o.Int32, true
 }
@@ -138,7 +138,7 @@ func (o *FormatTest) GetInt64() int64 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetInt64Ok() (*int64, bool) {
 	if o == nil || isNil(o.Int64) {
-    return nil, false
+		return nil, false
 	}
 	return o.Int64, true
 }
@@ -194,7 +194,7 @@ func (o *FormatTest) GetFloat() float32 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetFloatOk() (*float32, bool) {
 	if o == nil || isNil(o.Float) {
-    return nil, false
+		return nil, false
 	}
 	return o.Float, true
 }
@@ -226,7 +226,7 @@ func (o *FormatTest) GetDouble() float64 {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDoubleOk() (*float64, bool) {
 	if o == nil || isNil(o.Double) {
-    return nil, false
+		return nil, false
 	}
 	return o.Double, true
 }
@@ -258,7 +258,7 @@ func (o *FormatTest) GetString() string {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetStringOk() (*string, bool) {
 	if o == nil || isNil(o.String) {
-    return nil, false
+		return nil, false
 	}
 	return o.String, true
 }
@@ -314,7 +314,7 @@ func (o *FormatTest) GetBinary() *os.File {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetBinaryOk() (**os.File, bool) {
 	if o == nil || isNil(o.Binary) {
-    return nil, false
+		return nil, false
 	}
 	return o.Binary, true
 }
@@ -370,7 +370,7 @@ func (o *FormatTest) GetDateTime() time.Time {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || isNil(o.DateTime) {
-    return nil, false
+		return nil, false
 	}
 	return o.DateTime, true
 }
@@ -402,7 +402,7 @@ func (o *FormatTest) GetUuid() string {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetUuidOk() (*string, bool) {
 	if o == nil || isNil(o.Uuid) {
-    return nil, false
+		return nil, false
 	}
 	return o.Uuid, true
 }
@@ -458,7 +458,7 @@ func (o *FormatTest) GetPatternWithDigits() string {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetPatternWithDigitsOk() (*string, bool) {
 	if o == nil || isNil(o.PatternWithDigits) {
-    return nil, false
+		return nil, false
 	}
 	return o.PatternWithDigits, true
 }
@@ -490,7 +490,7 @@ func (o *FormatTest) GetPatternWithDigitsAndDelimiter() string {
 // and a boolean to check if the value has been set.
 func (o *FormatTest) GetPatternWithDigitsAndDelimiterOk() (*string, bool) {
 	if o == nil || isNil(o.PatternWithDigitsAndDelimiter) {
-    return nil, false
+		return nil, false
 	}
 	return o.PatternWithDigitsAndDelimiter, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -53,7 +53,7 @@ func (o *HasOnlyReadOnly) GetBar() string {
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetBarOk() (*string, bool) {
 	if o == nil || isNil(o.Bar) {
-    return nil, false
+		return nil, false
 	}
 	return o.Bar, true
 }
@@ -85,7 +85,7 @@ func (o *HasOnlyReadOnly) GetFoo() string {
 // and a boolean to check if the value has been set.
 func (o *HasOnlyReadOnly) GetFooOk() (*string, bool) {
 	if o == nil || isNil(o.Foo) {
-    return nil, false
+		return nil, false
 	}
 	return o.Foo, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
@@ -53,7 +53,7 @@ func (o *HealthCheckResult) GetNullableMessage() string {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *HealthCheckResult) GetNullableMessageOk() (*string, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.NullableMessage.Get(), o.NullableMessage.IsSet()
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_list.go
@@ -52,7 +52,7 @@ func (o *List) GetVar123List() string {
 // and a boolean to check if the value has been set.
 func (o *List) GetVar123ListOk() (*string, bool) {
 	if o == nil || isNil(o.Var123List) {
-    return nil, false
+		return nil, false
 	}
 	return o.Var123List, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
@@ -54,7 +54,7 @@ func (o *MapOfFileTest) GetPropTest() map[string]*os.File {
 // and a boolean to check if the value has been set.
 func (o *MapOfFileTest) GetPropTestOk() (*map[string]*os.File, bool) {
 	if o == nil || isNil(o.PropTest) {
-    return nil, false
+		return nil, false
 	}
 	return o.PropTest, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
@@ -55,7 +55,7 @@ func (o *MapTest) GetMapMapOfString() map[string]map[string]string {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapMapOfStringOk() (*map[string]map[string]string, bool) {
 	if o == nil || isNil(o.MapMapOfString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapMapOfString, true
 }
@@ -87,7 +87,7 @@ func (o *MapTest) GetMapOfEnumString() map[string]string {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetMapOfEnumStringOk() (*map[string]string, bool) {
 	if o == nil || isNil(o.MapOfEnumString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MapOfEnumString, true
 }
@@ -119,7 +119,7 @@ func (o *MapTest) GetDirectMap() map[string]bool {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetDirectMapOk() (*map[string]bool, bool) {
 	if o == nil || isNil(o.DirectMap) {
-    return nil, false
+		return nil, false
 	}
 	return o.DirectMap, true
 }
@@ -151,7 +151,7 @@ func (o *MapTest) GetIndirectMap() map[string]bool {
 // and a boolean to check if the value has been set.
 func (o *MapTest) GetIndirectMapOk() (*map[string]bool, bool) {
 	if o == nil || isNil(o.IndirectMap) {
-    return nil, false
+		return nil, false
 	}
 	return o.IndirectMap, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -55,7 +55,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuid() string {
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetUuidOk() (*string, bool) {
 	if o == nil || isNil(o.Uuid) {
-    return nil, false
+		return nil, false
 	}
 	return o.Uuid, true
 }
@@ -87,7 +87,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTime() time.Time {
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetDateTimeOk() (*time.Time, bool) {
 	if o == nil || isNil(o.DateTime) {
-    return nil, false
+		return nil, false
 	}
 	return o.DateTime, true
 }
@@ -119,7 +119,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMap() map[string]Animal
 // and a boolean to check if the value has been set.
 func (o *MixedPropertiesAndAdditionalPropertiesClass) GetMapOk() (*map[string]Animal, bool) {
 	if o == nil || isNil(o.Map) {
-    return nil, false
+		return nil, false
 	}
 	return o.Map, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -80,7 +80,7 @@ func (o *Name) GetSnakeCase() int32 {
 // and a boolean to check if the value has been set.
 func (o *Name) GetSnakeCaseOk() (*int32, bool) {
 	if o == nil || isNil(o.SnakeCase) {
-    return nil, false
+		return nil, false
 	}
 	return o.SnakeCase, true
 }
@@ -112,7 +112,7 @@ func (o *Name) GetProperty() string {
 // and a boolean to check if the value has been set.
 func (o *Name) GetPropertyOk() (*string, bool) {
 	if o == nil || isNil(o.Property) {
-    return nil, false
+		return nil, false
 	}
 	return o.Property, true
 }
@@ -144,7 +144,7 @@ func (o *Name) GetVar123Number() int32 {
 // and a boolean to check if the value has been set.
 func (o *Name) GetVar123NumberOk() (*int32, bool) {
 	if o == nil || isNil(o.Var123Number) {
-    return nil, false
+		return nil, false
 	}
 	return o.Var123Number, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
@@ -53,7 +53,7 @@ func (o *NullableAllOf) GetChild() NullableAllOfChild {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableAllOf) GetChildOk() (*NullableAllOfChild, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.Child.Get(), o.Child.IsSet()
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
@@ -52,7 +52,7 @@ func (o *NullableAllOfChild) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *NullableAllOfChild) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
@@ -66,7 +66,7 @@ func (o *NullableClass) GetIntegerProp() int32 {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetIntegerPropOk() (*int32, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.IntegerProp.Get(), o.IntegerProp.IsSet()
 }
@@ -108,7 +108,7 @@ func (o *NullableClass) GetNumberProp() float32 {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetNumberPropOk() (*float32, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.NumberProp.Get(), o.NumberProp.IsSet()
 }
@@ -150,7 +150,7 @@ func (o *NullableClass) GetBooleanProp() bool {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetBooleanPropOk() (*bool, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.BooleanProp.Get(), o.BooleanProp.IsSet()
 }
@@ -192,7 +192,7 @@ func (o *NullableClass) GetStringProp() string {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetStringPropOk() (*string, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.StringProp.Get(), o.StringProp.IsSet()
 }
@@ -234,7 +234,7 @@ func (o *NullableClass) GetDateProp() string {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetDatePropOk() (*string, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.DateProp.Get(), o.DateProp.IsSet()
 }
@@ -276,7 +276,7 @@ func (o *NullableClass) GetDatetimeProp() time.Time {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetDatetimePropOk() (*time.Time, bool) {
 	if o == nil {
-    return nil, false
+		return nil, false
 	}
 	return o.DatetimeProp.Get(), o.DatetimeProp.IsSet()
 }
@@ -318,7 +318,7 @@ func (o *NullableClass) GetArrayNullableProp() []map[string]interface{} {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetArrayNullablePropOk() ([]map[string]interface{}, bool) {
 	if o == nil || isNil(o.ArrayNullableProp) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayNullableProp, true
 }
@@ -351,7 +351,7 @@ func (o *NullableClass) GetArrayAndItemsNullableProp() []*map[string]interface{}
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetArrayAndItemsNullablePropOk() ([]*map[string]interface{}, bool) {
 	if o == nil || isNil(o.ArrayAndItemsNullableProp) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayAndItemsNullableProp, true
 }
@@ -383,7 +383,7 @@ func (o *NullableClass) GetArrayItemsNullable() []*map[string]interface{} {
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetArrayItemsNullableOk() ([]*map[string]interface{}, bool) {
 	if o == nil || isNil(o.ArrayItemsNullable) {
-    return nil, false
+		return nil, false
 	}
 	return o.ArrayItemsNullable, true
 }
@@ -416,7 +416,7 @@ func (o *NullableClass) GetObjectNullableProp() map[string]map[string]interface{
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetObjectNullablePropOk() (map[string]map[string]interface{}, bool) {
 	if o == nil || isNil(o.ObjectNullableProp) {
-    return map[string]map[string]interface{}{}, false
+		return map[string]map[string]interface{}{}, false
 	}
 	return o.ObjectNullableProp, true
 }
@@ -449,7 +449,7 @@ func (o *NullableClass) GetObjectAndItemsNullableProp() map[string]map[string]in
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *NullableClass) GetObjectAndItemsNullablePropOk() (map[string]map[string]interface{}, bool) {
 	if o == nil || isNil(o.ObjectAndItemsNullableProp) {
-    return map[string]map[string]interface{}{}, false
+		return map[string]map[string]interface{}{}, false
 	}
 	return o.ObjectAndItemsNullableProp, true
 }
@@ -481,7 +481,7 @@ func (o *NullableClass) GetObjectItemsNullable() map[string]map[string]interface
 // and a boolean to check if the value has been set.
 func (o *NullableClass) GetObjectItemsNullableOk() (map[string]map[string]interface{}, bool) {
 	if o == nil || isNil(o.ObjectItemsNullable) {
-    return map[string]map[string]interface{}{}, false
+		return map[string]map[string]interface{}{}, false
 	}
 	return o.ObjectItemsNullable, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
@@ -52,7 +52,7 @@ func (o *NumberOnly) GetJustNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *NumberOnly) GetJustNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.JustNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.JustNumber, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
@@ -52,7 +52,7 @@ func (o *OneOfPrimitiveTypeChild) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *OneOfPrimitiveTypeChild) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_order.go
@@ -63,7 +63,7 @@ func (o *Order) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Order) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -95,7 +95,7 @@ func (o *Order) GetPetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Order) GetPetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.PetId) {
-    return nil, false
+		return nil, false
 	}
 	return o.PetId, true
 }
@@ -127,7 +127,7 @@ func (o *Order) GetQuantity() int32 {
 // and a boolean to check if the value has been set.
 func (o *Order) GetQuantityOk() (*int32, bool) {
 	if o == nil || isNil(o.Quantity) {
-    return nil, false
+		return nil, false
 	}
 	return o.Quantity, true
 }
@@ -159,7 +159,7 @@ func (o *Order) GetShipDate() time.Time {
 // and a boolean to check if the value has been set.
 func (o *Order) GetShipDateOk() (*time.Time, bool) {
 	if o == nil || isNil(o.ShipDate) {
-    return nil, false
+		return nil, false
 	}
 	return o.ShipDate, true
 }
@@ -191,7 +191,7 @@ func (o *Order) GetStatus() string {
 // and a boolean to check if the value has been set.
 func (o *Order) GetStatusOk() (*string, bool) {
 	if o == nil || isNil(o.Status) {
-    return nil, false
+		return nil, false
 	}
 	return o.Status, true
 }
@@ -223,7 +223,7 @@ func (o *Order) GetComplete() bool {
 // and a boolean to check if the value has been set.
 func (o *Order) GetCompleteOk() (*bool, bool) {
 	if o == nil || isNil(o.Complete) {
-    return nil, false
+		return nil, false
 	}
 	return o.Complete, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
@@ -54,7 +54,7 @@ func (o *OuterComposite) GetMyNumber() float32 {
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyNumberOk() (*float32, bool) {
 	if o == nil || isNil(o.MyNumber) {
-    return nil, false
+		return nil, false
 	}
 	return o.MyNumber, true
 }
@@ -86,7 +86,7 @@ func (o *OuterComposite) GetMyString() string {
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyStringOk() (*string, bool) {
 	if o == nil || isNil(o.MyString) {
-    return nil, false
+		return nil, false
 	}
 	return o.MyString, true
 }
@@ -118,7 +118,7 @@ func (o *OuterComposite) GetMyBoolean() bool {
 // and a boolean to check if the value has been set.
 func (o *OuterComposite) GetMyBooleanOk() (*bool, bool) {
 	if o == nil || isNil(o.MyBoolean) {
-    return nil, false
+		return nil, false
 	}
 	return o.MyBoolean, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
@@ -61,7 +61,7 @@ func (o *Pet) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Pet) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -93,7 +93,7 @@ func (o *Pet) GetCategory() Category {
 // and a boolean to check if the value has been set.
 func (o *Pet) GetCategoryOk() (*Category, bool) {
 	if o == nil || isNil(o.Category) {
-    return nil, false
+		return nil, false
 	}
 	return o.Category, true
 }
@@ -173,7 +173,7 @@ func (o *Pet) GetTags() []Tag {
 // and a boolean to check if the value has been set.
 func (o *Pet) GetTagsOk() ([]Tag, bool) {
 	if o == nil || isNil(o.Tags) {
-    return nil, false
+		return nil, false
 	}
 	return o.Tags, true
 }
@@ -207,7 +207,7 @@ func (o *Pet) GetStatus() string {
 // Deprecated
 func (o *Pet) GetStatusOk() (*string, bool) {
 	if o == nil || isNil(o.Status) {
-    return nil, false
+		return nil, false
 	}
 	return o.Status, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
@@ -53,7 +53,7 @@ func (o *ReadOnlyFirst) GetBar() string {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBarOk() (*string, bool) {
 	if o == nil || isNil(o.Bar) {
-    return nil, false
+		return nil, false
 	}
 	return o.Bar, true
 }
@@ -85,7 +85,7 @@ func (o *ReadOnlyFirst) GetBaz() string {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyFirst) GetBazOk() (*string, bool) {
 	if o == nil || isNil(o.Baz) {
-    return nil, false
+		return nil, false
 	}
 	return o.Baz, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
@@ -70,7 +70,7 @@ func (o *ReadOnlyWithDefault) GetProp1() string {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetProp1Ok() (*string, bool) {
 	if o == nil || isNil(o.Prop1) {
-    return nil, false
+		return nil, false
 	}
 	return o.Prop1, true
 }
@@ -102,7 +102,7 @@ func (o *ReadOnlyWithDefault) GetProp2() string {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetProp2Ok() (*string, bool) {
 	if o == nil || isNil(o.Prop2) {
-    return nil, false
+		return nil, false
 	}
 	return o.Prop2, true
 }
@@ -134,7 +134,7 @@ func (o *ReadOnlyWithDefault) GetProp3() string {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetProp3Ok() (*string, bool) {
 	if o == nil || isNil(o.Prop3) {
-    return nil, false
+		return nil, false
 	}
 	return o.Prop3, true
 }
@@ -166,7 +166,7 @@ func (o *ReadOnlyWithDefault) GetBoolProp1() bool {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetBoolProp1Ok() (*bool, bool) {
 	if o == nil || isNil(o.BoolProp1) {
-    return nil, false
+		return nil, false
 	}
 	return o.BoolProp1, true
 }
@@ -198,7 +198,7 @@ func (o *ReadOnlyWithDefault) GetBoolProp2() bool {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetBoolProp2Ok() (*bool, bool) {
 	if o == nil || isNil(o.BoolProp2) {
-    return nil, false
+		return nil, false
 	}
 	return o.BoolProp2, true
 }
@@ -230,7 +230,7 @@ func (o *ReadOnlyWithDefault) GetIntProp1() float32 {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetIntProp1Ok() (*float32, bool) {
 	if o == nil || isNil(o.IntProp1) {
-    return nil, false
+		return nil, false
 	}
 	return o.IntProp1, true
 }
@@ -262,7 +262,7 @@ func (o *ReadOnlyWithDefault) GetIntProp2() float32 {
 // and a boolean to check if the value has been set.
 func (o *ReadOnlyWithDefault) GetIntProp2Ok() (*float32, bool) {
 	if o == nil || isNil(o.IntProp2) {
-    return nil, false
+		return nil, false
 	}
 	return o.IntProp2, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_return.go
@@ -52,7 +52,7 @@ func (o *Return) GetReturn() int32 {
 // and a boolean to check if the value has been set.
 func (o *Return) GetReturnOk() (*int32, bool) {
 	if o == nil || isNil(o.Return) {
-    return nil, false
+		return nil, false
 	}
 	return o.Return, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
@@ -53,7 +53,7 @@ func (o *Tag) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *Tag) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -85,7 +85,7 @@ func (o *Tag) GetName() string {
 // and a boolean to check if the value has been set.
 func (o *Tag) GetNameOk() (*string, bool) {
 	if o == nil || isNil(o.Name) {
-    return nil, false
+		return nil, false
 	}
 	return o.Name, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_user.go
@@ -68,7 +68,7 @@ func (o *User) GetId() int64 {
 // and a boolean to check if the value has been set.
 func (o *User) GetIdOk() (*int64, bool) {
 	if o == nil || isNil(o.Id) {
-    return nil, false
+		return nil, false
 	}
 	return o.Id, true
 }
@@ -100,7 +100,7 @@ func (o *User) GetUsername() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetUsernameOk() (*string, bool) {
 	if o == nil || isNil(o.Username) {
-    return nil, false
+		return nil, false
 	}
 	return o.Username, true
 }
@@ -132,7 +132,7 @@ func (o *User) GetFirstName() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetFirstNameOk() (*string, bool) {
 	if o == nil || isNil(o.FirstName) {
-    return nil, false
+		return nil, false
 	}
 	return o.FirstName, true
 }
@@ -164,7 +164,7 @@ func (o *User) GetLastName() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetLastNameOk() (*string, bool) {
 	if o == nil || isNil(o.LastName) {
-    return nil, false
+		return nil, false
 	}
 	return o.LastName, true
 }
@@ -196,7 +196,7 @@ func (o *User) GetEmail() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetEmailOk() (*string, bool) {
 	if o == nil || isNil(o.Email) {
-    return nil, false
+		return nil, false
 	}
 	return o.Email, true
 }
@@ -228,7 +228,7 @@ func (o *User) GetPassword() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetPasswordOk() (*string, bool) {
 	if o == nil || isNil(o.Password) {
-    return nil, false
+		return nil, false
 	}
 	return o.Password, true
 }
@@ -260,7 +260,7 @@ func (o *User) GetPhone() string {
 // and a boolean to check if the value has been set.
 func (o *User) GetPhoneOk() (*string, bool) {
 	if o == nil || isNil(o.Phone) {
-    return nil, false
+		return nil, false
 	}
 	return o.Phone, true
 }
@@ -292,7 +292,7 @@ func (o *User) GetUserStatus() int32 {
 // and a boolean to check if the value has been set.
 func (o *User) GetUserStatusOk() (*int32, bool) {
 	if o == nil || isNil(o.UserStatus) {
-    return nil, false
+		return nil, false
 	}
 	return o.UserStatus, true
 }
@@ -324,7 +324,7 @@ func (o *User) GetArbitraryObject() map[string]interface{} {
 // and a boolean to check if the value has been set.
 func (o *User) GetArbitraryObjectOk() (map[string]interface{}, bool) {
 	if o == nil || isNil(o.ArbitraryObject) {
-    return map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.ArbitraryObject, true
 }
@@ -357,7 +357,7 @@ func (o *User) GetArbitraryNullableObject() map[string]interface{} {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *User) GetArbitraryNullableObjectOk() (map[string]interface{}, bool) {
 	if o == nil || isNil(o.ArbitraryNullableObject) {
-    return map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.ArbitraryNullableObject, true
 }
@@ -390,7 +390,7 @@ func (o *User) GetArbitraryTypeValue() interface{} {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *User) GetArbitraryTypeValueOk() (*interface{}, bool) {
 	if o == nil || isNil(o.ArbitraryTypeValue) {
-    return nil, false
+		return nil, false
 	}
 	return &o.ArbitraryTypeValue, true
 }
@@ -423,7 +423,7 @@ func (o *User) GetArbitraryNullableTypeValue() interface{} {
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *User) GetArbitraryNullableTypeValueOk() (*interface{}, bool) {
 	if o == nil || isNil(o.ArbitraryNullableTypeValue) {
-    return nil, false
+		return nil, false
 	}
 	return &o.ArbitraryNullableTypeValue, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
@@ -55,7 +55,7 @@ func (o *Whale) GetHasBaleen() bool {
 // and a boolean to check if the value has been set.
 func (o *Whale) GetHasBaleenOk() (*bool, bool) {
 	if o == nil || isNil(o.HasBaleen) {
-    return nil, false
+		return nil, false
 	}
 	return o.HasBaleen, true
 }
@@ -87,7 +87,7 @@ func (o *Whale) GetHasTeeth() bool {
 // and a boolean to check if the value has been set.
 func (o *Whale) GetHasTeethOk() (*bool, bool) {
 	if o == nil || isNil(o.HasTeeth) {
-    return nil, false
+		return nil, false
 	}
 	return o.HasTeeth, true
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
@@ -54,7 +54,7 @@ func (o *Zebra) GetType() string {
 // and a boolean to check if the value has been set.
 func (o *Zebra) GetTypeOk() (*string, bool) {
 	if o == nil || isNil(o.Type) {
-    return nil, false
+		return nil, false
 	}
 	return o.Type, true
 }


### PR DESCRIPTION
This corrects the indentation for recent changes in #13843

#13843 used spaces for indentation which causes the generated code to have the incorrect space for go which should uses tab


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.1.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
