### PR TITLE
[GO] Fix broken time import when value is of pointer type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -660,13 +660,13 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             }
 
             for (CodegenProperty cp : codegenProperties) {
-                if (!addedTimeImport && ("time.Time".equals(cp.dataType) ||
-                        (cp.items != null && "time.Time".equals(cp.items.dataType)))) {
+                if ( !addedTimeImport && isType(cp.dataType, "time.Time") || 
+                        (cp.items != null && isType(cp.items.dataType, "time.Time") ) ) {
                     imports.add(createMapping("import", "time"));
                     addedTimeImport = true;
                 }
-                if (!addedOSImport && ("*os.File".equals(cp.dataType) ||
-                        (cp.items != null && "*os.File".equals(cp.items.dataType)))) {
+                if ( !addedOSImport && isType(cp.dataType, "os.File") || 
+                        (cp.items != null && isType(cp.items.dataType, "os.File") ) ) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }
@@ -709,6 +709,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         }
 
         return postProcessModelsEnum(objs);
+    }
+    
+    static protected boolean isType( String value, String type ) {
+        return value != null && (value.equals( type ) || value.equals( "*"+type ));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -660,13 +660,13 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             }
 
             for (CodegenProperty cp : codegenProperties) {
-                if ( !addedTimeImport && isType(cp.dataType, "time.Time") || 
-                        (cp.items != null && isType(cp.items.dataType, "time.Time") ) ) {
+                if ( !addedTimeImport && checkType(cp.dataType, "time.Time") || 
+                        (cp.items != null && checkType(cp.items.dataType, "time.Time") ) ) {
                     imports.add(createMapping("import", "time"));
                     addedTimeImport = true;
                 }
-                if ( !addedOSImport && isType(cp.dataType, "os.File") || 
-                        (cp.items != null && isType(cp.items.dataType, "os.File") ) ) {
+                if ( !addedOSImport && checkType(cp.dataType, "os.File") || 
+                        (cp.items != null && checkType(cp.items.dataType, "os.File") ) ) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }
@@ -711,7 +711,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         return postProcessModelsEnum(objs);
     }
     
-    static protected boolean isType( String value, String type ) {
+    boolean checkType( String value, String type ) {
         return value != null && (value.equals( type ) || value.equals( "*"+type ));
     }
 


### PR DESCRIPTION
Hi,
this fix restores the correct generation of go model files that contain a pointer to a time.Time member value which was broken with https://github.com/OpenAPITools/openapi-generator/commit/fa4f7e07fee865ee1b1b87690e1540733cfa0ea2?diff=unified

Example file affected file is samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_types.go