### PR TITLE
[BUG][RUBY] Fix ruby faraday HTTP 0 issue without libcurl 

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -13,7 +13,7 @@
         end
 
         unless response.success?
-          if response.status == 0
+          if response.status == 0 && response.respond_to?(:return_message)
             # Errors from libcurl will be made visible here
             fail ApiError.new(code: 0,
                               message: response.return_message)

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -58,7 +58,7 @@ module Petstore
         end
 
         unless response.success?
-          if response.status == 0
+          if response.status == 0 && response.respond_to?(:return_message)
             # Errors from libcurl will be made visible here
             fail ApiError.new(code: 0,
                               message: response.return_message)


### PR DESCRIPTION
fix #13943

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ```
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cliffano, @zlx, @autopp