### PR TITLE
Better error check if discriminator value is null in r client

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
@@ -85,8 +85,8 @@
       {{/isNull}}
       {{/composedSchemas.anyOf}}
       # no match
-      stop(paste("No match found when deserializing the input into {{{classname}}} with anyOf schemas {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: ",
-                 paste(error_messages, collapse = ", ")))
+      stop(paste("No match found when deserializing the input into {{{classname}}} with anyOf schemas {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: >>",
+                 paste(error_messages, collapse = " >> ")))
     },
     #' Serialize {{{classname}}} to JSON string.
     #'

--- a/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelAnyOf.mustache
@@ -85,7 +85,7 @@
       {{/isNull}}
       {{/composedSchemas.anyOf}}
       # no match
-      stop(paste("No match found when deserializing the payload into {{{classname}}} with anyOf schemas {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: ",
+      stop(paste("No match found when deserializing the input into {{{classname}}} with anyOf schemas {{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}. Details: ",
                  paste(error_messages, collapse = ", ")))
     },
     #' Serialize {{{classname}}} to JSON string.

--- a/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
@@ -65,6 +65,9 @@
       {{#discriminator}}
       oneof_lookup_result <- tryCatch({
           discriminatorValue <- (jsonlite::fromJSON(input, simplifyVector = FALSE))$`{{{propertyBaseName}}}`
+          if (is.null(discriminatorValue)) { # throw error if it's null
+            stop("Error! The value of discriminator property `{{{propertyBaseName}}}` is null")
+          }
           switch(discriminatorValue,
           {{#mappedModels}}
           {{{mappingName}}}={
@@ -89,7 +92,7 @@
           error = function(err) err
       )
       if (!is.null(oneof_lookup_result["error"])) {
-        error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for {{classname}}. Error message: %s. Input: %s", oneof_lookup_result["message"], input))
+        error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for {{classname}}. Error message: %s. JSON input: %s", oneof_lookup_result["message"], input))
       }
 
       {{/discriminator}}
@@ -127,10 +130,10 @@
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}.")
+        stop("Multiple matches found when deserializing the input into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}. Details: ",
+        stop(paste("No match found when deserializing the input into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelOneOf.mustache
@@ -66,7 +66,7 @@
       oneof_lookup_result <- tryCatch({
           discriminatorValue <- (jsonlite::fromJSON(input, simplifyVector = FALSE))$`{{{propertyBaseName}}}`
           if (is.null(discriminatorValue)) { # throw error if it's null
-            stop("Error! The value of discriminator property `{{{propertyBaseName}}}` is null")
+            stop("Error! The value of the discriminator property `{{{propertyBaseName}}}`, which should be the class type, is null")
           }
           switch(discriminatorValue,
           {{#mappedModels}}
@@ -130,11 +130,12 @@
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}.")
+        stop(paste("Multiple matches found when deserializing the input into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into {{{classname}}} with oneOf schemas {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
@@ -90,7 +90,7 @@ AnyOfPig <- R6::R6Class(
       }
 
       # no match
-      stop(paste("No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
+      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
                  paste(error_messages, collapse = ", ")))
     },
     #' Serialize AnyOfPig to JSON string.

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_pig.R
@@ -90,8 +90,8 @@ AnyOfPig <- R6::R6Class(
       }
 
       # no match
-      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
-                 paste(error_messages, collapse = ", ")))
+      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >>",
+                 paste(error_messages, collapse = " >> ")))
     },
     #' Serialize AnyOfPig to JSON string.
     #'

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
@@ -102,10 +102,10 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
+        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/any_of_primitive_type_test.R
@@ -102,11 +102,12 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop(paste("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2-wrapper/R/mammal.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/mammal.R
@@ -67,7 +67,7 @@ Mammal <- R6::R6Class(
       oneof_lookup_result <- tryCatch({
           discriminatorValue <- (jsonlite::fromJSON(input, simplifyVector = FALSE))$`className`
           if (is.null(discriminatorValue)) { # throw error if it's null
-            stop("Error! The value of discriminator property `className` is null")
+            stop("Error! The value of the discriminator property `className`, which should be the class type, is null")
           }
           switch(discriminatorValue,
           whale={
@@ -126,11 +126,12 @@ Mammal <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra.")
+        stop(paste("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2-wrapper/R/mammal.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/mammal.R
@@ -66,6 +66,9 @@ Mammal <- R6::R6Class(
 
       oneof_lookup_result <- tryCatch({
           discriminatorValue <- (jsonlite::fromJSON(input, simplifyVector = FALSE))$`className`
+          if (is.null(discriminatorValue)) { # throw error if it's null
+            stop("Error! The value of discriminator property `className` is null")
+          }
           switch(discriminatorValue,
           whale={
             Whale$public_methods$validateJSON(input)
@@ -84,7 +87,7 @@ Mammal <- R6::R6Class(
           error = function(err) err
       )
       if (!is.null(oneof_lookup_result["error"])) {
-        error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for Mammal. Error message: %s. Input: %s", oneof_lookup_result["message"], input))
+        error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for Mammal. Error message: %s. JSON input: %s", oneof_lookup_result["message"], input))
       }
 
       Whale_result <- tryCatch({
@@ -123,10 +126,10 @@ Mammal <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into Mammal with oneOf schemas Whale, Zebra.")
+        stop("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into Mammal with oneOf schemas Whale, Zebra. Details: ",
+        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
@@ -102,10 +102,10 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
+        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/one_of_primitive_type_test.R
@@ -102,11 +102,12 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop(paste("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2-wrapper/R/pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pig.R
@@ -66,6 +66,9 @@ Pig <- R6::R6Class(
 
       oneof_lookup_result <- tryCatch({
           discriminatorValue <- (jsonlite::fromJSON(input, simplifyVector = FALSE))$`className`
+          if (is.null(discriminatorValue)) { # throw error if it's null
+            stop("Error! The value of discriminator property `className` is null")
+          }
           switch(discriminatorValue,
           BasquePig={
             BasquePig$public_methods$validateJSON(input)
@@ -84,7 +87,7 @@ Pig <- R6::R6Class(
           error = function(err) err
       )
       if (!is.null(oneof_lookup_result["error"])) {
-        error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for Pig. Error message: %s. Input: %s", oneof_lookup_result["message"], input))
+        error_messages <- append(error_messages, sprintf("Failed to lookup discriminator value for Pig. Error message: %s. JSON input: %s", oneof_lookup_result["message"], input))
       }
 
       BasquePig_result <- tryCatch({
@@ -123,10 +126,10 @@ Pig <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig.")
+        stop("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
+        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2-wrapper/R/pig.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pig.R
@@ -67,7 +67,7 @@ Pig <- R6::R6Class(
       oneof_lookup_result <- tryCatch({
           discriminatorValue <- (jsonlite::fromJSON(input, simplifyVector = FALSE))$`className`
           if (is.null(discriminatorValue)) { # throw error if it's null
-            stop("Error! The value of discriminator property `className` is null")
+            stop("Error! The value of the discriminator property `className`, which should be the class type, is null")
           }
           switch(discriminatorValue,
           BasquePig={
@@ -126,11 +126,12 @@ Pig <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig.")
+        stop(paste("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
@@ -518,8 +518,8 @@ test_that("Tests oneOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details:  Failed to lookup discriminator value for Pig. Error message: EXPR must be a length 1 vector. Input: \\{\\}, The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details:  Failed to lookup discriminator value for Pig. Error message: EXPR must be a length 1 vector. Input: \\{\\}, The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  Failed to lookup discriminator value for Pig. Error message: Error! The value of discriminator property `className` is null. JSON input: \\{\\}, The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  Failed to lookup discriminator value for Pig. Error message: Error! The value of discriminator property `className` is null. JSON input: \\{\\}, The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
   # class name test
   expect_equal(get(class(basque_pig$actual_instance)[[1]], pos = -1)$classname, "BasquePig")

--- a/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2-wrapper/tests/testthat/test_petstore.R
@@ -518,8 +518,8 @@ test_that("Tests oneOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  Failed to lookup discriminator value for Pig. Error message: Error! The value of discriminator property `className` is null. JSON input: \\{\\}, The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  Failed to lookup discriminator value for Pig. Error message: Error! The value of discriminator property `className` is null. JSON input: \\{\\}, The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >> Failed to lookup discriminator value for Pig. Error message: Error! The value of the discriminator property `className`, which should be the class type, is null. JSON input: \\{\\} >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >> Failed to lookup discriminator value for Pig. Error message: Error! The value of the discriminator property `className`, which should be the class type, is null. JSON input: \\{\\} >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
   # class name test
   expect_equal(get(class(basque_pig$actual_instance)[[1]], pos = -1)$classname, "BasquePig")
@@ -587,8 +587,8 @@ test_that("Tests anyOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
 })
 

--- a/samples/client/petstore/R-httr2/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2/R/any_of_pig.R
@@ -90,7 +90,7 @@ AnyOfPig <- R6::R6Class(
       }
 
       # no match
-      stop(paste("No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
+      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
                  paste(error_messages, collapse = ", ")))
     },
     #' Serialize AnyOfPig to JSON string.

--- a/samples/client/petstore/R-httr2/R/any_of_pig.R
+++ b/samples/client/petstore/R-httr2/R/any_of_pig.R
@@ -90,8 +90,8 @@ AnyOfPig <- R6::R6Class(
       }
 
       # no match
-      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
-                 paste(error_messages, collapse = ", ")))
+      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >>",
+                 paste(error_messages, collapse = " >> ")))
     },
     #' Serialize AnyOfPig to JSON string.
     #'

--- a/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
@@ -102,10 +102,10 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
+        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/any_of_primitive_type_test.R
@@ -102,11 +102,12 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop(paste("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2/R/mammal.R
+++ b/samples/client/petstore/R-httr2/R/mammal.R
@@ -100,10 +100,10 @@ Mammal <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into Mammal with oneOf schemas Whale, Zebra.")
+        stop("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into Mammal with oneOf schemas Whale, Zebra. Details: ",
+        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2/R/mammal.R
+++ b/samples/client/petstore/R-httr2/R/mammal.R
@@ -100,11 +100,12 @@ Mammal <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra.")
+        stop(paste("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
@@ -102,10 +102,10 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
+        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R-httr2/R/one_of_primitive_type_test.R
@@ -102,11 +102,12 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop(paste("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2/R/pig.R
+++ b/samples/client/petstore/R-httr2/R/pig.R
@@ -100,10 +100,10 @@ Pig <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig.")
+        stop("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
+        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R-httr2/R/pig.R
+++ b/samples/client/petstore/R-httr2/R/pig.R
@@ -100,11 +100,12 @@ Pig <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig.")
+        stop(paste("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
@@ -270,7 +270,7 @@ test_that("Tests oneOf primitive types", {
   expect_equal(test$actual_instance,  456)
   expect_equal(test$actual_type,  'integer')
 
-  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the payload into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details:  Data type doesn't match. Expected: integer. Actual: list., Data type doesn't match. Expected: character. Actual: list.") # should throw an error
+  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details:  Data type doesn't match. Expected: integer. Actual: list., Data type doesn't match. Expected: character. Actual: list.") # should throw an error
 })
 
 test_that("Tests anyOf primitive types", {
@@ -283,7 +283,7 @@ test_that("Tests anyOf primitive types", {
   expect_equal(test$actual_instance,  456)
   expect_equal(test$actual_type,  'integer')
 
-  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the payload into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details:  Data type doesn't match. Expected: integer. Actual: list., Data type doesn't match. Expected: character. Actual: list.") # should throw an error
+  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details:  Data type doesn't match. Expected: integer. Actual: list., Data type doesn't match. Expected: character. Actual: list.") # should throw an error
 })
 
 test_that("Tests oneOf", {
@@ -325,8 +325,8 @@ test_that("Tests oneOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
   # class name test
   expect_equal(get(class(basque_pig$actual_instance)[[1]], pos = -1)$classname, "BasquePig")
@@ -394,7 +394,7 @@ test_that("Tests anyOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
 })

--- a/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R-httr2/tests/testthat/test_petstore.R
@@ -270,7 +270,7 @@ test_that("Tests oneOf primitive types", {
   expect_equal(test$actual_instance,  456)
   expect_equal(test$actual_type,  'integer')
 
-  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details:  Data type doesn't match. Expected: integer. Actual: list., Data type doesn't match. Expected: character. Actual: list.") # should throw an error
+  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >> Data type doesn't match. Expected: integer. Actual: list. >> Data type doesn't match. Expected: character. Actual: list.") # should throw an error
 })
 
 test_that("Tests anyOf primitive types", {
@@ -283,7 +283,7 @@ test_that("Tests anyOf primitive types", {
   expect_equal(test$actual_instance,  456)
   expect_equal(test$actual_type,  'integer')
 
-  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details:  Data type doesn't match. Expected: integer. Actual: list., Data type doesn't match. Expected: character. Actual: list.") # should throw an error
+  expect_error(test$fromJSONString("[45,12]"), "No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >> Data type doesn't match. Expected: integer. Actual: list. >> Data type doesn't match. Expected: character. Actual: list.") # should throw an error
 })
 
 test_that("Tests oneOf", {
@@ -325,8 +325,8 @@ test_that("Tests oneOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
   # class name test
   expect_equal(get(class(basque_pig$actual_instance)[[1]], pos = -1)$classname, "BasquePig")
@@ -394,7 +394,7 @@ test_that("Tests anyOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
 })

--- a/samples/client/petstore/R/R/any_of_pig.R
+++ b/samples/client/petstore/R/R/any_of_pig.R
@@ -90,7 +90,7 @@ AnyOfPig <- R6::R6Class(
       }
 
       # no match
-      stop(paste("No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
+      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
                  paste(error_messages, collapse = ", ")))
     },
     #' Serialize AnyOfPig to JSON string.

--- a/samples/client/petstore/R/R/any_of_pig.R
+++ b/samples/client/petstore/R/R/any_of_pig.R
@@ -90,8 +90,8 @@ AnyOfPig <- R6::R6Class(
       }
 
       # no match
-      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: ",
-                 paste(error_messages, collapse = ", ")))
+      stop(paste("No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >>",
+                 paste(error_messages, collapse = " >> ")))
     },
     #' Serialize AnyOfPig to JSON string.
     #'

--- a/samples/client/petstore/R/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/any_of_primitive_type_test.R
@@ -102,10 +102,10 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
+        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R/R/any_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/any_of_primitive_type_test.R
@@ -102,11 +102,12 @@ AnyOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop(paste("Multiple matches found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into AnyOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R/R/mammal.R
+++ b/samples/client/petstore/R/R/mammal.R
@@ -100,10 +100,10 @@ Mammal <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into Mammal with oneOf schemas Whale, Zebra.")
+        stop("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into Mammal with oneOf schemas Whale, Zebra. Details: ",
+        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R/R/mammal.R
+++ b/samples/client/petstore/R/R/mammal.R
@@ -100,11 +100,12 @@ Mammal <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra.")
+        stop(paste("Multiple matches found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into Mammal with oneOf schemas Whale, Zebra. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/one_of_primitive_type_test.R
@@ -102,10 +102,10 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
+        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R/R/one_of_primitive_type_test.R
+++ b/samples/client/petstore/R/R/one_of_primitive_type_test.R
@@ -102,11 +102,12 @@ OneOfPrimitiveTypeTest <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer.")
+        stop(paste("Multiple matches found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into OneOfPrimitiveTypeTest with oneOf schemas character, integer. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R/R/pig.R
+++ b/samples/client/petstore/R/R/pig.R
@@ -100,10 +100,10 @@ Pig <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig.")
+        stop("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig.")
       } else {
         # no match
-        stop(paste("No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
+        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
                    paste(error_messages, collapse = ", ")))
       }
 

--- a/samples/client/petstore/R/R/pig.R
+++ b/samples/client/petstore/R/R/pig.R
@@ -100,11 +100,12 @@ Pig <- R6::R6Class(
         self$actual_type <- instance_type
       } else if (matched > 1) {
         # more than 1 match
-        stop("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig.")
+        stop(paste("Multiple matches found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Matched schemas: ",
+                   paste(matched_schemas, collapse = ", ")))
       } else {
         # no match
-        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: ",
-                   paste(error_messages, collapse = ", ")))
+        stop(paste("No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >>",
+                   paste(error_messages, collapse = " >> ")))
       }
 
       self

--- a/samples/client/petstore/R/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R/tests/testthat/test_petstore.R
@@ -259,8 +259,8 @@ test_that("Tests oneOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the payload into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
   # class name test
   expect_equal(get(class(basque_pig$actual_instance)[[1]], pos = -1)$classname, "BasquePig")
@@ -328,8 +328,8 @@ test_that("Tests anyOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the payload into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
 })
 

--- a/samples/client/petstore/R/tests/testthat/test_petstore.R
+++ b/samples/client/petstore/R/tests/testthat/test_petstore.R
@@ -259,8 +259,8 @@ test_that("Tests oneOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into Pig with oneOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
   # class name test
   expect_equal(get(class(basque_pig$actual_instance)[[1]], pos = -1)$classname, "BasquePig")
@@ -328,8 +328,8 @@ test_that("Tests anyOf", {
   expect_equal(basque_pig$toJSONString(), original_basque_pig$toJSONString())
 
   # test exception when no matche found
-  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
-  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details:  The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\., The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$fromJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
+  expect_error(pig$validateJSON('{}'), 'No match found when deserializing the input into AnyOfPig with anyOf schemas BasquePig, DanishPig. Details: >> The JSON input ` \\{\\} ` is invalid for BasquePig: the required field `className` is missing\\. >> The JSON input ` \\{\\} ` is invalid for DanishPig: the required field `className` is missing\\.')
 
 })
 


### PR DESCRIPTION
- Better error check if discriminator value is null in r client
- Better error messages (e.g. Error! The value of discriminator property `className` is null  instead of EXPR must be a length 1 vector.)
- updated tests.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @Ramanth (2019/07) @saigiridhar21 (2019/07)