### PR TITLE
[BUG][Go] Remove "null" body value when body is empty #13927

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -108,7 +108,7 @@ func EncodeJSONResponse(i interface{}, status *int,{{#addResponseHeaders}} heade
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if (i) != nil {
+    if i != nil {
         return json.NewEncoder(w).Encode(i)
     }
 

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -108,7 +108,11 @@ func EncodeJSONResponse(i interface{}, status *int,{{#addResponseHeaders}} heade
 		w.WriteHeader(http.StatusOK)
 	}
 
-	return json.NewEncoder(w).Encode(i)
+    if (i) != nil {
+        return json.NewEncoder(w).Encode(i)
+    }
+
+    return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -76,7 +76,7 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if (i) != nil {
+    if i != nil {
         return json.NewEncoder(w).Encode(i)
     }
 

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -76,7 +76,11 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-	return json.NewEncoder(w).Encode(i)
+    if (i) != nil {
+        return json.NewEncoder(w).Encode(i)
+    }
+
+    return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -72,7 +72,7 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if (i) != nil {
+    if i != nil {
         return json.NewEncoder(w).Encode(i)
     }
 

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -72,7 +72,11 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-	return json.NewEncoder(w).Encode(i)
+    if (i) != nil {
+        return json.NewEncoder(w).Encode(i)
+    }
+
+    return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file

--- a/samples/server/petstore/go-server-required/go/routers.go
+++ b/samples/server/petstore/go-server-required/go/routers.go
@@ -72,7 +72,7 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-    if (i) != nil {
+    if i != nil {
         return json.NewEncoder(w).Encode(i)
     }
 

--- a/samples/server/petstore/go-server-required/go/routers.go
+++ b/samples/server/petstore/go-server-required/go/routers.go
@@ -72,7 +72,11 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		w.WriteHeader(http.StatusOK)
 	}
 
-	return json.NewEncoder(w).Encode(i)
+    if (i) != nil {
+        return json.NewEncoder(w).Encode(i)
+    }
+
+    return nil
 }
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

## Summary
This PR fix the issue [13927](https://github.com/OpenAPITools/openapi-generator/issues/13927).
The changes affects directly to go-server generator (chi and mux). The ```routers.go``` mustache template has been modified including a new clause that checks if there is body, encode an include.

### Technical committees
* @antihax
* @grokify 
* @kemokemo 
* @jirikuncar 
* @ph4r5h4d
