### PR TITLE
[swift5] less restrictive alamofire dependency resolution

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Cartfile.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Cartfile.mustache
@@ -1,4 +1,4 @@
-github "Flight-School/AnyCodable" ~> 0.6.1{{#useAlamofire}}
+github "Flight-School/AnyCodable" ~> 0.6{{#useAlamofire}}
 github "Alamofire/Alamofire" ~> 5.4{{/useAlamofire}}{{#usePromiseKit}}
-github "mxcl/PromiseKit" ~> 6.15.3{{/usePromiseKit}}{{#useRxSwift}}
-github "ReactiveX/RxSwift" ~> 6.2.0{{/useRxSwift}}
+github "mxcl/PromiseKit" ~> 6.15{{/usePromiseKit}}{{#useRxSwift}}
+github "ReactiveX/RxSwift" ~> 6.2{{/useRxSwift}}

--- a/modules/openapi-generator/src/main/resources/swift5/Cartfile.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Cartfile.mustache
@@ -1,4 +1,4 @@
 github "Flight-School/AnyCodable" ~> 0.6.1{{#useAlamofire}}
-github "Alamofire/Alamofire" ~> 5.4.3{{/useAlamofire}}{{#usePromiseKit}}
+github "Alamofire/Alamofire" ~> 5.4{{/useAlamofire}}{{#usePromiseKit}}
 github "mxcl/PromiseKit" ~> 6.15.3{{/usePromiseKit}}{{#useRxSwift}}
 github "ReactiveX/RxSwift" ~> 6.2.0{{/useRxSwift}}

--- a/modules/openapi-generator/src/main/resources/swift5/Package.swift.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Package.swift.mustache
@@ -33,7 +33,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
         {{#useAlamofire}}
-        .package(url: "https://github.com/Alamofire/Alamofire", from: "5.4.3"),
+        .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.4.3")),
         {{/useAlamofire}}
         {{#usePromiseKit}}
         .package(url: "https://github.com/mxcl/PromiseKit", from: "6.15.3"),

--- a/modules/openapi-generator/src/main/resources/swift5/Package.swift.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Package.swift.mustache
@@ -31,15 +31,15 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
         {{#useAlamofire}}
         .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.4.3")),
         {{/useAlamofire}}
         {{#usePromiseKit}}
-        .package(url: "https://github.com/mxcl/PromiseKit", from: "6.15.3"),
+        .package(url: "https://github.com/mxcl/PromiseKit", .upToNextMajor(from: "6.15.3")),
         {{/usePromiseKit}}
         {{#useRxSwift}}
-        .package(url: "https://github.com/ReactiveX/RxSwift", from: "6.2.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.2.0")),
         {{/useRxSwift}}
         {{#useVapor}}
         .package(url: "https://github.com/vapor/vapor", from: "4.0.0")

--- a/modules/openapi-generator/src/main/resources/swift5/Podspec.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Podspec.mustache
@@ -33,14 +33,14 @@ Pod::Spec.new do |s|
   s.documentation_url = '{{.}}'
   {{/podDocumentationURL}}
   s.source_files = '{{swiftPackagePath}}{{^swiftPackagePath}}{{#useSPMFileStructure}}Sources/{{projectName}}{{/useSPMFileStructure}}{{^useSPMFileStructure}}{{projectName}}/Classes{{/useSPMFileStructure}}{{/swiftPackagePath}}/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
   {{#useAlamofire}}
   s.dependency 'Alamofire', '~> 5.4'
   {{/useAlamofire}}
   {{#usePromiseKit}}
-  s.dependency 'PromiseKit/CorePromise', '~> 6.15.3'
+  s.dependency 'PromiseKit/CorePromise', '~> 6.15'
   {{/usePromiseKit}}
   {{#useRxSwift}}
-  s.dependency 'RxSwift', '~> 6.2.0'
+  s.dependency 'RxSwift', '~> 6.2'
   {{/useRxSwift}}
 end

--- a/modules/openapi-generator/src/main/resources/swift5/Podspec.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Podspec.mustache
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.source_files = '{{swiftPackagePath}}{{^swiftPackagePath}}{{#useSPMFileStructure}}Sources/{{projectName}}{{/useSPMFileStructure}}{{^useSPMFileStructure}}{{projectName}}/Classes{{/useSPMFileStructure}}{{/swiftPackagePath}}/**/*.swift'
   s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
   {{#useAlamofire}}
-  s.dependency 'Alamofire', '~> 5.4.3'
+  s.dependency 'Alamofire', '~> 5.4'
   {{/useAlamofire}}
   {{#usePromiseKit}}
   s.dependency 'PromiseKit/CorePromise', '~> 6.15.3'

--- a/samples/client/petstore/swift5/alamofireLibrary/Cartfile
+++ b/samples/client/petstore/swift5/alamofireLibrary/Cartfile
@@ -1,2 +1,2 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6
 github "Alamofire/Alamofire" ~> 5.4

--- a/samples/client/petstore/swift5/alamofireLibrary/Cartfile
+++ b/samples/client/petstore/swift5/alamofireLibrary/Cartfile
@@ -1,2 +1,2 @@
 github "Flight-School/AnyCodable" ~> 0.6.1
-github "Alamofire/Alamofire" ~> 5.4.3
+github "Alamofire/Alamofire" ~> 5.4

--- a/samples/client/petstore/swift5/alamofireLibrary/Package.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
         .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.4.3")),
     ],
     targets: [

--- a/samples/client/petstore/swift5/alamofireLibrary/Package.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
-        .package(url: "https://github.com/Alamofire/Alamofire", from: "5.4.3"),
+        .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.4.3")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
   s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
-  s.dependency 'Alamofire', '~> 5.4.3'
+  s.dependency 'Alamofire', '~> 5.4'
 end

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
   s.dependency 'Alamofire', '~> 5.4'
 end

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/Cartfile
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/Package.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/combineLibrary/Cartfile
+++ b/samples/client/petstore/swift5/combineLibrary/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/combineLibrary/Package.swift
+++ b/samples/client/petstore/swift5/combineLibrary/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/default/Cartfile
+++ b/samples/client/petstore/swift5/default/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/default/Package.swift
+++ b/samples/client/petstore/swift5/default/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/default/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/default/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/deprecated/Cartfile
+++ b/samples/client/petstore/swift5/deprecated/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/deprecated/Package.swift
+++ b/samples/client/petstore/swift5/deprecated/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/frozenEnums/Cartfile
+++ b/samples/client/petstore/swift5/frozenEnums/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/frozenEnums/Package.swift
+++ b/samples/client/petstore/swift5/frozenEnums/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/nonPublicApi/Cartfile
+++ b/samples/client/petstore/swift5/nonPublicApi/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/nonPublicApi/Package.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/objcCompatible/Cartfile
+++ b/samples/client/petstore/swift5/objcCompatible/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/objcCompatible/Package.swift
+++ b/samples/client/petstore/swift5/objcCompatible/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/oneOf/Cartfile
+++ b/samples/client/petstore/swift5/oneOf/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/oneOf/Package.swift
+++ b/samples/client/petstore/swift5/oneOf/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/promisekitLibrary/Cartfile
+++ b/samples/client/petstore/swift5/promisekitLibrary/Cartfile
@@ -1,2 +1,2 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
-github "mxcl/PromiseKit" ~> 6.15.3
+github "Flight-School/AnyCodable" ~> 0.6
+github "mxcl/PromiseKit" ~> 6.15

--- a/samples/client/petstore/swift5/promisekitLibrary/Package.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
-        .package(url: "https://github.com/mxcl/PromiseKit", from: "6.15.3"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
+        .package(url: "https://github.com/mxcl/PromiseKit", .upToNextMajor(from: "6.15.3")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
-  s.dependency 'PromiseKit/CorePromise', '~> 6.15.3'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
+  s.dependency 'PromiseKit/CorePromise', '~> 6.15'
 end

--- a/samples/client/petstore/swift5/readonlyProperties/Cartfile
+++ b/samples/client/petstore/swift5/readonlyProperties/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/readonlyProperties/Package.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/resultLibrary/Cartfile
+++ b/samples/client/petstore/swift5/resultLibrary/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/resultLibrary/Package.swift
+++ b/samples/client/petstore/swift5/resultLibrary/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/rxswiftLibrary/Cartfile
+++ b/samples/client/petstore/swift5/rxswiftLibrary/Cartfile
@@ -1,2 +1,2 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
-github "ReactiveX/RxSwift" ~> 6.2.0
+github "Flight-School/AnyCodable" ~> 0.6
+github "ReactiveX/RxSwift" ~> 6.2

--- a/samples/client/petstore/swift5/rxswiftLibrary/Package.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
-        .package(url: "https://github.com/ReactiveX/RxSwift", from: "6.2.0"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
+        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.2.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
-  s.dependency 'RxSwift', '~> 6.2.0'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
+  s.dependency 'RxSwift', '~> 6.2'
 end

--- a/samples/client/petstore/swift5/urlsessionLibrary/Cartfile
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/urlsessionLibrary/Package.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/urlsessionLibrary/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'Sources/PetstoreClient/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end

--- a/samples/client/petstore/swift5/vaporLibrary/Package.swift
+++ b/samples/client/petstore/swift5/vaporLibrary/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
         .package(url: "https://github.com/vapor/vapor", from: "4.0.0")
     ],
     targets: [

--- a/samples/client/petstore/swift5/x-swift-hashable/Cartfile
+++ b/samples/client/petstore/swift5/x-swift-hashable/Cartfile
@@ -1,1 +1,1 @@
-github "Flight-School/AnyCodable" ~> 0.6.1
+github "Flight-School/AnyCodable" ~> 0.6

--- a/samples/client/petstore/swift5/x-swift-hashable/Package.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient.podspec
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'PetstoreClient/Classes/**/*.swift'
-  s.dependency 'AnyCodable-FlightSchool', '~> 0.6.1'
+  s.dependency 'AnyCodable-FlightSchool', '~> 0.6'
 end


### PR DESCRIPTION
Follow up from discussion here: https://github.com/OpenAPITools/openapi-generator/pull/13667#discussion_r992466220
Currently we only allow dependency resolution to resolve Alamofire `5.4.3` and possible future patch versions of `5.4`.  Since Alamofire is using semver we can safely optimistically resolve to next major version instead without the danger of breaking API changes. Consuming projects can still opt-in whether to use an older version, currently they are forced to use the old 5.4.* versions.

This PR optimistically pins Alamofire to next major version allowing cocoapods / SPM to resolve everything from version 5.4 until **and not including** version 6. 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. -> @jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)

### Declaration
The program was tested solely for our own use cases, which might differ from yours.

### Link to provider information
https://github.com/mercedes-benz