### PR TITLE
[#13998][Bug][PHP] Move isNullable section to the top of the setter function in templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -404,7 +404,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
             throw new \InvalidArgumentException('non-nullable {{name}} cannot be null');
         }
         {{/isNullable}}
-
         {{#isEnum}}
         $allowedValues = $this->{{getter}}AllowableValues();
         {{^isContainer}}
@@ -464,7 +463,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         }
         {{/minItems}}
         {{/hasValidation}}
-
         $this->container['{{name}}'] = ${{name}};
 
         return $this;

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -387,66 +387,6 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      */
     public function {{setter}}(${{name}})
     {
-        {{#isEnum}}
-        $allowedValues = $this->{{getter}}AllowableValues();
-        {{^isContainer}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}!in_array(${{{name}}}, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value '%s' for '{{name}}', must be one of '%s'",
-                    ${{{name}}},
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
-        {{/isContainer}}
-        {{#isContainer}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}array_diff(${{{name}}}, $allowedValues)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid value for '{{name}}', must be one of '%s'",
-                    implode("', '", $allowedValues)
-                )
-            );
-        }
-        {{/isContainer}}
-        {{/isEnum}}
-        {{#hasValidation}}
-        {{#maxLength}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(mb_strlen(${{name}}) > {{maxLength}})) {
-            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
-        }{{/maxLength}}
-        {{#minLength}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(mb_strlen(${{name}}) < {{minLength}})) {
-            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
-        }
-        {{/minLength}}
-        {{#maximum}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(${{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
-            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');
-        }
-        {{/maximum}}
-        {{#minimum}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(${{name}} <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}})) {
-            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.');
-        }
-        {{/minimum}}
-        {{#pattern}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(!preg_match("{{{pattern}}}", ${{name}}))) {
-            throw new \InvalidArgumentException("invalid value for \${{name}} when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.");
-        }
-        {{/pattern}}
-        {{#maxItems}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(count(${{name}}) > {{maxItems}})) {
-            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{maxItems}}.');
-        }{{/maxItems}}
-        {{#minItems}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(count(${{name}}) < {{minItems}})) {
-            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
-        }
-        {{/minItems}}
-        {{/hasValidation}}
-
         {{#isNullable}}
         if (is_null(${{name}})) {
             array_push($this->openAPINullablesSetToNull, '{{name}}');
@@ -464,6 +404,66 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
             throw new \InvalidArgumentException('non-nullable {{name}} cannot be null');
         }
         {{/isNullable}}
+
+        {{#isEnum}}
+        $allowedValues = $this->{{getter}}AllowableValues();
+        {{^isContainer}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}!in_array(${{{name}}}, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for '{{name}}', must be one of '%s'",
+                    ${{{name}}},
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        {{/isContainer}}
+        {{#isContainer}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}array_diff(${{{name}}}, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for '{{name}}', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        {{/isContainer}}
+        {{/isEnum}}
+        {{#hasValidation}}
+        {{#maxLength}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) > {{maxLength}})) {
+            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
+        }{{/maxLength}}
+        {{#minLength}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) < {{minLength}})) {
+            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
+        }
+        {{/minLength}}
+        {{#maximum}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
+            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');
+        }
+        {{/maximum}}
+        {{#minimum}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}})) {
+            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.');
+        }
+        {{/minimum}}
+        {{#pattern}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(!preg_match("{{{pattern}}}", ${{name}}))) {
+            throw new \InvalidArgumentException("invalid value for \${{name}} when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.");
+        }
+        {{/pattern}}
+        {{#maxItems}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(count(${{name}}) > {{maxItems}})) {
+            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{maxItems}}.');
+        }{{/maxItems}}
+        {{#minItems}}
+        if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(count(${{name}}) < {{minItems}})) {
+            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
+        }
+        {{/minItems}}
+        {{/hasValidation}}
 
         $this->container['{{name}}'] = ${{name}};
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -318,8 +318,6 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
         if (is_null($map_property)) {
             throw new \InvalidArgumentException('non-nullable map_property cannot be null');
         }
-
-
         $this->container['map_property'] = $map_property;
 
         return $this;
@@ -347,8 +345,6 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
         if (is_null($map_of_map_property)) {
             throw new \InvalidArgumentException('non-nullable map_of_map_property cannot be null');
         }
-
-
         $this->container['map_of_map_property'] = $map_of_map_property;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -315,10 +315,10 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      */
     public function setMapProperty($map_property)
     {
-
         if (is_null($map_property)) {
             throw new \InvalidArgumentException('non-nullable map_property cannot be null');
         }
+
 
         $this->container['map_property'] = $map_property;
 
@@ -344,10 +344,10 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      */
     public function setMapOfMapProperty($map_of_map_property)
     {
-
         if (is_null($map_of_map_property)) {
             throw new \InvalidArgumentException('non-nullable map_of_map_property cannot be null');
         }
+
 
         $this->container['map_of_map_property'] = $map_of_map_property;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
@@ -315,10 +315,10 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     public function setUsername($username)
     {
-
         if (is_null($username)) {
             throw new \InvalidArgumentException('non-nullable username cannot be null');
         }
+
 
         $this->container['username'] = $username;
 
@@ -344,10 +344,10 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      */
     public function setSingleRefType($single_ref_type)
     {
-
         if (is_null($single_ref_type)) {
             throw new \InvalidArgumentException('non-nullable single_ref_type cannot be null');
         }
+
 
         $this->container['single_ref_type'] = $single_ref_type;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
@@ -318,8 +318,6 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
         if (is_null($username)) {
             throw new \InvalidArgumentException('non-nullable username cannot be null');
         }
-
-
         $this->container['username'] = $username;
 
         return $this;
@@ -347,8 +345,6 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
         if (is_null($single_ref_type)) {
             throw new \InvalidArgumentException('non-nullable single_ref_type cannot be null');
         }
-
-
         $this->container['single_ref_type'] = $single_ref_type;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -321,10 +321,10 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClassName($class_name)
     {
-
         if (is_null($class_name)) {
             throw new \InvalidArgumentException('non-nullable class_name cannot be null');
         }
+
 
         $this->container['class_name'] = $class_name;
 
@@ -350,10 +350,10 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setColor($color)
     {
-
         if (is_null($color)) {
             throw new \InvalidArgumentException('non-nullable color cannot be null');
         }
+
 
         $this->container['color'] = $color;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -324,8 +324,6 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($class_name)) {
             throw new \InvalidArgumentException('non-nullable class_name cannot be null');
         }
-
-
         $this->container['class_name'] = $class_name;
 
         return $this;
@@ -353,8 +351,6 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($color)) {
             throw new \InvalidArgumentException('non-nullable color cannot be null');
         }
-
-
         $this->container['color'] = $color;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -325,8 +325,6 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($code)) {
             throw new \InvalidArgumentException('non-nullable code cannot be null');
         }
-
-
         $this->container['code'] = $code;
 
         return $this;
@@ -354,8 +352,6 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($type)) {
             throw new \InvalidArgumentException('non-nullable type cannot be null');
         }
-
-
         $this->container['type'] = $type;
 
         return $this;
@@ -383,8 +379,6 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($message)) {
             throw new \InvalidArgumentException('non-nullable message cannot be null');
         }
-
-
         $this->container['message'] = $message;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -322,10 +322,10 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCode($code)
     {
-
         if (is_null($code)) {
             throw new \InvalidArgumentException('non-nullable code cannot be null');
         }
+
 
         $this->container['code'] = $code;
 
@@ -351,10 +351,10 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setType($type)
     {
-
         if (is_null($type)) {
             throw new \InvalidArgumentException('non-nullable type cannot be null');
         }
+
 
         $this->container['type'] = $type;
 
@@ -380,10 +380,10 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMessage($message)
     {
-
         if (is_null($message)) {
             throw new \InvalidArgumentException('non-nullable message cannot be null');
         }
+
 
         $this->container['message'] = $message;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -308,10 +308,10 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      */
     public function setArrayArrayNumber($array_array_number)
     {
-
         if (is_null($array_array_number)) {
             throw new \InvalidArgumentException('non-nullable array_array_number cannot be null');
         }
+
 
         $this->container['array_array_number'] = $array_array_number;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -311,8 +311,6 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
         if (is_null($array_array_number)) {
             throw new \InvalidArgumentException('non-nullable array_array_number cannot be null');
         }
-
-
         $this->container['array_array_number'] = $array_array_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -311,8 +311,6 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
         if (is_null($array_number)) {
             throw new \InvalidArgumentException('non-nullable array_number cannot be null');
         }
-
-
         $this->container['array_number'] = $array_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -308,10 +308,10 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      */
     public function setArrayNumber($array_number)
     {
-
         if (is_null($array_number)) {
             throw new \InvalidArgumentException('non-nullable array_number cannot be null');
         }
+
 
         $this->container['array_number'] = $array_number;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -330,16 +330,16 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayOfString($array_of_string)
     {
-
-        if (!is_null($array_of_string) && (count($array_of_string) > 3)) {
-            throw new \InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
-        }
-        if (!is_null($array_of_string) && (count($array_of_string) < 0)) {
-            throw new \InvalidArgumentException('invalid length for $array_of_string when calling ArrayTest., number of items must be greater than or equal to 0.');
-        }
-
         if (is_null($array_of_string)) {
             throw new \InvalidArgumentException('non-nullable array_of_string cannot be null');
+        }
+
+
+        if ((count($array_of_string) > 3)) {
+            throw new \InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
+        }
+        if ((count($array_of_string) < 0)) {
+            throw new \InvalidArgumentException('invalid length for $array_of_string when calling ArrayTest., number of items must be greater than or equal to 0.');
         }
 
         $this->container['array_of_string'] = $array_of_string;
@@ -366,10 +366,10 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayArrayOfInteger($array_array_of_integer)
     {
-
         if (is_null($array_array_of_integer)) {
             throw new \InvalidArgumentException('non-nullable array_array_of_integer cannot be null');
         }
+
 
         $this->container['array_array_of_integer'] = $array_array_of_integer;
 
@@ -395,10 +395,10 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayArrayOfModel($array_array_of_model)
     {
-
         if (is_null($array_array_of_model)) {
             throw new \InvalidArgumentException('non-nullable array_array_of_model cannot be null');
         }
+
 
         $this->container['array_array_of_model'] = $array_array_of_model;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -334,14 +334,12 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable array_of_string cannot be null');
         }
 
-
         if ((count($array_of_string) > 3)) {
             throw new \InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
         }
         if ((count($array_of_string) < 0)) {
             throw new \InvalidArgumentException('invalid length for $array_of_string when calling ArrayTest., number of items must be greater than or equal to 0.');
         }
-
         $this->container['array_of_string'] = $array_of_string;
 
         return $this;
@@ -369,8 +367,6 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($array_array_of_integer)) {
             throw new \InvalidArgumentException('non-nullable array_array_of_integer cannot be null');
         }
-
-
         $this->container['array_array_of_integer'] = $array_array_of_integer;
 
         return $this;
@@ -398,8 +394,6 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($array_array_of_model)) {
             throw new \InvalidArgumentException('non-nullable array_array_of_model cannot be null');
         }
-
-
         $this->container['array_array_of_model'] = $array_array_of_model;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -346,8 +346,6 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($small_camel)) {
             throw new \InvalidArgumentException('non-nullable small_camel cannot be null');
         }
-
-
         $this->container['small_camel'] = $small_camel;
 
         return $this;
@@ -375,8 +373,6 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($capital_camel)) {
             throw new \InvalidArgumentException('non-nullable capital_camel cannot be null');
         }
-
-
         $this->container['capital_camel'] = $capital_camel;
 
         return $this;
@@ -404,8 +400,6 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($small_snake)) {
             throw new \InvalidArgumentException('non-nullable small_snake cannot be null');
         }
-
-
         $this->container['small_snake'] = $small_snake;
 
         return $this;
@@ -433,8 +427,6 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($capital_snake)) {
             throw new \InvalidArgumentException('non-nullable capital_snake cannot be null');
         }
-
-
         $this->container['capital_snake'] = $capital_snake;
 
         return $this;
@@ -462,8 +454,6 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($sca_eth_flow_points)) {
             throw new \InvalidArgumentException('non-nullable sca_eth_flow_points cannot be null');
         }
-
-
         $this->container['sca_eth_flow_points'] = $sca_eth_flow_points;
 
         return $this;
@@ -491,8 +481,6 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($att_name)) {
             throw new \InvalidArgumentException('non-nullable att_name cannot be null');
         }
-
-
         $this->container['att_name'] = $att_name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -343,10 +343,10 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSmallCamel($small_camel)
     {
-
         if (is_null($small_camel)) {
             throw new \InvalidArgumentException('non-nullable small_camel cannot be null');
         }
+
 
         $this->container['small_camel'] = $small_camel;
 
@@ -372,10 +372,10 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCapitalCamel($capital_camel)
     {
-
         if (is_null($capital_camel)) {
             throw new \InvalidArgumentException('non-nullable capital_camel cannot be null');
         }
+
 
         $this->container['capital_camel'] = $capital_camel;
 
@@ -401,10 +401,10 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSmallSnake($small_snake)
     {
-
         if (is_null($small_snake)) {
             throw new \InvalidArgumentException('non-nullable small_snake cannot be null');
         }
+
 
         $this->container['small_snake'] = $small_snake;
 
@@ -430,10 +430,10 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCapitalSnake($capital_snake)
     {
-
         if (is_null($capital_snake)) {
             throw new \InvalidArgumentException('non-nullable capital_snake cannot be null');
         }
+
 
         $this->container['capital_snake'] = $capital_snake;
 
@@ -459,10 +459,10 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setScaEthFlowPoints($sca_eth_flow_points)
     {
-
         if (is_null($sca_eth_flow_points)) {
             throw new \InvalidArgumentException('non-nullable sca_eth_flow_points cannot be null');
         }
+
 
         $this->container['sca_eth_flow_points'] = $sca_eth_flow_points;
 
@@ -488,10 +488,10 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setAttName($att_name)
     {
-
         if (is_null($att_name)) {
             throw new \InvalidArgumentException('non-nullable att_name cannot be null');
         }
+
 
         $this->container['att_name'] = $att_name;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -302,10 +302,10 @@ class Cat extends Animal
      */
     public function setDeclawed($declawed)
     {
-
         if (is_null($declawed)) {
             throw new \InvalidArgumentException('non-nullable declawed cannot be null');
         }
+
 
         $this->container['declawed'] = $declawed;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -305,8 +305,6 @@ class Cat extends Animal
         if (is_null($declawed)) {
             throw new \InvalidArgumentException('non-nullable declawed cannot be null');
         }
-
-
         $this->container['declawed'] = $declawed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -308,10 +308,10 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDeclawed($declawed)
     {
-
         if (is_null($declawed)) {
             throw new \InvalidArgumentException('non-nullable declawed cannot be null');
         }
+
 
         $this->container['declawed'] = $declawed;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -311,8 +311,6 @@ class CatAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($declawed)) {
             throw new \InvalidArgumentException('non-nullable declawed cannot be null');
         }
-
-
         $this->container['declawed'] = $declawed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -321,8 +321,6 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
-
-
         $this->container['id'] = $id;
 
         return $this;
@@ -350,8 +348,6 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
-
-
         $this->container['name'] = $name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -318,10 +318,10 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
-
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
+
 
         $this->container['id'] = $id;
 
@@ -347,10 +347,10 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
+
 
         $this->container['name'] = $name;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -309,10 +309,10 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClass($_class)
     {
-
         if (is_null($_class)) {
             throw new \InvalidArgumentException('non-nullable _class cannot be null');
         }
+
 
         $this->container['_class'] = $_class;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -312,8 +312,6 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($_class)) {
             throw new \InvalidArgumentException('non-nullable _class cannot be null');
         }
-
-
         $this->container['_class'] = $_class;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -308,10 +308,10 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClient($client)
     {
-
         if (is_null($client)) {
             throw new \InvalidArgumentException('non-nullable client cannot be null');
         }
+
 
         $this->container['client'] = $client;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -311,8 +311,6 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($client)) {
             throw new \InvalidArgumentException('non-nullable client cannot be null');
         }
-
-
         $this->container['client'] = $client;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
@@ -308,10 +308,10 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
+
 
         $this->container['name'] = $name;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DeprecatedObject.php
@@ -311,8 +311,6 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
-
-
         $this->container['name'] = $name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -305,8 +305,6 @@ class Dog extends Animal
         if (is_null($breed)) {
             throw new \InvalidArgumentException('non-nullable breed cannot be null');
         }
-
-
         $this->container['breed'] = $breed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -302,10 +302,10 @@ class Dog extends Animal
      */
     public function setBreed($breed)
     {
-
         if (is_null($breed)) {
             throw new \InvalidArgumentException('non-nullable breed cannot be null');
         }
+
 
         $this->container['breed'] = $breed;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -308,10 +308,10 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBreed($breed)
     {
-
         if (is_null($breed)) {
             throw new \InvalidArgumentException('non-nullable breed cannot be null');
         }
+
 
         $this->container['breed'] = $breed;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -311,8 +311,6 @@ class DogAllOf implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($breed)) {
             throw new \InvalidArgumentException('non-nullable breed cannot be null');
         }
-
-
         $this->container['breed'] = $breed;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -354,8 +354,12 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setJustSymbol($just_symbol)
     {
+        if (is_null($just_symbol)) {
+            throw new \InvalidArgumentException('non-nullable just_symbol cannot be null');
+        }
+
         $allowedValues = $this->getJustSymbolAllowableValues();
-        if (!is_null($just_symbol) && !in_array($just_symbol, $allowedValues, true)) {
+        if (!in_array($just_symbol, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'just_symbol', must be one of '%s'",
@@ -363,10 +367,6 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($just_symbol)) {
-            throw new \InvalidArgumentException('non-nullable just_symbol cannot be null');
         }
 
         $this->container['just_symbol'] = $just_symbol;
@@ -393,18 +393,18 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayEnum($array_enum)
     {
+        if (is_null($array_enum)) {
+            throw new \InvalidArgumentException('non-nullable array_enum cannot be null');
+        }
+
         $allowedValues = $this->getArrayEnumAllowableValues();
-        if (!is_null($array_enum) && array_diff($array_enum, $allowedValues)) {
+        if (array_diff($array_enum, $allowedValues)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value for 'array_enum', must be one of '%s'",
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($array_enum)) {
-            throw new \InvalidArgumentException('non-nullable array_enum cannot be null');
         }
 
         $this->container['array_enum'] = $array_enum;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -357,7 +357,6 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($just_symbol)) {
             throw new \InvalidArgumentException('non-nullable just_symbol cannot be null');
         }
-
         $allowedValues = $this->getJustSymbolAllowableValues();
         if (!in_array($just_symbol, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -368,7 +367,6 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['just_symbol'] = $just_symbol;
 
         return $this;
@@ -396,7 +394,6 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($array_enum)) {
             throw new \InvalidArgumentException('non-nullable array_enum cannot be null');
         }
-
         $allowedValues = $this->getArrayEnumAllowableValues();
         if (array_diff($array_enum, $allowedValues)) {
             throw new \InvalidArgumentException(
@@ -406,7 +403,6 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['array_enum'] = $array_enum;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -463,7 +463,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($enum_string)) {
             throw new \InvalidArgumentException('non-nullable enum_string cannot be null');
         }
-
         $allowedValues = $this->getEnumStringAllowableValues();
         if (!in_array($enum_string, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -474,7 +473,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['enum_string'] = $enum_string;
 
         return $this;
@@ -502,7 +500,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($enum_string_required)) {
             throw new \InvalidArgumentException('non-nullable enum_string_required cannot be null');
         }
-
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
         if (!in_array($enum_string_required, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -513,7 +510,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['enum_string_required'] = $enum_string_required;
 
         return $this;
@@ -541,7 +537,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($enum_integer)) {
             throw new \InvalidArgumentException('non-nullable enum_integer cannot be null');
         }
-
         $allowedValues = $this->getEnumIntegerAllowableValues();
         if (!in_array($enum_integer, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -552,7 +547,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['enum_integer'] = $enum_integer;
 
         return $this;
@@ -580,7 +574,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($enum_number)) {
             throw new \InvalidArgumentException('non-nullable enum_number cannot be null');
         }
-
         $allowedValues = $this->getEnumNumberAllowableValues();
         if (!in_array($enum_number, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -591,7 +584,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['enum_number'] = $enum_number;
 
         return $this;
@@ -626,8 +618,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['outer_enum'] = $outer_enum;
 
         return $this;
@@ -655,8 +645,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($outer_enum_integer)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_integer cannot be null');
         }
-
-
         $this->container['outer_enum_integer'] = $outer_enum_integer;
 
         return $this;
@@ -684,8 +672,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($outer_enum_default_value)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_default_value cannot be null');
         }
-
-
         $this->container['outer_enum_default_value'] = $outer_enum_default_value;
 
         return $this;
@@ -713,8 +699,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($outer_enum_integer_default_value)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_integer_default_value cannot be null');
         }
-
-
         $this->container['outer_enum_integer_default_value'] = $outer_enum_integer_default_value;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -460,8 +460,12 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setEnumString($enum_string)
     {
+        if (is_null($enum_string)) {
+            throw new \InvalidArgumentException('non-nullable enum_string cannot be null');
+        }
+
         $allowedValues = $this->getEnumStringAllowableValues();
-        if (!is_null($enum_string) && !in_array($enum_string, $allowedValues, true)) {
+        if (!in_array($enum_string, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'enum_string', must be one of '%s'",
@@ -469,10 +473,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($enum_string)) {
-            throw new \InvalidArgumentException('non-nullable enum_string cannot be null');
         }
 
         $this->container['enum_string'] = $enum_string;
@@ -499,6 +499,10 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setEnumStringRequired($enum_string_required)
     {
+        if (is_null($enum_string_required)) {
+            throw new \InvalidArgumentException('non-nullable enum_string_required cannot be null');
+        }
+
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
         if (!in_array($enum_string_required, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -508,10 +512,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($enum_string_required)) {
-            throw new \InvalidArgumentException('non-nullable enum_string_required cannot be null');
         }
 
         $this->container['enum_string_required'] = $enum_string_required;
@@ -538,8 +538,12 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setEnumInteger($enum_integer)
     {
+        if (is_null($enum_integer)) {
+            throw new \InvalidArgumentException('non-nullable enum_integer cannot be null');
+        }
+
         $allowedValues = $this->getEnumIntegerAllowableValues();
-        if (!is_null($enum_integer) && !in_array($enum_integer, $allowedValues, true)) {
+        if (!in_array($enum_integer, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'enum_integer', must be one of '%s'",
@@ -547,10 +551,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($enum_integer)) {
-            throw new \InvalidArgumentException('non-nullable enum_integer cannot be null');
         }
 
         $this->container['enum_integer'] = $enum_integer;
@@ -577,8 +577,12 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setEnumNumber($enum_number)
     {
+        if (is_null($enum_number)) {
+            throw new \InvalidArgumentException('non-nullable enum_number cannot be null');
+        }
+
         $allowedValues = $this->getEnumNumberAllowableValues();
-        if (!is_null($enum_number) && !in_array($enum_number, $allowedValues, true)) {
+        if (!in_array($enum_number, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'enum_number', must be one of '%s'",
@@ -586,10 +590,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($enum_number)) {
-            throw new \InvalidArgumentException('non-nullable enum_number cannot be null');
         }
 
         $this->container['enum_number'] = $enum_number;
@@ -616,7 +616,6 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnum($outer_enum)
     {
-
         if (is_null($outer_enum)) {
             array_push($this->openAPINullablesSetToNull, 'outer_enum');
         } else {
@@ -627,6 +626,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['outer_enum'] = $outer_enum;
 
@@ -652,10 +652,10 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnumInteger($outer_enum_integer)
     {
-
         if (is_null($outer_enum_integer)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_integer cannot be null');
         }
+
 
         $this->container['outer_enum_integer'] = $outer_enum_integer;
 
@@ -681,10 +681,10 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnumDefaultValue($outer_enum_default_value)
     {
-
         if (is_null($outer_enum_default_value)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_default_value cannot be null');
         }
+
 
         $this->container['outer_enum_default_value'] = $outer_enum_default_value;
 
@@ -710,10 +710,10 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setOuterEnumIntegerDefaultValue($outer_enum_integer_default_value)
     {
-
         if (is_null($outer_enum_integer_default_value)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_integer_default_value cannot be null');
         }
+
 
         $this->container['outer_enum_integer_default_value'] = $outer_enum_integer_default_value;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -309,10 +309,10 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSourceUri($source_uri)
     {
-
         if (is_null($source_uri)) {
             throw new \InvalidArgumentException('non-nullable source_uri cannot be null');
         }
+
 
         $this->container['source_uri'] = $source_uri;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -312,8 +312,6 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($source_uri)) {
             throw new \InvalidArgumentException('non-nullable source_uri cannot be null');
         }
-
-
         $this->container['source_uri'] = $source_uri;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -318,8 +318,6 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
         if (is_null($file)) {
             throw new \InvalidArgumentException('non-nullable file cannot be null');
         }
-
-
         $this->container['file'] = $file;
 
         return $this;
@@ -347,8 +345,6 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
         if (is_null($files)) {
             throw new \InvalidArgumentException('non-nullable files cannot be null');
         }
-
-
         $this->container['files'] = $files;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -315,10 +315,10 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      */
     public function setFile($file)
     {
-
         if (is_null($file)) {
             throw new \InvalidArgumentException('non-nullable file cannot be null');
         }
+
 
         $this->container['file'] = $file;
 
@@ -344,10 +344,10 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      */
     public function setFiles($files)
     {
-
         if (is_null($files)) {
             throw new \InvalidArgumentException('non-nullable files cannot be null');
         }
+
 
         $this->container['files'] = $files;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -308,10 +308,10 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBar($bar)
     {
-
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
         }
+
 
         $this->container['bar'] = $bar;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -311,8 +311,6 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
         }
-
-
         $this->container['bar'] = $bar;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
@@ -311,8 +311,6 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
         if (is_null($string)) {
             throw new \InvalidArgumentException('non-nullable string cannot be null');
         }
-
-
         $this->container['string'] = $string;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FooGetDefaultResponse.php
@@ -308,10 +308,10 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      */
     public function setString($string)
     {
-
         if (is_null($string)) {
             throw new \InvalidArgumentException('non-nullable string cannot be null');
         }
+
 
         $this->container['string'] = $string;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -489,14 +489,12 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable integer cannot be null');
         }
 
-
         if (($integer > 100)) {
             throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
         }
         if (($integer < 10)) {
             throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be bigger than or equal to 10.');
         }
-
 
         $this->container['integer'] = $integer;
 
@@ -526,14 +524,12 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable int32 cannot be null');
         }
 
-
         if (($int32 > 200)) {
             throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
         }
         if (($int32 < 20)) {
             throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be bigger than or equal to 20.');
         }
-
 
         $this->container['int32'] = $int32;
 
@@ -562,8 +558,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($int64)) {
             throw new \InvalidArgumentException('non-nullable int64 cannot be null');
         }
-
-
         $this->container['int64'] = $int64;
 
         return $this;
@@ -592,14 +586,12 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable number cannot be null');
         }
 
-
         if (($number > 543.2)) {
             throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be smaller than or equal to 543.2.');
         }
         if (($number < 32.1)) {
             throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be bigger than or equal to 32.1.');
         }
-
 
         $this->container['number'] = $number;
 
@@ -629,14 +621,12 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable float cannot be null');
         }
 
-
         if (($float > 987.6)) {
             throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
         }
         if (($float < 54.3)) {
             throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be bigger than or equal to 54.3.');
         }
-
 
         $this->container['float'] = $float;
 
@@ -666,14 +656,12 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable double cannot be null');
         }
 
-
         if (($double > 123.4)) {
             throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
         }
         if (($double < 67.8)) {
             throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be bigger than or equal to 67.8.');
         }
-
 
         $this->container['double'] = $double;
 
@@ -702,8 +690,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($decimal)) {
             throw new \InvalidArgumentException('non-nullable decimal cannot be null');
         }
-
-
         $this->container['decimal'] = $decimal;
 
         return $this;
@@ -732,11 +718,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable string cannot be null');
         }
 
-
         if ((!preg_match("/[a-z]/i", $string))) {
             throw new \InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
         }
-
 
         $this->container['string'] = $string;
 
@@ -765,8 +749,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($byte)) {
             throw new \InvalidArgumentException('non-nullable byte cannot be null');
         }
-
-
         $this->container['byte'] = $byte;
 
         return $this;
@@ -794,8 +776,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($binary)) {
             throw new \InvalidArgumentException('non-nullable binary cannot be null');
         }
-
-
         $this->container['binary'] = $binary;
 
         return $this;
@@ -823,8 +803,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($date)) {
             throw new \InvalidArgumentException('non-nullable date cannot be null');
         }
-
-
         $this->container['date'] = $date;
 
         return $this;
@@ -852,8 +830,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($date_time)) {
             throw new \InvalidArgumentException('non-nullable date_time cannot be null');
         }
-
-
         $this->container['date_time'] = $date_time;
 
         return $this;
@@ -881,8 +857,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
         }
-
-
         $this->container['uuid'] = $uuid;
 
         return $this;
@@ -910,14 +884,12 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($password)) {
             throw new \InvalidArgumentException('non-nullable password cannot be null');
         }
-
         if ((mb_strlen($password) > 64)) {
             throw new \InvalidArgumentException('invalid length for $password when calling FormatTest., must be smaller than or equal to 64.');
         }
         if ((mb_strlen($password) < 10)) {
             throw new \InvalidArgumentException('invalid length for $password when calling FormatTest., must be bigger than or equal to 10.');
         }
-
 
         $this->container['password'] = $password;
 
@@ -947,11 +919,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
         }
 
-
         if ((!preg_match("/^\\d{10}$/", $pattern_with_digits))) {
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
         }
-
 
         $this->container['pattern_with_digits'] = $pattern_with_digits;
 
@@ -981,11 +951,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
         }
 
-
         if ((!preg_match("/^image_\\d{1,3}$/i", $pattern_with_digits_and_delimiter))) {
             throw new \InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
         }
-
 
         $this->container['pattern_with_digits_and_delimiter'] = $pattern_with_digits_and_delimiter;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -485,18 +485,18 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setInteger($integer)
     {
-
-        if (!is_null($integer) && ($integer > 100)) {
-            throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
-        }
-        if (!is_null($integer) && ($integer < 10)) {
-            throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be bigger than or equal to 10.');
-        }
-
-
         if (is_null($integer)) {
             throw new \InvalidArgumentException('non-nullable integer cannot be null');
         }
+
+
+        if (($integer > 100)) {
+            throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
+        }
+        if (($integer < 10)) {
+            throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be bigger than or equal to 10.');
+        }
+
 
         $this->container['integer'] = $integer;
 
@@ -522,18 +522,18 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setInt32($int32)
     {
-
-        if (!is_null($int32) && ($int32 > 200)) {
-            throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
-        }
-        if (!is_null($int32) && ($int32 < 20)) {
-            throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be bigger than or equal to 20.');
-        }
-
-
         if (is_null($int32)) {
             throw new \InvalidArgumentException('non-nullable int32 cannot be null');
         }
+
+
+        if (($int32 > 200)) {
+            throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
+        }
+        if (($int32 < 20)) {
+            throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be bigger than or equal to 20.');
+        }
+
 
         $this->container['int32'] = $int32;
 
@@ -559,10 +559,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setInt64($int64)
     {
-
         if (is_null($int64)) {
             throw new \InvalidArgumentException('non-nullable int64 cannot be null');
         }
+
 
         $this->container['int64'] = $int64;
 
@@ -588,6 +588,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setNumber($number)
     {
+        if (is_null($number)) {
+            throw new \InvalidArgumentException('non-nullable number cannot be null');
+        }
+
 
         if (($number > 543.2)) {
             throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be smaller than or equal to 543.2.');
@@ -596,10 +600,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be bigger than or equal to 32.1.');
         }
 
-
-        if (is_null($number)) {
-            throw new \InvalidArgumentException('non-nullable number cannot be null');
-        }
 
         $this->container['number'] = $number;
 
@@ -625,18 +625,18 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setFloat($float)
     {
-
-        if (!is_null($float) && ($float > 987.6)) {
-            throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
-        }
-        if (!is_null($float) && ($float < 54.3)) {
-            throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be bigger than or equal to 54.3.');
-        }
-
-
         if (is_null($float)) {
             throw new \InvalidArgumentException('non-nullable float cannot be null');
         }
+
+
+        if (($float > 987.6)) {
+            throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
+        }
+        if (($float < 54.3)) {
+            throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be bigger than or equal to 54.3.');
+        }
+
 
         $this->container['float'] = $float;
 
@@ -662,18 +662,18 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDouble($double)
     {
-
-        if (!is_null($double) && ($double > 123.4)) {
-            throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
-        }
-        if (!is_null($double) && ($double < 67.8)) {
-            throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be bigger than or equal to 67.8.');
-        }
-
-
         if (is_null($double)) {
             throw new \InvalidArgumentException('non-nullable double cannot be null');
         }
+
+
+        if (($double > 123.4)) {
+            throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
+        }
+        if (($double < 67.8)) {
+            throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be bigger than or equal to 67.8.');
+        }
+
 
         $this->container['double'] = $double;
 
@@ -699,10 +699,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDecimal($decimal)
     {
-
         if (is_null($decimal)) {
             throw new \InvalidArgumentException('non-nullable decimal cannot be null');
         }
+
 
         $this->container['decimal'] = $decimal;
 
@@ -728,15 +728,15 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setString($string)
     {
-
-        if (!is_null($string) && (!preg_match("/[a-z]/i", $string))) {
-            throw new \InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
-        }
-
-
         if (is_null($string)) {
             throw new \InvalidArgumentException('non-nullable string cannot be null');
         }
+
+
+        if ((!preg_match("/[a-z]/i", $string))) {
+            throw new \InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
+        }
+
 
         $this->container['string'] = $string;
 
@@ -762,10 +762,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setByte($byte)
     {
-
         if (is_null($byte)) {
             throw new \InvalidArgumentException('non-nullable byte cannot be null');
         }
+
 
         $this->container['byte'] = $byte;
 
@@ -791,10 +791,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBinary($binary)
     {
-
         if (is_null($binary)) {
             throw new \InvalidArgumentException('non-nullable binary cannot be null');
         }
+
 
         $this->container['binary'] = $binary;
 
@@ -820,10 +820,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDate($date)
     {
-
         if (is_null($date)) {
             throw new \InvalidArgumentException('non-nullable date cannot be null');
         }
+
 
         $this->container['date'] = $date;
 
@@ -849,10 +849,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDateTime($date_time)
     {
-
         if (is_null($date_time)) {
             throw new \InvalidArgumentException('non-nullable date_time cannot be null');
         }
+
 
         $this->container['date_time'] = $date_time;
 
@@ -878,10 +878,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setUuid($uuid)
     {
-
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
         }
+
 
         $this->container['uuid'] = $uuid;
 
@@ -907,6 +907,10 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPassword($password)
     {
+        if (is_null($password)) {
+            throw new \InvalidArgumentException('non-nullable password cannot be null');
+        }
+
         if ((mb_strlen($password) > 64)) {
             throw new \InvalidArgumentException('invalid length for $password when calling FormatTest., must be smaller than or equal to 64.');
         }
@@ -914,10 +918,6 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('invalid length for $password when calling FormatTest., must be bigger than or equal to 10.');
         }
 
-
-        if (is_null($password)) {
-            throw new \InvalidArgumentException('non-nullable password cannot be null');
-        }
 
         $this->container['password'] = $password;
 
@@ -943,15 +943,15 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPatternWithDigits($pattern_with_digits)
     {
-
-        if (!is_null($pattern_with_digits) && (!preg_match("/^\\d{10}$/", $pattern_with_digits))) {
-            throw new \InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
-        }
-
-
         if (is_null($pattern_with_digits)) {
             throw new \InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
         }
+
+
+        if ((!preg_match("/^\\d{10}$/", $pattern_with_digits))) {
+            throw new \InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
+        }
+
 
         $this->container['pattern_with_digits'] = $pattern_with_digits;
 
@@ -977,15 +977,15 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPatternWithDigitsAndDelimiter($pattern_with_digits_and_delimiter)
     {
-
-        if (!is_null($pattern_with_digits_and_delimiter) && (!preg_match("/^image_\\d{1,3}$/i", $pattern_with_digits_and_delimiter))) {
-            throw new \InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
-        }
-
-
         if (is_null($pattern_with_digits_and_delimiter)) {
             throw new \InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
         }
+
+
+        if ((!preg_match("/^image_\\d{1,3}$/i", $pattern_with_digits_and_delimiter))) {
+            throw new \InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
+        }
+
 
         $this->container['pattern_with_digits_and_delimiter'] = $pattern_with_digits_and_delimiter;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -318,8 +318,6 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
         }
-
-
         $this->container['bar'] = $bar;
 
         return $this;
@@ -347,8 +345,6 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($foo)) {
             throw new \InvalidArgumentException('non-nullable foo cannot be null');
         }
-
-
         $this->container['foo'] = $foo;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -315,10 +315,10 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBar($bar)
     {
-
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
         }
+
 
         $this->container['bar'] = $bar;
 
@@ -344,10 +344,10 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setFoo($foo)
     {
-
         if (is_null($foo)) {
             throw new \InvalidArgumentException('non-nullable foo cannot be null');
         }
+
 
         $this->container['foo'] = $foo;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -309,7 +309,6 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      */
     public function setNullableMessage($nullable_message)
     {
-
         if (is_null($nullable_message)) {
             array_push($this->openAPINullablesSetToNull, 'nullable_message');
         } else {
@@ -320,6 +319,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['nullable_message'] = $nullable_message;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -319,8 +319,6 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['nullable_message'] = $nullable_message;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -347,8 +347,6 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($map_map_of_string)) {
             throw new \InvalidArgumentException('non-nullable map_map_of_string cannot be null');
         }
-
-
         $this->container['map_map_of_string'] = $map_map_of_string;
 
         return $this;
@@ -376,7 +374,6 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($map_of_enum_string)) {
             throw new \InvalidArgumentException('non-nullable map_of_enum_string cannot be null');
         }
-
         $allowedValues = $this->getMapOfEnumStringAllowableValues();
         if (array_diff($map_of_enum_string, $allowedValues)) {
             throw new \InvalidArgumentException(
@@ -386,7 +383,6 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['map_of_enum_string'] = $map_of_enum_string;
 
         return $this;
@@ -414,8 +410,6 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($direct_map)) {
             throw new \InvalidArgumentException('non-nullable direct_map cannot be null');
         }
-
-
         $this->container['direct_map'] = $direct_map;
 
         return $this;
@@ -443,8 +437,6 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($indirect_map)) {
             throw new \InvalidArgumentException('non-nullable indirect_map cannot be null');
         }
-
-
         $this->container['indirect_map'] = $indirect_map;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -344,10 +344,10 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMapMapOfString($map_map_of_string)
     {
-
         if (is_null($map_map_of_string)) {
             throw new \InvalidArgumentException('non-nullable map_map_of_string cannot be null');
         }
+
 
         $this->container['map_map_of_string'] = $map_map_of_string;
 
@@ -373,18 +373,18 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMapOfEnumString($map_of_enum_string)
     {
+        if (is_null($map_of_enum_string)) {
+            throw new \InvalidArgumentException('non-nullable map_of_enum_string cannot be null');
+        }
+
         $allowedValues = $this->getMapOfEnumStringAllowableValues();
-        if (!is_null($map_of_enum_string) && array_diff($map_of_enum_string, $allowedValues)) {
+        if (array_diff($map_of_enum_string, $allowedValues)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value for 'map_of_enum_string', must be one of '%s'",
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($map_of_enum_string)) {
-            throw new \InvalidArgumentException('non-nullable map_of_enum_string cannot be null');
         }
 
         $this->container['map_of_enum_string'] = $map_of_enum_string;
@@ -411,10 +411,10 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDirectMap($direct_map)
     {
-
         if (is_null($direct_map)) {
             throw new \InvalidArgumentException('non-nullable direct_map cannot be null');
         }
+
 
         $this->container['direct_map'] = $direct_map;
 
@@ -440,10 +440,10 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setIndirectMap($indirect_map)
     {
-
         if (is_null($indirect_map)) {
             throw new \InvalidArgumentException('non-nullable indirect_map cannot be null');
         }
+
 
         $this->container['indirect_map'] = $indirect_map;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -322,10 +322,10 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      */
     public function setUuid($uuid)
     {
-
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
         }
+
 
         $this->container['uuid'] = $uuid;
 
@@ -351,10 +351,10 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      */
     public function setDateTime($date_time)
     {
-
         if (is_null($date_time)) {
             throw new \InvalidArgumentException('non-nullable date_time cannot be null');
         }
+
 
         $this->container['date_time'] = $date_time;
 
@@ -380,10 +380,10 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      */
     public function setMap($map)
     {
-
         if (is_null($map)) {
             throw new \InvalidArgumentException('non-nullable map cannot be null');
         }
+
 
         $this->container['map'] = $map;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -325,8 +325,6 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
         }
-
-
         $this->container['uuid'] = $uuid;
 
         return $this;
@@ -354,8 +352,6 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
         if (is_null($date_time)) {
             throw new \InvalidArgumentException('non-nullable date_time cannot be null');
         }
-
-
         $this->container['date_time'] = $date_time;
 
         return $this;
@@ -383,8 +379,6 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
         if (is_null($map)) {
             throw new \InvalidArgumentException('non-nullable map cannot be null');
         }
-
-
         $this->container['map'] = $map;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -319,8 +319,6 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
-
-
         $this->container['name'] = $name;
 
         return $this;
@@ -348,8 +346,6 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($class)) {
             throw new \InvalidArgumentException('non-nullable class cannot be null');
         }
-
-
         $this->container['class'] = $class;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -316,10 +316,10 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
+
 
         $this->container['name'] = $name;
 
@@ -345,10 +345,10 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setClass($class)
     {
-
         if (is_null($class)) {
             throw new \InvalidArgumentException('non-nullable class cannot be null');
         }
+
 
         $this->container['class'] = $class;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -311,8 +311,6 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($_123_list)) {
             throw new \InvalidArgumentException('non-nullable _123_list cannot be null');
         }
-
-
         $this->container['_123_list'] = $_123_list;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -308,10 +308,10 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function set123List($_123_list)
     {
-
         if (is_null($_123_list)) {
             throw new \InvalidArgumentException('non-nullable _123_list cannot be null');
         }
+
 
         $this->container['_123_list'] = $_123_list;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -312,8 +312,6 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($return)) {
             throw new \InvalidArgumentException('non-nullable return cannot be null');
         }
-
-
         $this->container['return'] = $return;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -309,10 +309,10 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setReturn($return)
     {
-
         if (is_null($return)) {
             throw new \InvalidArgumentException('non-nullable return cannot be null');
         }
+
 
         $this->container['return'] = $return;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -333,10 +333,10 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
+
 
         $this->container['name'] = $name;
 
@@ -362,10 +362,10 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSnakeCase($snake_case)
     {
-
         if (is_null($snake_case)) {
             throw new \InvalidArgumentException('non-nullable snake_case cannot be null');
         }
+
 
         $this->container['snake_case'] = $snake_case;
 
@@ -391,10 +391,10 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setProperty($property)
     {
-
         if (is_null($property)) {
             throw new \InvalidArgumentException('non-nullable property cannot be null');
         }
+
 
         $this->container['property'] = $property;
 
@@ -420,10 +420,10 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function set123Number($_123_number)
     {
-
         if (is_null($_123_number)) {
             throw new \InvalidArgumentException('non-nullable _123_number cannot be null');
         }
+
 
         $this->container['_123_number'] = $_123_number;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -336,8 +336,6 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
-
-
         $this->container['name'] = $name;
 
         return $this;
@@ -365,8 +363,6 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($snake_case)) {
             throw new \InvalidArgumentException('non-nullable snake_case cannot be null');
         }
-
-
         $this->container['snake_case'] = $snake_case;
 
         return $this;
@@ -394,8 +390,6 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($property)) {
             throw new \InvalidArgumentException('non-nullable property cannot be null');
         }
-
-
         $this->container['property'] = $property;
 
         return $this;
@@ -423,8 +417,6 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($_123_number)) {
             throw new \InvalidArgumentException('non-nullable _123_number cannot be null');
         }
-
-
         $this->container['_123_number'] = $_123_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -385,7 +385,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setIntegerProp($integer_prop)
     {
-
         if (is_null($integer_prop)) {
             array_push($this->openAPINullablesSetToNull, 'integer_prop');
         } else {
@@ -396,6 +395,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['integer_prop'] = $integer_prop;
 
@@ -421,7 +421,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setNumberProp($number_prop)
     {
-
         if (is_null($number_prop)) {
             array_push($this->openAPINullablesSetToNull, 'number_prop');
         } else {
@@ -432,6 +431,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['number_prop'] = $number_prop;
 
@@ -457,7 +457,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBooleanProp($boolean_prop)
     {
-
         if (is_null($boolean_prop)) {
             array_push($this->openAPINullablesSetToNull, 'boolean_prop');
         } else {
@@ -468,6 +467,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['boolean_prop'] = $boolean_prop;
 
@@ -493,7 +493,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setStringProp($string_prop)
     {
-
         if (is_null($string_prop)) {
             array_push($this->openAPINullablesSetToNull, 'string_prop');
         } else {
@@ -504,6 +503,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['string_prop'] = $string_prop;
 
@@ -529,7 +529,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDateProp($date_prop)
     {
-
         if (is_null($date_prop)) {
             array_push($this->openAPINullablesSetToNull, 'date_prop');
         } else {
@@ -540,6 +539,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['date_prop'] = $date_prop;
 
@@ -565,7 +565,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setDatetimeProp($datetime_prop)
     {
-
         if (is_null($datetime_prop)) {
             array_push($this->openAPINullablesSetToNull, 'datetime_prop');
         } else {
@@ -576,6 +575,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['datetime_prop'] = $datetime_prop;
 
@@ -601,7 +601,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayNullableProp($array_nullable_prop)
     {
-
         if (is_null($array_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'array_nullable_prop');
         } else {
@@ -612,6 +611,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['array_nullable_prop'] = $array_nullable_prop;
 
@@ -637,7 +637,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayAndItemsNullableProp($array_and_items_nullable_prop)
     {
-
         if (is_null($array_and_items_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'array_and_items_nullable_prop');
         } else {
@@ -648,6 +647,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['array_and_items_nullable_prop'] = $array_and_items_nullable_prop;
 
@@ -673,10 +673,10 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setArrayItemsNullable($array_items_nullable)
     {
-
         if (is_null($array_items_nullable)) {
             throw new \InvalidArgumentException('non-nullable array_items_nullable cannot be null');
         }
+
 
         $this->container['array_items_nullable'] = $array_items_nullable;
 
@@ -702,7 +702,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setObjectNullableProp($object_nullable_prop)
     {
-
         if (is_null($object_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'object_nullable_prop');
         } else {
@@ -713,6 +712,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['object_nullable_prop'] = $object_nullable_prop;
 
@@ -738,7 +738,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setObjectAndItemsNullableProp($object_and_items_nullable_prop)
     {
-
         if (is_null($object_and_items_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'object_and_items_nullable_prop');
         } else {
@@ -749,6 +748,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
+
 
         $this->container['object_and_items_nullable_prop'] = $object_and_items_nullable_prop;
 
@@ -774,10 +774,10 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setObjectItemsNullable($object_items_nullable)
     {
-
         if (is_null($object_items_nullable)) {
             throw new \InvalidArgumentException('non-nullable object_items_nullable cannot be null');
         }
+
 
         $this->container['object_items_nullable'] = $object_items_nullable;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -395,8 +395,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['integer_prop'] = $integer_prop;
 
         return $this;
@@ -431,8 +429,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['number_prop'] = $number_prop;
 
         return $this;
@@ -467,8 +463,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['boolean_prop'] = $boolean_prop;
 
         return $this;
@@ -503,8 +497,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['string_prop'] = $string_prop;
 
         return $this;
@@ -539,8 +531,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['date_prop'] = $date_prop;
 
         return $this;
@@ -575,8 +565,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['datetime_prop'] = $datetime_prop;
 
         return $this;
@@ -611,8 +599,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['array_nullable_prop'] = $array_nullable_prop;
 
         return $this;
@@ -647,8 +633,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['array_and_items_nullable_prop'] = $array_and_items_nullable_prop;
 
         return $this;
@@ -676,8 +660,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($array_items_nullable)) {
             throw new \InvalidArgumentException('non-nullable array_items_nullable cannot be null');
         }
-
-
         $this->container['array_items_nullable'] = $array_items_nullable;
 
         return $this;
@@ -712,8 +694,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['object_nullable_prop'] = $object_nullable_prop;
 
         return $this;
@@ -748,8 +728,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
         }
-
-
         $this->container['object_and_items_nullable_prop'] = $object_and_items_nullable_prop;
 
         return $this;
@@ -777,8 +755,6 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($object_items_nullable)) {
             throw new \InvalidArgumentException('non-nullable object_items_nullable cannot be null');
         }
-
-
         $this->container['object_items_nullable'] = $object_items_nullable;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -311,8 +311,6 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($just_number)) {
             throw new \InvalidArgumentException('non-nullable just_number cannot be null');
         }
-
-
         $this->container['just_number'] = $just_number;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -308,10 +308,10 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setJustNumber($just_number)
     {
-
         if (is_null($just_number)) {
             throw new \InvalidArgumentException('non-nullable just_number cannot be null');
         }
+
 
         $this->container['just_number'] = $just_number;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -332,8 +332,6 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
         }
-
-
         $this->container['uuid'] = $uuid;
 
         return $this;
@@ -363,8 +361,6 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
-
-
         $this->container['id'] = $id;
 
         return $this;
@@ -394,8 +390,6 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
         if (is_null($deprecated_ref)) {
             throw new \InvalidArgumentException('non-nullable deprecated_ref cannot be null');
         }
-
-
         $this->container['deprecated_ref'] = $deprecated_ref;
 
         return $this;
@@ -425,8 +419,6 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
         if (is_null($bars)) {
             throw new \InvalidArgumentException('non-nullable bars cannot be null');
         }
-
-
         $this->container['bars'] = $bars;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -329,10 +329,10 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setUuid($uuid)
     {
-
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
         }
+
 
         $this->container['uuid'] = $uuid;
 
@@ -360,10 +360,10 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setId($id)
     {
-
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
+
 
         $this->container['id'] = $id;
 
@@ -391,10 +391,10 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setDeprecatedRef($deprecated_ref)
     {
-
         if (is_null($deprecated_ref)) {
             throw new \InvalidArgumentException('non-nullable deprecated_ref cannot be null');
         }
+
 
         $this->container['deprecated_ref'] = $deprecated_ref;
 
@@ -422,10 +422,10 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      */
     public function setBars($bars)
     {
-
         if (is_null($bars)) {
             throw new \InvalidArgumentException('non-nullable bars cannot be null');
         }
+
 
         $this->container['bars'] = $bars;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -369,10 +369,10 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
-
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
+
 
         $this->container['id'] = $id;
 
@@ -398,10 +398,10 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPetId($pet_id)
     {
-
         if (is_null($pet_id)) {
             throw new \InvalidArgumentException('non-nullable pet_id cannot be null');
         }
+
 
         $this->container['pet_id'] = $pet_id;
 
@@ -427,10 +427,10 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setQuantity($quantity)
     {
-
         if (is_null($quantity)) {
             throw new \InvalidArgumentException('non-nullable quantity cannot be null');
         }
+
 
         $this->container['quantity'] = $quantity;
 
@@ -456,10 +456,10 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setShipDate($ship_date)
     {
-
         if (is_null($ship_date)) {
             throw new \InvalidArgumentException('non-nullable ship_date cannot be null');
         }
+
 
         $this->container['ship_date'] = $ship_date;
 
@@ -485,8 +485,12 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setStatus($status)
     {
+        if (is_null($status)) {
+            throw new \InvalidArgumentException('non-nullable status cannot be null');
+        }
+
         $allowedValues = $this->getStatusAllowableValues();
-        if (!is_null($status) && !in_array($status, $allowedValues, true)) {
+        if (!in_array($status, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'status', must be one of '%s'",
@@ -494,10 +498,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($status)) {
-            throw new \InvalidArgumentException('non-nullable status cannot be null');
         }
 
         $this->container['status'] = $status;
@@ -524,10 +524,10 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setComplete($complete)
     {
-
         if (is_null($complete)) {
             throw new \InvalidArgumentException('non-nullable complete cannot be null');
         }
+
 
         $this->container['complete'] = $complete;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -372,8 +372,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
-
-
         $this->container['id'] = $id;
 
         return $this;
@@ -401,8 +399,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($pet_id)) {
             throw new \InvalidArgumentException('non-nullable pet_id cannot be null');
         }
-
-
         $this->container['pet_id'] = $pet_id;
 
         return $this;
@@ -430,8 +426,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($quantity)) {
             throw new \InvalidArgumentException('non-nullable quantity cannot be null');
         }
-
-
         $this->container['quantity'] = $quantity;
 
         return $this;
@@ -459,8 +453,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($ship_date)) {
             throw new \InvalidArgumentException('non-nullable ship_date cannot be null');
         }
-
-
         $this->container['ship_date'] = $ship_date;
 
         return $this;
@@ -488,7 +480,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($status)) {
             throw new \InvalidArgumentException('non-nullable status cannot be null');
         }
-
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -499,7 +490,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['status'] = $status;
 
         return $this;
@@ -527,8 +517,6 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($complete)) {
             throw new \InvalidArgumentException('non-nullable complete cannot be null');
         }
-
-
         $this->container['complete'] = $complete;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -322,10 +322,10 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMyNumber($my_number)
     {
-
         if (is_null($my_number)) {
             throw new \InvalidArgumentException('non-nullable my_number cannot be null');
         }
+
 
         $this->container['my_number'] = $my_number;
 
@@ -351,10 +351,10 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMyString($my_string)
     {
-
         if (is_null($my_string)) {
             throw new \InvalidArgumentException('non-nullable my_string cannot be null');
         }
+
 
         $this->container['my_string'] = $my_string;
 
@@ -380,10 +380,10 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setMyBoolean($my_boolean)
     {
-
         if (is_null($my_boolean)) {
             throw new \InvalidArgumentException('non-nullable my_boolean cannot be null');
         }
+
 
         $this->container['my_boolean'] = $my_boolean;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -325,8 +325,6 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($my_number)) {
             throw new \InvalidArgumentException('non-nullable my_number cannot be null');
         }
-
-
         $this->container['my_number'] = $my_number;
 
         return $this;
@@ -354,8 +352,6 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($my_string)) {
             throw new \InvalidArgumentException('non-nullable my_string cannot be null');
         }
-
-
         $this->container['my_string'] = $my_string;
 
         return $this;
@@ -383,8 +379,6 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($my_boolean)) {
             throw new \InvalidArgumentException('non-nullable my_boolean cannot be null');
         }
-
-
         $this->container['my_boolean'] = $my_boolean;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
@@ -311,10 +311,10 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      */
     public function setValue($value)
     {
-
         if (is_null($value)) {
             throw new \InvalidArgumentException('non-nullable value cannot be null');
         }
+
 
         $this->container['value'] = $value;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterObjectWithEnumProperty.php
@@ -314,8 +314,6 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
         if (is_null($value)) {
             throw new \InvalidArgumentException('non-nullable value cannot be null');
         }
-
-
         $this->container['value'] = $value;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -378,8 +378,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
-
-
         $this->container['id'] = $id;
 
         return $this;
@@ -407,8 +405,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($category)) {
             throw new \InvalidArgumentException('non-nullable category cannot be null');
         }
-
-
         $this->container['category'] = $category;
 
         return $this;
@@ -436,8 +432,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
-
-
         $this->container['name'] = $name;
 
         return $this;
@@ -467,8 +461,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         }
 
 
-
-
         $this->container['photo_urls'] = $photo_urls;
 
         return $this;
@@ -496,8 +488,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($tags)) {
             throw new \InvalidArgumentException('non-nullable tags cannot be null');
         }
-
-
         $this->container['tags'] = $tags;
 
         return $this;
@@ -525,7 +515,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($status)) {
             throw new \InvalidArgumentException('non-nullable status cannot be null');
         }
-
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
             throw new \InvalidArgumentException(
@@ -536,7 +525,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
                 )
             );
         }
-
         $this->container['status'] = $status;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -375,10 +375,10 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
-
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
+
 
         $this->container['id'] = $id;
 
@@ -404,10 +404,10 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCategory($category)
     {
-
         if (is_null($category)) {
             throw new \InvalidArgumentException('non-nullable category cannot be null');
         }
+
 
         $this->container['category'] = $category;
 
@@ -433,10 +433,10 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
+
 
         $this->container['name'] = $name;
 
@@ -462,12 +462,12 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPhotoUrls($photo_urls)
     {
-
-
-
         if (is_null($photo_urls)) {
             throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
         }
+
+
+
 
         $this->container['photo_urls'] = $photo_urls;
 
@@ -493,10 +493,10 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setTags($tags)
     {
-
         if (is_null($tags)) {
             throw new \InvalidArgumentException('non-nullable tags cannot be null');
         }
+
 
         $this->container['tags'] = $tags;
 
@@ -522,8 +522,12 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setStatus($status)
     {
+        if (is_null($status)) {
+            throw new \InvalidArgumentException('non-nullable status cannot be null');
+        }
+
         $allowedValues = $this->getStatusAllowableValues();
-        if (!is_null($status) && !in_array($status, $allowedValues, true)) {
+        if (!in_array($status, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'status', must be one of '%s'",
@@ -531,10 +535,6 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
                     implode("', '", $allowedValues)
                 )
             );
-        }
-
-        if (is_null($status)) {
-            throw new \InvalidArgumentException('non-nullable status cannot be null');
         }
 
         $this->container['status'] = $status;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -318,8 +318,6 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
         }
-
-
         $this->container['bar'] = $bar;
 
         return $this;
@@ -347,8 +345,6 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($baz)) {
             throw new \InvalidArgumentException('non-nullable baz cannot be null');
         }
-
-
         $this->container['baz'] = $baz;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -315,10 +315,10 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBar($bar)
     {
-
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
         }
+
 
         $this->container['bar'] = $bar;
 
@@ -344,10 +344,10 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setBaz($baz)
     {
-
         if (is_null($baz)) {
             throw new \InvalidArgumentException('non-nullable baz cannot be null');
         }
+
 
         $this->container['baz'] = $baz;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -308,10 +308,10 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setSpecialPropertyName($special_property_name)
     {
-
         if (is_null($special_property_name)) {
             throw new \InvalidArgumentException('non-nullable special_property_name cannot be null');
         }
+
 
         $this->container['special_property_name'] = $special_property_name;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -311,8 +311,6 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($special_property_name)) {
             throw new \InvalidArgumentException('non-nullable special_property_name cannot be null');
         }
-
-
         $this->container['special_property_name'] = $special_property_name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -315,10 +315,10 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
-
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
+
 
         $this->container['id'] = $id;
 
@@ -344,10 +344,10 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
+
 
         $this->container['name'] = $name;
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -318,8 +318,6 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
-
-
         $this->container['id'] = $id;
 
         return $this;
@@ -347,8 +345,6 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
         }
-
-
         $this->container['name'] = $name;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -360,8 +360,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
-
-
         $this->container['id'] = $id;
 
         return $this;
@@ -389,8 +387,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($username)) {
             throw new \InvalidArgumentException('non-nullable username cannot be null');
         }
-
-
         $this->container['username'] = $username;
 
         return $this;
@@ -418,8 +414,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($first_name)) {
             throw new \InvalidArgumentException('non-nullable first_name cannot be null');
         }
-
-
         $this->container['first_name'] = $first_name;
 
         return $this;
@@ -447,8 +441,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($last_name)) {
             throw new \InvalidArgumentException('non-nullable last_name cannot be null');
         }
-
-
         $this->container['last_name'] = $last_name;
 
         return $this;
@@ -476,8 +468,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($email)) {
             throw new \InvalidArgumentException('non-nullable email cannot be null');
         }
-
-
         $this->container['email'] = $email;
 
         return $this;
@@ -505,8 +495,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($password)) {
             throw new \InvalidArgumentException('non-nullable password cannot be null');
         }
-
-
         $this->container['password'] = $password;
 
         return $this;
@@ -534,8 +522,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($phone)) {
             throw new \InvalidArgumentException('non-nullable phone cannot be null');
         }
-
-
         $this->container['phone'] = $phone;
 
         return $this;
@@ -563,8 +549,6 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
         if (is_null($user_status)) {
             throw new \InvalidArgumentException('non-nullable user_status cannot be null');
         }
-
-
         $this->container['user_status'] = $user_status;
 
         return $this;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -357,10 +357,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setId($id)
     {
-
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
         }
+
 
         $this->container['id'] = $id;
 
@@ -386,10 +386,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setUsername($username)
     {
-
         if (is_null($username)) {
             throw new \InvalidArgumentException('non-nullable username cannot be null');
         }
+
 
         $this->container['username'] = $username;
 
@@ -415,10 +415,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setFirstName($first_name)
     {
-
         if (is_null($first_name)) {
             throw new \InvalidArgumentException('non-nullable first_name cannot be null');
         }
+
 
         $this->container['first_name'] = $first_name;
 
@@ -444,10 +444,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setLastName($last_name)
     {
-
         if (is_null($last_name)) {
             throw new \InvalidArgumentException('non-nullable last_name cannot be null');
         }
+
 
         $this->container['last_name'] = $last_name;
 
@@ -473,10 +473,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setEmail($email)
     {
-
         if (is_null($email)) {
             throw new \InvalidArgumentException('non-nullable email cannot be null');
         }
+
 
         $this->container['email'] = $email;
 
@@ -502,10 +502,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPassword($password)
     {
-
         if (is_null($password)) {
             throw new \InvalidArgumentException('non-nullable password cannot be null');
         }
+
 
         $this->container['password'] = $password;
 
@@ -531,10 +531,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setPhone($phone)
     {
-
         if (is_null($phone)) {
             throw new \InvalidArgumentException('non-nullable phone cannot be null');
         }
+
 
         $this->container['phone'] = $phone;
 
@@ -560,10 +560,10 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setUserStatus($user_status)
     {
-
         if (is_null($user_status)) {
             throw new \InvalidArgumentException('non-nullable user_status cannot be null');
         }
+
 
         $this->container['user_status'] = $user_status;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Resolves #13998 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon @wing328 